### PR TITLE
refactor: rename CalibratedYieldCurve_ to CurveBlock_

### DIFF
--- a/.claude/methodology/aad.md
+++ b/.claude/methodology/aad.md
@@ -4,16 +4,16 @@ Documentation of the AAD framework in `dal/math/aad/`.
 
 ## File Map
 
-| File                         | Purpose                                                                                      |
-|------------------------------|----------------------------------------------------------------------------------------------|
-| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and backend-specific `Number_`            |
-| `dal/math/aad/tape.hpp`      | `Tape_` declaration for native `BlockList_`, XAD, CoDiPack, or Adept backends                |
-| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for native, XAD, CoDiPack, and Adept paths              |
-| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers                |
-| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the native tape             |
-| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`                           |
-| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_` in the native backend         |
-| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios                 |
+| File                         | Purpose                                                                               |
+|------------------------------|---------------------------------------------------------------------------------------|
+| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and backend-specific `Number_`     |
+| `dal/math/aad/tape.hpp`      | `Tape_` declaration for native `BlockList_`, XAD, CoDiPack, or Adept backends         |
+| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for native, XAD, CoDiPack, and Adept paths       |
+| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers        |
+| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the native tape      |
+| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`                    |
+| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_` in the native backend |
+| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios          |
 
 ## Design Overview
 
@@ -234,16 +234,16 @@ double dx2 = Adjoint(x2);  // ∂y/∂x₂
 
 The `DAL_USE_*_AAD` preprocessor branches in `expr.hpp` and `tape.hpp` provide interchangeable AAD backends behind identical free-function APIs:
 
-| Operation                     | Native Path                                            | XAD Path                                   | CoDiPack Path                    | Adept Path                       |
-|-------------------------------|--------------------------------------------------------|--------------------------------------------|----------------------------------|----------------------------------|
-| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            | `codi::RealReverseUnchecked`     | `adept::adouble`                 |
-| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            | `n.getValue()`                   | `adept::value(n)`                |
-| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       | `n.getGradient()`                | `n.get_gradient()`               |
-| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   | `tape_.registerInput(n)`         | No-op after active construction  |
-| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape | Returns CoDiPack's active tape   | Returns Adept thread-local tape  |
-| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          | `tape_.evaluate(position,start_)` | Reverses selected Adept range    |
-| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              | Saves/restores tape positions    | Saves/restores Adept positions   |
-| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   | Imported via `using codi::*`     | Imported via `using adept::*`    |
+| Operation                     | Native Path                                            | XAD Path                                   | CoDiPack Path                     | Adept Path                      |
+|-------------------------------|--------------------------------------------------------|--------------------------------------------|-----------------------------------|---------------------------------|
+| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            | `codi::RealReverseUnchecked`      | `adept::adouble`                |
+| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            | `n.getValue()`                    | `adept::value(n)`               |
+| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       | `n.getGradient()`                 | `n.get_gradient()`              |
+| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   | `tape_.registerInput(n)`          | No-op after active construction |
+| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape | Returns CoDiPack's active tape    | Returns Adept thread-local tape |
+| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          | `tape_.evaluate(position,start_)` | Reverses selected Adept range   |
+| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              | Saves/restores tape positions     | Saves/restores Adept positions  |
+| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   | Imported via `using codi::*`      | Imported via `using adept::*`   |
 
 The native path records operations eagerly during the forward pass — each expression assignment creates a tape node. External paths delegate operation recording to the selected backend, while DAL preserves the same free-function API and checkpoint-style propagation calls.
 

--- a/.claude/methodology/underdetermined_search.md
+++ b/.claude/methodology/underdetermined_search.md
@@ -19,11 +19,11 @@ This is the solver used by yield-curve calibration, but it is written as a gener
 | `dal/math/optimization/underdetermined.hpp`        | Core solver API declarations for `Find()` and `Approximate()`          |
 | `dal/math/optimization/underdetermined.cpp`        | Core solver implementation and Jacobian handling                       |
 | `dal/math/optimization/underdeterminedutils.hpp`   | Utility helpers for building smoothness weights such as `WeightsPWC()` |
-| `dal/curve/yccalibration.hpp`                      | Yield-curve calibration declarations using the underdetermined solver  |
-| `dal/curve/yccalibration.cpp`                      | Yield-curve calibration implementation using the solver                |
+| `dal/curve/curveblock.hpp`                      | Yield-curve calibration declarations using the underdetermined solver  |
+| `dal/curve/curveblock.cpp`                      | Yield-curve calibration implementation using the solver                |
 | `examples/underdetermined/underdetermined.cpp`     | End-to-end demonstration using curve calibration                       |
 | `tests/math/optimization/test_underdetermined.cpp` | Direct solver coverage                                                 |
-| `tests/curve/test_yccalibration.cpp`               | Integration coverage through yield-curve calibration                   |
+| `tests/curve/test_curveblock.cpp`               | Integration coverage through yield-curve calibration                   |
 
 ## Core API
 
@@ -296,7 +296,7 @@ This is useful when the unknowns represent values along time buckets or knot poi
 
 ## Curve Calibration Integration
 
-The solver is used directly in `dal/curve/yccalibration.cpp`.
+The solver is used directly in `dal/curve/curveblock.cpp`.
 
 ### Current Calibration Setup
 
@@ -307,7 +307,7 @@ The solver is used directly in `dal/curve/yccalibration.cpp`.
 - weights: a tridiagonal smoothing matrix built inline by `BuildSmoothingWeights()`
 - solve path: `Underdetermined::Find(...)`
 
-The calibration function in `dal/curve/yccalibration.cpp` builds a `PiecewiseLinear_` from the parameter vector, wraps it in `DiscountPWLF_` from `dal/curve/ycimp.cpp`, then reprices all instruments through `CalibratedYieldCurve_` declared in `dal/curve/yccalibration.hpp`.
+The calibration function in `dal/curve/curveblock.cpp` builds a `PiecewiseLinear_` from the parameter vector, wraps it in `DiscountPWLF_` from `dal/curve/ycimp.cpp`, then reprices all instruments through `CurveBlock_` declared in `dal/curve/curveblock.hpp`.
 
 ### High-Level Pipeline
 
