### PR TITLE
Fix underdetermined approximate termination and add Codex context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,8 +174,7 @@
   - imperative summary under 72 chars
   - blank line
   - body explaining why
-  - if AI-assisted, append:
-    - `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+  - if AI-assisted, append a co-author trailer in the format expected by the team's workflow
 - Keep one logical change per commit when possible.
 - PR body format from `.claude/rules/git-commit-pr.md`:
   - `## Summary`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,211 @@
+# Derivatives-Algorithms-Lib Codex Context
+
+## Project Identity
+
+- Name: DAL, Derivatives Algorithms Lib
+- Language: C++17
+- Domain: quantitative finance, derivatives pricing, risk, market curves, scripting, automatic differentiation
+- Main upstream inspiration:
+  - Tom Hyer, Antoine Savine, Brian Huge / Jesper Andreasen material referenced in `README.md`
+
+## Repo Structure
+
+- `dal/`: core implementation
+- `include/dal/`: installed/public headers mirroring the core API
+- `public/`: external-facing wrappers
+  - `public/src/`: public C++ wrapper layer
+  - `public/excel/`: Excel/XLL integration
+  - `public/python/`, `public/swig/`: SWIG-based Python bindings
+- `examples/`: standalone demos
+- `tests/`: Google Test suite, one file per module area
+- `config/`: Machinist codegen configs
+- `externals/`: vendored dependencies and submodules
+- `.claude/`: project methodology, rules, and workflow guidance
+
+## Architecture Summary
+
+- `dal/math/`: numerical kernels
+  - AAD, interpolation, matrix algebra, sparse/banded solvers, PDE/FD, RNG, Sobol, distributions, root finding, optimization
+- `dal/model/`: model data and implementations
+  - Black-Scholes, Dupire local vol, IVS, model factory
+- `dal/script/`: product DSL and simulation engine
+  - parser -> AST nodes -> visitors -> preprocess/compile -> evaluation/simulation
+- `dal/curve/`: yield/discount curve framework and calibration
+- `dal/indice/`: reference rate/index/fixings support
+- `dal/risk/`: reports and risk utilities
+- `dal/storage/`: storable objects and repository helpers
+- `dal/time/`: dates, calendars, schedules, day count conventions
+- `dal/concurrency/`: thread pool and concurrent queue
+
+## Important Design Notes
+
+- The project builds `dal_library` from `dal/`.
+- `public/src` builds `dal_public` as the external-facing API wrapper layer.
+- Code generation is part of normal builds:
+  - Machinist consumes `config/dal.ifc` and `config/dal.mgl`
+  - generated outputs land in `dal/auto/` and `public/auto/`
+- Generated `dal/auto/*` is excluded from the core library glob filters.
+- `dal/storage/_repository.*` is excluded from core build globs.
+- Excel COM integration is auto-enabled on Windows only if Office binaries are detected.
+- The repo supports AAD with XAD and also contains older/internal AAD machinery; current presets default to XAD enabled.
+
+## Build And Test
+
+- Full Linux build:
+  - `bash ./build_linux.sh`
+- Manual build:
+  - `cmake --preset=Release-linux ..`
+  - `make -j32`
+  - `make install`
+- Debug build:
+  - `cmake --preset=Debug-linux ..`
+  - `make -j32`
+  - `make install`
+- Tests:
+  - `bin/test_suite`
+  - `bin/test_suite --gtest_filter=<SuiteName>.*`
+  - `bin/test_suite --gtest_filter=<SuiteName>.<TestName>`
+
+## CMake / Build Behavior
+
+- Top-level install prefix is the repo root.
+- Installed outputs typically land in:
+  - `bin/`
+  - `lib/`
+  - `include/`
+- `build_linux.sh` does more than compile:
+  - clears `bin/` and `lib/`
+  - builds `externals/machinist`
+  - regenerates code in `dal/` and `public/`
+  - configures/builds/installs with CMake
+  - runs `bin/test_suite` if tests are enabled
+- Top-level `CMakeLists.txt` defaults `SKIP_TESTS` to `true`, but the shipped presets and build scripts set it to `false`.
+
+## Public Capabilities Present In Repo
+
+- README documents C++ examples, Excel functions, and Python bindings.
+- Public wrapper modules currently cover:
+  - models
+  - scripts/products
+  - interpolation
+  - random generators
+  - repository operations
+  - values/global state
+- Note: `CLAUDE.md` says Excel/Python are planned, but the codebase clearly contains working implementation scaffolding for both. Trust the repository code over that stale sentence.
+
+## Yield Curve Methodology
+
+- See `.claude/methodology/yield_curve.md`.
+- Core curve types:
+  - `YieldCurve_`
+  - `DiscountCurve_`
+  - `DiscountPWLF_`
+  - `PiecewiseConstant_`
+  - `PiecewiseLinear_`
+  - calibration instruments in `yccalibration.*`
+- Discount curves are built from piecewise-linear instantaneous forwards integrated into discount factors.
+- Calibration is framed as an underdetermined optimization problem using `dal/math/optimization/underdetermined.*`.
+- Curve framework supports dependency tracking, base-curve layering, cloning, and substitution for bump-and-reprice style risk.
+
+## Coding Conventions
+
+- Formatting is enforced by `.clang-format`.
+- Key style points from `.claude/rules/code-style.md`:
+  - 4-space indentation
+  - 150 column limit
+  - attach braces
+  - `T*` not `T *`
+  - `nullptr` not `NULL`
+  - all files end with newline
+- Naming:
+  - classes/types: `PascalCase_`
+  - template params: `T_`, `E_`, etc.
+  - functions/methods: `PascalCase`
+  - members: `camelCase_`
+  - locals: `camelCase`
+  - constants/macros: `UPPER_SNAKE_CASE`
+- Headers:
+  - always `#pragma once`
+  - standard three-line file header:
+    - `//`
+    - `// Created by <author> on <date>.`
+    - `//`
+- Include order:
+  - standard library
+  - DAL headers
+  - local headers
+- Most `.cpp` files include `<dal/platform/platform.hpp>`.
+- Prefer `using` over `typedef`.
+- Use `explicit` for single-argument constructors.
+- Use project exception/assertion macros:
+  - `THROW`
+  - `ASSERT`
+  - `REQUIRE`
+- Comments should be sparse and explain why, not what.
+- Namespace closing braces should be commented, e.g. `} // namespace Dal`
+
+## Test Conventions
+
+- Google Test only.
+- All tests compile into one executable: `test_suite`.
+- Prefer plain `TEST(...)`, not fixtures.
+- Prefer `ASSERT_*` over `EXPECT_*`.
+- Float checks typically use `ASSERT_NEAR(..., tol)` with tight tolerances such as `1e-8` to `1e-10`.
+- Test file naming:
+  - `tests/<module>/test_<name>.cpp`
+- Suite/test naming:
+  - suite in PascalCase, e.g. `InterpTest`
+  - test names prefixed with `Test...`
+- Common AAD test flow:
+  - clear tape
+  - setup variables
+  - start recording
+  - compute
+  - propagate adjoints
+  - assert values and sensitivities
+
+## Git / PR Conventions
+
+- Base branch: `master`
+- Branch naming:
+  - `feature/<short-description>`
+  - `fix/<short-description>`
+- Commit messages:
+  - imperative summary under 72 chars
+  - blank line
+  - body explaining why
+  - if AI-assisted, append:
+    - `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- Keep one logical change per commit when possible.
+- PR body format from `.claude/rules/git-commit-pr.md`:
+  - `## Summary`
+  - `## Test plan`
+
+## Examples / Reality Check
+
+- There are currently many examples under `examples/`, including:
+  - AAD
+  - vanilla MC
+  - finite difference
+  - sobol
+  - snowball
+  - script products
+  - barriers / UOC
+  - concurrency
+- There are about 90 `test_*.cpp` files in `tests/`.
+- `tests/math/optimization/test_underdetermined.cpp` now has concrete solver coverage:
+  - weighted `Underdetermined::Find` on a linear one-constraint system
+  - stable convergence/termination behavior for `Underdetermined::Approximate`
+  - custom `Jacobian_` path on a multi-residual system
+  - failure path when `UnderdeterminedControls_` exhausts allowed evaluations/restarts
+- The repo is large because `externals/` vendors substantial third-party code. Focus review/search work on project-owned paths first.
+
+## Working Guidance For Future Codex Sessions
+
+- Read `CLAUDE.md` first, then `.claude/rules/*`, then `.claude/methodology/*` relevant to the task.
+- Treat build scripts and current source tree as more authoritative than stale prose in docs when they conflict.
+- When changing public APIs, check both:
+  - core implementation in `dal/`
+  - wrapper exposure in `public/src`, `public/swig`, and possibly Excel glue
+- When changing generated interfaces, inspect `config/dal.ifc` / `config/dal.mgl` and the Machinist workflow before editing generated files directly.
+- For curve work, align with the documented `DiscountPWLF_` / underdetermined calibration design rather than introducing unrelated abstractions.

