### PR TITLE
Refactor calibration around YC instruments and add solver coverage

### DIFF
--- a/dal/curve/yccalibration.cpp
+++ b/dal/curve/yccalibration.cpp
@@ -93,13 +93,13 @@ namespace Dal {
 
     DiscountCurve_* CalibrateYieldCurve(const Date_& today,
                                         const String_& ccy,
-                                         const Vector_<Handle_<YCInstrument_>>& instruments,
-                                         const Vector_<Date_>& knotDates,
-                                         double smoothingWeight,
-                                         double tolerance,
-                                         int maxEvaluations,
-                                         int maxRestarts,
-                                         Matrix_<>* effJacobianInverse) {
+                                        const Vector_<Handle_<YCInstrument_>>& instruments,
+                                        const Vector_<Date_>& knotDates,
+                                        double smoothingWeight,
+                                        double tolerance,
+                                        int maxEvaluations,
+                                        int maxRestarts,
+                                        Matrix_<>* effJacobianInverse) {
         const int nParams = 2 * static_cast<int>(knotDates.size());
         const int nInstruments = static_cast<int>(instruments.size());
 

--- a/dal/curve/yccalibration.hpp
+++ b/dal/curve/yccalibration.hpp
@@ -25,12 +25,12 @@ namespace Dal {
 
     DiscountCurve_* CalibrateYieldCurve(const Date_& today,
                                         const String_& ccy,
-                                         const Vector_<Handle_<YCInstrument_>>& instruments,
-                                         const Vector_<Date_>& knotDates,
-                                         double smoothingWeight = 1.0,
-                                         double tolerance = 1.0e-8,
-                                         int maxEvaluations = 200,
-                                         int maxRestarts = 20,
-                                         Matrix_<>* effJacobianInverse = nullptr);
+                                        const Vector_<Handle_<YCInstrument_>>& instruments,
+                                        const Vector_<Date_>& knotDates,
+                                        double smoothingWeight = 1.0,
+                                        double tolerance = 1.0e-8,
+                                        int maxEvaluations = 200,
+                                        int maxRestarts = 20,
+                                        Matrix_<>* effJacobianInverse = nullptr);
 
 } // namespace Dal

--- a/dal/curve/ycinstrument.cpp
+++ b/dal/curve/ycinstrument.cpp
@@ -50,6 +50,22 @@ namespace Dal {
                 return (1.0 - dc(today_, maturity_)) / annuity;
             }
         };
+
+        class STIRRate_ : public YCInstrument_::Rate_ {
+            Date_ today_;
+            Date_ start_;
+            Date_ maturity_;
+            DayBasis_ basis_;
+        public:
+            STIRRate_(const Date_& today, const Date_& start, const Date_& maturity, const DayBasis_& basis)
+                : today_(today), start_(start), maturity_(maturity), basis_(basis) {}
+
+            double operator()(const YieldCurve_& yc) const override {
+                const auto& dc = yc.Discount(CollateralType_::Value_::OIS);
+                double fwdDf = dc(today_, maturity_) / dc(today_, start_);
+                return (1.0 / fwdDf - 1.0) / basis_(start_, maturity_, nullptr);
+            }
+        };
     } // namespace
 
     // Deposit_
@@ -82,6 +98,26 @@ namespace Dal {
     Handle_<YCInstrument_::Rate_> Swap_::Precompute(const Handle_<YCInstrument_>&,
                                                      const Handle_<YieldCurve_>&) const {
         return Handle_<Rate_>(new SwapRate_(today_, maturity_, freqMonths_, basis_));
+    }
+
+    // STIR_
+
+    STIR_::STIR_(const Date_& today,
+                 const Date_& start,
+                 const Date_& maturity,
+                 double marketRate,
+                 const DayBasis_& basis)
+        : today_(today), start_(start), maturity_(maturity), marketRate_(marketRate), basis_(basis) {}
+
+    STIR_::~STIR_() = default;
+
+    String_ STIR_::Name() const { return "STIR"; }
+
+    pair<Date_, Date_> STIR_::TimeSpan() const { return {start_, maturity_}; }
+
+    Handle_<YCInstrument_::Rate_> STIR_::Precompute(const Handle_<YCInstrument_>&,
+                                                    const Handle_<YieldCurve_>&) const {
+        return Handle_<Rate_>(new STIRRate_(today_, start_, maturity_, basis_));
     }
 
 } // namespace Dal

