### PR TITLE
Add normal quadrature utilities

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -67,6 +67,7 @@
 
 - Custom `Exception_` (from `std::runtime_error`) capturing file/line/function
 - Macro-based: `THROW(msg)`, `ASSERT(cond, msg)` (debug-only), `REQUIRE(cond, msg)` (configurable)
+- Use `REQUIRE`, not `ASSERT`, for runtime state, precondition, or invariant checks that must also run in release builds
 - Stack context via `NOTICE(x)` / `NOTE(msg)` macros
 - Safe pointer ops: `ASSIGN(p, v)`, `DEREFERENCE(p, v)`
 

--- a/.claude/skills/code-style-review/SKILL.md
+++ b/.claude/skills/code-style-review/SKILL.md
@@ -60,6 +60,7 @@ Review all changed files in the working tree against the project's coding conven
 - `using` over `typedef`
 - `explicit` on single-argument constructors
 - Error handling via `REQUIRE`/`ASSERT`/`THROW` macros, not raw exceptions
+- Use `REQUIRE`, not `ASSERT`, for runtime state, precondition, or invariant checks that must also run in release builds
 - Comments: sparse, focus on "why" not "what", no docstrings
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
@@ -68,4 +69,3 @@ Review all changed files in the working tree against the project's coding conven
 ### Documentation Sync
 - If code changes alter documented behavior, APIs, build/test workflow, architecture notes, or methodology, check that the corresponding markdown guidance under `.claude/` and `.codex/` is updated to stay consistent.
 - Call out missing doc updates as review findings, and note both the code file and the stale markdown file when possible.
-

--- a/.codex/rules/code-style.md
+++ b/.codex/rules/code-style.md
@@ -67,6 +67,7 @@
 
 - Custom `Exception_` (from `std::runtime_error`) capturing file/line/function
 - Macro-based: `THROW(msg)`, `ASSERT(cond, msg)` (debug-only), `REQUIRE(cond, msg)` (configurable)
+- Use `REQUIRE`, not `ASSERT`, for runtime state, precondition, or invariant checks that must also run in release builds
 - Stack context via `NOTICE(x)` / `NOTE(msg)` macros
 - Safe pointer ops: `ASSIGN(p, v)`, `DEREFERENCE(p, v)`
 

--- a/.codex/skills/code-style-review/SKILL.md
+++ b/.codex/skills/code-style-review/SKILL.md
@@ -60,6 +60,7 @@ Review all changed files in the working tree against the project's coding conven
 - `using` over `typedef`
 - `explicit` on single-argument constructors
 - Error handling via `REQUIRE`/`ASSERT`/`THROW` macros, not raw exceptions
+- Use `REQUIRE`, not `ASSERT`, for runtime state, precondition, or invariant checks that must also run in release builds
 - Comments: sparse, focus on "why" not "what", no docstrings
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
@@ -68,4 +69,3 @@ Review all changed files in the working tree against the project's coding conven
 ### Documentation Sync
 - If code changes alter documented behavior, APIs, build/test workflow, architecture notes, or methodology, check that the corresponding markdown guidance under `.claude/` and `.codex/` is updated to stay consistent.
 - Call out missing doc updates as review findings, and note both the code file and the stale markdown file when possible.
-

