### PR TITLE
Add interpolator serialization tests and Claude skills

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -19,8 +19,8 @@
 | Classes/Structs      | PascalCase + trailing `_`     | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>` |
 | Template params      | Single letter + `_`           | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                |
 | Functions/Methods    | PascalCase                    | `FromExcel()`, `AddDays()`, `GeneratePath()`      |
-| Member variables     | Trailing `_`                  | `serial_`, `spot_`, `vol_`, `name_`               |
-| Local variables      | snake_case                    | `num_paths`, `batch_size`, `n_threads`            |
+| Member variables     | camelCase + trailing `_`      | `serialNumber_`, `spot_`, `vol_`, `name_`         |
+| Local variables      | camelCase                     | `numPaths`, `batchSize`, `nThreads`               |
 | Constants/Macros     | UPPER_SNAKE_CASE              | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`           |
 | Files                | lowercase, no separators      | `threadpool.cpp`, `blackscholes.hpp`              |
 | Test files           | `test_` prefix, snake_case    | `test_vectors.cpp`, `test_date.cpp`               |

--- a/.claude/rules/git-commit-pr.md
+++ b/.claude/rules/git-commit-pr.md
@@ -1,0 +1,53 @@
+# Git Commit and PR Guide
+
+## Branch Naming
+
+- Feature branches: `feature/<short-description>` (e.g., `feature/log-linear-interp-and-refactor`)
+- Bug fix branches: `fix/<short-description>`
+- Base branch: `master`
+
+## Commit Messages
+
+- First line: imperative summary under 72 characters (e.g., "Add log-linear interpolation", "Fix include paths")
+- Blank line, then body explaining **why** the change was made, not just what changed
+- If AI-assisted, append: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- One logical change per commit -- don't mix unrelated fixes
+
+**Good examples:**
+```
+Add log-linear interpolation and extract linear interp into separate files
+
+- Add new LogLinear1_ interpolator that interpolates linearly on log(f)
+- Extract Interp1Linear_ from interp.hpp into dedicated interplinear.hpp/cpp
+- Update all dependent files to include interplinear.hpp directly
+```
+
+```
+Fix include paths and ordering in interp module
+
+Correct interploglinear.hpp include to use interp.hpp instead of interplinear.hpp,
+and reorder includes in test files to follow project convention (gtest first).
+```
+
+**Bad examples:**
+- `update` (too vague)
+- `some code modification` (says nothing)
+- `Fix bug and add feature and refactor` (too many things at once)
+
+## Pull Requests
+
+- Branch from `master`, PR back to `master`
+- Title: short summary under 70 characters
+- Body format:
+
+```markdown
+## Summary
+- Bullet points describing the key changes
+
+## Test plan
+- [x] Run specific test filters to verify new/changed functionality
+- [x] Full `bin/test_suite` to confirm no regressions
+```
+
+- All tests must pass before merging
+- Keep PRs focused -- one feature or fix per PR when possible

