### PR TITLE
Fix MSVC parsing error in test_ndarray.cpp

### DIFF
--- a/tests/math/test_ndarray.cpp
+++ b/tests/math/test_ndarray.cpp
@@ -14,7 +14,7 @@ TEST(NDArrayTest, TestEmptyArrayN) {
 }
 
 TEST(NDArrayTest, TestArrayNRequiresDimension) {
-    ASSERT_THROW(ArrayN_<>(Vector_<int>()), Dal::Exception_);
+    ASSERT_THROW(ArrayN_<>(Vector_<int>{}), Dal::Exception_);
 }
 
 TEST(NDArrayTest, TestArrayNSwapWithVector) {


### PR DESCRIPTION
## Summary
- Fix MSVC compiler parsing error where `Vector_<int>()` inside `ASSERT_THROW` was misinterpreted as a variable template call (C7538)
- Changed to brace initialization `Vector_<int>{}` which avoids the parsing ambiguity

## Test plan
- [x] Full `bin/test_suite` passes — 452 tests from 49 test suites