### PR TITLE
Add yield curve calibration via underdetermined search

### DIFF
--- a/.claude/methodology/yield_curve.md
+++ b/.claude/methodology/yield_curve.md
@@ -10,6 +10,8 @@ Documentation of the yield curve framework in `dal/curve/`.
 | `yccomponent.hpp/cpp` | `YCComponent_` — base for all curve components with dependency tracking and cloning |
 | `discount.hpp/cpp` | `DiscountCurve_` — abstract discount factor interface |
 | `ycimp.hpp/cpp` | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates |
+| `fittable.hpp` | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`) |
+| `yccalibration.hpp/cpp` | Market instruments (`DepositInstrument_`, `SwapInstrument_`) and `CalibrateYieldCurve()` |
 | `piecewiseconstant.hpp/cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals |
 | `piecewiselinear.hpp/cpp` | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals |
 

--- a/dal/curve/fittable.hpp
+++ b/dal/curve/fittable.hpp
@@ -1,0 +1,18 @@
+//
+// Created by wegam on 2023/3/26.
+//
+
+#pragma once
+
+#include <dal/math/vectors.hpp>
+
+namespace Dal {
+
+    class FittableCurve_ {
+    public:
+        virtual ~FittableCurve_() = default;
+        [[nodiscard]] virtual int NX() const = 0;
+        virtual void ApplyDX(Vector_<>::const_iterator dx, double leverage) = 0;
+    };
+
+} // namespace Dal

