### PR TITLE
chore: Rename skills with dal- prefix and add PR title conventions

### DIFF
--- a/.claude/agents/dal-dev-workflow.md
+++ b/.claude/agents/dal-dev-workflow.md
@@ -1,5 +1,5 @@
 ---
-name: dev-workflow
+name: dal-dev-workflow
 description: |
   Use this agent when the user wants to implement a feature, develop a new module, or execute a requirement specification in the DAL C++
   quantitative finance library. This agent handles the full development cycle: understanding requirements, technical design, implementation,
@@ -10,17 +10,17 @@ description: |
   <example>
   Context: User has a feature requirement to implement
   user: "I need to add log-linear interpolation to the interpolation module"
-  assistant: "Let me use the dev-workflow agent to handle this end-to-end."
+  assistant: "Let me use the dal-dev-workflow agent to handle this end-to-end."
   <commentary>
-  Feature implementation request in the DAL library. The dev-workflow agent handles everything from design through tested code.
+  Feature implementation request in the DAL library. The dal-dev-workflow agent handles everything from design through tested code.
   </commentary>
-  assistant: "I'll use the dev-workflow agent to implement this feature with full design, implementation, and tests."
+  assistant: "I'll use the dal-dev-workflow agent to implement this feature with full design, implementation, and tests."
   </example>
 
   <example>
   Context: User provides a written specification
   user: "Here's the spec for the normal quadrature module we need to build. Can you implement it?"
-  assistant: "I'll use the dev-workflow agent to work through this specification systematically."
+  assistant: "I'll use the dal-dev-workflow agent to work through this specification systematically."
   <commentary>
   Written specification triggers the full development workflow. Agent will create design doc, implement, test, and iterate.
   </commentary>
@@ -29,11 +29,11 @@ description: |
   <example>
   Context: User asks for a new class or module
   user: "Add a ConcentrationRisk_ class to the risk module with methods for computing concentration metrics"
-  assistant: "Let me use the dev-workflow agent to implement this properly."
+  assistant: "Let me use the dal-dev-workflow agent to implement this properly."
   <commentary>
   New class implementation benefits from systematic design -> implement -> test workflow.
   </commentary>
-  assistant: "I'll use the dev-workflow agent to design, implement, and test the ConcentrationRisk_ class."
+  assistant: "I'll use the dal-dev-workflow agent to design, implement, and test the ConcentrationRisk_ class."
   </example>
 model: inherit
 color: green

--- a/.claude/skills/dal-code-style-review/SKILL.md
+++ b/.claude/skills/dal-code-style-review/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: code-style-review
+name: dal-code-style-review
 description: Review changed C++ code for compliance with this project's coding and unit test style. Use when the user asks to review code style, check style compliance, lint code, verify naming conventions, review changed files for project conventions, or says "review my changes", "check the style", "does this follow our conventions", or similar.
 user-invocable: true
 ---
 
 # Code Style Review
 
-Review all changed files in the working tree against the project's coding conventions defined in `.codex/rules/code-style.md` and `.codex/rules/unit-test-style.md`.
+Review all changed files in the working tree against the project's coding conventions defined in `.claude/rules/code-style.md` and `.claude/rules/unit-test-style.md`.
 
 ## Steps
 
 1. Read the style guides:
-   - `.codex/rules/code-style.md`
-   - `.codex/rules/unit-test-style.md`
+   - `.claude/rules/code-style.md`
+   - `.claude/rules/unit-test-style.md`
 
 2. Identify changed files by running:
    ```bash

--- a/.claude/skills/dal-commit-and-pr/SKILL.md
+++ b/.claude/skills/dal-commit-and-pr/SKILL.md
@@ -49,7 +49,7 @@ There are two kinds of submodule changes — handle them differently:
 - Write commit messages following project conventions:
   - Imperative summary under 72 characters
   - Body explaining the "why", not just the "what"
-  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`
 - Use a multi-line commit message to preserve formatting:
   ```bash
   git commit -m "$(cat <<'EOF'
@@ -57,7 +57,7 @@ There are two kinds of submodule changes — handle them differently:
 
   Body explaining why.
 
-  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
   EOF
   )"
   ```
