### PR TITLE
chore: remove Co-Authored-By trailer from commit and PR guides

### DIFF
--- a/.claude/rules/git-commit-pr.md
+++ b/.claude/rules/git-commit-pr.md
@@ -10,7 +10,6 @@
 
 - First line: imperative summary under 72 characters (e.g., "Add log-linear interpolation", "Fix include paths")
 - Blank line, then body explaining **why** the change was made, not just what changed
-- If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
 - One logical change per commit -- don't mix unrelated fixes
 
 **Good examples:**

--- a/.claude/skills/dal-commit-and-pr/SKILL.md
+++ b/.claude/skills/dal-commit-and-pr/SKILL.md
@@ -49,15 +49,13 @@ There are two kinds of submodule changes — handle them differently:
 - Write commit messages following project conventions:
   - Imperative summary under 72 characters
   - Body explaining the "why", not just the "what"
-  - If the user wants an AI co-author trailer, use their preferred trailer; otherwise append `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`
+  - Do not append any co-author trailer
 - Use a multi-line commit message to preserve formatting:
   ```bash
   git commit -m "$(cat <<'EOF'
   Summary line here
 
   Body explaining why.
-
-  Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
   EOF
   )"
   ```


### PR DESCRIPTION
## Summary
- Remove Co-Authored-By trailer from `.claude/rules/git-commit-pr.md` commit conventions
- Replace co-author instruction in `.claude/skills/dal-commit-and-pr/SKILL.md` with explicit "do not append any co-author trailer"
- Remove co-author trailer from the commit message example in the skill

## Test plan
- [x] Review the changed markdown files for correctness