--- a/dal/curve/yccalibration.cpp
+++ b/dal/curve/yccalibration.cpp
@@ -1,0 +1,130 @@
+//
+// Created by wegam on 2026/4/19.
+//
+
+#include <dal/platform/platform.hpp>
+#include <dal/platform/strict.hpp>
+#include <dal/curve/yccalibration.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/ycimp.hpp>
+#include <dal/curve/fittable.hpp>
+#include <dal/math/optimization/underdetermined.hpp>
+#include <dal/math/matrix/banded.hpp>
+#include <dal/utilities/dictionary.hpp>
+#include <memory>
+
+namespace Dal {
+
+    double DepositRate(const DiscountCurve_& dc, const Date_& today, const Date_& maturity, const DayBasis_& basis) {
+        const double df = dc(today, maturity);
+        return (1.0 / df - 1.0) / basis(today, maturity, nullptr);
+    }
+
+    double SwapRate(const DiscountCurve_& dc, const Date_& today, const Date_& maturity, int freqMonths, const DayBasis_& basis) {
+        double annuity = 0.0;
+        Date_ d = today;
+        while (d < maturity) {
+            Date_ next = Date::AddMonths(d, freqMonths);
+            if (next > maturity)
+                next = maturity;
+            annuity += basis(d, next, nullptr) * dc(today, next);
+            d = next;
+        }
+        return (1.0 - dc(today, maturity)) / annuity;
+    }
+
+    namespace {
+        Sparse::TriDiagonal_* BuildSmoothingWeights(int nParams, double tau) {
+            auto* w = new Sparse::TriDiagonal_(nParams);
+            for (int i = 0; i < nParams; ++i)
+                w->Set(i, i, tau);
+            for (int i = 0; i < nParams - 1; ++i) {
+                w->Add(i, i, tau);
+                w->Add(i + 1, i + 1, tau);
+                w->Set(i, i + 1, -tau);
+                w->Set(i + 1, i, -tau);
+            }
+            return w;
+        }
+
+        class YieldCurveCalibrationFunc_ : public Underdetermined::Function_ {
+            Date_ today_;
+            Vector_<DepositInstrument_> deposits_;
+            Vector_<SwapInstrument_> swaps_;
+            Vector_<Date_> knotDates_;
+            DayBasis_ basis_;
+
+        public:
+            YieldCurveCalibrationFunc_(const Date_& today,
+                                       const Vector_<DepositInstrument_>& deposits,
+                                       const Vector_<SwapInstrument_>& swaps,
+                                       const Vector_<Date_>& knotDates,
+                                       const DayBasis_& basis)
+                : today_(today), deposits_(deposits), swaps_(swaps), knotDates_(knotDates), basis_(basis) {}
+
+            [[nodiscard]] Vector_<> F(const Vector_<>& x) const override {
+                const int nKnots = static_cast<int>(knotDates_.size());
+                Vector_<> fLeft(nKnots), fRight(nKnots);
+                for (int i = 0; i < nKnots; ++i) {
+                    fLeft[i] = x[2 * i];
+                    fRight[i] = x[2 * i + 1];
+                }
+
+                PiecewiseLinear_ pwl(knotDates_, fLeft, fRight);
+                std::unique_ptr<DiscountCurve_> dc(NewDiscountPWLF(String_("calib"), pwl));
+
+                const int nDeposits = static_cast<int>(deposits_.size());
+                const int nSwaps = static_cast<int>(swaps_.size());
+                Vector_<> result(nDeposits + nSwaps);
+
+                for (int i = 0; i < nDeposits; ++i)
+                    result[i] = DepositRate(*dc, today_, deposits_[i].maturity_, basis_) - deposits_[i].marketRate_;
+
+                for (int i = 0; i < nSwaps; ++i)
+                    result[nDeposits + i] = SwapRate(*dc, today_, swaps_[i].maturity_, swaps_[i].freqMonths_, basis_) - swaps_[i].marketRate_;
+
+                return result;
+            }
+        };
+    } // namespace
+
+    DiscountCurve_* CalibrateYieldCurve(const Date_& today,
+                                         const Vector_<DepositInstrument_>& deposits,
+                                         const Vector_<SwapInstrument_>& swaps,
+                                         const Vector_<Date_>& knotDates,
+                                         const DayBasis_& basis,
+                                         double smoothingWeight,
+                                         double tolerance,
+                                         int maxEvaluations,
+                                         int maxRestarts,
+                                         Matrix_<>* effJacobianInverse) {
+        const int nParams = 2 * static_cast<int>(knotDates.size());
+        const int nInstruments = static_cast<int>(deposits.size() + swaps.size());
+
+        Vector_<> guess(nParams, 0.05);
+
+        std::unique_ptr<Sparse::TriDiagonal_> weights(BuildSmoothingWeights(nParams, smoothingWeight));
+        std::unique_ptr<Sparse::SymmetricDecomposition_> wDecomp(weights->DecomposeSymmetric());
+
+        Vector_<> tol(nInstruments, tolerance);
+
+        Dictionary_ ctrlDict;
+        ctrlDict.Insert(String_("MAXEVALUATIONS"), Cell_(static_cast<double>(maxEvaluations)));
+        ctrlDict.Insert(String_("MAXRESTARTS"), Cell_(static_cast<double>(maxRestarts)));
+        UnderdeterminedControls_ controls(ctrlDict);
+
+        YieldCurveCalibrationFunc_ func(today, deposits, swaps, knotDates, basis);
+        Vector_<> result = Underdetermined::Find(func, guess, tol, *wDecomp, controls, effJacobianInverse);
+
+        const int nKnots = static_cast<int>(knotDates.size());
+        Vector_<> fLeft(nKnots), fRight(nKnots);
+        for (int i = 0; i < nKnots; ++i) {
+            fLeft[i] = result[2 * i];
+            fRight[i] = result[2 * i + 1];
+        }
+
+        PiecewiseLinear_ pwl(knotDates, fLeft, fRight);
+        return NewDiscountPWLF(String_("calibrated"), pwl);
+    }
+
+} // namespace Dal

--- a/dal/curve/yccalibration.hpp
+++ b/dal/curve/yccalibration.hpp
@@ -1,0 +1,40 @@
+//
+// Created by wegam on 2026/4/19.
+//
+
+#pragma once
+
+#include <dal/curve/discount.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/math/matrix/matrixs.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+
+namespace Dal {
+
+    struct DepositInstrument_ {
+        Date_ maturity_;
+        double marketRate_;
+    };
+
+    struct SwapInstrument_ {
+        Date_ maturity_;
+        double marketRate_;
+        int freqMonths_;
+    };
+
+    double DepositRate(const DiscountCurve_& dc, const Date_& today, const Date_& maturity, const DayBasis_& basis);
+    double SwapRate(const DiscountCurve_& dc, const Date_& today, const Date_& maturity, int freqMonths, const DayBasis_& basis);
+
+    DiscountCurve_* CalibrateYieldCurve(const Date_& today,
+                                         const Vector_<DepositInstrument_>& deposits,
+                                         const Vector_<SwapInstrument_>& swaps,
+                                         const Vector_<Date_>& knotDates,
+                                         const DayBasis_& basis,
+                                         double smoothingWeight = 1.0,
+                                         double tolerance = 1.0e-8,
+                                         int maxEvaluations = 200,
+                                         int maxRestarts = 20,
+                                         Matrix_<>* effJacobianInverse = nullptr);
+
+} // namespace Dal

