### PR TITLE
Fix Adept tape range handling

### DIFF
--- a/dal/math/aad/tape.cpp
+++ b/dal/math/aad/tape.cpp
@@ -83,48 +83,48 @@ namespace Dal::AAD {
 namespace Dal::AAD {
 
     void Clear(Tape_& tape) {
-        tape.tape_.new_recording();
-        tape.start_ = tape.tape_.Position();
+        tape.new_recording();
+        tape.start_ = tape.Position();
         tape.mark_ = tape.start_;
     }
 
     void Mark(Tape_& tape) {
-        tape.mark_ = tape.tape_.Position();
+        tape.mark_ = tape.Position();
     }
 
     void Rewind(Tape_& tape) {
-        tape.tape_.ResetTo(tape.start_);
+        tape.reset_to(tape.start_.statements_, tape.start_.operations_);
     }
 
     void RewindToMark(Tape_& tape) {
-        tape.tape_.ResetTo(tape.mark_);
+        tape.reset_to(tape.mark_.statements_, tape.mark_.operations_);
     }
 
     void PropagateMarkToStart(Tape_& tape) {
-        tape.tape_.ReverseRange(tape.mark_, tape.start_);
+        tape.compute_adjoint(tape.mark_.statements_, tape.start_.statements_);
     }
 
     void PropagateToStart(Tape_& tape) {
-        tape.tape_.ReverseRange(tape.tape_.Position(), tape.start_);
+        tape.compute_adjoint(tape.Position().statements_, tape.start_.statements_);
     }
 
     void PropagateToMark(Tape_& tape) {
-        tape.tape_.ReverseRange(tape.tape_.Position(), tape.mark_);
+        tape.compute_adjoint(tape.Position().statements_, tape.mark_.statements_);
     }
 
     void NewRecording(Tape_& tape) {
-        tape.tape_.new_recording();
-        tape.start_ = tape.tape_.Position();
+        tape.new_recording();
+        tape.start_ = tape.Position();
         tape.mark_ = tape.start_;
     }
 
     void Activate(Tape_& tape) {
-        if (!tape.tape_.is_active())
-            tape.tape_.activate();
+        if (!tape.is_active())
+            tape.activate();
     }
 
     void Deactivate(Tape_& tape) {
-        tape.tape_.deactivate();
+        tape.deactivate();
     }
 } // namespace Dal::AAD
 #elif defined(DAL_USE_XAD_AAD)

--- a/dal/math/aad/tape.hpp
+++ b/dal/math/aad/tape.hpp
@@ -86,24 +86,29 @@ namespace Dal::AAD {
         adept::uIndex operations_;
     };
 
-    class Stack_ : public adept::Stack {
+    class Tape_ : public adept::Stack {
     public:
-        explicit Stack_(bool activate = true) : adept::Stack(activate) {}
+        using adept::Stack::compute_adjoint;
+
+        Position_ start_;
+        Position_ mark_;
+
+        explicit Tape_(bool activate = true) : adept::Stack(activate), start_(Position()), mark_(start_) {}
 
         [[nodiscard]] Position_ Position() const {
-            return {n_statements_, n_operations_};
+            return {n_statements(), n_operations()};
         }
 
-        void ResetTo(Position_ position) {
-            n_statements_ = position.statements_;
-            n_operations_ = position.operations_;
+        void reset_to(adept::uIndex nStatements, adept::uIndex nOperations) {
+            n_statements_ = nStatements;
+            n_operations_ = nOperations;
         }
 
-        void ReverseRange(Position_ from, Position_ to) {
+        void compute_adjoint(adept::uIndex fromStatement, adept::uIndex toStatement) {
             if (!gradients_are_initialized())
                 THROW("Adept gradients are not initialized");
 
-            for (adept::uIndex ist = from.statements_; ist > to.statements_; --ist) {
+            for (adept::uIndex ist = fromStatement; ist > toStatement && ist > 1; --ist) {
                 const adept::uIndex statementIndex = ist - 1;
                 const auto& statement = statement_[statementIndex];
                 adept::Real adjoint = gradient_[statement.index];
@@ -114,15 +119,6 @@ namespace Dal::AAD {
                 }
             }
         }
-    };
-
-    class Tape_ {
-    public:
-        Stack_ tape_;
-        Position_ start_;
-        Position_ mark_;
-
-        explicit Tape_(bool activate = true) : tape_(activate), start_(tape_.Position()), mark_(start_) {}
     };
 
     void Clear(Tape_& tape);

--- a/dal/script/simulation.hpp
+++ b/dal/script/simulation.hpp
@@ -107,7 +107,7 @@ namespace Dal::Script {
         SimResults_ results(Vector::Join(mdl->ParameterLabels(), product.ConstVarNames()));
 
         Vector_<TaskHandle_> futures;
-        const int batchSize = std::max(BATCH_SIZE, static_cast<int>(n_paths / nThreads) + 1);
+        const int batchSize = std::min(BATCH_SIZE, static_cast<int>(n_paths / nThreads) + 1);
         futures.reserve(n_paths / batchSize + 1);
         Vector_<> simResults;
         simResults.reserve(n_paths / batchSize + 1);


### PR DESCRIPTION
Use the Adept stack directly for DAL tape operations so mark and rewind state stay aligned with backend recording positions, and cap simulation batch sizes to avoid oversized per-task work chunks.