--- a/dal/math/integral/quadrature.cpp
+++ b/dal/math/integral/quadrature.cpp
@@ -1,0 +1,86 @@
+//
+// Created by wegam on 2026/4/26.
+//
+
+#include <cmath>
+
+#include <dal/platform/platform.hpp>
+#include <dal/platform/strict.hpp>
+#include <dal/math/integral/quadrature.hpp>
+#include <dal/math/vectors.hpp>
+
+namespace Dal {
+
+    Quad1DBase_::~Quad1DBase_() = default;
+
+    namespace {
+        constexpr int MAX_NEWTON_ITERATIONS = 20;
+        constexpr double ROOT_TOLERANCE = 1.0e-14;
+    } // namespace
+
+    void Quadrature::NCDFGaussHermiteWeights(Vector_<>* x, Vector_<>* w) {
+        const int n = static_cast<int>(x->size());
+        x->Resize(n);
+        w->Resize(n);
+        if (n == 0)
+            return;
+
+        const int m = (n + 1) / 2;
+        const double invPiQuarter = 1.0 / sqrt(sqrt(PI));
+        const double invRootPi = 1.0 / sqrt(PI);
+        const double rootTwoN = sqrt(2.0 * n);
+        double z = 0.0;
+        for (int i = 0; i < m; ++i) {
+            // Compute positive Hermite roots, then map symmetric pairs to standard-normal coordinates.
+            if (i == 0) {
+                z = sqrt(2.0 * n + 1.0) - 1.85575 * pow(2.0 * n + 1.0, -1.0 / 6.0);
+            } else if (i == 1) {
+                z -= 1.14 * pow(static_cast<double>(n), 0.426) / z;
+            } else if (i == 2) {
+                z = 1.86 * z - 0.86 * (*x)[n - 1] / M_SQRT_2;
+            } else if (i == 3) {
+                z = 1.91 * z - 0.91 * (*x)[n - 2] / M_SQRT_2;
+            } else {
+                z = 2.0 * z - (*x)[n - i + 1] / M_SQRT_2;
+            }
+
+            double p2 = 0.0;
+            double pp = 0.0;
+            for (int its = 0; its < MAX_NEWTON_ITERATIONS; ++its) {
+                double p1 = invPiQuarter;
+                p2 = 0.0;
+                for (int j = 1; j <= n; ++j) {
+                    const double p3 = p2;
+                    p2 = p1;
+                    p1 = z * sqrt(2.0 / j) * p2 - sqrt(static_cast<double>(j - 1) / j) * p3;
+                }
+                pp = rootTwoN * p2;
+                const double z0 = z;
+                z -= p1 / pp;
+                if (std::abs(z - z0) <= ROOT_TOLERANCE)
+                    break;
+                if (its == MAX_NEWTON_ITERATIONS - 1)
+                    THROW("Too many iterations in Gauss-Hermite root search");
+            }
+
+            const int left = i;
+            const int right = n - 1 - i;
+            const double xValue = M_SQRT_2 * z;
+            const double wValue = 2.0 * invRootPi / (pp * pp);
+            (*x)[left] = -xValue;
+            (*x)[right] = xValue;
+            (*w)[left] = wValue;
+            (*w)[right] = wValue;
+        }
+    }
+
+    void Quadrature::SimpsonWeights(int n, double lo, double hi, Vector_<>* x, Vector_<>* w) {
+        n |= 1;
+        const double dx = (hi - lo) / (n - 1);
+        for (int ii = 0; ii < n; ++ii) {
+            (*x)[ii] = lo + ii * dx;
+            (*w)[ii] = (ii & 1 ? 4 : 2) * dx / 3.0;
+        }
+        w->front() = w->back() = dx / 3.0;
+    }
+} // namespace Dal