@@ -77,6 +77,14 @@ First check if a PR already exists for this branch:
 ```bash
 gh pr view --json number,title,body 2>/dev/null
 ```
+
+#### PR title conventions
+
+- Keep it under 70 characters.
+- Use imperative mood (e.g., "feat: add log-linear interpolation" not "feat: adds log-linear interpolation").
+- Start with a category prefix — this is mandatory. Choose from: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `style:`, `perf:`, `ci:`.
+- Describe the change at a high level, not implementation details.
+- If the PR is still in progress, prefix with `WIP:` (before the category prefix) or open it as a draft.
 
 #### If no PR exists — create one
 

--- a/.claude/skills/dal-commit-and-pr/SKILL.md
+++ b/.claude/skills/dal-commit-and-pr/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: commit-and-pr
+name: dal-commit-and-pr
 description: Commit current repository changes, push to a remote branch, and create or update a pull request. Use when the user says "ship it", "commit and PR", "push and create PR", "send this up for review", "wrap this up", or any variation of committing, pushing, and opening or updating a PR in one workflow.
 user-invocable: true
 ---
 
 # Commit, Push, and Create PR
 
-This skill packages up the current session's work into commits, pushes to a remote branch, and opens or updates a pull request. It follows the project's git conventions defined in `.codex/rules/git-commit-pr.md`.
+This skill packages up the current session's work into commits, pushes to a remote branch, and opens or updates a pull request. It follows the project's git conventions defined in `.claude/rules/git-commit-pr.md`.
 
 ## Steps
 
@@ -49,7 +49,7 @@ There are two kinds of submodule changes — handle them differently:
 - Write commit messages following project conventions:
   - Imperative summary under 72 characters
   - Body explaining the "why", not just the "what"
-  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Codex <noreply@openai.com>`
+  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
 - Use a multi-line commit message to preserve formatting:
   ```bash
   git commit -m "$(cat <<'EOF'
@@ -57,7 +57,7 @@ There are two kinds of submodule changes — handle them differently:
 
   Body explaining why.
 