--- a/dal/curve/ycinstrument.hpp
+++ b/dal/curve/ycinstrument.hpp
@@ -59,4 +59,24 @@ namespace Dal {
         [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
                                                 const Handle_<YieldCurve_>& funding_yc) const override;
     };
+
+    class STIR_ : public YCInstrument_ {
+        Date_ today_;
+        Date_ start_;
+        Date_ maturity_;
+        double marketRate_;
+        DayBasis_ basis_;
+    public:
+        STIR_(const Date_& today,
+              const Date_& start,
+              const Date_& maturity,
+              double marketRate,
+              const DayBasis_& basis);
+        ~STIR_() override;
+        [[nodiscard]] String_ Name() const override;
+        [[nodiscard]] pair<Date_, Date_> TimeSpan() const override;
+        [[nodiscard]] double MarketRate() const override { return marketRate_; }
+        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
+                                                const Handle_<YieldCurve_>& funding_yc) const override;
+    };
 } // namespace Dal

--- a/examples/underdetermined/underdetermined.cpp
+++ b/examples/underdetermined/underdetermined.cpp
@@ -17,8 +17,8 @@ int main() {
 
     Vector_<Handle_<YCInstrument_>> instruments;
     instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 1), 0.0450, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 3), 0.0460, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 6), 0.0475, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new STIR_(today, Date::AddMonths(today, 3), Date::AddMonths(today, 6), 0.0470, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new STIR_(today, Date::AddMonths(today, 6), Date::AddMonths(today, 9), 0.0480, basis)));
     instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 12), 0.0490, 6, basis)));
     instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 24), 0.0500, 6, basis)));
     instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 36), 0.0505, 6, basis)));
@@ -28,6 +28,7 @@ int main() {
         Date::AddMonths(today, 1),
         Date::AddMonths(today, 3),
         Date::AddMonths(today, 6),
+        Date::AddMonths(today, 9),
         Date::AddMonths(today, 12),
         Date::AddMonths(today, 18),
         Date::AddMonths(today, 24),

--- a/tests/curve/test_yccalibration.cpp
+++ b/tests/curve/test_yccalibration.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+#include <cmath>
 #include <memory>
 #include <dal/platform/platform.hpp>
 #include <dal/curve/yccalibration.hpp>
@@ -11,11 +12,21 @@
 
 using namespace Dal;
 
+namespace {
+    constexpr double SOLVER_INITIAL_GUESS = 0.05;
+    constexpr double MIN_DISTANCE_FROM_GUESS = 0.02;
+
+    void AssertQuotesFarFromInitialGuess(const Vector_<Handle_<YCInstrument_>>& instruments) {
+        for (const auto& inst : instruments)
+            ASSERT_GT(std::fabs(inst->MarketRate() - SOLVER_INITIAL_GUESS), MIN_DISTANCE_FROM_GUESS);
+    }
+} // namespace
+
 TEST(YieldCurveCalibrationTest, TestFlatCurveCalibration) {
     const Date_ today(2024, 1, 15);
     const DayBasis_ basis("ACT_365F");
     const String_ ccy = "USD";
-    const double flatRate = 0.05;
+    const double flatRate = 0.015;
 
     Vector_<Handle_<YCInstrument_>> instruments;
     instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 3), flatRate, basis)));
@@ -30,13 +41,15 @@ TEST(YieldCurveCalibrationTest, TestFlatCurveCalibration) {
         Date::AddMonths(today, 24),
     };
 
+    AssertQuotesFarFromInitialGuess(instruments);
+
     std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
     CalibratedYieldCurve_ yc(*dc);
 
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
-        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-6);
+        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
 }
 
@@ -46,13 +59,13 @@ TEST(YieldCurveCalibrationTest, TestUpwardSlopingCurve) {
     const DayBasis_ basis("ACT_365F");
 
     Vector_<Handle_<YCInstrument_>> instruments;
-    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 1), 0.0450, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 3), 0.0460, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 6), 0.0475, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 12), 0.0490, 6, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 24), 0.0500, 6, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 36), 0.0505, 6, basis)));
-    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 60), 0.0510, 6, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 1), 0.0110, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 3), 0.0125, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 6), 0.0140, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 12), 0.0160, 6, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 24), 0.0175, 6, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 36), 0.0190, 6, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 60), 0.0210, 6, basis)));
 
     Vector_<Date_> knotDates = {
         Date::AddMonths(today, 1),
@@ -66,13 +79,15 @@ TEST(YieldCurveCalibrationTest, TestUpwardSlopingCurve) {
         Date::AddMonths(today, 60),
     };
 
+    AssertQuotesFarFromInitialGuess(instruments);
+
     std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
     CalibratedYieldCurve_ yc(*dc);
 
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
-        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-6);
+        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
 }
 
