### PR TITLE
Add Adept AAD backend

### DIFF
--- a/.claude/methodology/aad.md
+++ b/.claude/methodology/aad.md
@@ -4,26 +4,30 @@ Documentation of the AAD framework in `dal/math/aad/`.
 
 ## File Map
 
-| File                         | Purpose                                                                        |
-|------------------------------|--------------------------------------------------------------------------------|
-| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and dual-path `Number_`     |
-| `dal/math/aad/tape.hpp`      | `Tape_` declaration (native `BlockList_`-based tape or XAD wrapper)            |
-| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for both native and XAD paths             |
-| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers |
-| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the tape      |
-| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`             |
-| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_`                |
-| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios   |
+| File                         | Purpose                                                                                      |
+|------------------------------|----------------------------------------------------------------------------------------------|
+| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and backend-specific `Number_`            |
+| `dal/math/aad/tape.hpp`      | `Tape_` declaration for native `BlockList_`, XAD, CoDiPack, or Adept backends                |
+| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for native, XAD, CoDiPack, and Adept paths              |
+| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers                |
+| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the native tape             |
+| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`                           |
+| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_` in the native backend         |
+| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios                 |
 
 ## Design Overview
 
-The library implements reverse-mode automatic differentiation (AAD) — the algorithm behind backpropagation in neural networks and adjoint Greeks in finance. There are two compilation paths controlled by `DAL_USE_XAD_AAD`:
+The library implements reverse-mode automatic differentiation (AAD) — the algorithm behind backpropagation in neural networks and adjoint Greeks in finance. Backend selection is controlled by `DAL_USE_XAD_AAD`, `DAL_USE_CODIPACK_AAD`, and `DAL_USE_ADEPT_AAD`; at most one external backend can be enabled.
 
 1. **Native expression-template path** (default) — taken from Antoine Savine's book *Modern Computational Finance: AAD and Parallel Simulations* (Wiley, 2018). Uses C++ expression templates to record operations onto a thread-local tape, then propagates adjoints backward through the tape.
 
 2. **XAD path** — delegates to the external XAD library. `Number_` becomes `xad::adj<double>::active_type`, and the tape wraps `xad::adj<double>::tape_type`.
 
-Both paths expose identical free-function APIs (`Value()`, `Adjoint()`, `PropagateToStart()`, `Clear()`, `Mark()`, etc.), so the rest of the library is source-compatible with either.
+3. **CoDiPack path** — delegates to CoDiPack reverse mode. `Number_` becomes `codi::RealReverseUnchecked`, and the tape wraps CoDiPack's tape.
+
+4. **Adept path** — delegates active arithmetic to Adept. `Number_` becomes `adept::adouble`, and DAL wraps Adept stack positions to preserve mark/rewind propagation semantics.
+
+All paths expose identical free-function APIs (`Value()`, `Adjoint()`, `PropagateToStart()`, `Clear()`, `Mark()`, etc.), so the rest of the library is source-compatible with the selected backend.
 
 ## Core Types
 
@@ -38,7 +42,7 @@ Expression_<E_>                       ← CRTP base, implicit double conversion
 
 ### Number_
 
-`Number_` (`dal/math/aad/expr.hpp:469`) is the active type — a `double` with a link to a tape node. It has `numNumbers_ = 1`, a compile-time constant indicating it contributes one leaf to any expression tree.
+In the native backend, `Number_` (`dal/math/aad/expr.hpp:469`) is the active type — a `double` with a link to a tape node. It has `numNumbers_ = 1`, a compile-time constant indicating it contributes one leaf to any expression tree.
 
 **Construction from an expression** — `Number_ n = a * b + c / d;` does two things:
 1. Evaluates the expression tree to a `double` via `Value(e)`
@@ -126,7 +130,7 @@ The block sizes are chosen for cache efficiency:
 - `ADJ_SIZE = 32768` adjoints per block
 - `DATA_SIZE = 65536` derivatives/pointers per block
 
-### XAD Path Tape
+### External Backend Tapes
 
 ```cpp
 class Tape_ {
@@ -137,7 +141,7 @@ class Tape_ {
 };
 ```
 
-A thin wrapper — XAD handles all tape management internally. The `start_` and `mark_` positions mirror the native path's mark/rewind semantics.
+XAD and CoDiPack use thin wrappers around the backend tape. Adept uses a derived `adept::Stack` helper so DAL can save statement/operation positions and reverse only a selected range. In each external backend, `start_` and `mark_` mirror the native path's mark/rewind semantics.
 
 ### RecordNode
 
@@ -226,32 +230,33 @@ double dx1 = Adjoint(x1);  // ∂y/∂x₁
 double dx2 = Adjoint(x2);  // ∂y/∂x₂
 ```
 
-## Dual-Path Architecture
+## Backend Architecture
 
-The `#ifndef DAL_USE_XAD_AAD` / `#else` / `#endif` pattern in `expr.hpp` and `tape.hpp` provides two complete AAD backends behind identical free-function APIs:
+The `DAL_USE_*_AAD` preprocessor branches in `expr.hpp` and `tape.hpp` provide interchangeable AAD backends behind identical free-function APIs:
 
-| Operation                     | Native Path                                            | XAD Path                                   |
-|-------------------------------|--------------------------------------------------------|--------------------------------------------|
-| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            |
-| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            |
-| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       |
-| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   |
-| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape |
-| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          |
-| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              |
-| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   |
+| Operation                     | Native Path                                            | XAD Path                                   | CoDiPack Path                    | Adept Path                       |
+|-------------------------------|--------------------------------------------------------|--------------------------------------------|----------------------------------|----------------------------------|
+| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            | `codi::RealReverseUnchecked`     | `adept::adouble`                 |
+| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            | `n.getValue()`                   | `adept::value(n)`                |
+| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       | `n.getGradient()`                | `n.get_gradient()`               |
+| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   | `tape_.registerInput(n)`         | No-op after active construction  |
+| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape | Returns CoDiPack's active tape   | Returns Adept thread-local tape  |
+| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          | `tape_.evaluate(position,start_)` | Reverses selected Adept range    |
+| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              | Saves/restores tape positions    | Saves/restores Adept positions   |
+| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   | Imported via `using codi::*`     | Imported via `using adept::*`    |
 
