### PR TITLE
Document Markdown table style

### DIFF
--- a/.claude/methodology/underdetermined_search.md
+++ b/.claude/methodology/underdetermined_search.md
@@ -83,14 +83,14 @@ This allows the solver to work with more than a plain dense matrix when the call
 
 `Controls_` is an alias of the generated `UnderdeterminedControls_` settings object.
 
-| Parameter | Default | Meaning |
-|-----------|---------|---------|
-| `maxEvaluations_` | required | Total residual evaluations allowed |
-| `maxRestarts_` | required | Total fresh Jacobian builds allowed |
-| `maxBacktrackTries_` | `5` | Backtracking iterations per step in `Find()` |
-| `restartTolerance_` | `0.4` | Restart with a fresh Jacobian if the fitted `kMin` exceeds this |
-| `backtrackTolerance_` | `0.1` | Accept a step if `kMin` is below this |
-| `maxBacktrack_` | `0.8` | Maximum fraction by which a step can be reduced |
+| Parameter             | Default  | Meaning                                                         |
+|-----------------------|----------|-----------------------------------------------------------------|
+| `maxEvaluations_`     | required | Total residual evaluations allowed                              |
+| `maxRestarts_`        | required | Total fresh Jacobian builds allowed                             |
+| `maxBacktrackTries_`  | `5`      | Backtracking iterations per step in `Find()`                    |
+| `restartTolerance_`   | `0.4`    | Restart with a fresh Jacobian if the fitted `kMin` exceeds this |
+| `backtrackTolerance_` | `0.1`    | Accept a step if `kMin` is below this                           |
+| `maxBacktrack_`       | `0.8`    | Maximum fraction by which a step can be reduced                 |
 
 The generated settings enforce:
 
@@ -379,4 +379,3 @@ These points reflect the code as it exists today:
 - `yield_curve.md` for the surrounding curve-construction framework
 - `tests/math/optimization/test_underdetermined.cpp` for concrete solver behavior
 - `examples/underdetermined/underdetermined.cpp` for a runnable integration example
-

--- a/.claude/methodology/yield_curve.md
+++ b/.claude/methodology/yield_curve.md
@@ -4,16 +4,16 @@ Documentation of the yield curve framework in `dal/curve/`.
 
 ## File Map
 
-| File | Purpose |
-|------|---------|
-| `yc.hpp/cpp` | `YieldCurve_` — top-level curve abstraction (currency, discount access, LIBOR forecast) |
-| `yccomponent.hpp/cpp` | `YCComponent_` — base for all curve components with dependency tracking and cloning |
-| `discount.hpp/cpp` | `DiscountCurve_` — abstract discount factor interface |
-| `ycimp.hpp/cpp` | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates |
-| `fittable.hpp` | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`) |
-| `yccalibration.hpp/cpp` | `YCInstrument_`-based calibration, `CalibratedYieldCurve_`, and `CalibrateYieldCurve()` |
-| `piecewiseconstant.hpp/cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals |
-| `piecewiselinear.hpp/cpp` | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals |
+| File                                                                 | Purpose                                                                                 |
+|----------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `dal/curve/yc.hpp`, `dal/curve/yc.cpp`                               | `YieldCurve_` — top-level curve abstraction (currency, discount access, LIBOR forecast) |
+| `dal/curve/yccomponent.hpp`, `dal/curve/yccomponent.cpp`             | `YCComponent_` — base for all curve components with dependency tracking and cloning     |
+| `dal/curve/discount.hpp`, `dal/curve/discount.cpp`                   | `DiscountCurve_` — abstract discount factor interface                                   |
+| `dal/curve/ycimp.hpp`, `dal/curve/ycimp.cpp`                         | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates       |
+| `dal/curve/fittable.hpp`                                             | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`)                      |
+| `dal/curve/yccalibration.hpp`, `dal/curve/yccalibration.cpp`         | `YCInstrument_`-based calibration, `CalibratedYieldCurve_`, and `CalibrateYieldCurve()` |
+| `dal/curve/piecewiseconstant.hpp`, `dal/curve/piecewiseconstant.cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals          |
+| `dal/curve/piecewiselinear.hpp`, `dal/curve/piecewiselinear.cpp`     | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals    |
 
 ## Class Hierarchy
 