--- a/.claude/skills/code-style-review/SKILL.md
+++ b/.claude/skills/code-style-review/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: code-style-review
+description: Review changed code for compliance with this project's C++ coding style. Use this skill whenever the user asks to review code style, check style compliance, lint code, or verify naming conventions. Also trigger when the user says "review my changes", "check the style", "does this follow our conventions", or similar.
+user-invocable: true
+---
+
+# Code Style Review
+
+Review all changed files in the working tree against the project's coding conventions defined in `.claude/rules/code-style.md` and `.claude/rules/unit-test-style.md`.
+
+## Steps
+
+1. Read the style guides:
+   - `.claude/rules/code-style.md`
+   - `.claude/rules/unit-test-style.md`
+
+2. Identify changed files by running:
+   ```bash
+   git diff --name-only HEAD
+   ```
+   If there are no uncommitted changes, check the latest commit instead:
+   ```bash
+   git diff --name-only HEAD~1
+   ```
+
+3. Read each changed `.hpp`, `.cpp` file and check for violations against the rules below.
+
+4. Report findings grouped by file, with line numbers and specific violations. If no violations are found, say so.
+
+## What to Check
+
+### Naming
+- Classes/Structs: PascalCase with trailing `_` (e.g., `Date_`, `Vector_<>`)
+- Template params: single letter or short name with trailing `_` (e.g., `T_`, `E_`)
+- Functions/Methods: PascalCase (e.g., `AddDays()`, `GeneratePath()`)
+- Member variables: camel case with trailing `_` (e.g., `serialNumber_`, `name_`)
+- Local variables: camel case (e.g., `numPaths`, `batchSize`)
+- Constants/Macros: UPPER_SNAKE_CASE
+- Files: lowercase, no separators; test files use `test_` prefix
+
+### Header Files
+- Must use `#pragma once` (not include guards)
+- Must have file header: `// Created by <author> on <date>.`
+- Include order: `<gtest/gtest.h>` first (test files) -> standard library -> dal headers
+
+### Test Files
+- Always `TEST(Suite, Name)` -- never `TEST_F`
+- Suite names: PascalCase matching module (e.g., `InterpTest`)
+- Test names: PascalCase with `Test` prefix (e.g., `TestNewCubic`)
+- Prefer `ASSERT_*` over `EXPECT_*`
+- Float comparison: `ASSERT_NEAR(actual, expected, tol)` with `1e-8` to `1e-10`
+- Exception testing: `ASSERT_THROW(expr, Dal::Exception_)`
+
+### General
+- 4-space indentation, no tabs
+- Brace style: Attach (opening `{` on same line)
+- Pointer binds to type: `T*` not `T *`
+- `using` over `typedef`
+- `explicit` on single-argument constructors
+- Error handling via `REQUIRE`/`ASSERT`/`THROW` macros, not raw exceptions
+- Comments: sparse, focus on "why" not "what", no docstrings

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: commit-and-pr
+description: Commit all current changes, push to remote, and create a pull request. Use this skill whenever the user says "ship it", "commit and PR", "push and create PR", "send this up for review", "wrap this up", or any variation of committing + pushing + opening a PR in one go.
+user-invocable: true
+---
+
+# Commit, Push, and Create PR
+
+This skill packages up the current session's work into commits, pushes to a remote branch, and opens a pull request — all in one shot. It follows the project's git conventions defined in `.claude/rules/git-commit-pr.md`.
+
+## Steps
+
+### 1. Assess the current state
+
+Run these in parallel to understand what needs to be committed:
+
+```bash
+git status
+git diff --stat
+git diff --staged --stat
+git log --oneline -5
+```
+
+If there are no changes (staged or unstaged), tell the user and stop.
+
+### 2. Determine the branch
+
+- If already on a feature/fix branch, use it.
+- If on `master`, create a new branch. Ask the user for a name, or suggest one based on the changes (e.g., `feature/add-interp-serialization-tests`).
+
+### 3. Stage and commit
+
+- Review the diff carefully to understand what changed and why.
+- Skip files that should not be committed: binaries (`*.xll`), dirty submodules (`externals/`), generated cmake files, secrets (`.env`, credentials).
+- Group related changes into logical commits — one commit per logical unit of work. If all changes are related, a single commit is fine.
+- Write commit messages following project conventions:
+  - Imperative summary under 72 characters
+  - Body explaining the "why", not just the "what"
+  - Append `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- Use a HEREDOC for the commit message to preserve formatting:
+  ```bash
+  git commit -m "$(cat <<'EOF'
+  Summary line here
+
+  Body explaining why.
+
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+### 4. Push to remote
+
+```bash
+git push -u origin <branch-name>
+```
+
+If the branch already tracks a remote, a plain `git push` is sufficient.
+
+### 5. Create the pull request
+
+Use `gh pr create` with the project's PR template. Analyze all commits on the branch (not just the latest) to write the summary.
+
+```bash
+gh pr create --title "<short title under 70 chars>" --body "$(cat <<'EOF'
+## Summary
+- <bullet points covering all key changes>
+
+## Test plan
+- [ ] Run `bin/test_suite --gtest_filter=<RelevantSuite>.*` to verify changes
+- [ ] Full `bin/test_suite` to confirm no regressions
+EOF
+)"
+```
+
+The base branch is always `master`.
+
+### 6. Report back
+
+Print the PR URL so the user can review it.

--- a/.claude/skills/unit-test-skill/SKILL.md
+++ b/.claude/skills/unit-test-skill/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 - In the windows terminal, run the following command to execute all unit tests for the codebase:
 
 ```bash
-$ powershell -Command "Set-Location 'D:\dev\github\dal.cpp'; Start-Process -FilePath '.\build_windows.bat' -Wait -NoNewWindow -RedirectStandardOutput 'test_output.txt'" 2>&1
+$ ./build_windows.bat > 'test_output.txt' 2>&1
 ```
 
 - Get the output of the unit tests from the `test_output.txt` file generated in the root directory of the codebase. The output should look like:

--- a/dal/storage/json.cpp
+++ b/dal/storage/json.cpp
@@ -2,6 +2,7 @@
 // Created by wegam on 2023/1/21.
 //
 