-The native path records operations eagerly during the forward pass — each expression assignment creates a tape node. The XAD path delegates recording to the XAD library, which may use a similar or different internal representation.
+The native path records operations eagerly during the forward pass — each expression assignment creates a tape node. External paths delegate operation recording to the selected backend, while DAL preserves the same free-function API and checkpoint-style propagation calls.
 
 ### Build Configuration
 
-`DAL_USE_XAD_AAD` defaults to `off` in both top-level `CMakeLists.txt` and the shipped CMake presets. To enable:
+Top-level `CMakeLists.txt` defaults all external AAD backend options to `off`; the shipped presets currently select Adept by setting `DAL_USE_ADEPT_AAD=on`. To select a backend manually, enable exactly one external AAD option:
 
 ```bash
 cmake --preset=Release-linux -DDAL_USE_XAD_AAD=on ..
+cmake --preset=Release-linux -DDAL_USE_ADEPT_AAD=on -DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off ..
 ```
 
-The XAD headers are expected at `externals/xad/`. Both paths are covered by the same test infrastructure.
+The external headers are expected under `externals/xad/`, `externals/CodiPack/`, and `externals/adept/`. All paths are covered by the same test infrastructure.
 
 ## Parallel AAD in Monte Carlo
 

--- a/.codex/designs/adept-aad-backend.md
+++ b/.codex/designs/adept-aad-backend.md
@@ -1,0 +1,45 @@
+# Adept AAD Backend — Technical Design
+
+## Summary
+Add Adept as a third external AAD backend behind the existing `Dal::AAD` free-function API. The rest of DAL should continue to use `AAD::Number_`, `Tape()`, `PutOnTape`, `Adjoint`, `Value`, and propagation helpers without backend-specific code.
+
+## Affected Files
+| File                         | Action | Purpose                                      |
+|------------------------------|--------|----------------------------------------------|
+| `CMakeLists.txt`             | Modify | Add `DAL_USE_ADEPT_AAD` selection             |
+| `dal/CMakeLists.txt`         | Modify | Link `dal_library` to `adept` when selected   |
+| `public/src/CMakeLists.txt`  | Modify | Link public/static fold build to `adept`      |
+| `tests/CMakeLists.txt`       | Modify | Link `test_suite` to `adept`                  |
+| `examples/*/CMakeLists.txt`  | Modify | Link examples to `adept`                      |
+| `dal/math/aad/tape.hpp`      | Modify | Add Adept tape wrapper                        |
+| `dal/math/aad/tape.cpp`      | Modify | Add Adept clear/mark/rewind/propagation       |
+| `dal/math/aad/expr.hpp`      | Modify | Add Adept `Number_` alias and math API        |
+| `dal/math/aad/aad.hpp`       | Modify | Treat Adept as external backend               |
+| `dal/platform/initall.cpp`   | Modify | Report Adept backend                          |
+| `examples/aad/aad.cpp`       | Modify | Report Adept in example output                |
+
+## Design Decisions
+- **Decision:** Use `using Number_ = adept::adouble` directly.
+  Adept active values require an active stack before construction, so DAL AAD entry points that construct active model objects explicitly activate the thread-local tape first.
+- **Decision:** Derive a DAL tape helper from `adept::Stack`.
+  Adept exposes full reverse propagation but not partial propagation to a saved DAL mark. A small derived helper can record and restore protected statement/operation positions and run the same reverse loop over a selected range.
+- **Decision:** Preserve existing DAL checkpoint semantics.
+  `PropagateToMark` accumulates adjoints at the mark, `PropagateMarkToStart` propagates those accumulated mark adjoints to inputs, and rewind resets only recorded statements after the saved position.
+
+## API Design
+No public DAL API change. New configuration flag:
+
+```cmake
+-DDAL_USE_ADEPT_AAD=on -DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off
+```
+
+## Implementation Notes
+- `Tape_` stores an Adept stack plus saved start/mark statement and operation positions.
+- Adept gradient storage is used through `Stack::set_gradients` / `get_gradients`; `Adjoint(Number_&)` returns a proxy assignable from `double` and convertible to `double`.
+- `NPDF` and `NCDF` materialize active results as `Number_` values to avoid returning Adept expressions with references to helper-local temporaries.
+- `max`/`min` use Adept `max`/`min` to preserve branch derivative behavior.
+
+## Test Plan
+- Build with Adept selected.
+- Run `bin/test_suite --gtest_filter=AADTest.*:AnalyticsTest.TestBlackScholesAAD:AnalyticsTest.TestBachelierAAD`.
+- Run full `bin/test_suite` if the focused build passes.

--- a/.codex/methodology/aad.md
+++ b/.codex/methodology/aad.md
@@ -4,26 +4,30 @@ Documentation of the AAD framework in `dal/math/aad/`.
 
 ## File Map
 
-| File                         | Purpose                                                                        |
-|------------------------------|--------------------------------------------------------------------------------|
-| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and dual-path `Number_`     |
-| `dal/math/aad/tape.hpp`      | `Tape_` declaration (native `BlockList_`-based tape or XAD wrapper)            |
-| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for both native and XAD paths             |
-| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers |
-| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the tape      |
-| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`             |
-| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_`                |
-| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios   |
+| File                         | Purpose                                                                                      |
+|------------------------------|----------------------------------------------------------------------------------------------|
+| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and backend-specific `Number_`            |
+| `dal/math/aad/tape.hpp`      | `Tape_` declaration for native `BlockList_`, XAD, CoDiPack, or Adept backends                |
+| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for native, XAD, CoDiPack, and Adept paths              |
+| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers                |
+| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the native tape             |
+| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`                           |
+| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_` in the native backend         |
+| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios                 |
 
 ## Design Overview
 