@@ -332,7 +332,7 @@ class FittableCurve_ {
 };
 ```
 
-`DiscountPWLF_` in `dal/curve/ycimp.cpp` implements that interface, but the current `CalibrateYieldCurve()` path in `dal/curve/yccalibration.cpp` does not drive calibration through `FittableCurve_` directly. Instead it rebuilds a temporary `PiecewiseLinear_` from the candidate parameter vector inside the residual function.
+`DiscountPWLF_` in `dal/curve/ycimp.cpp` implements that interface, but the current `CalibrateYieldCurve()` path in `dal/curve/curveblock.cpp` does not drive calibration through `FittableCurve_` directly. Instead it rebuilds a temporary `PiecewiseLinear_` from the candidate parameter vector inside the residual function.
 
 ## Example and Tests
 
@@ -356,7 +356,7 @@ class FittableCurve_ {
 
 ### Integration Tests
 
-`tests/curve/test_yccalibration.cpp` checks successful repricing for:
+`tests/curve/test_curveblock.cpp` checks successful repricing for:
 
 - a flat curve
 - an upward-sloping curve
@@ -370,7 +370,7 @@ These points reflect the code as it exists today:
 1. `Find()` accepts `Matrix_<>* eff_j_inv`, but the current implementation does **not** populate it.
 2. `Approximate()` returns the last iterate if it runs out of evaluation budget without meeting `fit_tol`; it does not throw on non-convergence by default.
 3. `CalibrateYieldCurve()` currently builds its smoothing matrix inline instead of reusing `WeightsPWC()`.
-4. `CalibratedYieldCurve_` supports discounting for repricing, but `FwdLibor()` currently throws.
+4. `CurveBlock_` supports discounting for repricing, but `FwdLibor()` currently throws.
 5. The exact solver throws if it cannot find a descent direction and does not have a fresh-approximation path available:
    `REQUIRE(tookStep || approxJ, "Could not find a descent direction in underdetermined search")`.
 

--- a/.claude/methodology/underdetermined_search.md
+++ b/.claude/methodology/underdetermined_search.md
@@ -19,11 +19,11 @@ This is the solver used by yield-curve calibration, but it is written as a gener
 | `dal/math/optimization/underdetermined.hpp`        | Core solver API declarations for `Find()` and `Approximate()`          |
 | `dal/math/optimization/underdetermined.cpp`        | Core solver implementation and Jacobian handling                       |
 | `dal/math/optimization/underdeterminedutils.hpp`   | Utility helpers for building smoothness weights such as `WeightsPWC()` |
-| `dal/curve/curveblock.hpp`                      | Yield-curve calibration declarations using the underdetermined solver  |
-| `dal/curve/curveblock.cpp`                      | Yield-curve calibration implementation using the solver                |
+| `dal/curve/curveblock.hpp`                         | Yield-curve calibration declarations using the underdetermined solver  |
+| `dal/curve/curveblock.cpp`                         | Yield-curve calibration implementation using the solver                |
 | `examples/underdetermined/underdetermined.cpp`     | End-to-end demonstration using curve calibration                       |
 | `tests/math/optimization/test_underdetermined.cpp` | Direct solver coverage                                                 |
-| `tests/curve/test_curveblock.cpp`               | Integration coverage through yield-curve calibration                   |
+| `tests/curve/test_curveblock.cpp`                  | Integration coverage through yield-curve calibration                   |
 
 ## Core API
 

--- a/.claude/methodology/yield_curve.md
+++ b/.claude/methodology/yield_curve.md
@@ -19,16 +19,16 @@ Documentation of the yield curve framework in `dal/curve/`.
 
 ```
 Storable_
-└── YCComponent_                        (dependency tracking, Poll/Clone)
-    ├── DiscountCurve_                  (abstract: operator()(from, to) → df)
-    │   └── DiscountPWLF_              (piecewise-linear forwards → discount factors)
+└── YCComponent_                                   (dependency tracking, Poll/Clone)
+    ├── DiscountCurve_                             (abstract: operator()(from, to) → df)
+    │   └── DiscountPWLF_                          (piecewise-linear forwards → discount factors)
 
 Storable_
-└── YieldCurve_                        (currency, discount access, LIBOR forecast interface)
-    └── CurveBlock_          (lightweight wrapper around a calibrated discount curve)
+└── YieldCurve_                                    (currency, discount access, LIBOR forecast interface)
+    └── CurveBlock_                                (lightweight wrapper around a calibrated discount curve)
 
-CurveWithBase_<T_, B_>                  (template mixin: optional base curve + substitution)
-└── DiscountPWLF_                      (also inherits FittableCurve_ for calibration)
+CurveWithBase_<T_, B_>                             (template mixin: optional base curve + substitution)
+└── DiscountPWLF_                                  (also inherits FittableCurve_ for calibration)
 ```
 
 ## Core Abstractions

--- a/.claude/methodology/yield_curve.md
+++ b/.claude/methodology/yield_curve.md
@@ -11,7 +11,7 @@ Documentation of the yield curve framework in `dal/curve/`.
 | `dal/curve/discount.hpp`, `dal/curve/discount.cpp`                   | `DiscountCurve_` — abstract discount factor interface                                   |
 | `dal/curve/ycimp.hpp`, `dal/curve/ycimp.cpp`                         | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates       |
 | `dal/curve/fittable.hpp`                                             | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`)                      |
-| `dal/curve/yccalibration.hpp`, `dal/curve/yccalibration.cpp`         | `YCInstrument_`-based calibration, `CalibratedYieldCurve_`, and `CalibrateYieldCurve()` |
+| `dal/curve/curveblock.hpp`, `dal/curve/curveblock.cpp`         | `YCInstrument_`-based calibration, `CurveBlock_`, and `CalibrateYieldCurve()` |
 | `dal/curve/piecewiseconstant.hpp`, `dal/curve/piecewiseconstant.cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals          |
 | `dal/curve/piecewiselinear.hpp`, `dal/curve/piecewiselinear.cpp`     | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals    |
 
@@ -25,7 +25,7 @@ Storable_
 
 Storable_
 └── YieldCurve_                        (currency, discount access, LIBOR forecast interface)
-    └── CalibratedYieldCurve_          (lightweight wrapper around a calibrated discount curve)
+    └── CurveBlock_          (lightweight wrapper around a calibrated discount curve)
 
 CurveWithBase_<T_, B_>                  (template mixin: optional base curve + substitution)
 └── DiscountPWLF_                      (also inherits FittableCurve_ for calibration)
@@ -40,7 +40,7 @@ Top-level entry point. Holds a currency and provides the interface for:
 - `Discount(CollateralType_)` → returns the `DiscountCurve_` for a given collateral type
 - `FwdLibor(PeriodLength_, Date_)` → forward LIBOR rate for a given tenor and fixing date
 
-Note: the current `CalibratedYieldCurve_` implementation wraps a discount curve for calibration/pricing, but deliberately leaves `FwdLibor()` unsupported.
+Note: the current `CurveBlock_` implementation wraps a discount curve for calibration/pricing, but deliberately leaves `FwdLibor()` unsupported.
 
 ### DiscountCurve_
 
@@ -206,7 +206,7 @@ PiecewiseLinear_ of instantaneous forward rates
 DiscountPWLF_ (discount factors via integration)
         │  DF = exp(-∫f(t)dt / 365) × base_DF
         ▼
-CalibratedYieldCurve_ (wraps the calibrated discount curve; `FwdLibor()` is currently unsupported)
+CurveBlock_ (wraps the calibrated discount curve; `FwdLibor()` is currently unsupported)
 ```
 
 ## Underdetermined Search for Curve Calibration