--- a/dal/math/integral/quadrature.cpp
+++ b/dal/math/integral/quadrature.cpp
@@ -16,6 +16,54 @@ namespace Dal {
     namespace {
         constexpr int MAX_NEWTON_ITERATIONS = 20;
         constexpr double ROOT_TOLERANCE = 1.0e-14;
+
+        struct HermiteRoot_ {
+            double root_;
+            double derivative_;
+        };
+
+        double InitialHermiteRoot(int i, int n, double previousRoot, const Vector_<>& x) {
+            if (i == 0)
+                return sqrt(2.0 * n + 1.0) - 1.85575 * pow(2.0 * n + 1.0, -1.0 / 6.0);
+            if (i == 1)
+                return previousRoot - 1.14 * pow(static_cast<double>(n), 0.426) / previousRoot;
+            if (i == 2)
+                return 1.86 * previousRoot - 0.86 * x[n - 1] / M_SQRT_2;
+            if (i == 3)
+                return 1.91 * previousRoot - 0.91 * x[n - 2] / M_SQRT_2;
+            return 2.0 * previousRoot - x[n - i + 1] / M_SQRT_2;
+        }
+
+        HermiteRoot_ FindHermiteRoot(int n, double initialRoot, double invPiQuarter, double rootTwoN) {
+            double root = initialRoot;
+            double derivative = 0.0;
+            for (int its = 0; its < MAX_NEWTON_ITERATIONS; ++its) {
+                double p1 = invPiQuarter;
+                double p2 = 0.0;
+                for (int j = 1; j <= n; ++j) {
+                    const double p3 = p2;
+                    p2 = p1;
+                    p1 = root * sqrt(2.0 / j) * p2 - sqrt(static_cast<double>(j - 1) / j) * p3;
+                }
+                derivative = rootTwoN * p2;
+                const double previousRoot = root;
+                root -= p1 / derivative;
+                if (std::abs(root - previousRoot) <= ROOT_TOLERANCE)
+                    return {root, derivative};
+            }
+            THROW("Too many iterations in Gauss-Hermite root search");
+        }
+
+        void SetNormalHermitePair(int i, int n, double root, double derivative, double invRootPi, Vector_<>* x, Vector_<>* w) {
+            const int left = i;
+            const int right = n - 1 - i;
+            const double xValue = M_SQRT_2 * root;
+            const double wValue = 2.0 * invRootPi / (derivative * derivative);
+            (*x)[left] = -xValue;
+            (*x)[right] = xValue;
+            (*w)[left] = wValue;
+            (*w)[right] = wValue;
+        }
     } // namespace
 
     void Quadrature::NCDFGaussHermiteWeights(Vector_<>* x, Vector_<>* w) {
@@ -32,45 +80,10 @@ namespace Dal {
         double z = 0.0;
         for (int i = 0; i < m; ++i) {
             // Compute positive Hermite roots, then map symmetric pairs to standard-normal coordinates.
-            if (i == 0) {
-                z = sqrt(2.0 * n + 1.0) - 1.85575 * pow(2.0 * n + 1.0, -1.0 / 6.0);
-            } else if (i == 1) {
-                z -= 1.14 * pow(static_cast<double>(n), 0.426) / z;
-            } else if (i == 2) {
-                z = 1.86 * z - 0.86 * (*x)[n - 1] / M_SQRT_2;
-            } else if (i == 3) {
-                z = 1.91 * z - 0.91 * (*x)[n - 2] / M_SQRT_2;
-            } else {
-                z = 2.0 * z - (*x)[n - i + 1] / M_SQRT_2;
-            }
-
-            double p2 = 0.0;
-            double pp = 0.0;
-            for (int its = 0; its < MAX_NEWTON_ITERATIONS; ++its) {
-                double p1 = invPiQuarter;
-                p2 = 0.0;
-                for (int j = 1; j <= n; ++j) {
-                    const double p3 = p2;
-                    p2 = p1;
-                    p1 = z * sqrt(2.0 / j) * p2 - sqrt(static_cast<double>(j - 1) / j) * p3;
-                }
-                pp = rootTwoN * p2;
-                const double z0 = z;
-                z -= p1 / pp;
-                if (std::abs(z - z0) <= ROOT_TOLERANCE)
-                    break;
-                if (its == MAX_NEWTON_ITERATIONS - 1)
-                    THROW("Too many iterations in Gauss-Hermite root search");
-            }
-
-            const int left = i;
-            const int right = n - 1 - i;
-            const double xValue = M_SQRT_2 * z;
-            const double wValue = 2.0 * invRootPi / (pp * pp);
-            (*x)[left] = -xValue;
-            (*x)[right] = xValue;
-            (*w)[left] = wValue;
-            (*w)[right] = wValue;
+            z = InitialHermiteRoot(i, n, z, *x);
+            const HermiteRoot_ root = FindHermiteRoot(n, z, invPiQuarter, rootTwoN);
+            z = root.root_;
+            SetNormalHermitePair(i, n, root.root_, root.derivative_, invRootPi, x, w);
         }
     }
 

--- a/dal/math/integral/quadrature.hpp
+++ b/dal/math/integral/quadrature.hpp
@@ -1,0 +1,89 @@
+//
+// Created by wegam on 2026/4/26.
+//
+
+#pragma once
+
+#include <dal/math/vectors.hpp>
+#include <dal/utilities/algorithms.hpp>
+#include <dal/utilities/exceptions.hpp>
+#include <dal/utilities/functionals.hpp>
+
+namespace Dal {
+    namespace Quadrature {
+        template <class T_> inline void Increment(T_* dst, const T_& inc, double w) {
+            T_ z(inc);
+            z *= w;
+            *dst += z;
+        }
+
+        template <> inline void Increment(Vector_<>* dst, const Vector_<>& inc, double w) {
+            Transform(dst, inc, LinearIncrement(w));
+        }
+
+        void NCDFGaussHermiteWeights(Vector_<>* x, Vector_<>* w);
+        void SimpsonWeights(int n, double lo, double hi, Vector_<>* x, Vector_<>* w);
+    } // namespace Quadrature
+
+    class Quad1DBase_ {
+    public:
+        virtual ~Quad1DBase_();
+    };
+
+    template <class T_>
+    class Quad1D_ : public Quad1DBase_ {
+    public:
+        virtual double GetX() = 0;
+        virtual void PutY(const T_& y) = 0;
+        [[nodiscard]] virtual bool IsComplete() const = 0;
+        virtual T_ Result() const = 0;
+        virtual void Restart() = 0;
+    };
+
+    template <class T_>
+    class Quad1DFixed_ : public Quad1D_<T_> {
+        size_t i_;
+        T_ sum_, initial_;
+
+    protected:
+        Vector_<> x_, w_;
+        Quad1DFixed_(int size, const T_& initial) : i_(0), sum_(initial), initial_(initial), x_(size), w_(size) {}
+
+    public:
+        double GetX() override {
+            ASSERT(!IsComplete(), "quadrature is complete");
+            return x_[i_];
+        }
+        void PutY(const T_& y) override {
+            ASSERT(!IsComplete(), "quadrature is complete");
+            Quadrature::Increment(&sum_, y, w_[i_++]);
+        }
+        [[nodiscard]] bool IsComplete() const override { return i_ == x_.size(); }
+        T_ Result() const override {
+            ASSERT(IsComplete(), "quadrature is incomplete");
+            return sum_;
+        }
+        void Restart() override {
+            i_ = 0;
+            sum_ = initial_;
+        }
+        [[nodiscard]] const Vector_<>& Abscissa() const { return x_; }
+        [[nodiscard]] const Vector_<>& Weight() const { return w_; }
+    };
+
+    template <class T_ = double>
+    class NormalExpectation_ : public Quad1DFixed_<T_> {
+    public:
+        explicit NormalExpectation_(int n, const T_& initial = 0.0) : Quad1DFixed_<T_>(n, initial) {
+            Quadrature::NCDFGaussHermiteWeights(&this->x_, &this->w_);
+        }
+    };
+
+    template <class T_ = double>
+    class QuadSimpson_ : public Quad1DFixed_<T_> {
+    public:
+        QuadSimpson_(int n, double lo, double hi, const T_& initial = 0.0) : Quad1DFixed_<T_>(n | 1, initial) {
+            Quadrature::SimpsonWeights(n, lo, hi, &this->x_, &this->w_);
+        }
+    };
+} // namespace Dal

--- a/dal/math/integral/quadrature.hpp
+++ b/dal/math/integral/quadrature.hpp
@@ -51,16 +51,16 @@ namespace Dal {
 
     public:
         double GetX() override {
-            ASSERT(!IsComplete(), "quadrature is complete");
+            REQUIRE(!IsComplete(), "quadrature is complete");
             return x_[i_];
         }
         void PutY(const T_& y) override {
-            ASSERT(!IsComplete(), "quadrature is complete");
+            REQUIRE(!IsComplete(), "quadrature is complete");
             Quadrature::Increment(&sum_, y, w_[i_++]);
         }
         [[nodiscard]] bool IsComplete() const override { return i_ == x_.size(); }
         T_ Result() const override {
-            ASSERT(IsComplete(), "quadrature is incomplete");
+            REQUIRE(IsComplete(), "quadrature is incomplete");
             return sum_;
         }
         void Restart() override {

--- a/tests/math/integral/test_quadrature.cpp
+++ b/tests/math/integral/test_quadrature.cpp
@@ -1,0 +1,280 @@
+//
+// Created by wegam on 2026/4/26.
+//
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include <dal/platform/platform.hpp>
+#include <dal/math/integral/quadrature.hpp>
+
+using Dal::Quad1DBase_;
+using Dal::Quad1DFixed_;
+using Dal::NormalExpectation_;
+using Dal::QuadSimpson_;
+using Dal::Quadrature::NCDFGaussHermiteWeights;
+using Dal::Quadrature::SimpsonWeights;
+using Dal::Quadrature::Increment;
+using Dal::Vector_;
+
+namespace {
+    double Square(double x) { return x * x; }
+    double Cube(double x) { return x * x * x; }
+    double Quartic(double x) { return x * x * x * x; }
+} // namespace
+
+// --- Increment ---
+
+TEST(QuadratureTest, TestIncrementScalar) {
+    double dst = 1.0;
+    Increment(&dst, 2.0, 0.5);
+    ASSERT_DOUBLE_EQ(dst, 2.0);
+}
+
+TEST(QuadratureTest, TestIncrementVector) {
+    Vector_<> dst = {0.0, 0.0, 0.0};
+    Vector_<> inc = {1.0, 2.0, 3.0};
+    Increment(&dst, inc, 0.5);
+    ASSERT_NEAR(dst[0], 0.5, 1e-10);
+    ASSERT_NEAR(dst[1], 1.0, 1e-10);
+    ASSERT_NEAR(dst[2], 1.5, 1e-10);
+}
+
+// --- SimpsonWeights ---
+
+TEST(QuadratureTest, TestSimpsonWeightsBasic) {
+    Vector_<> x(3), w(3);
+    SimpsonWeights(3, 0.0, 1.0, &x, &w);
+
+    ASSERT_NEAR(x[0], 0.0, 1e-10);
+    ASSERT_NEAR(x[1], 0.5, 1e-10);
+    ASSERT_NEAR(x[2], 1.0, 1e-10);
+
+    const double dx = 0.5;
+    ASSERT_NEAR(w[0], dx / 3.0, 1e-10);
+    ASSERT_NEAR(w[1], 4.0 * dx / 3.0, 1e-10);
+    ASSERT_NEAR(w[2], dx / 3.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestSimpsonWeightsOddify) {
+    // passing an even n should be corrected to odd
+    Vector_<> x(5), w(5);
+    SimpsonWeights(4, 0.0, 1.0, &x, &w);
+    ASSERT_EQ(x.size(), 5u);
+    ASSERT_NEAR(x[4], 1.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestSimpsonWeightsSum) {
+    for (int n : {3, 5, 7, 9}) {
+        Vector_<> x(n), w(n);
+        SimpsonWeights(n, 0.0, 4.0, &x, &w);
+        double sum = 0.0;
+        for (int i = 0; i < n; ++i)
+            sum += w[i];
+        ASSERT_NEAR(sum, 4.0, 1e-10);
+    }
+}
+
+// --- QuadSimpson_ ---
+
+TEST(QuadratureTest, TestSimpsonConstant) {
+    QuadSimpson_<> quad(3, 0.0, 1.0);
+    while (!quad.IsComplete())
+        quad.PutY(1.0);
+    ASSERT_NEAR(quad.Result(), 1.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestSimpsonLinear) {
+    QuadSimpson_<> quad(3, 0.0, 1.0);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(x);
+    }
+    ASSERT_NEAR(quad.Result(), 0.5, 1e-10);
+}
+
+TEST(QuadratureTest, TestSimpsonQuadratic) {
+    QuadSimpson_<> quad(3, 0.0, 1.0);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(Square(x));
+    }
+    ASSERT_NEAR(quad.Result(), 1.0 / 3.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestSimpsonCubic) {
+    QuadSimpson_<> quad(3, 0.0, 1.0);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(Cube(x));
+    }
+    ASSERT_NEAR(quad.Result(), 0.25, 1e-10);
+}
+
+// --- NCDFGaussHermiteWeights ---
+
+TEST(QuadratureTest, TestHermiteOneNode) {
+    Vector_<> x(1), w(1);
+    NCDFGaussHermiteWeights(&x, &w);
+    ASSERT_NEAR(x[0], 0.0, 1e-10);
+    ASSERT_NEAR(w[0], 1.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestHermiteTwoNodes) {
+    Vector_<> x(2), w(2);
+    NCDFGaussHermiteWeights(&x, &w);
+    ASSERT_NEAR(x[0], -1.0, 1e-10);
+    ASSERT_NEAR(x[1], 1.0, 1e-10);
+    ASSERT_NEAR(w[0], 0.5, 1e-10);
+    ASSERT_NEAR(w[1], 0.5, 1e-10);
+}
+
+TEST(QuadratureTest, TestHermiteWeightsSumToOne) {
+    for (int n : {1, 2, 3, 5, 7, 10}) {
+        Vector_<> x(n), w(n);
+        NCDFGaussHermiteWeights(&x, &w);
+        double sum = 0.0;
+        for (int i = 0; i < n; ++i)
+            sum += w[i];
+        ASSERT_NEAR(sum, 1.0, 1e-10) << "n=" << n;
+    }
+}
+
+TEST(QuadratureTest, TestHermiteSymmetry) {
+    for (int n : {3, 5, 7}) {
+        Vector_<> x(n), w(n);
+        NCDFGaussHermiteWeights(&x, &w);
+        for (int i = 0; i < n / 2; ++i) {
+            int j = n - 1 - i;
+            ASSERT_NEAR(x[i], -x[j], 1e-10) << "n=" << n << " i=" << i;
+            ASSERT_NEAR(w[i], w[j], 1e-10) << "n=" << n << " i=" << i;
+        }
+    }
+}
+
+// --- NormalExpectation_ ---
+
+TEST(QuadratureTest, TestNormalExpectConstant) {
+    NormalExpectation_<> quad(5);
+    while (!quad.IsComplete())
+        quad.PutY(1.0);
+    ASSERT_NEAR(quad.Result(), 1.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestNormalExpectX) {
+    NormalExpectation_<> quad(5);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(x);
+    }
+    ASSERT_NEAR(quad.Result(), 0.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestNormalExpectXSquared) {
+    NormalExpectation_<> quad(5);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(Square(x));
+    }
+    ASSERT_NEAR(quad.Result(), 1.0, 1e-8);
+}
+
+TEST(QuadratureTest, TestNormalExpectXFourth) {
+    NormalExpectation_<> quad(5);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(Quartic(x));
+    }
+    ASSERT_NEAR(quad.Result(), 3.0, 1e-8);
+}
+
+TEST(QuadratureTest, TestNormalExpectOddFunction) {
+    // E[sin(x)] = 0 for standard normal (odd function)
+    NormalExpectation_<> quad(5);
+    while (!quad.IsComplete()) {
+        double x = quad.GetX();
+        quad.PutY(sin(x));
+    }
+    ASSERT_NEAR(quad.Result(), 0.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestNormalExpectConvergence) {
+    // as n increases, E[x^6] should converge to 15
+    {
+        NormalExpectation_<> quad(5);
+        while (!quad.IsComplete()) {
+            double x = quad.GetX();
+            quad.PutY(x * x * x * x * x * x);
+        }
+        ASSERT_NEAR(quad.Result(), 15.0, 1e-10);
+    }
+    {
+        NormalExpectation_<> quad(7);
+        while (!quad.IsComplete()) {
+            double x = quad.GetX();
+            quad.PutY(x * x * x * x * x * x);
+        }
+        ASSERT_NEAR(quad.Result(), 15.0, 1e-10);
+    }
+}
+
+// --- Quad1DFixed_ state machine ---
+
+TEST(QuadratureTest, TestStateTransitions) {
+    QuadSimpson_<> quad(3, 0.0, 1.0);
+    ASSERT_FALSE(quad.IsComplete());
+    quad.PutY(1.0);
+    quad.PutY(1.0);
+    ASSERT_FALSE(quad.IsComplete());
+    quad.PutY(1.0);
+    ASSERT_TRUE(quad.IsComplete());
+
+    quad.Restart();
+    ASSERT_FALSE(quad.IsComplete());
+    double x = quad.GetX();
+    ASSERT_NEAR(x, 0.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestSimpsonRestartReuse) {
+    QuadSimpson_<> quad(5, 0.0, 1.0);
+    while (!quad.IsComplete())
+        quad.PutY(Square(quad.GetX()));
+    double first = quad.Result();
+
+    quad.Restart();
+    while (!quad.IsComplete())
+        quad.PutY(Square(quad.GetX()));
+    double second = quad.Result();
+
+    ASSERT_NEAR(first, second, 1e-10);
+}
+
+// --- Vector-valued quadrature ---
+
+TEST(QuadratureTest, TestVectorValuedSimpson) {
+    QuadSimpson_<Vector_<>> quad(3, 0.0, 1.0, Vector_<>(2));
+    while (!quad.IsComplete()) {
+        Vector_<> y(2);
+        double x = quad.GetX();
+        y[0] = x;
+        y[1] = x * x;
+        quad.PutY(y);
+    }
+    Vector_<> result = quad.Result();
+    ASSERT_NEAR(result[0], 0.5, 1e-10);
+    ASSERT_NEAR(result[1], 1.0 / 3.0, 1e-10);
+}
+
+TEST(QuadratureTest, TestVectorValuedNormal) {
+    NormalExpectation_<Vector_<>> quad(5, Vector_<>(2));
+    while (!quad.IsComplete()) {
+        Vector_<> y(2);
+        double x = quad.GetX();
+        y[0] = 1.0;
+        y[1] = Square(x);
+        quad.PutY(y);
+    }
+    Vector_<> result = quad.Result();
+    ASSERT_NEAR(result[0], 1.0, 1e-10);
+    ASSERT_NEAR(result[1], 1.0, 1e-8);
+}


### PR DESCRIPTION
## Summary
- add fixed one-dimensional quadrature interfaces with Simpson and standard-normal expectation implementations
- compute normal Gauss-Hermite nodes and weights using direct Hermite root search instead of a full eigenvector workspace
- split Hermite root initialization, Newton solving, and symmetric node assignment into helpers to keep NCDFGaussHermiteWeights simpler
- use REQUIRE for quadrature state-machine guards so misuse is checked in release builds
- document the REQUIRE-vs-ASSERT release-check rule in mirrored style and review guidance
- add quadrature coverage for scalar, vector-valued, Simpson, and normal expectation paths

## Test plan
- [x] cmake --build build --target test_suite -j32
- [x] bin/test_suite --gtest_filter=QuadratureTest.*