-The library implements reverse-mode automatic differentiation (AAD) — the algorithm behind backpropagation in neural networks and adjoint Greeks in finance. There are two compilation paths controlled by `DAL_USE_XAD_AAD`:
+The library implements reverse-mode automatic differentiation (AAD) — the algorithm behind backpropagation in neural networks and adjoint Greeks in finance. Backend selection is controlled by `DAL_USE_XAD_AAD`, `DAL_USE_CODIPACK_AAD`, and `DAL_USE_ADEPT_AAD`; at most one external backend can be enabled.
 
 1. **Native expression-template path** (default) — taken from Antoine Savine's book *Modern Computational Finance: AAD and Parallel Simulations* (Wiley, 2018). Uses C++ expression templates to record operations onto a thread-local tape, then propagates adjoints backward through the tape.
 
 2. **XAD path** — delegates to the external XAD library. `Number_` becomes `xad::adj<double>::active_type`, and the tape wraps `xad::adj<double>::tape_type`.
 
-Both paths expose identical free-function APIs (`Value()`, `Adjoint()`, `PropagateToStart()`, `Clear()`, `Mark()`, etc.), so the rest of the library is source-compatible with either.
+3. **CoDiPack path** — delegates to CoDiPack reverse mode. `Number_` becomes `codi::RealReverseUnchecked`, and the tape wraps CoDiPack's tape.
+
+4. **Adept path** — delegates active arithmetic to Adept. `Number_` becomes `adept::adouble`, and DAL wraps Adept stack positions to preserve mark/rewind propagation semantics.
+
+All paths expose identical free-function APIs (`Value()`, `Adjoint()`, `PropagateToStart()`, `Clear()`, `Mark()`, etc.), so the rest of the library is source-compatible with the selected backend.
 
 ## Core Types
 
@@ -38,7 +42,7 @@ Expression_<E_>                       ← CRTP base, implicit double conversion
 
 ### Number_
 
-`Number_` (`dal/math/aad/expr.hpp:469`) is the active type — a `double` with a link to a tape node. It has `numNumbers_ = 1`, a compile-time constant indicating it contributes one leaf to any expression tree.
+In the native backend, `Number_` (`dal/math/aad/expr.hpp:469`) is the active type — a `double` with a link to a tape node. It has `numNumbers_ = 1`, a compile-time constant indicating it contributes one leaf to any expression tree.
 
 **Construction from an expression** — `Number_ n = a * b + c / d;` does two things:
 1. Evaluates the expression tree to a `double` via `Value(e)`
@@ -126,7 +130,7 @@ The block sizes are chosen for cache efficiency:
 - `ADJ_SIZE = 32768` adjoints per block
 - `DATA_SIZE = 65536` derivatives/pointers per block
 
-### XAD Path Tape
+### External Backend Tapes
 
 ```cpp
 class Tape_ {
@@ -137,7 +141,7 @@ class Tape_ {
 };
 ```
 
-A thin wrapper — XAD handles all tape management internally. The `start_` and `mark_` positions mirror the native path's mark/rewind semantics.
+XAD and CoDiPack use thin wrappers around the backend tape. Adept uses a derived `adept::Stack` helper so DAL can save statement/operation positions and reverse only a selected range. In each external backend, `start_` and `mark_` mirror the native path's mark/rewind semantics.
 
 ### RecordNode
 
@@ -226,32 +230,33 @@ double dx1 = Adjoint(x1);  // ∂y/∂x₁
 double dx2 = Adjoint(x2);  // ∂y/∂x₂
 ```
 
-## Dual-Path Architecture
+## Backend Architecture
 
-The `#ifndef DAL_USE_XAD_AAD` / `#else` / `#endif` pattern in `expr.hpp` and `tape.hpp` provides two complete AAD backends behind identical free-function APIs:
+The `DAL_USE_*_AAD` preprocessor branches in `expr.hpp` and `tape.hpp` provide interchangeable AAD backends behind identical free-function APIs:
 
-| Operation                     | Native Path                                            | XAD Path                                   |
-|-------------------------------|--------------------------------------------------------|--------------------------------------------|
-| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            |
-| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            |
-| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       |
-| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   |
-| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape |
-| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          |
-| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              |
-| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   |
+| Operation                     | Native Path                                            | XAD Path                                   | CoDiPack Path                    | Adept Path                       |
+|-------------------------------|--------------------------------------------------------|--------------------------------------------|----------------------------------|----------------------------------|
+| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            | `codi::RealReverseUnchecked`     | `adept::adouble`                 |
+| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            | `n.getValue()`                   | `adept::value(n)`                |
+| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       | `n.getGradient()`                | `n.get_gradient()`               |
+| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   | `tape_.registerInput(n)`         | No-op after active construction  |
+| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape | Returns CoDiPack's active tape   | Returns Adept thread-local tape  |
+| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          | `tape_.evaluate(position,start_)` | Reverses selected Adept range    |
+| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              | Saves/restores tape positions    | Saves/restores Adept positions   |
+| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   | Imported via `using codi::*`     | Imported via `using adept::*`    |
 
-The native path records operations eagerly during the forward pass — each expression assignment creates a tape node. The XAD path delegates recording to the XAD library, which may use a similar or different internal representation.
+The native path records operations eagerly during the forward pass — each expression assignment creates a tape node. External paths delegate operation recording to the selected backend, while DAL preserves the same free-function API and checkpoint-style propagation calls.
 
 ### Build Configuration
 
-`DAL_USE_XAD_AAD` defaults to `off` in both top-level `CMakeLists.txt` and the shipped CMake presets. To enable:
+Top-level `CMakeLists.txt` defaults all external AAD backend options to `off`; the shipped presets currently select Adept by setting `DAL_USE_ADEPT_AAD=on`. To select a backend manually, enable exactly one external AAD option:
 
 ```bash
 cmake --preset=Release-linux -DDAL_USE_XAD_AAD=on ..
+cmake --preset=Release-linux -DDAL_USE_ADEPT_AAD=on -DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off ..
 ```
 
-The XAD headers are expected at `externals/xad/`. Both paths are covered by the same test infrastructure.
+The external headers are expected under `externals/xad/`, `externals/CodiPack/`, and `externals/adept/`. All paths are covered by the same test infrastructure.
 
 ## Parallel AAD in Monte Carlo
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ public/python/dal/dal_wrap.py
 test_output.txt
 .claude/settings.json
 .claude/settings.local.json