@@ -334,7 +334,7 @@ where `jWeight = ||func_tol||² / fit_tol²`. This balances fitting accuracy aga
 
 ### Integration with Curve Building
 
-The solver connects to `DiscountPWLF_` through the `FittableCurve_` interface. In the current `CalibrateYieldCurve()` implementation, `yccalibration.cpp` builds a simple tridiagonal smoothing matrix directly and solves for the `2K` left/right forward parameters.
+The solver connects to `DiscountPWLF_` through the `FittableCurve_` interface. In the current `CalibrateYieldCurve()` implementation, `curveblock.cpp` builds a simple tridiagonal smoothing matrix directly and solves for the `2K` left/right forward parameters.
 
 ```cpp
 class FittableCurve_ {

--- a/.claude/methodology/yield_curve.md
+++ b/.claude/methodology/yield_curve.md
@@ -11,7 +11,7 @@ Documentation of the yield curve framework in `dal/curve/`.
 | `dal/curve/discount.hpp`, `dal/curve/discount.cpp`                   | `DiscountCurve_` — abstract discount factor interface                                   |
 | `dal/curve/ycimp.hpp`, `dal/curve/ycimp.cpp`                         | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates       |
 | `dal/curve/fittable.hpp`                                             | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`)                      |
-| `dal/curve/curveblock.hpp`, `dal/curve/curveblock.cpp`         | `YCInstrument_`-based calibration, `CurveBlock_`, and `CalibrateYieldCurve()` |
+| `dal/curve/curveblock.hpp`, `dal/curve/curveblock.cpp`               | `YCInstrument_`-based calibration, `CurveBlock_`, and `CalibrateYieldCurve()`           |
 | `dal/curve/piecewiseconstant.hpp`, `dal/curve/piecewiseconstant.cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals          |
 | `dal/curve/piecewiselinear.hpp`, `dal/curve/piecewiselinear.cpp`     | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals    |
 

--- a/.claude/skills/dal-code-style-review/SKILL.md
+++ b/.claude/skills/dal-code-style-review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: dal-code-style-review
-description: Review changed C++ code for compliance with this project's coding and unit test style. Use when the user asks to review code style, check style compliance, lint code, verify naming conventions, review changed files for project conventions, or says "review my changes", "check the style", "does this follow our conventions", or similar.
+description: Review changed C++ code and DAL markdown guidance for compliance with this project's coding, unit test, and documentation style. Use when the user asks to review code style, check style compliance, lint code, verify naming conventions, review changed files for project conventions, check .claude/.codex markdown guidance, or says "review my changes", "check the style", "does this follow our conventions", or similar.
 user-invocable: true
 ---
 
 # Code Style Review
 
-Review all changed files in the working tree against the project's coding conventions defined in `.claude/rules/code-style.md` and `.claude/rules/unit-test-style.md`.
+Review all changed C++ files and changed markdown guidance under `.claude/` and `.codex/` in the working tree against the project's conventions defined in `.claude/rules/code-style.md` and `.claude/rules/unit-test-style.md`.
 
 ## Steps
 
@@ -23,7 +23,7 @@ Review all changed files in the working tree against the project's coding conven
    git diff --name-only HEAD~1
    ```
 
-3. Read each changed `.hpp`, `.cpp` file and check for violations against the rules below.
+3. Read each changed `.hpp`, `.cpp` file and each changed `.md` file under `.claude/` or `.codex/`, then check for violations against the rules below.
 
 4. If the code changes affect documented behavior, workflows, architecture notes, or methodology, also check whether the related markdown files under `.claude/` and `.codex/` were updated consistently.
 
@@ -65,6 +65,12 @@ Review all changed files in the working tree against the project's coding conven
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
 - Namespace closing braces must have a comment: `} // namespace Dal`
+
+### Markdown Guidance Files
+- Review changed `.md` files under `.claude/` and `.codex/` as part of every code style review.
+- If a changed guidance file has a mirrored counterpart in the other tree, verify the counterpart is updated consistently. Path references may differ intentionally between `.claude` and `.codex`.
+- Check markdown tables against `.claude/rules/code-style.md`: aligned pipe columns, compact separator rows, and project-relative C++ file paths in table cells.
+- Check that guidance changes remain internally consistent with current source, build/test commands, APIs, architecture notes, and methodology.
 
 ### Documentation Sync
 - If code changes alter documented behavior, APIs, build/test workflow, architecture notes, or methodology, check that the corresponding markdown guidance under `.claude/` and `.codex/` is updated to stay consistent.

--- a/.claude/skills/dal-code-style-review/SKILL.md
+++ b/.claude/skills/dal-code-style-review/SKILL.md
@@ -70,6 +70,7 @@ Review all changed C++ files and changed markdown guidance under `.claude/` and 
 - Review changed `.md` files under `.claude/` and `.codex/` as part of every code style review.
 - If a changed guidance file has a mirrored counterpart in the other tree, verify the counterpart is updated consistently. Path references may differ intentionally between `.claude` and `.codex`.
 - Check markdown tables against `.claude/rules/code-style.md`: aligned pipe columns, compact separator rows, and project-relative C++ file paths in table cells.
+- Check that code block diagrams (class hierarchies, pipelines) have trailing comments aligned to a consistent column.
 - Check that guidance changes remain internally consistent with current source, build/test commands, APIs, architecture notes, and methodology.
 
 ### Documentation Sync