+#include <cstdio>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -87,12 +88,14 @@ namespace Dal {
 
             // store atoms
             XDocStore_& operator=(const double val) override {
-                dst_ << String::FromDouble(val);
+                char buf[32];
+                std::snprintf(buf, sizeof(buf), "%.15g", val);
+                dst_ << buf;
                 return *this;
             }
 
             XDocStore_& operator=(const int val) {
-                dst_ << String::FromDouble(val);
+                dst_ << val;
                 return *this;
             }
             XDocStore_& operator=(const bool val) {
@@ -217,7 +220,7 @@ namespace Dal {
         Cell_ ECell(const element_t& doc) {
             static const std::regex DATE_PATTERN(R"(\d{4}-\d{2}-\d{2})");
             static const std::regex DATE_TIME_PATTERN(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})");
-            if (doc.IsDouble())
+            if (doc.IsDouble() || doc.IsInt())
                 return Cell_(doc.GetDouble());
             if (doc.IsBool())
                 return Cell_(doc.GetBool());

--- a/tests/math/interp/test_interp.cpp
+++ b/tests/math/interp/test_interp.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include <dal/math/interp/interplinear.hpp>
 #include <dal/platform/platform.hpp>
+#include <dal/storage/json.hpp>
+#include <dal/storage/splat.hpp>
 
 using Dal::Interp1Linear_;
 using Dal::Vector_;
@@ -12,6 +14,7 @@ using Dal::String_;
 using Dal::Interp::NewLinear;
 using Dal::Interp1_;
 using Dal::Handle_;
+using Dal::Storable_;
 
 TEST(InterpTest, TestInterpLinearImplXWithSmooth) {
     Vector_<> x = {1., 2., 3., 4., 5.};
@@ -68,4 +71,34 @@ TEST(InterpTest, TestNewLinear) {
     ASSERT_DOUBLE_EQ(f[0], (*interp)(x[0] - 1.));
     ASSERT_DOUBLE_EQ(f[4], (*interp)(x[4] + 1.));
     ASSERT_DOUBLE_EQ((f[2] + f[3]) / 2., (*interp)((x[2] + x[3]) / 2.));
+}
+
+TEST(InterpTest, TestInterp1LinearSplatSerialization) {
+    Vector_<> x = {1., 2., 3., 4., 5.};
+    Vector_<> f = {2.5, 3.5, 1.7, 2.8, 3.6};
+
+    Interp1Linear_ src("interp", x, f);
+    auto dst = Dal::Splat(src);
+    Handle_<Storable_> rtn = Dal::UnSplat(dst, true);
+    Handle_<Interp1Linear_> val(std::dynamic_pointer_cast<const Interp1Linear_>(rtn));
+
+    ASSERT_TRUE(val.get() != nullptr);
+    ASSERT_EQ(x, val->x());
+    ASSERT_EQ(f, val->f());
+    ASSERT_DOUBLE_EQ(src(2.5), (*val)(2.5));
+}
+
+TEST(InterpTest, TestInterp1LinearJsonSerialization) {
+    Vector_<> x = {1., 2., 3., 4., 5.};
+    Vector_<> f = {2.5, 3.5, 1.7, 2.8, 3.6};
+
+    Interp1Linear_ src("interp", x, f);
+    auto json = Dal::JSON::WriteString(src);
+    Handle_<Storable_> rtn = Dal::JSON::ReadString(json, true);
+    Handle_<Interp1Linear_> val(std::dynamic_pointer_cast<const Interp1Linear_>(rtn));
+
+    ASSERT_TRUE(val.get() != nullptr);
+    ASSERT_EQ(x, val->x());
+    ASSERT_EQ(f, val->f());
+    ASSERT_DOUBLE_EQ(src(2.5), (*val)(2.5));
 }

--- a/tests/math/interp/test_interpcubic.cpp
+++ b/tests/math/interp/test_interpcubic.cpp
@@ -2,10 +2,12 @@
 // Created by wegam on 2020/12/17.
 //
 
-#include <cmath>
+#include <gtest/gtest.h>
 #include <dal/math/interp/interpcubic.hpp>
 #include <dal/math/vectors.hpp>
-#include <gtest/gtest.h>
+#include <dal/storage/json.hpp>
+#include <dal/storage/splat.hpp>
+#include <cmath>
 
 using namespace Dal;
 
@@ -43,4 +45,38 @@ TEST(InterpTest, TestNewCubic) {
         ErrorFunction_ func(interp);
         ASSERT_DOUBLE_EQ(func(x[0]), 0.0);
     }
+}
+
+TEST(InterpTest, TestCubicSplatSerialization) {
+    Vector_<> x = Vector::XRange(-1.7, 1.9, 9);
+    Vector_<> y = Gaussian(x);
+
+    Interp::Boundary_ lhs(2, 0.);
+    Interp::Boundary_ rhs(2, 0.);
+    Handle_<Interp1_> src(Interp::NewCubic("interp", x, y, lhs, rhs));
+
+    auto dst = Splat(*src);
+    Handle_<Storable_> rtn = UnSplat(dst, true);
+    Handle_<Interp1_> val(std::dynamic_pointer_cast<const Interp1_>(rtn));
+
+    ASSERT_TRUE(val.get() != nullptr);
+    double test_x = 0.5;
+    ASSERT_NEAR((*val)(test_x), (*src)(test_x), 1e-10);
+}
+
+TEST(InterpTest, TestCubicJsonSerialization) {
+    Vector_<> x = Vector::XRange(-1.7, 1.9, 9);
+    Vector_<> y = Gaussian(x);
+
+    Interp::Boundary_ lhs(2, 0.);
+    Interp::Boundary_ rhs(2, 0.);
+    Handle_<Interp1_> src(Interp::NewCubic("interp", x, y, lhs, rhs));
+
+    auto json = JSON::WriteString(*src);
+    Handle_<Storable_> rtn = JSON::ReadString(json, true);
+    Handle_<Interp1_> val(std::dynamic_pointer_cast<const Interp1_>(rtn));
+
+    ASSERT_TRUE(val.get() != nullptr);
+    double test_x = 0.5;
+    ASSERT_NEAR((*val)(test_x), (*src)(test_x), 1e-10);
 }

--- a/tests/math/interp/test_interploglinear.cpp
+++ b/tests/math/interp/test_interploglinear.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include <dal/math/interp/interploglinear.hpp>
+#include <dal/storage/json.hpp>
+#include <dal/storage/splat.hpp>
 #include <cmath>
 
 using namespace Dal;
@@ -46,4 +48,36 @@ TEST(InterpTest, TestNewLogLinearRejectsMismatchedSizes) {
     Vector_<> f = {1.0, 2.0, 4.0};
 
     ASSERT_THROW(Interp::NewLogLinear("test", x, f), Dal::Exception_);
+}
+
+TEST(InterpTest, TestLogLinearSplatSerialization) {
+    Vector_<> x = {0.0, 1.0, 2.0, 3.0};
+    Vector_<> f = {1.0, 2.0, 4.0, 8.0};
+
+    Handle_<Interp1_> src(Interp::NewLogLinear("test", x, f));
+
+    auto dst = Splat(*src);
+    Handle_<Storable_> rtn = UnSplat(dst, true);
+    Handle_<Interp1_> val(std::dynamic_pointer_cast<const Interp1_>(rtn));
+
+    ASSERT_TRUE(val.get() != nullptr);
+    for (int i = 0; i < x.size(); ++i)
+        ASSERT_NEAR((*val)(x[i]), f[i], 1e-10);
+    ASSERT_NEAR((*val)(0.5), (*src)(0.5), 1e-10);
+}
+
+TEST(InterpTest, TestLogLinearJsonSerialization) {
+    Vector_<> x = {0.0, 1.0, 2.0, 3.0};
+    Vector_<> f = {1.0, 2.0, 4.0, 8.0};
+
+    Handle_<Interp1_> src(Interp::NewLogLinear("test", x, f));
+
+    auto json = JSON::WriteString(*src);
+    Handle_<Storable_> rtn = JSON::ReadString(json, true);
+    Handle_<Interp1_> val(std::dynamic_pointer_cast<const Interp1_>(rtn));
+
+    ASSERT_TRUE(val.get() != nullptr);
+    for (int i = 0; i < x.size(); ++i)
+        ASSERT_NEAR((*val)(x[i]), f[i], 1e-10);
+    ASSERT_NEAR((*val)(0.5), (*src)(0.5), 1e-10);
 }


### PR DESCRIPTION
## Summary
- Add Splat and JSON round-trip serialization tests for Linear, Cubic, and LogLinear interpolators
- Fix include order in test_interpcubic.cpp (gtest first per project convention)
- Fix JSON serialization precision: use %.15g instead of std::to_string (%f, 6 decimal places) to preserve full double precision during round-trip serialization
- Handle integer-parsed doubles in ECell deserialization (RapidJSON parses whole numbers as int)
- Update code-style.md naming conventions (member variables: camelCase + trailing _, local variables: camelCase) to match code-style-review skill
- Add `.claude/rules/git-commit-pr.md` with branch naming, commit message, and PR conventions
- Add `code-style-review` skill for checking code against project style guide
- Add `commit-and-pr` skill to automate the commit/push/PR workflow
- Simplify unit-test-skill Windows build command

## Test plan
- [x] Run `bin/test_suite --gtest_filter=InterpTest.*` to verify serialization tests
- [x] Full `bin/test_suite` — all 419 tests pass