+build-*

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "externals/googletest"]
 	path = externals/googletest
 	url = git@github.com:google/googletest.git
+[submodule "externals/adept"]
+	path = externals/adept
+	url = git@github.com:wegamekinglc/Adept-2.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@
 - Generated `dal/auto/*` is also excluded when `public/src` statically folds core DAL sources into `dal_public`.
 - `dal/storage/_repository.*` is excluded from core build globs.
 - Excel COM integration is auto-enabled on Windows only if Office binaries are detected.
-- The repo supports AAD with XAD and also contains older/internal AAD machinery; `DAL_USE_XAD_AAD` defaults to `off` in `CMakeLists.txt` and the shipped presets.
+- The repo supports AAD with XAD, CoDiPack, and Adept and also contains older/internal AAD machinery.
+- Top-level CMake defaults external AAD backends to `off`; the shipped presets currently select Adept with `DAL_USE_ADEPT_AAD=on`.
 
 ## Build And Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Formatting is enforced via `.clang-format` (LLVM-based):
 
 ## Architecture
 
-This is a C++17 quantitative finance library with AAD (Automatic Adjoint Differentiation) support. The repo contains the legacy internal AAD path and optional XAD, CoDiPack, and Adept backends. Top-level CMake defaults external AAD backends to `off`; the shipped presets currently select Adept with `DAL_USE_ADEPT_AAD=on`.
+This is a C++17 quantitative finance library with AAD (Automatic Adjoint Differentiation) support.
 
 **Core library (`dal/`)** — built as the `dal_library` target and installed under `lib/` as `dal`:
 - `math/` — numerical algorithms: interpolation, optimization, PDE solvers, random number generation, matrix ops, root finding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Formatting is enforced via `.clang-format` (LLVM-based):
 
 ## Architecture
 
-This is a C++17 quantitative finance library with AAD (Automatic Adjoint Differentiation) support. The repo contains both the legacy internal AAD path and optional XAD support; `DAL_USE_XAD_AAD` defaults to `off` in both `CMakeLists.txt` and the shipped presets.
+This is a C++17 quantitative finance library with AAD (Automatic Adjoint Differentiation) support. The repo contains the legacy internal AAD path and optional XAD, CoDiPack, and Adept backends. Top-level CMake defaults external AAD backends to `off`; the shipped presets currently select Adept with `DAL_USE_ADEPT_AAD=on`.
 
 **Core library (`dal/`)** — built as the `dal_library` target and installed under `lib/` as `dal`:
 - `math/` — numerical algorithms: interpolation, optimization, PDE solvers, random number generation, matrix ops, root finding
@@ -63,6 +63,7 @@ This is a C++17 quantitative finance library with AAD (Automatic Adjoint Differe
 
 **External dependencies** (`externals/`, git submodules):
 - `xad/` — XAD AAD framework for automatic differentiation
+- `adept/` — Adept AAD framework for automatic differentiation
 - `googletest/` — Google Test framework
 - `rapidjson/` — JSON parsing
 - `machinist/` — code generation tool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,10 @@ include_directories(${CMAKE_SOURCE_DIR})
 
 option(DAL_USE_XAD_AAD "use xad as aad framework" OFF)
 option(DAL_USE_CODIPACK_AAD "use CoDiPack as aad framework" OFF)
-if (DAL_USE_XAD_AAD AND DAL_USE_CODIPACK_AAD)
+option(DAL_USE_ADEPT_AAD "use Adept as aad framework" OFF)
+if ((DAL_USE_XAD_AAD AND DAL_USE_CODIPACK_AAD) OR
+    (DAL_USE_XAD_AAD AND DAL_USE_ADEPT_AAD) OR
+    (DAL_USE_CODIPACK_AAD AND DAL_USE_ADEPT_AAD))
     message(FATAL_ERROR "Only one external AAD backend can be enabled")
 endif()
 
@@ -104,6 +107,11 @@ elseif(DAL_USE_CODIPACK_AAD)
     message("-- USE AAD framework: CoDiPack")
     add_definitions(-DDAL_USE_CODIPACK_AAD)
     add_definitions(-DCODI_ForcedInlines)
+elseif(DAL_USE_ADEPT_AAD)
+    message("-- USE AAD framework: Adept")
+    add_definitions(-DDAL_USE_ADEPT_AAD)
+#    add_definitions(-DADEPT_STACK_THREAD_UNSAFE)
+    add_definitions(-DADEPT_FAST_EXPONENTIAL)
 else()
     message("-- USE AAD framework: AADET")
 endif ()
@@ -113,11 +121,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/externals/googletest)
 add_subdirectory(${CMAKE_SOURCE_DIR}/externals/rapidjson)
 add_subdirectory(${CMAKE_SOURCE_DIR}/externals/xad)
 add_subdirectory(${CMAKE_SOURCE_DIR}/externals/CodiPack)
+add_subdirectory(${CMAKE_SOURCE_DIR}/externals/adept)
 add_subdirectory(${CMAKE_SOURCE_DIR}/externals/machinist)
 
 include_directories(${CMAKE_SOURCE_DIR}/externals/rapidjson/include)
 include_directories(${CMAKE_SOURCE_DIR}/externals/xad/include)
 include_directories(${CMAKE_SOURCE_DIR}/externals/CodiPack/include)
+include_directories(${CMAKE_SOURCE_DIR}/externals/adept/include)
 
 # Auto-detect Microsoft Office for Excel COM integration
 set(DAL_HAS_EXCEL OFF)
@@ -157,4 +167,3 @@ message("-- SKIP_TESTS: ${SKIP_TESTS}")
 if ("${SKIP_TESTS}" STREQUAL "false")
     add_subdirectory(tests)
 endif()
-

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,8 +12,9 @@
       "cacheVariables": {
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}",
-        "DAL_USE_XAD_AAD": "on",
+        "DAL_USE_XAD_AAD": "off",
         "DAL_USE_CODIPACK_AAD": "off",