--- a/.codex/designs/adept-aad-backend.md
+++ b/.codex/designs/adept-aad-backend.md
@@ -4,19 +4,19 @@
 Add Adept as a third external AAD backend behind the existing `Dal::AAD` free-function API. The rest of DAL should continue to use `AAD::Number_`, `Tape()`, `PutOnTape`, `Adjoint`, `Value`, and propagation helpers without backend-specific code.
 
 ## Affected Files
-| File                         | Action | Purpose                                      |
-|------------------------------|--------|----------------------------------------------|
-| `CMakeLists.txt`             | Modify | Add `DAL_USE_ADEPT_AAD` selection             |
-| `dal/CMakeLists.txt`         | Modify | Link `dal_library` to `adept` when selected   |
-| `public/src/CMakeLists.txt`  | Modify | Link public/static fold build to `adept`      |
-| `tests/CMakeLists.txt`       | Modify | Link `test_suite` to `adept`                  |
-| `examples/*/CMakeLists.txt`  | Modify | Link examples to `adept`                      |
-| `dal/math/aad/tape.hpp`      | Modify | Add Adept tape wrapper                        |
-| `dal/math/aad/tape.cpp`      | Modify | Add Adept clear/mark/rewind/propagation       |
-| `dal/math/aad/expr.hpp`      | Modify | Add Adept `Number_` alias and math API        |
-| `dal/math/aad/aad.hpp`       | Modify | Treat Adept as external backend               |
-| `dal/platform/initall.cpp`   | Modify | Report Adept backend                          |
-| `examples/aad/aad.cpp`       | Modify | Report Adept in example output                |
+| File                        | Action | Purpose                                     |
+|-----------------------------|--------|---------------------------------------------|
+| `CMakeLists.txt`            | Modify | Add `DAL_USE_ADEPT_AAD` selection           |
+| `dal/CMakeLists.txt`        | Modify | Link `dal_library` to `adept` when selected |
+| `public/src/CMakeLists.txt` | Modify | Link public/static fold build to `adept`    |
+| `tests/CMakeLists.txt`      | Modify | Link `test_suite` to `adept`                |
+| `examples/*/CMakeLists.txt` | Modify | Link examples to `adept`                    |
+| `dal/math/aad/tape.hpp`     | Modify | Add Adept tape wrapper                      |
+| `dal/math/aad/tape.cpp`     | Modify | Add Adept clear/mark/rewind/propagation     |
+| `dal/math/aad/expr.hpp`     | Modify | Add Adept `Number_` alias and math API      |
+| `dal/math/aad/aad.hpp`      | Modify | Treat Adept as external backend             |
+| `dal/platform/initall.cpp`  | Modify | Report Adept backend                        |
+| `examples/aad/aad.cpp`      | Modify | Report Adept in example output              |
 
 ## Design Decisions
 - **Decision:** Use `using Number_ = adept::adouble` directly.

--- a/.codex/methodology/aad.md
+++ b/.codex/methodology/aad.md
@@ -4,16 +4,16 @@ Documentation of the AAD framework in `dal/math/aad/`.
 
 ## File Map
 
-| File                         | Purpose                                                                                      |
-|------------------------------|----------------------------------------------------------------------------------------------|
-| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and backend-specific `Number_`            |
-| `dal/math/aad/tape.hpp`      | `Tape_` declaration for native `BlockList_`, XAD, CoDiPack, or Adept backends                |
-| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for native, XAD, CoDiPack, and Adept paths              |
-| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers                |
-| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the native tape             |
-| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`                           |
-| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_` in the native backend         |
-| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios                 |
+| File                         | Purpose                                                                               |
+|------------------------------|---------------------------------------------------------------------------------------|
+| `dal/math/aad/expr.hpp`      | Expression template hierarchy, operator overloads, and backend-specific `Number_`     |
+| `dal/math/aad/tape.hpp`      | `Tape_` declaration for native `BlockList_`, XAD, CoDiPack, or Adept backends         |
+| `dal/math/aad/tape.cpp`      | Propagation, mark, rewind, and clear for native, XAD, CoDiPack, and Adept paths       |
+| `dal/math/aad/node.hpp`      | `TapNode_` — per-operation node storing local derivatives and adjoint pointers        |
+| `dal/math/aad/blocklist.hpp` | `BlockList_<T_, BLOCK_SIZE>` — segmented arena allocator backing the native tape      |
+| `dal/math/aad/aad.hpp`       | Multi-result support (`SetNumResultsForAAD`), `PutOnTape`, `Clear`                    |
+| `dal/math/aad/aad.cpp`       | Static initializers for `TapNode_::numAdj_` and `Tape_::multi_` in the native backend |
+| `dal/math/aad/sample.hpp`    | `Sample_<T_>` and `Scenario_<T_>` — container for AAD-aware market scenarios          |
 
 ## Design Overview
 
@@ -234,16 +234,16 @@ double dx2 = Adjoint(x2);  // ∂y/∂x₂
 
 The `DAL_USE_*_AAD` preprocessor branches in `expr.hpp` and `tape.hpp` provide interchangeable AAD backends behind identical free-function APIs:
 