@@ -259,14 +259,14 @@ Vector_<> Underdetermined::Approximate(
 
 **Control parameters** (`UnderdeterminedControls_`):
 
-| Parameter | Default | Meaning |
-|-----------|---------|---------|
-| `maxEvaluations_` | — | Total function calls allowed |
-| `maxRestarts_` | — | Total fresh Jacobian computations |
-| `maxBacktrackTries_` | 5 | Linesearch iterations per step |
-| `restartTolerance_` | 0.4 | Restart Jacobian when `kMin` exceeds this |
-| `backtrackTolerance_` | 0.1 | Accept step when `kMin` is below this |
-| `maxBacktrack_` | 0.8 | Maximum step reduction fraction |
+| Parameter             | Default | Meaning                                   |
+|-----------------------|---------|-------------------------------------------|
+| `maxEvaluations_`     | —       | Total function calls allowed              |
+| `maxRestarts_`        | —       | Total fresh Jacobian computations         |
+| `maxBacktrackTries_`  | 5       | Linesearch iterations per step            |
+| `restartTolerance_`   | 0.4     | Restart Jacobian when `kMin` exceeds this |
+| `backtrackTolerance_` | 0.1     | Accept step when `kMin` is below this     |
+| `maxBacktrack_`       | 0.8     | Maximum step reduction fraction           |
 
 ### Algorithm: Scaled Quasi-Newton with Backtracking
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -18,23 +18,24 @@
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
 
-| Element           | Convention                 | Examples                                                       |
-|-------------------|----------------------------|----------------------------------------------------------------|
-| Classes/Structs   | PascalCase + trailing `_`  | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>`              |
-| Template params   | Single letter + `_`        | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                              |
-| Functions/Methods | PascalCase                 | `FromExcel()`, `AddDays()`, `GeneratePath()`                   |
-| Member variables  | camelCase + trailing `_`   | `serialNumber_`, `spot_`, `vol_`, `name_`                      |
-| Local variables   | camelCase                  | `numPaths`, `batchSize`, `nThreads`                            |
-| Constants/Macros  | UPPER_SNAKE_CASE           | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`                        |
-| Files             | lowercase, no separators   | `dal/concurrency/threadpool.cpp`, `dal/model/blackscholes.hpp` |
-| Test files        | `test_` prefix, snake_case | `tests/math/test_vectors.cpp`, `tests/time/test_date.cpp`      |
-| Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`                       |
+| Element           | Convention                 | Examples                                          |
+|-------------------|----------------------------|---------------------------------------------------|
+| Classes/Structs   | PascalCase + trailing `_`  | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>` |
+| Template params   | Single letter + `_`        | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                 |
+| Functions/Methods | PascalCase                 | `FromExcel()`, `AddDays()`, `GeneratePath()`      |
+| Member variables  | camelCase + trailing `_`   | `serialNumber_`, `spot_`, `vol_`, `name_`         |
+| Local variables   | camelCase                  | `numPaths`, `batchSize`, `nThreads`               |
+| Constants/Macros  | UPPER_SNAKE_CASE           | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`           |
+| Files             | lowercase, no separators   | `threadpool.cpp`, `blackscholes.hpp`              |
+| Test files        | `test_` prefix, snake_case | `test_vectors.cpp`, `test_date.cpp`               |
+| Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`          |
 
 ## Markdown Tables
 
 - Align pipe-table columns by padding cells with spaces.
 - Keep separator rows compact: use `|---|---|`, not `| --- | --- |`.
-- When table cells reference C++ files, use project-relative paths such as `dal/curve/yc.hpp`, not short names like `yc.hpp` or shorthand like `yc.hpp/cpp`.
+- When table cells reference specific C++ files, use project-relative paths such as `dal/curve/yc.hpp`, not short names like `yc.hpp` or shorthand like `yc.hpp/cpp`.
+- For convention-only filename examples, use filenames without project-relative paths, such as `threadpool.cpp` or `test_date.cpp`.
 - Keep mirrored tables under `.claude` and `.codex` consistent.
 
 ## Header Files

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -18,17 +18,24 @@
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
 
-| Element              | Convention                    | Examples                                          |
-|----------------------|-------------------------------|---------------------------------------------------|
-| Classes/Structs      | PascalCase + trailing `_`     | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>` |
-| Template params      | Single letter + `_`           | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                |
-| Functions/Methods    | PascalCase                    | `FromExcel()`, `AddDays()`, `GeneratePath()`      |
-| Member variables     | camelCase + trailing `_`      | `serialNumber_`, `spot_`, `vol_`, `name_`         |
-| Local variables      | camelCase                     | `numPaths`, `batchSize`, `nThreads`               |
-| Constants/Macros     | UPPER_SNAKE_CASE              | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`           |
-| Files                | lowercase, no separators      | `threadpool.cpp`, `blackscholes.hpp`              |
-| Test files           | `test_` prefix, snake_case    | `test_vectors.cpp`, `test_date.cpp`               |
-| Namespaces           | PascalCase or lowercase       | `Dal`, `Dal::AAD`, `namespace exception`          |
+| Element           | Convention                 | Examples                                                       |
+|-------------------|----------------------------|----------------------------------------------------------------|
+| Classes/Structs   | PascalCase + trailing `_`  | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>`              |
+| Template params   | Single letter + `_`        | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                              |
+| Functions/Methods | PascalCase                 | `FromExcel()`, `AddDays()`, `GeneratePath()`                   |
+| Member variables  | camelCase + trailing `_`   | `serialNumber_`, `spot_`, `vol_`, `name_`                      |
+| Local variables   | camelCase                  | `numPaths`, `batchSize`, `nThreads`                            |
+| Constants/Macros  | UPPER_SNAKE_CASE           | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`                        |
+| Files             | lowercase, no separators   | `dal/concurrency/threadpool.cpp`, `dal/model/blackscholes.hpp` |
+| Test files        | `test_` prefix, snake_case | `tests/math/test_vectors.cpp`, `tests/time/test_date.cpp`      |
+| Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`                       |
+
+## Markdown Tables
+
+- Align pipe-table columns by padding cells with spaces.
+- Keep separator rows compact: use `|---|---|`, not `| --- | --- |`.
+- When table cells reference C++ files, use project-relative paths such as `dal/curve/yc.hpp`, not short names like `yc.hpp` or shorthand like `yc.hpp/cpp`.
+- Keep mirrored tables under `.claude` and `.codex` consistent.
 
 ## Header Files
 

--- a/.codex/methodology/underdetermined_search.md
+++ b/.codex/methodology/underdetermined_search.md
@@ -83,14 +83,14 @@ This allows the solver to work with more than a plain dense matrix when the call
 
 `Controls_` is an alias of the generated `UnderdeterminedControls_` settings object.
 
-| Parameter | Default | Meaning |
-|-----------|---------|---------|
-| `maxEvaluations_` | required | Total residual evaluations allowed |
-| `maxRestarts_` | required | Total fresh Jacobian builds allowed |
-| `maxBacktrackTries_` | `5` | Backtracking iterations per step in `Find()` |
-| `restartTolerance_` | `0.4` | Restart with a fresh Jacobian if the fitted `kMin` exceeds this |
-| `backtrackTolerance_` | `0.1` | Accept a step if `kMin` is below this |
-| `maxBacktrack_` | `0.8` | Maximum fraction by which a step can be reduced |
+| Parameter             | Default  | Meaning                                                         |
+|-----------------------|----------|-----------------------------------------------------------------|
+| `maxEvaluations_`     | required | Total residual evaluations allowed                              |
+| `maxRestarts_`        | required | Total fresh Jacobian builds allowed                             |
+| `maxBacktrackTries_`  | `5`      | Backtracking iterations per step in `Find()`                    |
+| `restartTolerance_`   | `0.4`    | Restart with a fresh Jacobian if the fitted `kMin` exceeds this |
+| `backtrackTolerance_` | `0.1`    | Accept a step if `kMin` is below this                           |
+| `maxBacktrack_`       | `0.8`    | Maximum fraction by which a step can be reduced                 |
 
 The generated settings enforce:
 
@@ -379,4 +379,3 @@ These points reflect the code as it exists today:
 - `yield_curve.md` for the surrounding curve-construction framework
 - `tests/math/optimization/test_underdetermined.cpp` for concrete solver behavior
 - `examples/underdetermined/underdetermined.cpp` for a runnable integration example
-

--- a/.codex/methodology/yield_curve.md
+++ b/.codex/methodology/yield_curve.md
@@ -4,16 +4,16 @@ Documentation of the yield curve framework in `dal/curve/`.
 
 ## File Map
 
-| File | Purpose |
-|------|---------|
-| `yc.hpp/cpp` | `YieldCurve_` — top-level curve abstraction (currency, discount access, LIBOR forecast) |
-| `yccomponent.hpp/cpp` | `YCComponent_` — base for all curve components with dependency tracking and cloning |
-| `discount.hpp/cpp` | `DiscountCurve_` — abstract discount factor interface |
-| `ycimp.hpp/cpp` | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates |
-| `fittable.hpp` | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`) |
-| `yccalibration.hpp/cpp` | `YCInstrument_`-based calibration, `CalibratedYieldCurve_`, and `CalibrateYieldCurve()` |
-| `piecewiseconstant.hpp/cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals |
-| `piecewiselinear.hpp/cpp` | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals |
+| File                                                                 | Purpose                                                                                 |
+|----------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `dal/curve/yc.hpp`, `dal/curve/yc.cpp`                               | `YieldCurve_` — top-level curve abstraction (currency, discount access, LIBOR forecast) |
+| `dal/curve/yccomponent.hpp`, `dal/curve/yccomponent.cpp`             | `YCComponent_` — base for all curve components with dependency tracking and cloning     |
+| `dal/curve/discount.hpp`, `dal/curve/discount.cpp`                   | `DiscountCurve_` — abstract discount factor interface                                   |
+| `dal/curve/ycimp.hpp`, `dal/curve/ycimp.cpp`                         | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates       |
+| `dal/curve/fittable.hpp`                                             | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`)                      |
+| `dal/curve/yccalibration.hpp`, `dal/curve/yccalibration.cpp`         | `YCInstrument_`-based calibration, `CalibratedYieldCurve_`, and `CalibrateYieldCurve()` |
+| `dal/curve/piecewiseconstant.hpp`, `dal/curve/piecewiseconstant.cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals          |
+| `dal/curve/piecewiselinear.hpp`, `dal/curve/piecewiselinear.cpp`     | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals    |
 
 ## Class Hierarchy
 
@@ -259,14 +259,14 @@ Vector_<> Underdetermined::Approximate(
 
 **Control parameters** (`UnderdeterminedControls_`):
 
-| Parameter | Default | Meaning |
-|-----------|---------|---------|
-| `maxEvaluations_` | — | Total function calls allowed |
-| `maxRestarts_` | — | Total fresh Jacobian computations |
-| `maxBacktrackTries_` | 5 | Linesearch iterations per step |
-| `restartTolerance_` | 0.4 | Restart Jacobian when `kMin` exceeds this |
-| `backtrackTolerance_` | 0.1 | Accept step when `kMin` is below this |
-| `maxBacktrack_` | 0.8 | Maximum step reduction fraction |
+| Parameter             | Default | Meaning                                   |
+|-----------------------|---------|-------------------------------------------|
+| `maxEvaluations_`     | —       | Total function calls allowed              |
+| `maxRestarts_`        | —       | Total fresh Jacobian computations         |
+| `maxBacktrackTries_`  | 5       | Linesearch iterations per step            |
+| `restartTolerance_`   | 0.4     | Restart Jacobian when `kMin` exceeds this |
+| `backtrackTolerance_` | 0.1     | Accept step when `kMin` is below this     |
+| `maxBacktrack_`       | 0.8     | Maximum step reduction fraction           |
 
 ### Algorithm: Scaled Quasi-Newton with Backtracking
 

--- a/.codex/rules/code-style.md
+++ b/.codex/rules/code-style.md
@@ -18,23 +18,24 @@
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
 
-| Element           | Convention                 | Examples                                                       |
-|-------------------|----------------------------|----------------------------------------------------------------|
-| Classes/Structs   | PascalCase + trailing `_`  | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>`              |
-| Template params   | Single letter + `_`        | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                              |
-| Functions/Methods | PascalCase                 | `FromExcel()`, `AddDays()`, `GeneratePath()`                   |
-| Member variables  | camelCase + trailing `_`   | `serialNumber_`, `spot_`, `vol_`, `name_`                      |
-| Local variables   | camelCase                  | `numPaths`, `batchSize`, `nThreads`                            |
-| Constants/Macros  | UPPER_SNAKE_CASE           | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`                        |
-| Files             | lowercase, no separators   | `dal/concurrency/threadpool.cpp`, `dal/model/blackscholes.hpp` |
-| Test files        | `test_` prefix, snake_case | `tests/math/test_vectors.cpp`, `tests/time/test_date.cpp`      |
-| Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`                       |
+| Element           | Convention                 | Examples                                          |
+|-------------------|----------------------------|---------------------------------------------------|
+| Classes/Structs   | PascalCase + trailing `_`  | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>` |
+| Template params   | Single letter + `_`        | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                 |
+| Functions/Methods | PascalCase                 | `FromExcel()`, `AddDays()`, `GeneratePath()`      |
+| Member variables  | camelCase + trailing `_`   | `serialNumber_`, `spot_`, `vol_`, `name_`         |
+| Local variables   | camelCase                  | `numPaths`, `batchSize`, `nThreads`               |
+| Constants/Macros  | UPPER_SNAKE_CASE           | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`           |
+| Files             | lowercase, no separators   | `threadpool.cpp`, `blackscholes.hpp`              |
+| Test files        | `test_` prefix, snake_case | `test_vectors.cpp`, `test_date.cpp`               |
+| Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`          |
 
 ## Markdown Tables
 
 - Align pipe-table columns by padding cells with spaces.
 - Keep separator rows compact: use `|---|---|`, not `| --- | --- |`.
-- When table cells reference C++ files, use project-relative paths such as `dal/curve/yc.hpp`, not short names like `yc.hpp` or shorthand like `yc.hpp/cpp`.
+- When table cells reference specific C++ files, use project-relative paths such as `dal/curve/yc.hpp`, not short names like `yc.hpp` or shorthand like `yc.hpp/cpp`.
+- For convention-only filename examples, use filenames without project-relative paths, such as `threadpool.cpp` or `test_date.cpp`.
 - Keep mirrored tables under `.claude` and `.codex` consistent.
 
 ## Header Files

--- a/.codex/rules/code-style.md
+++ b/.codex/rules/code-style.md
@@ -18,17 +18,24 @@
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
 
-| Element              | Convention                    | Examples                                          |
-|----------------------|-------------------------------|---------------------------------------------------|
-| Classes/Structs      | PascalCase + trailing `_`     | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>` |
-| Template params      | Single letter + `_`           | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                |
-| Functions/Methods    | PascalCase                    | `FromExcel()`, `AddDays()`, `GeneratePath()`      |
-| Member variables     | camelCase + trailing `_`      | `serialNumber_`, `spot_`, `vol_`, `name_`         |
-| Local variables      | camelCase                     | `numPaths`, `batchSize`, `nThreads`               |
-| Constants/Macros     | UPPER_SNAKE_CASE              | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`           |
-| Files                | lowercase, no separators      | `threadpool.cpp`, `blackscholes.hpp`              |
-| Test files           | `test_` prefix, snake_case    | `test_vectors.cpp`, `test_date.cpp`               |
-| Namespaces           | PascalCase or lowercase       | `Dal`, `Dal::AAD`, `namespace exception`          |
+| Element           | Convention                 | Examples                                                       |
+|-------------------|----------------------------|----------------------------------------------------------------|
+| Classes/Structs   | PascalCase + trailing `_`  | `Date_`, `Vector_<>`, `ThreadPool_`, `Model_<T_>`              |
+| Template params   | Single letter + `_`        | `T_`, `E_`, `LHS_`, `RHS_`, `OP_`                              |
+| Functions/Methods | PascalCase                 | `FromExcel()`, `AddDays()`, `GeneratePath()`                   |
+| Member variables  | camelCase + trailing `_`   | `serialNumber_`, `spot_`, `vol_`, `name_`                      |
+| Local variables   | camelCase                  | `numPaths`, `batchSize`, `nThreads`                            |
+| Constants/Macros  | UPPER_SNAKE_CASE           | `BATCH_SIZE`, `EPSILON`, `FORCE_INLINE`                        |
+| Files             | lowercase, no separators   | `dal/concurrency/threadpool.cpp`, `dal/model/blackscholes.hpp` |
+| Test files        | `test_` prefix, snake_case | `tests/math/test_vectors.cpp`, `tests/time/test_date.cpp`      |
+| Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`                       |
+
+## Markdown Tables
+
+- Align pipe-table columns by padding cells with spaces.
+- Keep separator rows compact: use `|---|---|`, not `| --- | --- |`.
+- When table cells reference C++ files, use project-relative paths such as `dal/curve/yc.hpp`, not short names like `yc.hpp` or shorthand like `yc.hpp/cpp`.
+- Keep mirrored tables under `.claude` and `.codex` consistent.
 
 ## Header Files
 


### PR DESCRIPTION
## Summary
- Normalize mirrored .claude and .codex Markdown tables with aligned columns and compact separator rows
- Expand specific C++ file references in methodology tables to project-relative paths
- Add Markdown table requirements to the code style guide, including bare filenames for convention-only examples

## Test plan
- [x] Run documentation consistency checks for mirrored .claude/.codex files
- [x] Verify specific C++ table paths are project-relative and exist
- [ ] Full bin/test_suite not run; docs-only change