-  Co-Authored-By: Codex <noreply@openai.com>
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
   EOF
   )"
   ```

--- a/.claude/skills/dal-unit-test-skill/SKILL.md
+++ b/.claude/skills/dal-unit-test-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: unit-test-skill
+name: dal-unit-test-skill
 description: Run and inspect this repository's build and Google Test workflow. Use when the user asks to run all tests, verify the whole codebase, execute the Linux or Windows build/test scripts, inspect `test_output.txt`, or confirm whether the test suite passes.
 user-invocable: true
 ---

--- a/.claude/skills/dal-unit-test-write/SKILL.md
+++ b/.claude/skills/dal-unit-test-write/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: unit-test-write
+name: dal-unit-test-write
 description: |
   Write Google Test unit tests for the DAL C++ quantitative finance library. Use when the user asks to write tests, add test coverage, create unit
   tests, or mentions testing for new or existing C++ code. Also trigger when implementing features that need test coverage, refactoring code

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -16,18 +16,18 @@ scripts, `CMakeLists.txt`, `CMakePresets.json`, and source tree.
 - Use `methodology/aad.md` for automatic differentiation, expression templates, tape management, or adjoint propagation work.
 - Use `methodology/yield_curve.md` for curve construction, discount curve, calibration, or underdetermined optimization work.
 - Use `methodology/underdetermined_search.md` when working on the solver itself, weight construction, Jacobian handling, or convergence behavior.
-- Use `agents/dev-workflow.md` when implementing a feature, developing a new module, or executing a requirement specification end-to-end.
+- Use `agents/dal-dev-workflow.md` when implementing a feature, developing a new module, or executing a requirement specification end-to-end.
 
 ## Local Workflow Skills
 
 The folders under `skills/` use Codex-compatible `SKILL.md` frontmatter. If a user request matches one of these workflows, read the matching file
 and follow it.
 
-- `skills/commit-and-pr/SKILL.md`: use for "ship it", "commit and PR", "push and create PR", "send this up for review", "wrap this up", or
+- `skills/dal-commit-and-pr/SKILL.md`: use for "ship it", "commit and PR", "push and create PR", "send this up for review", "wrap this up", or
   similar commit + push + PR requests.
-- `skills/code-style-review/SKILL.md`: use for style review, lint-like checks, naming convention checks, or "review my changes" when the likely
+- `skills/dal-code-style-review/SKILL.md`: use for style review, lint-like checks, naming convention checks, or "review my changes" when the likely
   intent is coding style.
-- `skills/dev-workflow/SKILL.md`: use for feature implementation, new modules, or requirement specifications that need design, implementation,
+- `skills/dal-dev-workflow/SKILL.md`: use for feature implementation, new modules, or requirement specifications that need design, implementation,
   tests, and verification.
-- `skills/unit-test-write/SKILL.md`: use for writing Google Test coverage for new or existing C++ code.
-- `skills/unit-test-skill/SKILL.md`: use for running the repository build/test workflow or verifying the whole test suite.
+- `skills/dal-unit-test-write/SKILL.md`: use for writing Google Test coverage for new or existing C++ code.
+- `skills/dal-unit-test-skill/SKILL.md`: use for running the repository build/test workflow or verifying the whole test suite.

--- a/.codex/agents/dal-dev-workflow.md
+++ b/.codex/agents/dal-dev-workflow.md
@@ -1,5 +1,5 @@
 ---
-name: dev-workflow
+name: dal-dev-workflow
 description: |
   Use this agent when the user wants to implement a feature, develop a new module, or execute a requirement specification in the DAL C++
   quantitative finance library. This agent handles the full development cycle: understanding requirements, technical design, implementation,
@@ -10,17 +10,17 @@ description: |
   <example>
   Context: User has a feature requirement to implement
   user: "I need to add log-linear interpolation to the interpolation module"
-  assistant: "Let me use the dev-workflow agent to handle this end-to-end."
+  assistant: "Let me use the dal-dev-workflow agent to handle this end-to-end."
   <commentary>
-  Feature implementation request in the DAL library. The dev-workflow agent handles everything from design through tested code.
+  Feature implementation request in the DAL library. The dal-dev-workflow agent handles everything from design through tested code.
   </commentary>
-  assistant: "I'll use the dev-workflow agent to implement this feature with full design, implementation, and tests."
+  assistant: "I'll use the dal-dev-workflow agent to implement this feature with full design, implementation, and tests."
   </example>
 
   <example>
   Context: User provides a written specification
   user: "Here's the spec for the normal quadrature module we need to build. Can you implement it?"
-  assistant: "I'll use the dev-workflow agent to work through this specification systematically."
+  assistant: "I'll use the dal-dev-workflow agent to work through this specification systematically."
   <commentary>
   Written specification triggers the full development workflow. Agent will create design doc, implement, test, and iterate.
   </commentary>
@@ -29,11 +29,11 @@ description: |
   <example>
   Context: User asks for a new class or module
   user: "Add a ConcentrationRisk_ class to the risk module with methods for computing concentration metrics"
-  assistant: "Let me use the dev-workflow agent to implement this properly."
+  assistant: "Let me use the dal-dev-workflow agent to implement this properly."
   <commentary>
   New class implementation benefits from systematic design -> implement -> test workflow.
   </commentary>
-  assistant: "I'll use the dev-workflow agent to design, implement, and test the ConcentrationRisk_ class."
+  assistant: "I'll use the dal-dev-workflow agent to design, implement, and test the ConcentrationRisk_ class."
   </example>
 model: inherit
 color: green

--- a/.codex/skills/dal-code-style-review/SKILL.md
+++ b/.codex/skills/dal-code-style-review/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: code-style-review
+name: dal-code-style-review
 description: Review changed C++ code for compliance with this project's coding and unit test style. Use when the user asks to review code style, check style compliance, lint code, verify naming conventions, review changed files for project conventions, or says "review my changes", "check the style", "does this follow our conventions", or similar.
 user-invocable: true
 ---
 
 # Code Style Review
 
-Review all changed files in the working tree against the project's coding conventions defined in `.claude/rules/code-style.md` and `.claude/rules/unit-test-style.md`.
+Review all changed files in the working tree against the project's coding conventions defined in `.codex/rules/code-style.md` and `.codex/rules/unit-test-style.md`.
 
 ## Steps
 
 1. Read the style guides:
-   - `.claude/rules/code-style.md`
-   - `.claude/rules/unit-test-style.md`
+   - `.codex/rules/code-style.md`
+   - `.codex/rules/unit-test-style.md`
 
 2. Identify changed files by running:
    ```bash