-| Operation                     | Native Path                                            | XAD Path                                   | CoDiPack Path                    | Adept Path                       |
-|-------------------------------|--------------------------------------------------------|--------------------------------------------|----------------------------------|----------------------------------|
-| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            | `codi::RealReverseUnchecked`     | `adept::adouble`                 |
-| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            | `n.getValue()`                   | `adept::value(n)`                |
-| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       | `n.getGradient()`                | `n.get_gradient()`               |
-| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   | `tape_.registerInput(n)`         | No-op after active construction  |
-| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape | Returns CoDiPack's active tape   | Returns Adept thread-local tape  |
-| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          | `tape_.evaluate(position,start_)` | Reverses selected Adept range    |
-| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              | Saves/restores tape positions    | Saves/restores Adept positions   |
-| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   | Imported via `using codi::*`     | Imported via `using adept::*`    |
+| Operation                     | Native Path                                            | XAD Path                                   | CoDiPack Path                     | Adept Path                      |
+|-------------------------------|--------------------------------------------------------|--------------------------------------------|-----------------------------------|---------------------------------|
+| `Number_`                     | Custom expression-template type                        | `xad::adj<double>::active_type`            | `codi::RealReverseUnchecked`      | `adept::adouble`                |
+| `Value(n)`                    | Returns `n.value_`                                     | `xad::value(n)`                            | `n.getValue()`                    | `adept::value(n)`               |
+| `Adjoint(n)`                  | Returns `n.node_->Adjoint()`                           | `xad::derivative(n)`                       | `n.getGradient()`                 | `n.get_gradient()`              |
+| `PutOnTape(n)`                | Creates zero-arg node                                  | `tape_.registerInput(n)`                   | `tape_.registerInput(n)`          | No-op after active construction |
+| `Tape()`                      | Returns `thread_local Tape_` with `BlockList_` storage | Returns `thread_local Tape_` with XAD tape | Returns CoDiPack's active tape    | Returns Adept thread-local tape |
+| `PropagateToStart(t)`         | Walks native tape backward                             | `tape_.computeAdjointsTo(start_)`          | `tape_.evaluate(position,start_)` | Reverses selected Adept range   |
+| `Mark(t)` / `RewindToMark(t)` | Saves/restores `BlockList_` cursor positions           | Saves/restores tape positions              | Saves/restores tape positions     | Saves/restores Adept positions  |
+| Operator overloads            | Return `BinaryExpression_`/`UnaryExpression_`          | Imported via `using xad::operator*` etc.   | Imported via `using codi::*`      | Imported via `using adept::*`   |
 
 The native path records operations eagerly during the forward pass — each expression assignment creates a tape node. External paths delegate operation recording to the selected backend, while DAL preserves the same free-function API and checkpoint-style propagation calls.
 

--- a/.codex/methodology/underdetermined_search.md
+++ b/.codex/methodology/underdetermined_search.md
@@ -19,11 +19,11 @@ This is the solver used by yield-curve calibration, but it is written as a gener
 | `dal/math/optimization/underdetermined.hpp`        | Core solver API declarations for `Find()` and `Approximate()`          |
 | `dal/math/optimization/underdetermined.cpp`        | Core solver implementation and Jacobian handling                       |
 | `dal/math/optimization/underdeterminedutils.hpp`   | Utility helpers for building smoothness weights such as `WeightsPWC()` |
-| `dal/curve/yccalibration.hpp`                      | Yield-curve calibration declarations using the underdetermined solver  |
-| `dal/curve/yccalibration.cpp`                      | Yield-curve calibration implementation using the solver                |
+| `dal/curve/curveblock.hpp`                      | Yield-curve calibration declarations using the underdetermined solver  |
+| `dal/curve/curveblock.cpp`                      | Yield-curve calibration implementation using the solver                |
 | `examples/underdetermined/underdetermined.cpp`     | End-to-end demonstration using curve calibration                       |
 | `tests/math/optimization/test_underdetermined.cpp` | Direct solver coverage                                                 |
-| `tests/curve/test_yccalibration.cpp`               | Integration coverage through yield-curve calibration                   |
+| `tests/curve/test_curveblock.cpp`               | Integration coverage through yield-curve calibration                   |
 
 ## Core API
 
@@ -296,7 +296,7 @@ This is useful when the unknowns represent values along time buckets or knot poi
 
 ## Curve Calibration Integration
 
-The solver is used directly in `dal/curve/yccalibration.cpp`.
+The solver is used directly in `dal/curve/curveblock.cpp`.
 
 ### Current Calibration Setup
 
@@ -307,7 +307,7 @@ The solver is used directly in `dal/curve/yccalibration.cpp`.
 - weights: a tridiagonal smoothing matrix built inline by `BuildSmoothingWeights()`
 - solve path: `Underdetermined::Find(...)`
 
-The calibration function in `dal/curve/yccalibration.cpp` builds a `PiecewiseLinear_` from the parameter vector, wraps it in `DiscountPWLF_` from `dal/curve/ycimp.cpp`, then reprices all instruments through `CalibratedYieldCurve_` declared in `dal/curve/yccalibration.hpp`.
+The calibration function in `dal/curve/curveblock.cpp` builds a `PiecewiseLinear_` from the parameter vector, wraps it in `DiscountPWLF_` from `dal/curve/ycimp.cpp`, then reprices all instruments through `CurveBlock_` declared in `dal/curve/curveblock.hpp`.
 
 ### High-Level Pipeline
 
@@ -332,7 +332,7 @@ class FittableCurve_ {
 };
 ```
 
-`DiscountPWLF_` in `dal/curve/ycimp.cpp` implements that interface, but the current `CalibrateYieldCurve()` path in `dal/curve/yccalibration.cpp` does not drive calibration through `FittableCurve_` directly. Instead it rebuilds a temporary `PiecewiseLinear_` from the candidate parameter vector inside the residual function.
+`DiscountPWLF_` in `dal/curve/ycimp.cpp` implements that interface, but the current `CalibrateYieldCurve()` path in `dal/curve/curveblock.cpp` does not drive calibration through `FittableCurve_` directly. Instead it rebuilds a temporary `PiecewiseLinear_` from the candidate parameter vector inside the residual function.
 
 ## Example and Tests
 
@@ -356,7 +356,7 @@ class FittableCurve_ {
 
 ### Integration Tests
 
-`tests/curve/test_yccalibration.cpp` checks successful repricing for:
+`tests/curve/test_curveblock.cpp` checks successful repricing for:
 
 - a flat curve
 - an upward-sloping curve
@@ -370,7 +370,7 @@ These points reflect the code as it exists today:
 1. `Find()` accepts `Matrix_<>* eff_j_inv`, but the current implementation does **not** populate it.
 2. `Approximate()` returns the last iterate if it runs out of evaluation budget without meeting `fit_tol`; it does not throw on non-convergence by default.
 3. `CalibrateYieldCurve()` currently builds its smoothing matrix inline instead of reusing `WeightsPWC()`.
-4. `CalibratedYieldCurve_` supports discounting for repricing, but `FwdLibor()` currently throws.
+4. `CurveBlock_` supports discounting for repricing, but `FwdLibor()` currently throws.
 5. The exact solver throws if it cannot find a descent direction and does not have a fresh-approximation path available:
    `REQUIRE(tookStep || approxJ, "Could not find a descent direction in underdetermined search")`.
 

--- a/.codex/methodology/underdetermined_search.md
+++ b/.codex/methodology/underdetermined_search.md
@@ -19,11 +19,11 @@ This is the solver used by yield-curve calibration, but it is written as a gener
 | `dal/math/optimization/underdetermined.hpp`        | Core solver API declarations for `Find()` and `Approximate()`          |
 | `dal/math/optimization/underdetermined.cpp`        | Core solver implementation and Jacobian handling                       |
 | `dal/math/optimization/underdeterminedutils.hpp`   | Utility helpers for building smoothness weights such as `WeightsPWC()` |
-| `dal/curve/curveblock.hpp`                      | Yield-curve calibration declarations using the underdetermined solver  |
-| `dal/curve/curveblock.cpp`                      | Yield-curve calibration implementation using the solver                |
+| `dal/curve/curveblock.hpp`                         | Yield-curve calibration declarations using the underdetermined solver  |
+| `dal/curve/curveblock.cpp`                         | Yield-curve calibration implementation using the solver                |
 | `examples/underdetermined/underdetermined.cpp`     | End-to-end demonstration using curve calibration                       |
 | `tests/math/optimization/test_underdetermined.cpp` | Direct solver coverage                                                 |
-| `tests/curve/test_curveblock.cpp`               | Integration coverage through yield-curve calibration                   |
+| `tests/curve/test_curveblock.cpp`                  | Integration coverage through yield-curve calibration                   |
 
 ## Core API
 

--- a/.codex/methodology/yield_curve.md
+++ b/.codex/methodology/yield_curve.md
@@ -19,16 +19,16 @@ Documentation of the yield curve framework in `dal/curve/`.
 
 ```
 Storable_
