### PR TITLE
Validate ArrayN dimensions

### DIFF
--- a/dal/math/ndarray.hpp
+++ b/dal/math/ndarray.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <iterator>
+#include <utility>
 #include <dal/math/vectors.hpp>
 #include <dal/utilities/numerics.hpp>
 
@@ -20,9 +21,14 @@ namespace Dal {
         Vector_<int> strides_;
         Vector_<E_> vals_;
 
+        static Vector_<int> CheckedSizes(Vector_<int> sizes) {
+            REQUIRE(!sizes.empty(), "ArrayN_ requires at least one dimension");
+            return sizes;
+        }
+
     public:
-        explicit ArrayN_(const Vector_<int>& sizes, const E_& fill = E_(0.0))
-            : sizes_(sizes), strides_(ArrayN::Strides(sizes)), vals_(strides_[0] * sizes[0], fill) {}
+        explicit ArrayN_(Vector_<int> sizes, const E_& fill = E_(0.0))
+            : sizes_(CheckedSizes(std::move(sizes))), strides_(ArrayN::Strides(sizes_)), vals_(strides_[0] * sizes_[0], fill) {}
 
         const E_& operator[](const Vector_<int>& where) const { return vals_[InnerProduct(where, strides_)]; }
         E_& operator[](const Vector_<int>& where) { return vals_[InnerProduct(where, strides_)]; }

--- a/tests/math/test_ndarray.cpp
+++ b/tests/math/test_ndarray.cpp
@@ -13,6 +13,10 @@ TEST(NDArrayTest, TestEmptyArrayN) {
     ASSERT_TRUE(array_n.IsEmpty());
 }
 
+TEST(NDArrayTest, TestArrayNRequiresDimension) {
+    ASSERT_THROW(ArrayN_<>(Vector_<int>()), Dal::Exception_);
+}
+
 TEST(NDArrayTest, TestArrayNSwapWithVector) {
     ArrayN_<> array_1(Vector_<int>({0}));
     Vector_<> vec1{1.0, 2.0, 3.0};


### PR DESCRIPTION
## Summary
- move ArrayN shape vectors into construction to avoid GCC's warning-prone vector copy path
- add an ArrayN precondition that rejects empty shape vectors before stride/storage indexing
- add NDArray coverage for the empty-shape failure path

## Test plan
- [x] cmake --build build --target test_suite -j2
- [x] build/tests/test_suite --gtest_filter=NDArrayTest.*