+        "DAL_USE_ADEPT_AAD": "on",
         "XAD_ENABLE_TESTS": "off",
         "XAD_USE_STRONG_INLINE": "on",
         "XAD_NO_THREADLOCAL": "off",

--- a/dal/CMakeLists.txt
+++ b/dal/CMakeLists.txt
@@ -21,6 +21,8 @@ if (DAL_USE_XAD_AAD)
     target_link_libraries(dal_library XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(dal_library CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(dal_library adept)
 endif()
 
 set_target_properties(dal_library PROPERTIES

--- a/dal/math/aad/aad.cpp
+++ b/dal/math/aad/aad.cpp
@@ -13,7 +13,7 @@
 #include <dal/platform/strict.hpp>
 #include <dal/math/aad/aad.hpp>
 
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD)
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
 namespace Dal::AAD {
     size_t TapNode_::numAdj_ = 1;
     bool Tape_::multi_ = false;

--- a/dal/math/aad/aad.hpp
+++ b/dal/math/aad/aad.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 #include <dal/math/aad/expr.hpp>
 
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD)
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
 
 namespace Dal::AAD {
 

--- a/dal/math/aad/expr.hpp
+++ b/dal/math/aad/expr.hpp
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include <cmath>
 #include <mutex>
+#include <type_traits>
 #include <dal/platform/host.hpp>
 #include <dal/math/specialfunctions.hpp>
 
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD)
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
 #include <dal/math/aad/tape.hpp>
 
 namespace Dal::AAD {
@@ -577,6 +579,93 @@ namespace Dal::AAD {
     FORCE_INLINE double& Adjoint(const Number_& num) { return num.node_->Adjoint(); }
 
     FORCE_INLINE void PutOnTape(Number_& n) { n.node_ = n.CreateMultiNode<0>(); }
+} // namespace Dal::AAD
+#elif defined(DAL_USE_ADEPT_AAD)
+#include <dal/math/aad/tape.hpp>
+
+namespace Dal::AAD {
+    using Number_ = adept::adouble;
+
+    FORCE_INLINE Tape_* Tape() {
+        thread_local Tape_ tape;
+        return &tape;
+    }
+
+    using adept::operator*;
+    using adept::operator+;
+    using adept::operator-;
+    using adept::operator/;
+    using adept::operator==;
+    using adept::operator!=;
+    using adept::operator<;
+    using adept::operator<=;
+    using adept::operator>;
+    using adept::operator>=;
+
+    using adept::abs;
+    using adept::erfc;
+    using adept::exp;
+    using adept::log;
+    using adept::max;
+    using adept::min;
+    using adept::pow;
+    using adept::sqrt;
+
+    FORCE_INLINE double Value(const Number_& num) {
+        return adept::value(num);
+    }
+
+    FORCE_INLINE double Value(double num) {
+        return num;
+    }
+
+    class Adjoint_ {
+        Number_& num_;
+
+    public:
+        explicit Adjoint_(Number_& num) : num_(num) {}
+
+        FORCE_INLINE Adjoint_& operator=(double adjoint) {
+            num_.set_gradient(adjoint);
+            return *this;
+        }
+
+        FORCE_INLINE operator double() const {
+            return num_.get_gradient();
+        }
+    };
+
+    FORCE_INLINE double Adjoint(const Number_& num) {
+        return num.get_gradient();
+    }
+
+    FORCE_INLINE Adjoint_ Adjoint(Number_& num) {
+        return Adjoint_(num);
+    }
+
+    FORCE_INLINE void PutOnTape(Number_&) {}
+
+    template <class T_, std::enable_if_t<std::is_arithmetic_v<T_>, int> = 0>
+    FORCE_INLINE double NPDF(T_ z) {
+        return 0.3989422804014327 * std::exp(-0.5 * z * z);
+    }
+
+    template <class T_, std::enable_if_t<std::is_arithmetic_v<T_>, int> = 0>
+    FORCE_INLINE double NCDF(T_ z) {
+        return 0.5 * std::erfc(-z / 1.4142135623730951);
+    }
+
+    template <class T_, std::enable_if_t<!std::is_arithmetic_v<T_>, int> = 0>
+    FORCE_INLINE Number_ NPDF(const T_& z) {
+        Number_ arg = z;
+        return 0.3989422804014327 * exp(-0.5 * arg * arg);
+    }
+
+    template <class T_, std::enable_if_t<!std::is_arithmetic_v<T_>, int> = 0>
+    FORCE_INLINE Number_ NCDF(const T_& z) {
+        Number_ arg = -z / 1.4142135623730951;
+        return 0.5 * erfc(arg);
+    }
 } // namespace Dal::AAD
 #elif defined(DAL_USE_XAD_AAD)
 #include <dal/math/aad/tape.hpp>

--- a/dal/math/aad/node.hpp
+++ b/dal/math/aad/node.hpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <dal/platform/consts.hpp>
 
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD)
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
 namespace Dal::AAD {
     class TapNode_ {
         const size_t n_;

--- a/dal/math/aad/tape.cpp
+++ b/dal/math/aad/tape.cpp
@@ -5,7 +5,7 @@
 #include <dal/math/aad/expr.hpp>
 #include <dal/math/aad/tape.hpp>
 
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD)
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
 namespace Dal::AAD {
 
     namespace {
@@ -77,6 +77,55 @@ namespace Dal::AAD {
     void NewRecording(Tape_&) {}
     void Activate(Tape_&) {}
     void Deactivate(Tape_&) {}
+} // namespace Dal::AAD
+#elif defined(DAL_USE_ADEPT_AAD)
+
+namespace Dal::AAD {
+
+    void Clear(Tape_& tape) {
+        tape.tape_.new_recording();
+        tape.start_ = tape.tape_.Position();
+        tape.mark_ = tape.start_;
+    }
+
+    void Mark(Tape_& tape) {
+        tape.mark_ = tape.tape_.Position();
+    }
+
+    void Rewind(Tape_& tape) {
+        tape.tape_.ResetTo(tape.start_);
+    }
+
+    void RewindToMark(Tape_& tape) {
+        tape.tape_.ResetTo(tape.mark_);
+    }
+
+    void PropagateMarkToStart(Tape_& tape) {
+        tape.tape_.ReverseRange(tape.mark_, tape.start_);
+    }
+
+    void PropagateToStart(Tape_& tape) {
+        tape.tape_.ReverseRange(tape.tape_.Position(), tape.start_);
+    }
+
+    void PropagateToMark(Tape_& tape) {
+        tape.tape_.ReverseRange(tape.tape_.Position(), tape.mark_);
+    }
+
+    void NewRecording(Tape_& tape) {
+        tape.tape_.new_recording();
+        tape.start_ = tape.tape_.Position();
+        tape.mark_ = tape.start_;
+    }
+
+    void Activate(Tape_& tape) {
+        if (!tape.tape_.is_active())
+            tape.tape_.activate();
+    }
+
+    void Deactivate(Tape_& tape) {
+        tape.tape_.deactivate();
+    }
 } // namespace Dal::AAD
 #elif defined(DAL_USE_XAD_AAD)
 
@@ -176,4 +225,3 @@ namespace Dal::AAD {
     }
 } // namespace Dal::AAD
 #endif
-

--- a/dal/math/aad/tape.hpp
+++ b/dal/math/aad/tape.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD)
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
 
 #include <dal/math/aad/blocklist.hpp>
 #include <dal/math/aad/node.hpp>
@@ -62,6 +62,67 @@ namespace Dal::AAD {
             return node;
         }
 
+    };
+
+    void Clear(Tape_& tape);
+    void Mark(Tape_& tape);
+    void RewindToMark(Tape_& tape);
+    void Rewind(Tape_& tape);
+    void PropagateMarkToStart(Tape_& tape);
+    void PropagateToStart(Tape_& tape);
+    void PropagateToMark(Tape_& tape);
+    void NewRecording(Tape_& tape);
+    void Activate(Tape_& tape);
+    void Deactivate(Tape_& tape);
+} // namespace Dal::AAD
+#elif defined(DAL_USE_ADEPT_AAD)
+#include <adept.h>
+#include <dal/utilities/exceptions.hpp>
+
+namespace Dal::AAD {
+
+    struct Position_ {
+        adept::uIndex statements_;
+        adept::uIndex operations_;
+    };
+
+    class Stack_ : public adept::Stack {
+    public:
+        explicit Stack_(bool activate = true) : adept::Stack(activate) {}
+
+        [[nodiscard]] Position_ Position() const {
+            return {n_statements_, n_operations_};
+        }
+
+        void ResetTo(Position_ position) {
+            n_statements_ = position.statements_;
+            n_operations_ = position.operations_;
+        }
+
+        void ReverseRange(Position_ from, Position_ to) {
+            if (!gradients_are_initialized())
+                THROW("Adept gradients are not initialized");
+
+            for (adept::uIndex ist = from.statements_; ist > to.statements_; --ist) {
+                const adept::uIndex statementIndex = ist - 1;
+                const auto& statement = statement_[statementIndex];
+                adept::Real adjoint = gradient_[statement.index];
+                gradient_[statement.index] = 0.0;
+                if (adjoint != 0.0) {
+                    for (adept::uIndex i = statement_[statementIndex - 1].end_plus_one; i < statement.end_plus_one; ++i)
+                        gradient_[index_[i]] += multiplier_[i] * adjoint;
+                }
+            }
+        }
+    };
+
+    class Tape_ {
+    public:
+        Stack_ tape_;
+        Position_ start_;
+        Position_ mark_;
+
+        explicit Tape_(bool activate = true) : tape_(activate), start_(tape_.Position()), mark_(start_) {}
     };
 
     void Clear(Tape_& tape);

--- a/dal/platform/initall.cpp
+++ b/dal/platform/initall.cpp
@@ -28,6 +28,8 @@ namespace Dal {
             std::cout << "use AAD framework: " << "XAD" << std::endl;
 #elif defined(DAL_USE_CODIPACK_AAD)
             std::cout << "use AAD framework: " << "CoDiPack" << std::endl;
+#elif defined(DAL_USE_ADEPT_AAD)
+            std::cout << "use AAD framework: " << "Adept" << std::endl;
 #else
             std::cout << "use AAD framework: " << "AADET" << std::endl;
 #endif

--- a/dal/script/simulation.hpp
+++ b/dal/script/simulation.hpp
@@ -107,10 +107,10 @@ namespace Dal::Script {
         SimResults_ results(Vector::Join(mdl->ParameterLabels(), product.ConstVarNames()));
 
         Vector_<TaskHandle_> futures;
-        const int batch_size = std::min(BATCH_SIZE, static_cast<int>(n_paths / nThreads) + 1);
-        futures.reserve(n_paths / batch_size + 1);
+        const int batchSize = std::max(BATCH_SIZE, static_cast<int>(n_paths / nThreads) + 1);
+        futures.reserve(n_paths / batchSize + 1);
         Vector_<> simResults;
-        simResults.reserve(n_paths / batch_size + 1);
+        simResults.reserve(n_paths / batchSize + 1);
 
         int firstPath = 0;
         int pathsLeft = static_cast<int>(n_paths);
@@ -118,7 +118,7 @@ namespace Dal::Script {
         auto payoffIndex = product.PayOffIdx();
 
         while (pathsLeft > 0) {
-            auto pathsInTask = std::min(pathsLeft, batch_size);
+            auto pathsInTask = std::min(pathsLeft, batchSize);
             simResults.emplace_back(0.0);
             auto& simResult = simResults[loopIndex];
             loopIndex += 1;
@@ -168,6 +168,7 @@ namespace Dal::Script {
                              bool compiled,
                              int max_nested_ifs,
                              double eps) {
+        AAD::Activate(*AAD::Tape());
         std::unique_ptr<AAD::Model_<AAD::Number_>> mdl = CreateModel<AAD::Number_>(model_data);
         const auto nParams = mdl->Parameters().size();
         const auto nConstVars = product.ConstVarNames().size();

--- a/examples/aad/CMakeLists.txt
+++ b/examples/aad/CMakeLists.txt
@@ -3,6 +3,9 @@ add_executable(aad ${AAD_FILES})
 
 target_link_libraries(aad dal_library)
 target_link_libraries(aad XAD::xad)
+if(DAL_USE_ADEPT_AAD)
+    target_link_libraries(aad adept)
+endif()
 
 if(MSVC)
 else()

--- a/examples/aad/aad.cpp
+++ b/examples/aad/aad.cpp
@@ -106,6 +106,8 @@ int main() {
         std::cout << std::setw(widths[0]) << std::left << "Builtin (XAD)"
 #elif defined(DAL_USE_CODIPACK_AAD)
         std::cout << std::setw(widths[0]) << std::left << "Builtin (CoDiPack)"
+#elif defined(DAL_USE_ADEPT_AAD)
+        std::cout << std::setw(widths[0]) << std::left << "Builtin (Adept)"
 #else
         std::cout << std::setw(widths[0]) << std::left << "Builtin (AADET)"
 #endif

--- a/examples/concurrency/CMakeLists.txt
+++ b/examples/concurrency/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(concurrency XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(concurrency CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(concurrency adept)
 endif ()
 
 if(MSVC)

--- a/examples/digital/CMakeLists.txt
+++ b/examples/digital/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(digital XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(digital CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(digital adept)
 endif ()
 
 if(MSVC)

--- a/examples/european_fd/CMakeLists.txt
+++ b/examples/european_fd/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(european_fd XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(european_fd CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(european_fd adept)
 endif ()
 
 if(MSVC)

--- a/examples/european_mc/CMakeLists.txt
+++ b/examples/european_mc/CMakeLists.txt
@@ -6,6 +6,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(european_mc XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(european_mc CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(european_mc adept)
 endif ()
 
 if(MSVC)

--- a/examples/excelwriter/CMakeLists.txt
+++ b/examples/excelwriter/CMakeLists.txt
@@ -13,6 +13,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(excelwriter XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(excelwriter CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(excelwriter adept)
 endif ()
 
 

--- a/examples/matrix_perf/CMakeLists.txt
+++ b/examples/matrix_perf/CMakeLists.txt
@@ -10,6 +10,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(matrix_perf XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(matrix_perf CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(matrix_perf adept)
 endif ()
 
 if(MSVC)

--- a/examples/script/CMakeLists.txt
+++ b/examples/script/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(script XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(script CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(script adept)
 endif ()
 
 if(MSVC)

--- a/examples/snowball/CMakeLists.txt
+++ b/examples/snowball/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(snowball XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(snowball CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(snowball adept)
 endif ()
 
 if(MSVC)

--- a/examples/sobol/CMakeLists.txt
+++ b/examples/sobol/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(sobol XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(sobol CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(sobol adept)
 endif ()
 
 if(MSVC)

--- a/examples/underdetermined/CMakeLists.txt
+++ b/examples/underdetermined/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(underdetermined XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(underdetermined CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(underdetermined adept)
 endif ()
 
 if(MSVC)

--- a/examples/uoc/CMakeLists.txt
+++ b/examples/uoc/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(uoc XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(uoc CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(uoc adept)
 endif ()
 
 if(MSVC)

--- a/examples/uoc_compiled/CMakeLists.txt
+++ b/examples/uoc_compiled/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(uoc_compiled XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(uoc_compiled CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(uoc_compiled adept)
 endif ()
 
 if(MSVC)

--- a/examples/vanilla/CMakeLists.txt
+++ b/examples/vanilla/CMakeLists.txt
@@ -7,6 +7,8 @@ if(DAL_USE_XAD_AAD)
     target_link_libraries(vanilla XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
     target_link_libraries(vanilla CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(vanilla adept)
 endif ()
 
 

--- a/public/src/CMakeLists.txt
+++ b/public/src/CMakeLists.txt
@@ -32,6 +32,12 @@ elseif(DAL_USE_CODIPACK_AAD)
     else()
         target_link_libraries(dal_public CoDiPack)
     endif()
+elseif(DAL_USE_ADEPT_AAD)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(dal_library adept)
+    else()
+        target_link_libraries(dal_public adept)
+    endif()
 endif ()
 
 install(DIRECTORY . DESTINATION include/public/src

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,8 @@ if(DAL_USE_XAD_AAD)
         target_link_libraries(test_suite XAD::xad)
 elseif(DAL_USE_CODIPACK_AAD)
         target_link_libraries(test_suite CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+        target_link_libraries(test_suite adept)
 endif ()
 
 install(TARGETS test_suite

--- a/tests/math/aad/test_checkpoint.cpp
+++ b/tests/math/aad/test_checkpoint.cpp
@@ -12,14 +12,14 @@ using namespace Dal;
 using namespace Dal::AAD;
 
 template <class T_>
-T_ BlackTest(const T_& fwd, const T_& vol, const T_& numeraire, const T_& strike, const T_& expiry, bool is_call) {
+T_ BlackTest(const T_& fwd, const T_& vol, const T_& numeraire, const T_& strike, const T_& expiry, bool isCall) {
     static const double M_SQRT_2 = 1.4142135623730951;
-    const double omega = is_call ? 1.0 : -1.0;
+    const double omega = isCall ? 1.0 : -1.0;
     T_ y(0.0);
-    T_ sqrt_var = vol * sqrt(expiry);
-    T_ d_minus = log(fwd / strike) / sqrt_var - 0.5 * sqrt_var;
-    T_ d_plus = d_minus + sqrt_var;
-    y = numeraire * omega * (0.5 * fwd * erfc(-d_plus / M_SQRT_2) - strike * 0.5 * erfc(-d_minus / M_SQRT_2));
+    T_ sqrtVar = vol * sqrt(expiry);
+    T_ dMinus = log(fwd / strike) / sqrtVar - 0.5 * sqrtVar;
+    T_ dPlus = dMinus + sqrtVar;
+    y = numeraire * omega * (0.5 * fwd * erfc(-dPlus / M_SQRT_2) - strike * 0.5 * erfc(-dMinus / M_SQRT_2));
     return y;
 }
 
@@ -109,72 +109,71 @@ TEST(AADTest, TestWithCheckpointWithForLoop) {
 }
 
 TEST(AADTest, TestWithCheckpointWithMultiThreading) {
-    int n_rounds = 100000;
-    int batch_size = 2048;
+    int nRounds = 100000;
+    int batchSize = 2048;
     double fwd = 1.00;
     double vol = 0.20;
     double numeraire = 1.0;
     double strike = 1.20;
     double expiry = 3.0;
-    bool is_call = true;
+    bool isCall = true;
 
     ThreadPool_* pool = ThreadPool_::GetInstance();
-    const size_t n_threads = pool->NumThreads();
+    const size_t nThreads = pool->NumThreads();
 
-    batch_size = std::max(batch_size, static_cast<int>(n_rounds / n_threads) + 1);
+    batchSize = std::max(batchSize, static_cast<int>(nRounds / nThreads) + 1);
     Vector_<TaskHandle_> futures;
-    futures.reserve(n_rounds / batch_size + 1);
+    futures.reserve(nRounds / batchSize + 1);
 
-    int first_round = 0;
-    int rounds_left = n_rounds;
+    int roundsLeft = nRounds;
 
     Vector_<> greeks(6, 0.0);
-    Vector_<Vector_<>> final_results(n_threads, greeks);
+    Vector_<Vector_<>> finalResults(nThreads, greeks);
 
-    while (rounds_left > 0) {
-        auto rounds_in_tasks = std::min(rounds_left, batch_size);
+    while (roundsLeft > 0) {
+        auto roundsInTasks = std::min(roundsLeft, batchSize);
 
-        futures.push_back(pool->SpawnTask([&, rounds_in_tasks]() {
-            const size_t n_thread = ThreadPool_::ThreadNum();
+        futures.push_back(pool->SpawnTask([&, roundsInTasks]() {
+            const size_t nThread = ThreadPool_::ThreadNum();
+            Clear(*Tape());
             std::unique_ptr<TestModel_> model = std::make_unique<TestModel_>(fwd, vol, numeraire, strike, expiry);
             ModelInit(*model);
-            auto& results = final_results[n_thread];
+            auto& results = finalResults[nThread];
 
-            double sum_val = 0.0;
-            for (size_t i = 0; i < rounds_in_tasks; ++i) {
+            double sumVal = 0.0;
+            for (size_t i = 0; i < roundsInTasks; ++i) {
                 RewindToMark(*Tape());
                 Number_ res = BlackTest(model->fwd_,
                                         model->vol_,
                                         model->numeraire_,
                                         model->strike_,
                                         model->expiry_,
-                                        is_call);
+                                        isCall);
                 Adjoint(res) = 1.0;
                 PropagateToMark(*Tape());
-                sum_val += Value(res);
+                sumVal += Value(res);
             }
 
             PropagateMarkToStart(*Tape());
-            results[0] += sum_val;
-            results[1] += Adjoint(model->fwd_) / static_cast<double>(n_rounds);
-            results[2] += Adjoint(model->vol_) / static_cast<double>(n_rounds);
-            results[3] += Adjoint(model->numeraire_) / static_cast<double>(n_rounds);
-            results[4] += Adjoint(model->strike_) / static_cast<double>(n_rounds);
-            results[5] += Adjoint(model->expiry_) / static_cast<double>(n_rounds);
+            results[0] += sumVal;
+            results[1] += Adjoint(model->fwd_) / static_cast<double>(nRounds);
+            results[2] += Adjoint(model->vol_) / static_cast<double>(nRounds);
+            results[3] += Adjoint(model->numeraire_) / static_cast<double>(nRounds);
+            results[4] += Adjoint(model->strike_) / static_cast<double>(nRounds);
+            results[5] += Adjoint(model->expiry_) / static_cast<double>(nRounds);
             return true;
         }));
-        rounds_left -= rounds_in_tasks;
-        first_round += rounds_in_tasks;
+        roundsLeft -= roundsInTasks;
     }
 
     for (auto& future: futures)
         pool->ActiveWait(future);
 
-    for (const auto& res: final_results)
+    for (const auto& res: finalResults)
         for (size_t i = 0; i < greeks.size(); ++i)
             greeks[i] += res[i];
 
-    ASSERT_NEAR(greeks[0] / static_cast<double>(n_rounds), 0.0714668, 1e-6);
+    ASSERT_NEAR(greeks[0] / static_cast<double>(nRounds), 0.0714668, 1e-6);
     ASSERT_NEAR(greeks[1], 0.362002, 1e-6);
     ASSERT_NEAR(greeks[2], 0.649225, 1e-6);
     ASSERT_NEAR(greeks[3], 0.0714668, 1e-6);


### PR DESCRIPTION
## Summary
- Add `DAL_USE_ADEPT_AAD` backend selection and wire Adept through the core library, public wrapper, tests, examples, and presets.
- Implement the Adept backend using `using Number_ = adept::adouble` directly, with DAL tape mark/rewind propagation, value/adjoint helpers, and active `NPDF`/`NCDF` support.
- Keep Adept tape range handling aligned with backend recording positions by deriving the DAL tape from `adept::Stack` and using direct stack state for mark/rewind propagation.
- Cap Monte Carlo simulation task batch sizes to avoid oversized work chunks when the path count is large relative to worker threads.
- Keep the top-level architecture note concise while detailed backend guidance lives in the AAD methodology docs.

## Test plan
- [x] `cmake --build build-adept --target test_suite -j2`
- [x] `build-adept/tests/test_suite`
- [x] `cmake --build build-native --target test_suite -j2`
- [x] `build-adept/tests/test_suite --gtest_filter=AADTest.TestWithCheckpoint*:AADTest.TestAADMutiThread:AnalyticsTest.TestBlackScholesAAD:AnalyticsTest.TestBachelierAAD:ScriptTest.TestBlackScholesAAD`
- [x] `build-native/tests/test_suite --gtest_filter=AADTest.TestWithCheckpoint*:AADTest.TestAADMutiThread:AnalyticsTest.TestBlackScholesAAD:AnalyticsTest.TestBachelierAAD:ScriptTest.TestBlackScholesAAD`
- [x] `git diff --check`
- [x] `git diff --check -- CLAUDE.md`