-└── YCComponent_                        (dependency tracking, Poll/Clone)
-    ├── DiscountCurve_                  (abstract: operator()(from, to) → df)
-    │   └── DiscountPWLF_              (piecewise-linear forwards → discount factors)
+└── YCComponent_                                   (dependency tracking, Poll/Clone)
+    ├── DiscountCurve_                             (abstract: operator()(from, to) → df)
+    │   └── DiscountPWLF_                          (piecewise-linear forwards → discount factors)
 
 Storable_
-└── YieldCurve_                        (currency, discount access, LIBOR forecast interface)
-    └── CurveBlock_          (lightweight wrapper around a calibrated discount curve)
+└── YieldCurve_                                    (currency, discount access, LIBOR forecast interface)
+    └── CurveBlock_                                (lightweight wrapper around a calibrated discount curve)
 
-CurveWithBase_<T_, B_>                  (template mixin: optional base curve + substitution)
-└── DiscountPWLF_                      (also inherits FittableCurve_ for calibration)
+CurveWithBase_<T_, B_>                             (template mixin: optional base curve + substitution)
+└── DiscountPWLF_                                  (also inherits FittableCurve_ for calibration)
 ```
 
 ## Core Abstractions

--- a/.codex/methodology/yield_curve.md
+++ b/.codex/methodology/yield_curve.md
@@ -11,7 +11,7 @@ Documentation of the yield curve framework in `dal/curve/`.
 | `dal/curve/discount.hpp`, `dal/curve/discount.cpp`                   | `DiscountCurve_` — abstract discount factor interface                                   |
 | `dal/curve/ycimp.hpp`, `dal/curve/ycimp.cpp`                         | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates       |
 | `dal/curve/fittable.hpp`                                             | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`)                      |
-| `dal/curve/yccalibration.hpp`, `dal/curve/yccalibration.cpp`         | `YCInstrument_`-based calibration, `CalibratedYieldCurve_`, and `CalibrateYieldCurve()` |
+| `dal/curve/curveblock.hpp`, `dal/curve/curveblock.cpp`         | `YCInstrument_`-based calibration, `CurveBlock_`, and `CalibrateYieldCurve()` |
 | `dal/curve/piecewiseconstant.hpp`, `dal/curve/piecewiseconstant.cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals          |
 | `dal/curve/piecewiselinear.hpp`, `dal/curve/piecewiselinear.cpp`     | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals    |
 
@@ -25,7 +25,7 @@ Storable_
 
 Storable_
 └── YieldCurve_                        (currency, discount access, LIBOR forecast interface)
-    └── CalibratedYieldCurve_          (lightweight wrapper around a calibrated discount curve)
+    └── CurveBlock_          (lightweight wrapper around a calibrated discount curve)
 
 CurveWithBase_<T_, B_>                  (template mixin: optional base curve + substitution)
 └── DiscountPWLF_                      (also inherits FittableCurve_ for calibration)
@@ -40,7 +40,7 @@ Top-level entry point. Holds a currency and provides the interface for:
 - `Discount(CollateralType_)` → returns the `DiscountCurve_` for a given collateral type
 - `FwdLibor(PeriodLength_, Date_)` → forward LIBOR rate for a given tenor and fixing date
 
-Note: the current `CalibratedYieldCurve_` implementation wraps a discount curve for calibration/pricing, but deliberately leaves `FwdLibor()` unsupported.
+Note: the current `CurveBlock_` implementation wraps a discount curve for calibration/pricing, but deliberately leaves `FwdLibor()` unsupported.
 
 ### DiscountCurve_
 
@@ -206,7 +206,7 @@ PiecewiseLinear_ of instantaneous forward rates
 DiscountPWLF_ (discount factors via integration)
         │  DF = exp(-∫f(t)dt / 365) × base_DF
         ▼
-CalibratedYieldCurve_ (wraps the calibrated discount curve; `FwdLibor()` is currently unsupported)
+CurveBlock_ (wraps the calibrated discount curve; `FwdLibor()` is currently unsupported)
 ```
 
 ## Underdetermined Search for Curve Calibration
@@ -334,7 +334,7 @@ where `jWeight = ||func_tol||² / fit_tol²`. This balances fitting accuracy aga
 
 ### Integration with Curve Building
 
