### PR TITLE
fix: simplify Adept NPDF/NCDF overloads and add tape unit tests

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -26,6 +26,7 @@ if (MSVC)
 
     # /wd26812
     # Suppress warnings: "Prefer enum class over enum" (Enum.3)
+
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         SET(MSVC_COMPILER_OPTION /wd4267 /wd26812 /std:c++17)
     else()

--- a/dal/math/aad/expr.hpp
+++ b/dal/math/aad/expr.hpp
@@ -645,26 +645,12 @@ namespace Dal::AAD {
 
     FORCE_INLINE void PutOnTape(Number_&) {}
 
-    template <class T_, std::enable_if_t<std::is_arithmetic_v<T_>, int> = 0>
-    FORCE_INLINE double NPDF(T_ z) {
-        return 0.3989422804014327 * std::exp(-0.5 * z * z);
+    FORCE_INLINE Number_ NPDF(const Number_& z) {
+        return 0.3989422804014327 * exp(-0.5 * z * z);
     }
 
-    template <class T_, std::enable_if_t<std::is_arithmetic_v<T_>, int> = 0>
-    FORCE_INLINE double NCDF(T_ z) {
-        return 0.5 * std::erfc(-z / 1.4142135623730951);
-    }
-
-    template <class T_, std::enable_if_t<!std::is_arithmetic_v<T_>, int> = 0>
-    FORCE_INLINE Number_ NPDF(const T_& z) {
-        Number_ arg = z;
-        return 0.3989422804014327 * exp(-0.5 * arg * arg);
-    }
-
-    template <class T_, std::enable_if_t<!std::is_arithmetic_v<T_>, int> = 0>
-    FORCE_INLINE Number_ NCDF(const T_& z) {
-        Number_ arg = -z / 1.4142135623730951;
-        return 0.5 * erfc(arg);
+    FORCE_INLINE Number_ NCDF(const Number_& z) {
+        return 0.5 * erfc(-z / 1.4142135623730951);
     }
 } // namespace Dal::AAD
 #elif defined(DAL_USE_XAD_AAD)

--- a/tests/math/aad/test_tape.cpp
+++ b/tests/math/aad/test_tape.cpp
@@ -1,0 +1,69 @@
+//
+// Created by wegam on 2026/5/2.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/math/aad/aad.hpp>
+
+using Dal::AAD::Number_;
+using Dal::AAD::Tape_;
+using Dal::AAD::Adjoint;
+
+TEST(AADTapeTest, TestPropagateToMark) {
+    auto* tape = Dal::AAD::Tape();
+    Clear(*tape);
+
+    Number_ x0 = 1.0;
+    Number_ x1 = 2.0;
+    Mark(*tape);
+
+    Number_ y = x0 * x1;
+    Adjoint(y) = 1.0;
+    PropagateToMark(*tape);
+
+    ASSERT_NEAR(Adjoint(x0), 2.0, 1e-10);
+    ASSERT_NEAR(Adjoint(x1), 1.0, 1e-10);
+
+    Clear(*tape);
+}
+
+TEST(AADTapeTest, TestMultipleMarkCycles) {
+    auto* tape = Dal::AAD::Tape();
+    Clear(*tape);
+
+    Number_ x0 = 1.0;
+    Mark(*tape);
+
+    {
+        Number_ y = x0 * 3.0;
+        Adjoint(y) = 1.0;
+        PropagateToMark(*tape);
+        ASSERT_NEAR(Adjoint(x0), 3.0, 1e-10);
+    }
+
+    RewindToMark(*tape);
+
+    {
+        Number_ y = x0 * 5.0;
+        Adjoint(y) = 1.0;
+        PropagateToMark(*tape);
+        ASSERT_NEAR(Adjoint(x0), 8.0, 1e-10);
+    }
+
+    Clear(*tape);
+}
+
+TEST(AADTapeTest, TestRepeatedClearAndRecord) {
+    auto* tape = Dal::AAD::Tape();
+
+    for (int i = 0; i < 3; ++i) {
+        Clear(*tape);
+        Number_ x = 1.0;
+        Mark(*tape);
+        Number_ y = x * 2.0;
+        Adjoint(y) = 1.0;
+        PropagateToMark(*tape);
+        ASSERT_NEAR(Adjoint(x), 2.0, 1e-10);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace SFINAE-dispatched NPDF/NCDF templates with direct Number_ overloads in the Adept backend path, reducing template complexity
- Add unit tests for the tape public API covering PropagateToMark, multiple mark/rewind cycles with adjoint accumulation, and repeated clear+record

## Test plan
- [x] `bin/test_suite --gtest_filter=AADTapeTest.*` — all 3 tests pass (Windows MSVC, Adept backend)
- [x] `bin/test_suite` — 460/462 pass (2 pre-existing AnalyticsTest failures unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)