--- a/dal/math/optimization/underdetermined.cpp
+++ b/dal/math/optimization/underdetermined.cpp
@@ -265,6 +265,8 @@ namespace Dal {
         XScaledFunc_ func(func_tol, func_in, controls);
         Vector_<> xOld(guess);
         Vector_<> fOld = func.F(xOld);
+        if (sqrt(InnerProduct(fOld, fOld)) <= fit_tol)
+            return xOld;
         std::unique_ptr<Jacobian_> j;
         Vector_<> xNew(xOld.size());
         SquareMatrix_<> q;
@@ -280,6 +282,8 @@ namespace Dal {
             // const double sNorm = InnerProduct(s, s); POSTPONED -- stop early when step is very small
             Transform(xOld, s, std::plus<>(), &xNew);
             Vector_<> fNew = func.F(xNew);
+            if (sqrt(InnerProduct(fNew, fNew)) <= fit_tol)
+                return xNew;
             if (ticker > controls.maxRestarts_) // we are not about to restart
                 j->SecantUpdate(s, Apply(std::minus<>(), fNew, fOld));
             xOld = xNew;

--- a/tests/math/optimization/test_underdetermined.cpp
+++ b/tests/math/optimization/test_underdetermined.cpp
@@ -1,12 +1,172 @@
 //
-// Created by wegam on 2022/12/18.
+// Created by wegam on 2026/4/23.
 //
 
+#include <memory>
 #include <gtest/gtest.h>
 #include <dal/platform/platform.hpp>
+#include <dal/math/matrix/banded.hpp>
+#include <dal/math/matrix/matrixs.hpp>
+#include <dal/math/matrix/squarematrix.hpp>
 #include <dal/math/optimization/underdetermined.hpp>
+#include <dal/utilities/dictionary.hpp>
 
-using namespace Dal;
+using Dal::Cell_;
+using Dal::Dictionary_;
+using Dal::Exception_;
+using Dal::Matrix_;
+using Dal::SquareMatrix_;
+using Dal::UnderdeterminedControls_;
+using Dal::Vector_;
+using Dal::Sparse::SymmetricDecomposition_;
+using Dal::Sparse::TriDiagonal_;
 
-TEST(UnderdeterminedTest, TestFind) {
+namespace Underdetermined = Dal::Underdetermined;
+
+namespace {
+    UnderdeterminedControls_ MakeControls(int maxEvaluations = 20, int maxRestarts = 10) {
+        Dictionary_ dict;
+        dict.Insert("MAXEVALUATIONS", Cell_(static_cast<double>(maxEvaluations)));
+        dict.Insert("MAXRESTARTS", Cell_(static_cast<double>(maxRestarts)));
+        return UnderdeterminedControls_(dict);
+    }
+
+    void SetDiagonalWeights(TriDiagonal_* weights, double w0, double w1) {
+        weights->Set(0, 0, w0);
+        weights->Set(1, 1, w1);
+    }
+
+    class LinearSumFunc_ : public Underdetermined::Function_ {
+        double target_;
+
+    public:
+        explicit LinearSumFunc_(double target) : target_(target) {}
+
+        [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] + x[1] - target_}; }
+    };
+
+    class DenseJacobian_ : public Underdetermined::Jacobian_ {
+        Matrix_<> j_;
+
+    public:
+        explicit DenseJacobian_(const Matrix_<>& j) : j_(j) {}
+
+        [[nodiscard]] int Rows() const override { return j_.Rows(); }
+        [[nodiscard]] int Columns() const override { return j_.Cols(); }
+
+        void DivideRows(const Vector_<>& tol) override {
+            for (int iRow = 0; iRow < j_.Rows(); ++iRow)
+                for (int iCol = 0; iCol < j_.Cols(); ++iCol)
+                    j_(iRow, iCol) /= tol[iRow];
+        }
+
+        [[nodiscard]] Vector_<> MultiplyLeft(const Vector_<>& dx) const override {
+            Vector_<> retVal(j_.Rows(), 0.0);
+            for (int iRow = 0; iRow < j_.Rows(); ++iRow)
+                for (int iCol = 0; iCol < j_.Cols(); ++iCol)
+                    retVal[iRow] += j_(iRow, iCol) * dx[iCol];
+            return retVal;
+        }
+
+        [[nodiscard]] Vector_<> MultiplyRight(const Vector_<>& t) const override {
+            Vector_<> retVal(j_.Cols(), 0.0);
+            for (int iCol = 0; iCol < j_.Cols(); ++iCol)
+                for (int iRow = 0; iRow < j_.Rows(); ++iRow)
+                    retVal[iCol] += t[iRow] * j_(iRow, iCol);
+            return retVal;
+        }
+
+        void QForm(const SymmetricDecomposition_& w, SquareMatrix_<>* form) const override { w.QForm(j_, form); }
+
+        void SecantUpdate(const Vector_<>&, const Vector_<>&) override {}
+    };
+
+    class MultiResidualFunc_ : public Underdetermined::Function_ {
+        mutable int fastCalls_;
+
+    public:
+        MultiResidualFunc_() : fastCalls_(0) {}
+
+        [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] + x[2] - 3.0, x[1] + x[2] - 4.0}; }
+
+        [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>&, const Vector_<>&) const override {
+            Matrix_<> j(2, 3, 0.0);
+            j(0, 0) = 1.0;
+            j(0, 2) = 1.0;
+            j(1, 1) = 1.0;
+            j(1, 2) = 1.0;
+            return new DenseJacobian_(j);
+        }
+
+        [[nodiscard]] int FastCalls() const { return fastCalls_; }
+
+    private:
+        void FFast(const Vector_<>&, Vector_<>*) const override {
+            ++fastCalls_;
+            THROW("custom Jacobian path should not call finite-difference fallback");
+        }
+    };
+} // namespace
+
+TEST(UnderdeterminedTest, TestFindRespectsWeights) {
+    LinearSumFunc_ func(3.0);
+    Vector_<> guess = {0.0, 0.0};
+    Vector_<> tol = {1.0e-10};
+
+    TriDiagonal_ weights(2);
+    SetDiagonalWeights(&weights, 1.0, 4.0);
+    std::unique_ptr<SymmetricDecomposition_> decomp(weights.DecomposeSymmetric());
+
+    Vector_<> calculated = Underdetermined::Find(func, guess, tol, *decomp, MakeControls());
+
+    ASSERT_NEAR(calculated[0], 2.4, 1e-10);
+    ASSERT_NEAR(calculated[1], 0.6, 1e-10);
+    ASSERT_NEAR(func.F(calculated)[0], 0.0, 1e-10);
+}
+
+TEST(UnderdeterminedTest, TestApproximateBalancesFitAndDistance) {
+    LinearSumFunc_ func(3.0);
+    Vector_<> guess = {0.0, 0.0};
+    Vector_<> funcTol = {1.0};
+
+    TriDiagonal_ weights(2);
+    SetDiagonalWeights(&weights, 1.0, 1.0);
+    Vector_<> calculated = Underdetermined::Approximate(func, guess, funcTol, 1.0, weights, MakeControls());
+
+    ASSERT_NEAR(calculated[0], 1.0, 1e-10);
+    ASSERT_NEAR(calculated[1], 1.0, 1e-10);
+    ASSERT_NEAR(func.F(calculated)[0], -1.0, 1e-10);
+}
+
+TEST(UnderdeterminedTest, TestFindWithCustomJacobianAndMultipleResiduals) {
+    MultiResidualFunc_ func;
+    Vector_<> guess = {0.0, 0.0, 0.0};
+    Vector_<> tol = {1.0e-10, 1.0e-10};
+
+    TriDiagonal_ weights(3);
+    weights.Set(0, 0, 1.0);
+    weights.Set(1, 1, 1.0);
+    weights.Set(2, 2, 1.0);
+    std::unique_ptr<SymmetricDecomposition_> decomp(weights.DecomposeSymmetric());
+
+    Vector_<> calculated = Underdetermined::Find(func, guess, tol, *decomp, MakeControls());
+
+    ASSERT_NEAR(calculated[0], 2.0 / 3.0, 1e-10);
+    ASSERT_NEAR(calculated[1], 5.0 / 3.0, 1e-10);
+    ASSERT_NEAR(calculated[2], 7.0 / 3.0, 1e-10);
+    ASSERT_NEAR(func.F(calculated)[0], 0.0, 1e-10);
+    ASSERT_NEAR(func.F(calculated)[1], 0.0, 1e-10);
+    ASSERT_EQ(func.FastCalls(), 0);
+}
+
+TEST(UnderdeterminedTest, TestFindThrowsWhenControlsAreExhausted) {
+    LinearSumFunc_ func(3.0);
+    Vector_<> guess = {0.0, 0.0};
+    Vector_<> tol = {1.0e-10};
+
+    TriDiagonal_ weights(2);
+    SetDiagonalWeights(&weights, 1.0, 1.0);
+    std::unique_ptr<SymmetricDecomposition_> decomp(weights.DecomposeSymmetric());
+
+    ASSERT_THROW(Underdetermined::Find(func, guess, tol, *decomp, MakeControls(1, 1)), Exception_);
 }


### PR DESCRIPTION
## Summary
- Fix Underdetermined::Approximate to stop once the requested fit tolerance is met instead of continuing into avoidable downstream failures.
- Add regression coverage for weighted solves, the custom Jacobian path, and control exhaustion in tests/math/optimization/test_underdetermined.cpp.
- Add AGENTS.md with repo-specific architecture, build/test flow, and coding guidance for future Codex sessions.
- Remove the example email address from AGENTS.md while keeping the commit-trailer guidance generic.

## Test plan
- [x] Run build/tests/test_suite --gtest_filter=UnderdeterminedTest.*
- [x] Run bash ./build_linux.sh > test_output.txt 2>&1 and confirm full suite passes (428 tests from 48 test suites).