-The solver connects to `DiscountPWLF_` through the `FittableCurve_` interface. In the current `CalibrateYieldCurve()` implementation, `yccalibration.cpp` builds a simple tridiagonal smoothing matrix directly and solves for the `2K` left/right forward parameters.
+The solver connects to `DiscountPWLF_` through the `FittableCurve_` interface. In the current `CalibrateYieldCurve()` implementation, `curveblock.cpp` builds a simple tridiagonal smoothing matrix directly and solves for the `2K` left/right forward parameters.
 
 ```cpp
 class FittableCurve_ {

--- a/.codex/methodology/yield_curve.md
+++ b/.codex/methodology/yield_curve.md
@@ -11,7 +11,7 @@ Documentation of the yield curve framework in `dal/curve/`.
 | `dal/curve/discount.hpp`, `dal/curve/discount.cpp`                   | `DiscountCurve_` — abstract discount factor interface                                   |
 | `dal/curve/ycimp.hpp`, `dal/curve/ycimp.cpp`                         | `DiscountPWLF_` — concrete discount curve built on piecewise-linear forward rates       |
 | `dal/curve/fittable.hpp`                                             | `FittableCurve_` — interface for calibration (`NX()`, `ApplyDX()`)                      |
-| `dal/curve/curveblock.hpp`, `dal/curve/curveblock.cpp`         | `YCInstrument_`-based calibration, `CurveBlock_`, and `CalibrateYieldCurve()` |
+| `dal/curve/curveblock.hpp`, `dal/curve/curveblock.cpp`               | `YCInstrument_`-based calibration, `CurveBlock_`, and `CalibrateYieldCurve()`           |
 | `dal/curve/piecewiseconstant.hpp`, `dal/curve/piecewiseconstant.cpp` | `PiecewiseConstant_` — step-function representation with precomputed integrals          |
 | `dal/curve/piecewiselinear.hpp`, `dal/curve/piecewiselinear.cpp`     | `PiecewiseLinear_` — continuous piecewise-linear function with precomputed integrals    |
 

--- a/.codex/skills/dal-code-style-review/SKILL.md
+++ b/.codex/skills/dal-code-style-review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: dal-code-style-review
-description: Review changed C++ code for compliance with this project's coding and unit test style. Use when the user asks to review code style, check style compliance, lint code, verify naming conventions, review changed files for project conventions, or says "review my changes", "check the style", "does this follow our conventions", or similar.
+description: Review changed C++ code and DAL markdown guidance for compliance with this project's coding, unit test, and documentation style. Use when the user asks to review code style, check style compliance, lint code, verify naming conventions, review changed files for project conventions, check .claude/.codex markdown guidance, or says "review my changes", "check the style", "does this follow our conventions", or similar.
 user-invocable: true
 ---
 
 # Code Style Review
 
-Review all changed files in the working tree against the project's coding conventions defined in `.codex/rules/code-style.md` and `.codex/rules/unit-test-style.md`.
+Review all changed C++ files and changed markdown guidance under `.claude/` and `.codex/` in the working tree against the project's conventions defined in `.codex/rules/code-style.md` and `.codex/rules/unit-test-style.md`.
 
 ## Steps
 
@@ -23,7 +23,7 @@ Review all changed files in the working tree against the project's coding conven
    git diff --name-only HEAD~1
    ```
 
-3. Read each changed `.hpp`, `.cpp` file and check for violations against the rules below.
+3. Read each changed `.hpp`, `.cpp` file and each changed `.md` file under `.claude/` or `.codex/`, then check for violations against the rules below.
 
 4. If the code changes affect documented behavior, workflows, architecture notes, or methodology, also check whether the related markdown files under `.claude/` and `.codex/` were updated consistently.
 
@@ -65,6 +65,12 @@ Review all changed files in the working tree against the project's coding conven
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
 - Namespace closing braces must have a comment: `} // namespace Dal`
+
+### Markdown Guidance Files
+- Review changed `.md` files under `.claude/` and `.codex/` as part of every code style review.
+- If a changed guidance file has a mirrored counterpart in the other tree, verify the counterpart is updated consistently. Path references may differ intentionally between `.claude` and `.codex`.
+- Check markdown tables against `.codex/rules/code-style.md`: aligned pipe columns, compact separator rows, and project-relative C++ file paths in table cells.
+- Check that guidance changes remain internally consistent with current source, build/test commands, APIs, architecture notes, and methodology.
 
 ### Documentation Sync
 - If code changes alter documented behavior, APIs, build/test workflow, architecture notes, or methodology, check that the corresponding markdown guidance under `.claude/` and `.codex/` is updated to stay consistent.

--- a/.codex/skills/dal-code-style-review/SKILL.md
+++ b/.codex/skills/dal-code-style-review/SKILL.md
@@ -70,6 +70,7 @@ Review all changed C++ files and changed markdown guidance under `.claude/` and 
 - Review changed `.md` files under `.claude/` and `.codex/` as part of every code style review.
 - If a changed guidance file has a mirrored counterpart in the other tree, verify the counterpart is updated consistently. Path references may differ intentionally between `.claude` and `.codex`.
 - Check markdown tables against `.codex/rules/code-style.md`: aligned pipe columns, compact separator rows, and project-relative C++ file paths in table cells.
+- Check that code block diagrams (class hierarchies, pipelines) have trailing comments aligned to a consistent column.
 - Check that guidance changes remain internally consistent with current source, build/test commands, APIs, architecture notes, and methodology.
 
 ### Documentation Sync

--- a/dal/curve/curveblock.cpp
+++ b/dal/curve/curveblock.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
-#include <dal/curve/yccalibration.hpp>
+#include <dal/curve/curveblock.hpp>
 #include <dal/curve/yc.hpp>
 #include <dal/curve/piecewiselinear.hpp>
 #include <dal/curve/ycimp.hpp>
