### PR TITLE
Add serialization tests, interp refactoring, and Excel COM integration

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -57,7 +57,15 @@ git push -u origin <branch-name>
 
 If the branch already tracks a remote, a plain `git push` is sufficient.
 
-### 5. Create the pull request
+### 5. Create or update the pull request
+
+First check if a PR already exists for this branch:
+
+```bash
+gh pr view --json number,title,body 2>/dev/null
+```
+
+#### If no PR exists — create one
 
 Use `gh pr create` with the project's PR template. Analyze all commits on the branch (not just the latest) to write the summary.
 
@@ -74,6 +82,29 @@ EOF
 ```
 
 The base branch is always `master`.
+
+#### If a PR already exists — update its description
+
+Read the existing PR body, then amend it to incorporate the new commit(s). The goal is a single coherent description covering all work on the branch, not an append-only changelog.
+
+1. Read all commits on the branch (`git log --oneline master..HEAD`) and the existing PR body.
+2. Rewrite the Summary section to cover all changes holistically. Don't just append bullet points — reorganize if needed so the description reads well as a whole.
+3. Update the Test plan if the new changes affect different test suites.
+4. Apply with:
+   ```bash
+   gh pr edit --body "$(cat <<'EOF'
+   ## Summary
+   - <updated bullet points covering ALL changes on the branch>
+
+   ## Test plan
+   - [ ] Updated test plan items
+   EOF
+   )"
+   ```
+5. Optionally update the title if it no longer reflects the full scope:
+   ```bash
+   gh pr edit --title "<new title under 70 chars>"
+   ```
 
 ### 6. Report back
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,36 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/externals/machinist)
 include_directories(${CMAKE_SOURCE_DIR}/externals/rapidjson/include)
 include_directories(${CMAKE_SOURCE_DIR}/externals/xad/include)
 
+# Auto-detect Microsoft Office for Excel COM integration
+set(DAL_HAS_EXCEL OFF)
+if(WIN32)
+    set(_OFFICE_SEARCH_PATHS
+        "C:/Program Files/Microsoft Office/root/VFS/ProgramFilesCommonX86/Microsoft Shared/OFFICE16"
+        "C:/Program Files (x86)/Common Files/microsoft shared/OFFICE16"
+        "C:/Program Files/Common Files/Microsoft Shared/OFFICE16"
+    )
+    set(_VBA_SEARCH_PATHS
+        "C:/Program Files/Microsoft Office/root/VFS/ProgramFilesCommonX86/Microsoft Shared/VBA/VBA6"
+        "C:/Program Files (x86)/Common Files/microsoft shared/VBA/VBA6"
+        "C:/Program Files/Common Files/Microsoft Shared/VBA/VBA6"
+    )
+    set(_EXCEL_SEARCH_PATHS
+        "C:/Program Files/Microsoft Office/root/Office16"
+        "C:/Program Files (x86)/Microsoft Office/Office16"
+        "C:/Program Files/Microsoft Office/Office16"
+    )
+    find_file(OFFICE_MSO_DLL NAMES "MSO.DLL" PATHS ${_OFFICE_SEARCH_PATHS} NO_DEFAULT_PATH)
+    find_file(OFFICE_VBE_OLB NAMES "VBE6EXT.OLB" PATHS ${_VBA_SEARCH_PATHS} NO_DEFAULT_PATH)
+    find_file(OFFICE_EXCEL_EXE NAMES "EXCEL.EXE" PATHS ${_EXCEL_SEARCH_PATHS} NO_DEFAULT_PATH)
+
+    if(OFFICE_MSO_DLL AND OFFICE_VBE_OLB AND OFFICE_EXCEL_EXE)
+        set(DAL_HAS_EXCEL ON)
+        message(STATUS "Office found - Excel COM integration enabled")
+    else()
+        message(STATUS "Office not found - Excel COM integration disabled")
+    endif()
+endif()
+
 add_subdirectory(dal)
 add_subdirectory(public)
 add_subdirectory(examples)

--- a/dal/CMakeLists.txt
+++ b/dal/CMakeLists.txt
@@ -8,6 +8,15 @@ list(FILTER DAL_FILES EXCLUDE REGEX "${PROJECT_SOURCE_DIR}/dal/storage/_reposito
 
 add_library(dal_library ${DAL_FILES})
 
+if(DAL_HAS_EXCEL)
+    target_compile_definitions(dal_library PRIVATE
+        USE_EXCEL_REPORT
+        OFFICE_MSO_PATH="${OFFICE_MSO_DLL}"
+        OFFICE_VBE_PATH="${OFFICE_VBE_OLB}"
+        OFFICE_EXCEL_PATH="${OFFICE_EXCEL_EXE}"
+    )
+endif()
+
 if (DAL_USE_XAD_AAD)
     target_link_libraries(dal_library XAD::xad)
 endif()

--- a/dal/io/exceldriverlite.cpp
+++ b/dal/io/exceldriverlite.cpp
@@ -1,0 +1,306 @@
+//
+// Created by wegam on 2023/1/23.
+//
+
+#include <dal/platform/config.hpp>
+
+#ifdef USE_EXCEL_REPORT
+#include <stdexcept>
+#include <dal/io/exceldriverlite.hpp>
+#include <dal/io/excelimport.hpp>
+#include <dal/math/matrix/matrixutils.hpp>
+
+
+namespace Dal {
+
+    void ExcelDriver_::ToSheetHorizontal(Excel::_WorksheetPtr sheet,
+                                         int sheetRow,
+                                         int sheetColumn,
+                                         const String_& label,
+                                         const Vector_<>& values) {
+        // Get cells.
+        Excel::RangePtr pRange = sheet->Cells;
+
+        // First cell contains the label.
+        Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
+        //	item->Value = label.c_str();
+        item->Value2 = label.c_str();
+
+        sheetColumn++;
+
+        // Next cells contain the values.
+        for (std::size_t i = 0; i < values.size(); i++) {
+            Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
+            item->Value2 = values[i];
+
+            sheetColumn++;
+        }
+    }
+
+    // Writes label and vector to cells in vertical direction.
+
+    void ExcelDriver_::ToSheetVertical(Excel::_WorksheetPtr sheet,
+                                       int sheetRow,
+                                       int sheetColumn,
+                                       const String_& label,
+                                       const Vector_<>& values) {
+        // Get cells.
+        Excel::RangePtr pRange = sheet->Cells;
+
+        // First cell contains the label.
+        Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
+        // item->Value = label.c_str();
+        item->Value2 = label.c_str();
+
+        sheetRow++;
+
+        // Next cells contain the values.
+        for (std::size_t i = 0; i < values.size(); i++) {
+            Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
+            // item->Value = values[i];
+            item->Value2 = values[i];
+            sheetRow++;
+        }
+    }
+
+    // Throw COM error as string.
+
+    void ExcelDriver_::ThrowAsString(_com_error& error) {
+        bstr_t description = error.Description();
+        if (!description) {
+            description = error.ErrorMessage();
+        }
+        THROW(String_(description));
+    }
+
+    // Constructor. Starts Excel in invisible mode.
+
+    ExcelDriver_::ExcelDriver_(int currentColumn) : curDataColumn_(currentColumn) {
+        try {
+            // Initialize COM Runtime Libraries.
+            CoInitialize(NULL);
+
+            // Start excel application.
+            xl_.CreateInstance(L"Excel.Application");
+            xl_->Workbooks->Add((long)Excel::xlWorksheet);
+
+            // Rename "Sheet1" to "Chart Data".
+            Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+            Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->GetItem(1);
+            pSheet->Name = "Chart Data";
+        } catch (_com_error& error) {
+            ThrowAsString(error);
+        }
+    }
+
+    // Destructor.
+
+    ExcelDriver_::~ExcelDriver_() {
+        // Undo initialization of COM Runtime Libraries.
+        CoUninitialize();
+    }
+
+    // Access to single, shared instance of ExcelDriver (singleton).
+
+    ExcelDriver_& ExcelDriver_::Instance() {
+        static ExcelDriver_ singleton;
+        return singleton;
+    }
+
+    // Create chart with a number of functions. The arguments are:
+    //  x:			vector with input values
+    //  labels:		labels for output values
+    //  vectorList: list of vectors with output values.
+    //  chartTitle:	title of chart
+    //  xTitle:		label of x axis
+    //  yTitle:		label of y axis
+    void ExcelDriver_::CreateChart(const Vector_<>& x,
+                                   const Vector_<String_>& labels,
+                                   const Vector_<Vector_<>>& vectorList,
+                                   const String_& chartTitle,
+                                   const String_& xTitle,
+                                   const String_& yTitle) {
+        try {
+            // Activate sheet with numbers.
+            Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+            Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->GetItem("Chart Data");
+
+            // Calculate range with source data.
+            // The first row contains the labels shown in the chart's legend.
+            int beginRow = 1;
+            int beginColumn = curDataColumn_;
+            int endRow = x.size() + 1;                       // +1 to include labels.
+            int endColumn = beginColumn + vectorList.size(); // 1st is input, rest is output.
+
+            // Write label + input values to cells in vertical direction.
+            ToSheetVertical(pSheet, 1, curDataColumn_, xTitle, x); // X values.
+            curDataColumn_++;
+
+            // Write label + output values to cells in vertical direction.
+            auto labelIt = labels.begin();
+            for (auto vectorIt = vectorList.begin(); vectorIt != vectorList.end(); ++vectorIt) {
+                // Get label and row index.
+                String_ label = *labelIt;
+
+                // Add label + output values to Excel.
+                ToSheetVertical(pSheet, 1, curDataColumn_, label, *vectorIt);
+
+                // Advance row and label.
+                curDataColumn_++;
+                ++labelIt;
+            }
+
+            // Create range objects for source data.
+            Excel::RangePtr pBeginRange = pSheet->Cells->Item[beginRow][beginColumn];
+            Excel::RangePtr pEndRange = pSheet->Cells->Item[endRow][endColumn];
+            Excel::RangePtr pTotalRange = pSheet->Range[static_cast<Excel::Range*>(pBeginRange)][static_cast<Excel::Range*>(pEndRange)];
+
+            // Create the chart and sets its type
+            Excel::_ChartPtr pChart = xl_->ActiveWorkbook->Charts->Add();
+            pChart->ChartWizard(static_cast<Excel::Range*>(pTotalRange), (long)Excel::xlXYScatter, 6L, (long)Excel::xlColumns, 1L,
+                                1L, true, chartTitle.c_str(), xTitle.c_str(), yTitle.c_str());
+            pChart->ApplyCustomType(Excel::xlXYScatterSmooth);
+            pChart->Name = chartTitle.c_str();
+
+            // Make all titles visible again. They were erased by the ApplyCustomType method.
+            pChart->HasTitle = true;
+            pChart->ChartTitle->Text = chartTitle.c_str();
+
+            Excel::AxisPtr pAxis = pChart->Axes((long)Excel::xlValue, Excel::xlPrimary);
+            pAxis->HasTitle = true;
+            pAxis->AxisTitle->Text = yTitle.c_str();
+
+            pAxis = pChart->Axes((long)Excel::xlCategory, Excel::xlPrimary);
+            pAxis->HasTitle = true;
+            pAxis->AxisTitle->Text = xTitle.c_str();
+
+            // Add extra row space to make sheet more readable.
+            curDataColumn_++;
+        } catch (_com_error& error) {
+            ThrowAsString(error);
+        }
+    }
+
+    // Create chart with a number of functions. The arguments are:
+    //  x:			vector with input values
+    //  y:			vector with output values.
+    //  chartTitle:	title of chart
+    //  xTitle:		label of x axis
+    //  yTitle:		label of y axis
+    void ExcelDriver_::CreateChart(const Vector_<>& x,
+                                  const Vector_<>& y,
+                                  const String_& chartTitle,
+                                  const String_& xTitle,
+                                  const String_& yTitle) {
+        // Create list with single function and single label.
+        Vector_<Vector_<>> functions = {y};
+        Vector_<String_> labels = {chartTitle};
+
+        CreateChart(x, labels, functions, chartTitle, xTitle, yTitle);
+    }
+
+    // Make Excel window visible.
+
+    void ExcelDriver_::MakeVisible(bool b) {
+        // Make excel visible.
+        xl_->Visible = b ? VARIANT_TRUE : VARIANT_FALSE;
+    }
+
+    void ExcelDriver_::AddMatrix(const Matrix_<>& matrix,
+                                 const String_& sheetName,
+                                 const Vector_<String_>& rowLabels,
+                                 const Vector_<String_>& columnLabels,
+                                 int row,
+                                 int col) {
+        // Add sheet.
+        Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+        Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
+        pSheet->Name = sheetName.c_str();
+
+        // Add column labels starting at column col.
+        Excel::RangePtr pRange = pSheet->Cells;
+
+        long col2 = col + 1;
+        for (auto columnLabelIt = columnLabels.begin(); columnLabelIt != columnLabels.end(); ++columnLabelIt) {
+            pRange->Item[row][col2] = columnLabelIt->c_str();
+            ++col2;
+        }
+
+        // Add row labels + values.
+        row++;
+        auto rowLabelIt = rowLabels.begin();
+        for (long r = 0; r < matrix.Rows(); ++r) {
+            Vector_<> rowArray = matrix.Row(r);
+            ToSheetHorizontal(pSheet, row, col, *rowLabelIt, rowArray);
+            ++rowLabelIt;
+            ++row;
+        }
+    }
+
+    void ExcelDriver_::AddMatrix(const Matrix_<>& matrix, const String_& name, int row, int col) {
+        // Add sheet.
+        Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+        Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
+        pSheet->Name = name.c_str();
+
+        // Make empty row labels. Can later make it more general
+        Vector_<String_> rowLabels;
+        for (std::size_t r2 = 0; r2 < matrix.Rows(); ++r2) {
+            rowLabels.push_back(String_());
+        }
+
+        // Add row labels + values.
+        auto rowLabelIt = rowLabels.begin();
+        for (std::size_t r = 0; r < matrix.Rows(); ++r) {
+            Vector_<> rowArray = matrix.Row(r);
+            ToSheetHorizontal(pSheet, row, col, *rowLabelIt, rowArray);
+            ++rowLabelIt;
+            ++row;
+        }
+    }
+
+    // Vector visualisation
+    void ExcelDriver_::AddVector(const Vector_<>& vec, const String_& name, int row, int col) {
+        Matrix_<> m = Matrix::FromVectors(Vector_<Vector_<>>(1, vec));
+        AddMatrix(m, name, row, col);
+    }
+
+    void ExcelDriver_::AddVector(const Vector_<>& vec,
+                                 const String_& sheetName,
+                                 const String_& rowLabel,
+                                 const Vector_<String_>& columnLabels,
+                                 int row,
+                                 int col) {
+        Matrix_<> m = Matrix::FromVectors(Vector_<Vector_<>>(1, vec));
+        Vector_<String_> rowLabels;
+        rowLabels.push_back(rowLabel);
+        AddMatrix(m, sheetName, rowLabels, columnLabels, row, col);
+    }
+
+    // For debugging, for example
+
+    void ExcelDriver_::PrintStringInExcel(const String_& s, int row, int col) {
+        // Add sheet.
+        Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+        Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
+
+        // Add properties to cells.
+        Excel::RangePtr pRange = pSheet->Cells;
+        pRange->Item[row][col] = s.c_str();
+    }
+
+    void ExcelDriver_::PrintStringInExcel(const Vector_<String_>& s, int row, int col) {
+        // Add sheet.
+        Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+        Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
+
+        Excel::RangePtr pRange = pSheet->Cells;
+
+        for (auto it = s.begin(); it != s.end(); ++it) {
+            pRange->Item[row][col] = (*it).c_str();
+            ++row;
+        }
+    }
+}
+
+#endif

--- a/dal/io/exceldriverlite.cpp
+++ b/dal/io/exceldriverlite.cpp
@@ -5,11 +5,12 @@
 #include <dal/platform/config.hpp>
 
 #ifdef USE_EXCEL_REPORT
+#include <comdef.h>
 #include <stdexcept>
 #include <dal/io/exceldriverlite.hpp>
 #include <dal/io/excelimport.hpp>
 #include <dal/math/matrix/matrixutils.hpp>
-
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal {
 
@@ -23,13 +24,12 @@ namespace Dal {
 
         // First cell contains the label.
         Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
-        //	item->Value = label.c_str();
         item->Value2 = label.c_str();
 
         sheetColumn++;
 
         // Next cells contain the values.
-        for (std::size_t i = 0; i < values.size(); i++) {
+        for (std::size_t i = 0; i < values.size(); ++i) {
             Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
             item->Value2 = values[i];
 
@@ -49,15 +49,13 @@ namespace Dal {
 
         // First cell contains the label.
         Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
-        // item->Value = label.c_str();
         item->Value2 = label.c_str();
 
         sheetRow++;
 
         // Next cells contain the values.
-        for (std::size_t i = 0; i < values.size(); i++) {
+        for (std::size_t i = 0; i < values.size(); ++i) {
             Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
-            // item->Value = values[i];
             item->Value2 = values[i];
             sheetRow++;
         }
@@ -73,13 +71,38 @@ namespace Dal {
         THROW(String_(description));
     }
 
+    // RAII helper for COM initialization/uninitialization
+    class ComInitializer_ {
+    private:
+        bool initialized_;
+    public:
+        ComInitializer_() : initialized_(false) {
+            HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+            if (SUCCEEDED(hr)) {
+                initialized_ = true;
+            } else if (hr != S_FALSE) {
+                // S_FALSE means COM is already initialized on this thread, which is OK
+                THROW(String_("CoInitializeEx failed"));
+            }
+        }
+
+        ~ComInitializer_() {
+            if (initialized_) {
+                CoUninitialize();
+            }
+        }
+
+        ComInitializer_(const ComInitializer_&) = delete;
+        ComInitializer_& operator=(const ComInitializer_&) = delete;
+    };
+
     // Constructor. Starts Excel in invisible mode.
 
     ExcelDriver_::ExcelDriver_(int currentColumn) : curDataColumn_(currentColumn) {
-        try {
-            // Initialize COM Runtime Libraries.
-            CoInitialize(NULL);
+        // Initialize COM Runtime Libraries with RAII guard
+        ComInitializer_ comInit;
 
+        try {
             // Start excel application.
             xl_.CreateInstance(L"Excel.Application");
             xl_->Workbooks->Add((long)Excel::xlWorksheet);
@@ -96,16 +119,23 @@ namespace Dal {
     // Destructor.
 
     ExcelDriver_::~ExcelDriver_() {
-        // Undo initialization of COM Runtime Libraries.
-        CoUninitialize();
+        try {
+            if (xl_) {
+                Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
+                if (pWorkbook) {
+                    pWorkbook->Close(VARIANT_FALSE);
+                }
+                xl_->Quit();
+                xl_ = nullptr;
+            }
+        } catch (_com_error&) {
+            // Destructors must not throw; continue with COM uninitialization.
+        } catch (...) {
+            // Destructors must not throw; continue with COM uninitialization.
+        }
+        // COM is automatically uninitialized when ComInitializer_ is destroyed during static destruction
     }
 
-    // Access to single, shared instance of ExcelDriver (singleton).
-
-    ExcelDriver_& ExcelDriver_::Instance() {
-        static ExcelDriver_ singleton;
-        return singleton;
-    }
 
     // Create chart with a number of functions. The arguments are:
     //  x:			vector with input values
@@ -121,6 +151,16 @@ namespace Dal {
                                    const String_& xTitle,
                                    const String_& yTitle) {
         try {
+            // Validate input sizes
+            if (labels.size() != vectorList.size()) {
+                THROW(String_("CreateChart error: labels.size() must equal vectorList.size()"));
+            }
+            for (size_t i = 0; i < vectorList.size(); ++i) {
+                if (vectorList[i].size() != x.size()) {
+                    THROW(String_("CreateChart error: each series must have the same length as x"));
+                }
+            }
+
             // Activate sheet with numbers.
             Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
             Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->GetItem("Chart Data");
@@ -212,6 +252,14 @@ namespace Dal {
                                  const Vector_<String_>& columnLabels,
                                  int row,
                                  int col) {
+        // Validate input sizes
+        if (rowLabels.size() != matrix.Rows()) {
+            THROW(String_("AddMatrix error: rowLabels.size() must equal matrix.Rows()"));
+        }
+        if (columnLabels.size() != matrix.Cols()) {
+            THROW(String_("AddMatrix error: columnLabels.size() must equal matrix.Cols()"));
+        }
+
         // Add sheet.
         Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
         Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();

--- a/dal/io/exceldriverlite.hpp
+++ b/dal/io/exceldriverlite.hpp
@@ -14,7 +14,7 @@
 
 // Excel driver class definition. Contains functionality to add charts
 // and matrices. Hides all COM details. COM exceptions are re-thrown
-// as STL strings.
+// as Dal::Exception_.
 namespace Dal {
     class ExcelDriver_ {
     private:
@@ -45,8 +45,13 @@ namespace Dal {
         explicit ExcelDriver_(int currentColumn = 1);
         ~ExcelDriver_();
 
-        // Access to single, shared instance of ExcelDriver (Singleton pattern).
-        static ExcelDriver_& Instance();
+        // Access to a per-thread instance of ExcelDriver.
+        // Excel COM automation objects are thread-affine, so the driver must
+        // not be shared across threads.
+        static ExcelDriver_& Instance() {
+            thread_local ExcelDriver_ instance;
+            return instance;
+        }
 
         // Create chart with a number of functions. The arguments are:
         //  x:			std::vector<double> with input values

--- a/dal/io/exceldriverlite.hpp
+++ b/dal/io/exceldriverlite.hpp
@@ -1,0 +1,109 @@
+// Created by wegam on 2023/1/23.
+
+#pragma once
+
+#include <dal/platform/config.hpp>
+
+#ifdef USE_EXCEL_REPORT
+
+#include <dal/math/matrix/matrixs.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/platform/platform.hpp>
+#include <dal/string/strings.hpp>
+#include <dal/io/excelimport.hpp>
+
+// Excel driver class definition. Contains functionality to add charts
+// and matrices. Hides all COM details. COM exceptions are re-thrown
+// as STL strings.
+namespace Dal {
+    class ExcelDriver_ {
+    private:
+        // Private member data.
+        Excel::_ApplicationPtr xl_; // Pointer to Excel.
+
+        int curDataColumn_;
+
+        // Writes label and std::vector<double> to cells in horizontal direction.
+        void ToSheetHorizontal(Excel::_WorksheetPtr sheet,
+                               int sheetRow,
+                               int sheetColumn,
+                               const String_& label,
+                               const Vector_<>& values);
+
+        // Writes label and std::vector<double> to cells in vertical direction.
+        void ToSheetVertical(Excel::_WorksheetPtr sheet,
+                             int sheetRow,
+                             int sheetColumn,
+                             const String_& label,
+                             const Vector_<>& values);
+
+        // Throw COM error as string.
+        void ThrowAsString(_com_error& error);
+
+    public:
+        // Constructor. Starts Excel in invisible mode.
+        explicit ExcelDriver_(int currentColumn = 1);
+        ~ExcelDriver_();
+
+        // Access to single, shared instance of ExcelDriver (Singleton pattern).
+        static ExcelDriver_& Instance();
+
+        // Create chart with a number of functions. The arguments are:
+        //  x:			std::vector<double> with input values
+        //  labels:		labels for output values
+        //  vectorList: list of vectors with output values.
+        //  chartTitle:	title of chart
+        //  xTitle:		label of x axis
+        //  yTitle:		label of y axis
+        void CreateChart(const Vector_<>& x,
+                         const Vector_<String_>& labels,
+                         const Vector_<Vector_<>>& vectorList,
+                         const String_& chartTitle,
+                         const String_& xTitle = "X",
+                         const String_& yTitle = "Y");
+
+        // Create chart with a number of functions. The arguments are:
+        //  x:			std::vector<double> with input values
+        //  y:			std::vector<double> with output values.
+        //  chartTitle:	title of chart
+        //  xTitle:		label of x axis
+        //  yTitle:		label of y axis
+
+        void CreateChart(const Vector_<>& x,
+                         const Vector_<>& y,
+                         const String_& chartTitle,
+                         const String_& xTitle = "X",
+                         const String_& yTitle = "Y");
+
+        void MakeVisible(bool b);
+
+        // Matrix visualisation
+        void AddMatrix(const Matrix_<>& matrix, const String_& name = String_("Matrix"), int row = 1, int col = 1);
+
+        void AddMatrix(const Matrix_<>& matrix,
+                       const String_& sheetName,
+                       const Vector_<String_>& rowLabels,
+                       const Vector_<String_>& columnLabels,
+                       int row = 1,
+                       int col = 1);
+
+        // Vector visualisation as numbers
+        void AddVector(const Vector_<>& vec,
+                       const String_& sheetName = String_("Vector"),
+                       int row = 1,
+                       int col = 1);
+
+        void AddVector(const Vector_<>& vec,
+                       const String_& sheetName,
+                       const String_& rowLabel,
+                       const Vector_<String_>& columnLabels,
+                       int row = 1,
+                       int col = 1);
+
+        // For debugging, for example; print string at a (row,col) position
+        void PrintStringInExcel(const String_& s, int row, int col);
+        void PrintStringInExcel(const Vector_<String_>& s, int row, int col);
+    };
+}
+
+#endif

--- a/dal/io/excelimport.hpp
+++ b/dal/io/excelimport.hpp
@@ -8,7 +8,10 @@
 
 #ifdef USE_EXCEL_REPORT
 
-// Office type libraries - paths provided by CMake via OFFICE_MSO_PATH, OFFICE_VBE_PATH, OFFICE_EXCEL_PATH
+#ifndef _MSC_VER
+#error "Excel support requires MSVC compiler (or clang-cl). #import directive is not portable across other Windows toolchains."
+#endif
+
 #import OFFICE_MSO_PATH rename("DocumentProperties", "DocumentPropertiesXL") rename("RGB", "RGBXL")
 #import OFFICE_VBE_PATH
 #import OFFICE_EXCEL_PATH rename("DialogBox", "DialogBoxXL") rename("RGB", "RGBXL") rename("DocumentProperties", "DocumentPropertiesXL") rename("ReplaceText", "ReplaceTextXL") rename("CopyFile", "CopyFileXL") no_dual_interfaces

--- a/dal/io/excelimport.hpp
+++ b/dal/io/excelimport.hpp
@@ -1,0 +1,16 @@
+//
+// Created by wegam on 2023/1/23.
+//
+
+#pragma once
+
+#include <dal/platform/config.hpp>
+
+#ifdef USE_EXCEL_REPORT
+
+// Office type libraries - paths provided by CMake via OFFICE_MSO_PATH, OFFICE_VBE_PATH, OFFICE_EXCEL_PATH
+#import OFFICE_MSO_PATH rename("DocumentProperties", "DocumentPropertiesXL") rename("RGB", "RGBXL")
+#import OFFICE_VBE_PATH
+#import OFFICE_EXCEL_PATH rename("DialogBox", "DialogBoxXL") rename("RGB", "RGBXL") rename("DocumentProperties", "DocumentPropertiesXL") rename("ReplaceText", "ReplaceTextXL") rename("CopyFile", "CopyFileXL") no_dual_interfaces
+
+#endif

--- a/dal/platform/config.hpp
+++ b/dal/platform/config.hpp
@@ -11,7 +11,3 @@
 #ifndef DAL_USE_NOTE
 #define DAL_USE_NOTE
 #endif
-
-#ifdef WIN32
-#define USE_EXCEL_REPORT
-#endif

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,3 +11,7 @@ add_subdirectory(underdetermined)
 add_subdirectory(uoc)
 add_subdirectory(uoc_compiled)
 add_subdirectory(vanilla)
+
+if(DAL_HAS_EXCEL)
+    add_subdirectory(excelwriter)
+endif()

--- a/examples/excelwriter/CMakeLists.txt
+++ b/examples/excelwriter/CMakeLists.txt
@@ -1,0 +1,25 @@
+file(GLOB_RECURSE EXCELWRITER_FILES "*.hpp" "*.cpp")
+add_executable(excelwriter ${EXCELWRITER_FILES})
+
+target_link_libraries(excelwriter dal_library)
+target_compile_definitions(excelwriter PRIVATE
+    USE_EXCEL_REPORT
+    OFFICE_MSO_PATH="${OFFICE_MSO_DLL}"
+    OFFICE_VBE_PATH="${OFFICE_VBE_OLB}"
+    OFFICE_EXCEL_PATH="${OFFICE_EXCEL_EXE}"
+)
+
+if(DAL_USE_XAD_AAD)
+    target_link_libraries(excelwriter XAD::xad)
+endif ()
+
+
+if(MSVC)
+else()
+    target_link_libraries(excelwriter pthread)
+endif()
+
+install(TARGETS excelwriter
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )

--- a/examples/excelwriter/excelwriter.cpp
+++ b/examples/excelwriter/excelwriter.cpp
@@ -22,7 +22,7 @@ namespace Vector = Dal::Vector;
 int main() {
     RegisterAll_::Init();
 
-    // DON'T FORGET TO MODIFY EXCELIMPORTS.CPP for correct version of Excel.
+    // Ensure the Excel integration is configured for the correct Excel version.
     int N = 40;
 
     // Create abscissa x array
@@ -36,7 +36,7 @@ int main() {
     auto fun4 = [](double x) { return exp(x); };
     auto fun5 = [](double x) { return x; };
 
-    // Exx.Higher order functions in C++11 g = f op h, e.g. g = f - h
+    // Ex. Higher-order functions in C++11: g = f op h, e.g. g = f - h
     auto vec1 = Apply(fun, x);
     auto vec2 = Apply(fun2, x);
     auto vec3 = Apply(fun3, x);

--- a/examples/excelwriter/excelwriter.cpp
+++ b/examples/excelwriter/excelwriter.cpp
@@ -1,0 +1,67 @@
+//
+// Created by wegam on 2023/1/23.
+//
+
+#include <dal/platform/config.hpp>
+
+#ifdef USE_EXCEL_REPORT
+
+#include <dal/io/exceldriverlite.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/math/operators.hpp>
+#include <dal/string/strings.hpp>
+#include <dal/utilities/algorithms.hpp>
+
+using Dal::ExcelDriver_;
+using Dal::RegisterAll_;
+using Dal::String_;
+using Dal::Vector_;
+using Dal::Apply;
+namespace Vector = Dal::Vector;
+
+int main() {
+    RegisterAll_::Init();
+
+    // DON'T FORGET TO MODIFY EXCELIMPORTS.CPP for correct version of Excel.
+    int N = 40;
+
+    // Create abscissa x array
+    double A = 0.0;
+    double B = 3.0; // Interval_
+    auto x = Vector::XRange(A, B, N);
+
+    auto fun = [](double x) { return log(x + 0.01); };
+    auto fun2 = [](double x) { return x * x; };
+    auto fun3 = [](double x) { return x * x * x; };
+    auto fun4 = [](double x) { return exp(x); };
+    auto fun5 = [](double x) { return x; };
+
+    // Exx.Higher order functions in C++11 g = f op h, e.g. g = f - h
+    auto vec1 = Apply(fun, x);
+    auto vec2 = Apply(fun2, x);
+    auto vec3 = Apply(fun3, x);
+    auto vec4 = Apply(fun4, x);
+    auto vec5 = Apply(fun5, x);
+
+    // Now Excel output in one sheet for comparison purposes
+
+    // Names of each vector
+    Vector_<String_> labels{"log(x+0.01)", "x^2", "x^3", "exp(x)", "x"};
+
+    // The list of Y values
+    Vector_<Vector_<>> curves{ vec1, vec2, vec3, vec4, vec5 };
+
+    std::cout << "Data has been created" << std::endl;
+    ExcelDriver_ xl;
+    xl.MakeVisible(true);
+    xl.CreateChart(x, labels, curves, "Comparing Functions", "x", "y");
+
+    return 0;
+}
+#else
+
+int main() {
+    return 0;
+}
+
+#endif

--- a/public/CMakeLists.txt
+++ b/public/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(src)
-if(MSVC)
+if(DAL_HAS_EXCEL)
     add_subdirectory(excel)
 endif()
 

--- a/public/excel/CMakeLists.txt
+++ b/public/excel/CMakeLists.txt
@@ -2,6 +2,12 @@ file(GLOB_RECURSE EXCEL_FILES "*.hpp" "*.cpp")
 add_definitions(-DIS_BASE)
 add_library(dal_excel SHARED ${EXCEL_FILES})
 target_link_libraries(dal_excel dal_public)
+target_compile_definitions(dal_excel PRIVATE
+    USE_EXCEL_REPORT
+    OFFICE_MSO_PATH="${OFFICE_MSO_DLL}"
+    OFFICE_VBE_PATH="${OFFICE_VBE_OLB}"
+    OFFICE_EXCEL_PATH="${OFFICE_EXCEL_EXE}"
+)
 
 set_target_properties(dal_excel PROPERTIES SUFFIX .xll)
 

--- a/public/src/CMakeLists.txt
+++ b/public/src/CMakeLists.txt
@@ -11,6 +11,15 @@ else()
     add_library(dal_public ${PUBLIC_FILES})
 endif()
 
+if(DAL_HAS_EXCEL)
+    target_compile_definitions(dal_public PRIVATE
+        USE_EXCEL_REPORT
+        OFFICE_MSO_PATH="${OFFICE_MSO_DLL}"
+        OFFICE_VBE_PATH="${OFFICE_VBE_OLB}"
+        OFFICE_EXCEL_PATH="${OFFICE_EXCEL_EXE}"
+    )
+endif()
+
 if(DAL_USE_XAD_AAD)
     if (BUILD_SHARED_LIBS)
         target_link_libraries(dal_library XAD::xad)


### PR DESCRIPTION
## Summary
- Add JSON serialization round-trip tests for all interpolator types (Linear, Cubic, CubicSpline, CubicNext)
- Add Splat tests verifying interpolators reproduce knot-point values
- Fix JSON serialization precision loss for doubles by using `SetMaxDecimalPlaces`
- Hide `Interp1Linear_` as implementation detail; expose only `NewLinear` factory
- Update code-style.md naming conventions and add code-style-review/commit-and-pr skills
- Enhance commit-and-pr skill to detect and update existing PRs instead of duplicating
- Add Excel COM integration with CMake auto-detection of Microsoft Office
- Add `dal/io/` module with Excel COM driver and `examples/excelwriter/` demo
- Fix self-referencing call in `build_windows.bat`
- Fix code style issues in Excel COM driver files

## Test plan
- [x] Run `bin/test_suite --gtest_filter=InterpTest.*` to verify interpolation changes
- [x] Run `bin/test_suite --gtest_filter=SerializationTest.*` to verify serialization
- [x] Full `bin/test_suite` — all 418 tests pass