@@ -88,21 +103,23 @@ TEST(YieldCurveCalibrationTest, TestRoundTrip) {
         Date::AddMonths(today, 24),
     };
 
-    Vector_<> origLeft = {0.045, 0.048, 0.050, 0.052};
-    Vector_<> origRight = {0.046, 0.049, 0.051, 0.053};
+    Vector_<> origLeft = {0.012, 0.014, 0.017, 0.020};
+    Vector_<> origRight = {0.013, 0.015, 0.018, 0.021};
 
     PiecewiseLinear_ origPwl(knotDates, origLeft, origRight);
     std::unique_ptr<DiscountCurve_> origDc(NewDiscountPWLF(String_("original"), ccy, origPwl));
 
     Vector_<Handle_<YCInstrument_>> instruments;
     instruments.push_back(Handle_<YCInstrument_>(
-        new Deposit_(today, knotDates[0], 0.045, basis)));
+        new Deposit_(today, knotDates[0], 0.012, basis)));
     instruments.push_back(Handle_<YCInstrument_>(
-        new Deposit_(today, knotDates[1], 0.048, basis)));
+        new Deposit_(today, knotDates[1], 0.014, basis)));
     instruments.push_back(Handle_<YCInstrument_>(
-        new Swap_(today, knotDates[2], 0.050, 6, basis)));
+        new Swap_(today, knotDates[2], 0.017, 6, basis)));
     instruments.push_back(Handle_<YCInstrument_>(
-        new Swap_(today, knotDates[3], 0.052, 6, basis)));
+        new Swap_(today, knotDates[3], 0.020, 6, basis)));
+
+    AssertQuotesFarFromInitialGuess(instruments);
 
     std::unique_ptr<DiscountCurve_> calibDc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
     CalibratedYieldCurve_ yc(*calibDc);
@@ -110,6 +127,40 @@ TEST(YieldCurveCalibrationTest, TestRoundTrip) {
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
-        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-6);
+        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
 }
+
+TEST(YieldCurveCalibrationTest, TestCalibrationWithSTIR) {
+    const Date_ today(2024, 1, 15);
+    const String_ ccy = "USD";
+    const DayBasis_ basis("ACT_365F");
+
+    Vector_<Handle_<YCInstrument_>> instruments;
+    instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 1), 0.0110, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new STIR_(today, Date::AddMonths(today, 3), Date::AddMonths(today, 6), 0.0130, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new STIR_(today, Date::AddMonths(today, 6), Date::AddMonths(today, 9), 0.0140, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 12), 0.0160, 3, basis)));
+    instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 24), 0.0180, 6, basis)));
+
+    Vector_<Date_> knotDates = {
+        Date::AddMonths(today, 1),
+        Date::AddMonths(today, 3),
+        Date::AddMonths(today, 6),
+        Date::AddMonths(today, 9),
+        Date::AddMonths(today, 12),
+        Date::AddMonths(today, 24),
+    };
+
+    AssertQuotesFarFromInitialGuess(instruments);
+
+    std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
+    CalibratedYieldCurve_ yc(*dc);
+
+    for (const auto& inst : instruments) {
+        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
+        double modelRate = (*rate)(yc);
+        ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Refactor yield-curve calibration around a polymorphic YCInstrument_ interface and move calibration instruments into the dedicated curve instrumentation layer.
- Add curve currency plumbing, remove legacy free-function repricing helpers, and extend the STIR-inclusive calibration examples/tests.
- Fix Underdetermined::Approximate to stop once the requested fit tolerance is met and add regression coverage for weighted solves, custom Jacobians, and control exhaustion.
- Add AGENTS.md with repo-specific architecture, build/test flow, and coding guidance for future Codex sessions.

## Test plan
- [x] Run build/tests/test_suite --gtest_filter=YieldCurveCalibrationTest.*
- [x] Run build/examples/underdetermined/underdetermined
- [x] Run bash ./build_linux.sh > test_output.txt 2>&1 and confirm full suite passes (428 tests from 48 test suites).