--- a/.codex/skills/dal-commit-and-pr/SKILL.md
+++ b/.codex/skills/dal-commit-and-pr/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: commit-and-pr
+name: dal-commit-and-pr
 description: Commit current repository changes, push to a remote branch, and create or update a pull request. Use when the user says "ship it", "commit and PR", "push and create PR", "send this up for review", "wrap this up", or any variation of committing, pushing, and opening or updating a PR in one workflow.
 user-invocable: true
 ---
 
 # Commit, Push, and Create PR
 
-This skill packages up the current session's work into commits, pushes to a remote branch, and opens or updates a pull request. It follows the project's git conventions defined in `.claude/rules/git-commit-pr.md`.
+This skill packages up the current session's work into commits, pushes to a remote branch, and opens or updates a pull request. It follows the project's git conventions defined in `.codex/rules/git-commit-pr.md`.
 
 ## Steps
 
@@ -49,7 +49,7 @@ There are two kinds of submodule changes — handle them differently:
 - Write commit messages following project conventions:
   - Imperative summary under 72 characters
   - Body explaining the "why", not just the "what"
-  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Codex <noreply@openai.com>`
 - Use a multi-line commit message to preserve formatting:
   ```bash
   git commit -m "$(cat <<'EOF'
@@ -57,7 +57,7 @@ There are two kinds of submodule changes — handle them differently:
 
   Body explaining why.
 
-  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  Co-Authored-By: Codex <noreply@openai.com>
   EOF
   )"
   ```

--- a/.codex/skills/dal-dev-workflow/SKILL.md
+++ b/.codex/skills/dal-dev-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dev-workflow
+name: dal-dev-workflow
 description: |
   Implement features, develop new modules, or execute requirement specifications end-to-end in the DAL C++ quantitative finance library. Use when
   the user asks for a complete design, implementation, unit-test, and verification workflow.
@@ -8,7 +8,7 @@ user-invocable: true
 
 # Dev Workflow
 
-Use the workflow in `.codex/agents/dev-workflow.md`.
+Use the workflow in `.codex/agents/dal-dev-workflow.md`.
 
 Before implementation, read the relevant `.codex/rules/` files and any applicable `.codex/methodology/` documents. If the work needs new or changed
-Google Test coverage, also use `.codex/skills/unit-test-write/SKILL.md`.
+Google Test coverage, also use `.codex/skills/dal-unit-test-write/SKILL.md`.

--- a/.codex/skills/dal-unit-test-skill/SKILL.md
+++ b/.codex/skills/dal-unit-test-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: unit-test-skill
+name: dal-unit-test-skill
 description: Run and inspect this repository's build and Google Test workflow. Use when the user asks to run all tests, verify the whole codebase, execute the Linux or Windows build/test scripts, inspect `test_output.txt`, or confirm whether the test suite passes.
 user-invocable: true
 ---

--- a/.codex/skills/dal-unit-test-write/SKILL.md
+++ b/.codex/skills/dal-unit-test-write/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: unit-test-write
+name: dal-unit-test-write
 description: |
   Write Google Test unit tests for the DAL C++ quantitative finance library. Use when the user asks to write tests, add test coverage, create unit
   tests, or mentions testing for new or existing C++ code. Also trigger when implementing features that need test coverage, refactoring code


### PR DESCRIPTION
## Summary
- Rename all `.claude/` and `.codex/` skills and agents to use a `dal-` prefix to prevent naming conflicts
- Update `.codex/AGENTS.md` to reference the new dal- prefixed names
- Add mandatory PR title conventions section to `dal-commit-and-pr` skill (category prefix, imperative mood, under 70 chars)
- Fix Co-Authored-By version to 4.7 across the skill

## Test plan
- [x] Verified git correctly detects all file renames
- [x] Confirmed no binary files or externals were included