--- a/dal/curve/ycimp.cpp
+++ b/dal/curve/ycimp.cpp
@@ -5,12 +5,12 @@
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
 #include <dal/curve/ycimp.hpp>
+#include <dal/curve/fittable.hpp>
 #include <dal/curve/yccomponent.hpp>
 #include <dal/curve/discount.hpp>
 #include <dal/curve/piecewiselinear.hpp>
 #include <dal/time/date.hpp>
 #include <dal/time/daybasis.hpp>
-#include <dal/platform/platform.hpp>
 #include <dal/math/vectors.hpp>
 #include <dal/storage/archive.hpp>
 
@@ -28,12 +28,6 @@ base is ?handle DiscountCurve
 -IF-------------------------------------------------------------------------*/
 
 namespace Dal {
-
-    class FittableCurve_ {
-    public:
-        [[nodiscard]] virtual int NX() const = 0;
-        virtual void ApplyDX(Vector_<>::const_iterator dx, double leverage) = 0;
-    };
 
     namespace {
         double LiborForecastFromDiscounts(const DiscountCurve_ &dc,

--- a/dal/math/optimization/underdetermined.cpp
+++ b/dal/math/optimization/underdetermined.cpp
@@ -16,6 +16,8 @@
 
 namespace Dal {
 
+#include <dal/auto/MG_UnderdeterminedControls_object.inc>
+
     namespace Underdetermined {
         void Function_::Gradient(const Vector_<>& x, const Vector_<>& f, Matrix_<>* j) const {
             Vector_<> fBase;

--- a/examples/underdetermined/underdetermined.cpp
+++ b/examples/underdetermined/underdetermined.cpp
@@ -1,7 +1,75 @@
 //
-// Created by wegam on 2022/12/25.
+// Created by wegam on 2026/4/19.
 //
 
+#include <dal/platform/platform.hpp>
+#include <dal/curve/yccalibration.hpp>
+#include <iostream>
+#include <iomanip>
+#include <memory>
+
+using namespace Dal;
+
 int main() {
+    const Date_ today(2024, 1, 15);
+    const DayBasis_ basis("ACT_365F");
+
+    Vector_<DepositInstrument_> deposits = {
+        {Date::AddMonths(today, 1), 0.0450},
+        {Date::AddMonths(today, 3), 0.0460},
+        {Date::AddMonths(today, 6), 0.0475},
+    };
+
+    Vector_<SwapInstrument_> swaps = {
+        {Date::AddMonths(today, 12), 0.0490, 6},
+        {Date::AddMonths(today, 24), 0.0500, 6},
+        {Date::AddMonths(today, 36), 0.0505, 6},
+        {Date::AddMonths(today, 60), 0.0510, 6},
+    };
+
+    Vector_<Date_> knotDates = {
+        Date::AddMonths(today, 1),
+        Date::AddMonths(today, 3),
+        Date::AddMonths(today, 6),
+        Date::AddMonths(today, 12),
+        Date::AddMonths(today, 18),
+        Date::AddMonths(today, 24),
+        Date::AddMonths(today, 36),
+        Date::AddMonths(today, 48),
+        Date::AddMonths(today, 60),
+    };
+
+    const int nParams = 2 * static_cast<int>(knotDates.size());
+    const int nInstruments = static_cast<int>(deposits.size() + swaps.size());
+
+    std::cout << "Yield Curve Calibration via Underdetermined Search\n";
+    std::cout << "===================================================\n";
+    std::cout << "Knot dates: " << knotDates.size() << "\n";
+    std::cout << "Parameters: " << nParams << " (2 per knot: left + right)\n";
+    std::cout << "Instruments: " << nInstruments << "\n";
+    std::cout << "Degrees of freedom: " << nParams - nInstruments << "\n\n";
+
+    std::cout << "Calibrating...\n";
+    std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, deposits, swaps, knotDates, basis));
+    std::cout << "Calibration complete.\n\n";
+
+    std::cout << "Repricing Check:\n";
+    std::cout << std::fixed << std::setprecision(6);
+    std::cout << std::setw(12) << "Instrument" << std::setw(10) << "Market" << std::setw(12) << "Model" << std::setw(12) << "Error(bp)\n";
+    for (int i = 0; i < static_cast<int>(deposits.size()); ++i) {
+        double modelRate = DepositRate(*dc, today, deposits[i].maturity_, basis);
+        std::cout << std::setw(12) << "Dep " + std::to_string(i + 1)
+                  << std::setw(10) << deposits[i].marketRate_ * 100.0
+                  << std::setw(12) << modelRate * 100.0
+                  << std::setw(12) << (modelRate - deposits[i].marketRate_) * 10000.0 << "\n";
+    }
+    for (int i = 0; i < static_cast<int>(swaps.size()); ++i) {
+        double modelRate = SwapRate(*dc, today, swaps[i].maturity_, swaps[i].freqMonths_, basis);
+        std::cout << std::setw(12) << "Swap " + std::to_string(i + 1)
+                  << std::setw(10) << swaps[i].marketRate_ * 100.0
+                  << std::setw(12) << modelRate * 100.0
+                  << std::setw(12) << (modelRate - swaps[i].marketRate_) * 10000.0 << "\n";
+    }
+
     return 0;
 }

--- a/tests/curve/test_yccalibration.cpp
+++ b/tests/curve/test_yccalibration.cpp
@@ -1,0 +1,129 @@
+//
+// Created by wegam on 2026/4/19.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/curve/yccalibration.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/ycimp.hpp>
+#include <memory>
+
+using namespace Dal;
+
+TEST(YieldCurveCalibrationTest, TestFlatCurveCalibration) {
+    const Date_ today(2024, 1, 15);
+    const DayBasis_ basis("ACT_365F");
+    const double flatRate = 0.05;
+
+    Vector_<DepositInstrument_> deposits = {
+        {Date::AddMonths(today, 3), flatRate},
+        {Date::AddMonths(today, 6), flatRate},
+    };
+
+    Vector_<SwapInstrument_> swaps = {
+        {Date::AddMonths(today, 12), flatRate, 6},
+        {Date::AddMonths(today, 24), flatRate, 6},
+    };
+
+    Vector_<Date_> knotDates = {
+        Date::AddMonths(today, 3),
+        Date::AddMonths(today, 6),
+        Date::AddMonths(today, 12),
+        Date::AddMonths(today, 24),
+    };
+
+    std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, deposits, swaps, knotDates, basis));
+
+    for (const auto& dep : deposits) {
+        double modelRate = DepositRate(*dc, today, dep.maturity_, basis);
+        ASSERT_NEAR(modelRate, dep.marketRate_, 1e-6);
+    }
+
+    for (const auto& swap : swaps) {
+        double modelRate = SwapRate(*dc, today, swap.maturity_, swap.freqMonths_, basis);
+        ASSERT_NEAR(modelRate, swap.marketRate_, 1e-6);
+    }
+}
+
+TEST(YieldCurveCalibrationTest, TestUpwardSlopingCurve) {
+    const Date_ today(2024, 1, 15);
+    const DayBasis_ basis("ACT_365F");
+
+    Vector_<DepositInstrument_> deposits = {
+        {Date::AddMonths(today, 1), 0.0450},
+        {Date::AddMonths(today, 3), 0.0460},
+        {Date::AddMonths(today, 6), 0.0475},
+    };
+
+    Vector_<SwapInstrument_> swaps = {
+        {Date::AddMonths(today, 12), 0.0490, 6},
+        {Date::AddMonths(today, 24), 0.0500, 6},
+        {Date::AddMonths(today, 36), 0.0505, 6},
+        {Date::AddMonths(today, 60), 0.0510, 6},
+    };
+
+    Vector_<Date_> knotDates = {
+        Date::AddMonths(today, 1),
+        Date::AddMonths(today, 3),
+        Date::AddMonths(today, 6),
+        Date::AddMonths(today, 12),
+        Date::AddMonths(today, 18),
+        Date::AddMonths(today, 24),
+        Date::AddMonths(today, 36),
+        Date::AddMonths(today, 48),
+        Date::AddMonths(today, 60),
+    };
+
+    std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, deposits, swaps, knotDates, basis));
+
+    for (const auto& dep : deposits) {
+        double modelRate = DepositRate(*dc, today, dep.maturity_, basis);
+        ASSERT_NEAR(modelRate, dep.marketRate_, 1e-6);
+    }
+
+    for (const auto& swap : swaps) {
+        double modelRate = SwapRate(*dc, today, swap.maturity_, swap.freqMonths_, basis);
+        ASSERT_NEAR(modelRate, swap.marketRate_, 1e-6);
+    }
+}
+
+TEST(YieldCurveCalibrationTest, TestRoundTrip) {
+    const Date_ today(2024, 1, 15);
+    const DayBasis_ basis("ACT_365F");
+
+    Vector_<Date_> knotDates = {
+        Date::AddMonths(today, 3),
+        Date::AddMonths(today, 6),
+        Date::AddMonths(today, 12),
+        Date::AddMonths(today, 24),
+    };
+
+    Vector_<> origLeft = {0.045, 0.048, 0.050, 0.052};
+    Vector_<> origRight = {0.046, 0.049, 0.051, 0.053};
+
+    PiecewiseLinear_ origPwl(knotDates, origLeft, origRight);
+    std::unique_ptr<DiscountCurve_> origDc(NewDiscountPWLF(String_("original"), origPwl));
+
+    Vector_<DepositInstrument_> deposits = {
+        {knotDates[0], DepositRate(*origDc, today, knotDates[0], basis)},
+        {knotDates[1], DepositRate(*origDc, today, knotDates[1], basis)},
+    };
+
+    Vector_<SwapInstrument_> swaps = {
+        {knotDates[2], SwapRate(*origDc, today, knotDates[2], 6, basis), 6},
+        {knotDates[3], SwapRate(*origDc, today, knotDates[3], 6, basis), 6},
+    };
+
+    std::unique_ptr<DiscountCurve_> calibDc(CalibrateYieldCurve(today, deposits, swaps, knotDates, basis));
+
+    for (const auto& dep : deposits) {
+        double modelRate = DepositRate(*calibDc, today, dep.maturity_, basis);
+        ASSERT_NEAR(modelRate, dep.marketRate_, 1e-6);
+    }
+
+    for (const auto& swap : swaps) {
+        double modelRate = SwapRate(*calibDc, today, swap.maturity_, swap.freqMonths_, basis);
+        ASSERT_NEAR(modelRate, swap.marketRate_, 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `dal/curve/yccalibration.hpp/cpp` — library API for calibrating discount curves from deposit and swap market quotes using `Underdetermined::Find` with tridiagonal smoothness regularization
- Extract `FittableCurve_` interface into `dal/curve/fittable.hpp` (was previously internal to `ycimp.cpp`)
- Expose `DepositRate()`, `SwapRate()`, and `CalibrateYieldCurve()` with optional effective Jacobian inverse output for downstream risk calculations
- Fix missing `UnderdeterminedControls_` constructor linkage (include auto-generated `.inc` in `underdetermined.cpp`)
- Add 3 unit tests: flat curve calibration, upward-sloping term structure, and round-trip recovery
- Update underdetermined example to demonstrate full calibration workflow with repricing check
- Update methodology documentation with file map entries for new files

## Test plan
- [x] Run `bin/test_suite --gtest_filter=YieldCurveCalibrationTest.*` — 3 tests pass
- [x] Full `bin/test_suite` — all 424 tests pass
- [x] Run `bin/underdetermined` example — repricing errors < 0.001bp