@@ -16,20 +16,20 @@
 #include <dal/utilities/dictionary.hpp>
 
 namespace Dal {
-    // CalibratedYieldCurve_
+    // CurveBlock_
 
-    CalibratedYieldCurve_::CalibratedYieldCurve_(const DiscountCurve_& dc)
+    CurveBlock_::CurveBlock_(const DiscountCurve_& dc)
         : YieldCurve_(dc.name_, dc.ccy_.String()), dc_(dc) {}
 
-    const DiscountCurve_& CalibratedYieldCurve_::Discount(const CollateralType_&) const { return dc_; }
+    const DiscountCurve_& CurveBlock_::Discount(const CollateralType_&) const { return dc_; }
 
-    double CalibratedYieldCurve_::FwdLibor(const PeriodLength_&, const Date_&) const {
-        REQUIRE(false, "CalibratedYieldCurve_ does not support FwdLibor");
+    double CurveBlock_::FwdLibor(const PeriodLength_&, const Date_&) const {
+        REQUIRE(false, "CurveBlock_ does not support FwdLibor");
         return 0.0;
     }
 
-    void CalibratedYieldCurve_::Write(Archive::Store_&) const {
-        REQUIRE(false, "CalibratedYieldCurve_ is not serializable");
+    void CurveBlock_::Write(Archive::Store_&) const {
+        REQUIRE(false, "CurveBlock_ is not serializable");
     }
 
     // Calibration
@@ -79,7 +79,7 @@ namespace Dal {
 
                 PiecewiseLinear_ pwl(knotDates_, fLeft, fRight);
                 std::unique_ptr<DiscountCurve_> dc(NewDiscountPWLF(String_("calib"), ccy_.String(), pwl));
-                CalibratedYieldCurve_ yc(*dc);
+                CurveBlock_ yc(*dc);
 
                 const int nInst = static_cast<int>(instruments_.size());
                 Vector_<> result(nInst);

--- a/dal/curve/curveblock.hpp
+++ b/dal/curve/curveblock.hpp
@@ -14,10 +14,10 @@
 
 namespace Dal {
 
-    class CalibratedYieldCurve_ : public YieldCurve_ {
+    class CurveBlock_ : public YieldCurve_ {
         const DiscountCurve_& dc_;
     public:
-        explicit CalibratedYieldCurve_(const DiscountCurve_& dc);
+        explicit CurveBlock_(const DiscountCurve_& dc);
         [[nodiscard]] const DiscountCurve_& Discount(const CollateralType_& collateral) const override;
         [[nodiscard]] double FwdLibor(const PeriodLength_& tenor, const Date_& fixing_date) const override;
         void Write(Archive::Store_& dst) const override;

--- a/examples/underdetermined/underdetermined.cpp
+++ b/examples/underdetermined/underdetermined.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <memory>
 #include <dal/platform/platform.hpp>
-#include <dal/curve/yccalibration.hpp>
+#include <dal/curve/curveblock.hpp>
 
 using namespace Dal;
 
@@ -55,7 +55,7 @@ int main() {
     std::cout << std::fixed << std::setprecision(6);
     std::cout << std::setw(12) << "Instrument" << std::setw(10) << "Market" << std::setw(12) << "Model" << std::setw(12) << "Error(bp)\n";
 
-    CalibratedYieldCurve_ calibYC(*dc);
+    CurveBlock_ calibYC(*dc);
     for (int i = 0; i < nInstruments; ++i) {
         Handle_<YCInstrument_::Rate_> rate = instruments[i]->Precompute(instruments[i], Handle_<YieldCurve_>());
         double modelRate = (*rate)(calibYC);

--- a/tests/curve/test_curveblock.cpp
+++ b/tests/curve/test_curveblock.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <memory>
 #include <dal/platform/platform.hpp>
-#include <dal/curve/yccalibration.hpp>
+#include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiselinear.hpp>
 #include <dal/curve/ycimp.hpp>
 
@@ -22,7 +22,7 @@ namespace {
     }
 } // namespace
 
-TEST(YieldCurveCalibrationTest, TestFlatCurveCalibration) {
+TEST(CurveBlockTest, TestFlatCurveCalibration) {
     const Date_ today(2024, 1, 15);
     const DayBasis_ basis("ACT_365F");
     const String_ ccy = "USD";
@@ -44,7 +44,7 @@ TEST(YieldCurveCalibrationTest, TestFlatCurveCalibration) {
     AssertQuotesFarFromInitialGuess(instruments);
 
     std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
-    CalibratedYieldCurve_ yc(*dc);
+    CurveBlock_ yc(*dc);
 
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
@@ -53,7 +53,7 @@ TEST(YieldCurveCalibrationTest, TestFlatCurveCalibration) {
     }
 }
 
-TEST(YieldCurveCalibrationTest, TestUpwardSlopingCurve) {
+TEST(CurveBlockTest, TestUpwardSlopingCurve) {
     const Date_ today(2024, 1, 15);
     const String_ ccy = "USD";
     const DayBasis_ basis("ACT_365F");
@@ -82,7 +82,7 @@ TEST(YieldCurveCalibrationTest, TestUpwardSlopingCurve) {
     AssertQuotesFarFromInitialGuess(instruments);
 
     std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
-    CalibratedYieldCurve_ yc(*dc);
+    CurveBlock_ yc(*dc);
 
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
@@ -91,7 +91,7 @@ TEST(YieldCurveCalibrationTest, TestUpwardSlopingCurve) {
     }
 }
 
-TEST(YieldCurveCalibrationTest, TestRoundTrip) {
+TEST(CurveBlockTest, TestRoundTrip) {
     const Date_ today(2024, 1, 15);
     const String_ ccy = "USD";
     const DayBasis_ basis("ACT_365F");
@@ -122,7 +122,7 @@ TEST(YieldCurveCalibrationTest, TestRoundTrip) {
     AssertQuotesFarFromInitialGuess(instruments);
 
     std::unique_ptr<DiscountCurve_> calibDc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
-    CalibratedYieldCurve_ yc(*calibDc);
+    CurveBlock_ yc(*calibDc);
 
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
@@ -131,7 +131,7 @@ TEST(YieldCurveCalibrationTest, TestRoundTrip) {
     }
 }
 
-TEST(YieldCurveCalibrationTest, TestCalibrationWithSTIR) {
+TEST(CurveBlockTest, TestCalibrationWithSTIR) {
     const Date_ today(2024, 1, 15);
     const String_ ccy = "USD";
     const DayBasis_ basis("ACT_365F");
@@ -155,7 +155,7 @@ TEST(YieldCurveCalibrationTest, TestCalibrationWithSTIR) {
     AssertQuotesFarFromInitialGuess(instruments);
 
     std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
-    CalibratedYieldCurve_ yc(*dc);
+    CurveBlock_ yc(*dc);
 
     for (const auto& inst : instruments) {
         Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());


### PR DESCRIPTION
## Summary
- Rename class CalibratedYieldCurve_ to CurveBlock_ across all source, test, and example files
- Rename source files yccalibration.hpp/cpp to curveblock.hpp/cpp
- Rename test file test_yccalibration.cpp to test_curveblock.cpp and suite to CurveBlockTest
- Sync all methodology documentation and skill definitions in .claude/ and .codex/
- Align Class Hierarchy code block comments to consistent column in yield_curve.md
- Add code block diagram alignment rule to dal-code-style-review skill

## Test plan
- [x] Full bin/test_suite — 455 tests from 50 suites pass
- [x] bin/test_suite --gtest_filter=CurveBlockTest.* — 4/4 pass

Generated with Claude Code (https://claude.com/claude-code)