### PR TITLE
chore: Phase 0 documentation and Phase 1 project scaffolding for multi-project refactor

### DIFF
--- a/.claude/refactor/phase0-baseline.md
+++ b/.claude/refactor/phase0-baseline.md
@@ -1,0 +1,35 @@
+# Phase 0: Build and Test Baseline
+
+## Build Result: PASSED
+
+- **Date**: 2026-05-30
+- **Command**: `bash ./build_linux.sh`
+- **Build type**: Release, static (BUILD_SHARED_LIBS=OFF)
+- **AAD backend**: Native (AADET) -- no external backend enabled in current preset
+- **Platform**: Linux (WSL2), 32 cores
+- **Warnings**: None
+- **Errors**: None
+- **Targets built**: dal_library, dal_public (not built, SKIP_TESTS=false means tests subdirectory was added), test_suite, all examples (aad, concurrency, curve_calibration, digital, european_mc, european_fd, matrix_perf, script, snowball, sobol, underdetermined, uoc, uoc_compiled, vanilla)
+
+## Test Result: PASSED
+
+- **Binary**: `bin/test_suite`
+- **Framework**: Google Test (gtest)
+- **Total tests**: 524
+- **Test suites**: 56
+- **Passed**: 524
+- **Failed**: 0
+- **Skipped**: 0
+- **Duration**: 10019 ms (~10 seconds)
+
+## CTest Status
+
+- **Current state**: NOT registered. There is no `enable_testing()`, `add_test()`, or `gtest_discover_tests()` anywhere in the CMake project. Running `ctest` would produce "No tests were found."
+- **Action needed**: Add `enable_testing()` to top-level CMakeLists.txt, `include(GoogleTest)` and `gtest_discover_tests(test_suite)` to tests/CMakeLists.txt.
+
+## Key Observations
+
+1. The build produces a complete, passing codebase -- ideal baseline for refactoring.
+2. dal_public was NOT built in this run because SKIP_TESTS=false only controls the tests subdirectory. However, DAL_BUILD_PUBLIC is ON by default, so dal_public IS built as part of the `make` step.
+3. Excel example targets (from public/excel) were not built -- Excel detection failed on Linux (expected).
+4. Code generation ran successfully: `dal/auto/` has 86 generated files, `public/auto/` was also generated.

--- a/.claude/refactor/phase0-build-targets.md
+++ b/.claude/refactor/phase0-build-targets.md
@@ -1,0 +1,69 @@
+# Phase 0: Build Targets and Directory Ownership
+
+## Current Build Process
+
+The build is driven by `build_linux.sh`. Steps:
+
+1. Build Machinist code-gen tool from `externals/machinist/`
+2. Run code generation: `Machinist -c config/dal.ifc -l config/dal.mgl -d ./dal` and `... -d ./public`
+3. Configure with `cmake --preset Release-linux` (installs to repo root)
+4. Build with `make -j<N>`
+5. Install with `make install` (libs to `lib/`, bins to `bin/`, headers to `include/`)
+6. Run `bin/test_suite` if SKIP_TESTS=false
+
+Build type: Release, static libraries (BUILD_SHARED_LIBS=OFF on Linux via preset).
+
+## CMake Targets
+
+### dal_library (defined in dal/CMakeLists.txt)
+- Type: static library (`libdal.a`)
+- Sources: all `.h`, `.hpp`, `.cpp`, `.inc` under `dal/` EXCEPT `dal/auto/` and `dal/storage/_repository.*`
+- Links: external AAD library (Adept by default)
+- Install: headers to `include/dal/`, library to `lib/`, export set `DALTargets`
+
+### dal_public (defined in public/src/CMakeLists.txt)
+- Type: static library (`libdal_public.a`)
+- **CRITICAL DUPLICATE COMPILATION**: When `BUILD_SHARED_LIBS=OFF` (current default), dal_public globs `dal/*.cpp` files directly:
+  ```cmake
+  file(GLOB_RECURSE PUBLIC_FILES "*.hpp" "*.cpp" "${PROJECT_SOURCE_DIR}/dal/*.h" 
+       "${PROJECT_SOURCE_DIR}/dal/*.hpp" "${PROJECT_SOURCE_DIR}/dal/*.cpp")
+  ```
+  This means every dal/ source file is compiled TWICE: once in dal_library and once in dal_public.
+  When `BUILD_SHARED_LIBS=ON`, dal_public links dal_library instead.
+- Sources: `public/src/*.hpp`, `public/src/*.cpp`
+- Links: AAD library directly when static (redundant with dal_library)
+- Install: headers to `include/public/src/`, library to `lib/`
+
+### dal_excel (defined in public/excel/CMakeLists.txt, conditional on DAL_HAS_EXCEL and Windows)
+- Not built on Linux
+
+### test_suite (defined in tests/CMakeLists.txt)
+- Type: executable (`bin/test_suite`)
+- Sources: all `.hpp` and `.cpp` under `tests/`
+- Links: `dal_library`, `gtest`, `gtest_main`, `gmock`, `gmock_main`, plus AAD backend
+- Install: to `bin/`
+
+### Example programs (in examples/, not a single target)
+- Each example subdirectory has its own CMakeLists.txt with `add_executable`
+- All link `dal_library`
+
+## Directory Ownership Mapping
+
+| Current Directory    | Future Home    | Contents                                                                    |
+|----------------------|----------------|-----------------------------------------------------------------------------|
+| `dal/`               | `dal-cpp`      | Core library: math, model, curve, indice, risk, concurrency, storage, auto |
+| `public/src/`        | `dal-public`   | Public C++ API wrapper layer                                                |
+| `public/swig/`       | `dal-python`   | SWIG interface files for Python bindings                                    |
+| `public/python/`     | `dal-python`   | Python packaging (setup.py, dal package)                                    |
+| `public/excel/`      | `dal-excel`    | Excel add-in interface code                                                 |
+| `tests/`             | `dal-cpp`      | All C++ unit tests (initially; later split)                                 |
+| `examples/`          | `dal-cpp`      | Example programs                                                            |
+| `config/`            | Top-level      | Codegen source of truth (dal.ifc, dal.mgl)                                  |
+| `externals/`         | `dal-cpp`      | External dependencies (XAD, CoDiPack, Adept, gtest, rapidjson, machinist)  |
+
+## Tech Debt to Resolve
+
+1. **Duplicate compilation**: `dal-public` statically compiles all `dal/*.cpp` again. Fix: always link `DAL::cpp`.
+2. **No CTest registration**: `test_suite` is built but not registered with CTest. Fix: add `gtest_discover_tests()`.
+3. **No enable_testing()**: Missing at top-level CMakeLists.txt.
+4. **AAD library linked in two places**: Both dal_library and dal_public link the external AAD library; should only be dal_library.

--- a/.claude/refactor/phase0-codegen.md
+++ b/.claude/refactor/phase0-codegen.md
@@ -1,0 +1,96 @@
+# Phase 0: Code Generation Pipeline
+
+## Tool: Machinist
+
+- **Location**: `externals/machinist/`
+- **Binary**: `externals/machinist/bin/Machinist`
+- **Template dir**: `externals/machinist/template/` (set via `MACHINIST_TEMPLATE_DIR` env var)
+- **Built by**: `externals/machinist/build_linux.sh` (called from parent `build_linux.sh`)
+
+## Build Commands
+
+From `build_linux.sh` (lines 40-41):
+
+```bash
+export MACHINIST_TEMPLATE_DIR=$PWD/externals/machinist/template/
+./externals/machinist/bin/Machinist -c config/dal.ifc -l config/dal.mgl -d ./dal
+./externals/machinist/bin/Machinist -c config/dal.ifc -l config/dal.mgl -d ./public
+```
+
+## Inputs
+
+| File             | Purpose                                          |
+|------------------|--------------------------------------------------|
+| `config/dal.ifc`  | Interface definition file (enum/object/settings) |
+| `config/dal.mgl`  | Machinist glossary/template config               |
+
+## Outputs
+
+### dal/auto/ (generated from `-d ./dal`)
+
+Contains ~86 files organized into three categories:
+
+**Enum types** (`.hpp` + `.inc` pairs):
+```
+MG_BizDayConvention_enum.hpp    MG_BizDayConvention_enum.inc
+MG_Ccy_enum.hpp                 MG_Ccy_enum.inc
+MG_Clearer_enum.hpp             MG_Clearer_enum.inc
+MG_CollateralType_enum.hpp      MG_CollateralType_enum.inc
+MG_CurveKnotPolicy_enum.hpp     MG_CurveKnotPolicy_enum.inc
+MG_CurveParameterization_enum.hpp MG_CurveParameterization_enum.inc
+MG_CurveSolveMode_enum.hpp      MG_CurveSolveMode_enum.inc
+MG_DateGeneration_enum.hpp      MG_DateGeneration_enum.inc
+MG_DateStepSize_enum.hpp        MG_DateStepSize_enum.inc
+MG_DayBasis_enum.hpp            MG_DayBasis_enum.inc
+MG_DomainCondProp_enum.hpp      MG_DomainCondProp_enum.inc
+MG_NodeType_enum.hpp            MG_NodeType_enum.inc
+MG_OptionType_enum.hpp          MG_OptionType_enum.inc
+MG_PeriodLength_enum.hpp        MG_PeriodLength_enum.inc
+MG_RNGType_enum.hpp             MG_RNGType_enum.inc
+MG_RepositoryErase_enum.hpp     MG_RepositoryErase_enum.inc
+MG_SpecialDay_enum.hpp          MG_SpecialDay_enum.inc
+MG_TradedRate_enum.hpp          MG_TradedRate_enum.inc
+```
+
+**Object serialization** (`_object.hpp` + `_v1_Read.inc` + `_v1_Write.inc`):
+```
+MG_BSModelData_object.*
+MG_Bag_object.*
+MG_Box_object.*
+MG_Cubic1_object.*
+MG_DiscountPWLF_object.*
+MG_DupireModelData_object.*
+MG_Fixings_object.*
+MG_Interp1Linear_object.*
+MG_Interp2Linear_object.*
+MG_LogLinear1_object.*
+MG_PiecewiseConstant_object.*
+MG_PseudoRSG_object.*
+MG_Report_object.*
+MG_ScriptProductData_object.*
+MG_SobolRSG_object.*
+MG_UnderdeterminedControls_object.*
+```
+
+**Java** (`java/` directory with `.java` files)
+
+### public/auto/ (generated from `-d ./public`)
+
+Contains Excel public function stubs (`MG_*_public.inc`). These are included directly by `public/excel/` source files at specific line numbers:
+- `MG_EvaluationDate_Set_public.inc` / `_Get_public.inc` (included in `__global.cpp`)
+- `MG_Interp1_New_Linear_public.inc` etc. (included in `__interp.cpp`)
+- `MG_BSModelData_New_public.inc` etc. (included in `__models.cpp`)
+- `MG_PseudoRSG_New_public.inc` etc. (included in `__random.cpp`)
+- `MG_Repository_Erase_public.inc` etc. (included in `__repository.cpp`)
+- `MG_Product_New_public.inc` etc. (included in `__script.cpp`)
+- `MG_MonteCarlo_Value_public.inc` (included in `__value.cpp`)
+- `MG_Format_public.inc`, `MG_PasteWithArgs_public.inc` (included in `_excel.cpp`)
+
+## Source-of-Truth Problem
+
+**ONE input file** (`config/dal.ifc`) generates outputs in **TWO directories** (`dal/auto/` and `public/auto/`). This means:
+
+1. We cannot simply move `config/` into `dal-cpp/` -- dal-public would lose access to its auto-generated stubs.
+2. First-round strategy (per the refactor plan): keep `config/` at the top level as the migration-period source of truth.
+3. Second-round: split into `dal-cpp/config/dal.ifc` (core enums + objects) and `dal-public/config/dal_public.ifc` (public Excel stubs).
+4. The Machinist invocation commands would need to be updated to route output to dal-cpp/ and dal-public/ respectively.

--- a/.claude/refactor/phase0-ctest.md
+++ b/.claude/refactor/phase0-ctest.md
@@ -1,0 +1,47 @@
+# Phase 0: CTest Registration
+
+## Status: COMPLETED
+
+CTest was not previously registered. Two files were modified:
+
+### Edit 1: Top-level `CMakeLists.txt` (line before `add_subdirectory(dal)`)
+
+Added:
+```cmake
+enable_testing()
+```
+
+### Edit 2: `tests/CMakeLists.txt` (top and bottom)
+
+Added `include(GoogleTest)` at the top (before `file(GLOB_RECURSE...)`):
+```cmake
+include(GoogleTest)
+```
+
+Added `gtest_discover_tests(test_suite)` at the bottom (after `install(...)`):
+```cmake
+gtest_discover_tests(test_suite)
+```
+
+## Verification
+
+```bash
+cd build && cmake .. && make -j4 && ctest --output-on-failure
+```
+
+Results:
+- **Tests discovered**: 524
+- **Passed**: 524
+- **Failed**: 0
+- **Time**: 11.89 seconds (real)
+
+Previously, `ctest` would have shown "No tests were found." Now all 524 gtest tests are registered as individual CTest tests, e.g.:
+- `AADTest.TestNumberAdd` (test 1)
+- `InterpTest.TestInterp1Linear` 
+- ... up to `NumericsTest.TestCorrelation` (test 524)
+
+## Notes
+
+- `gtest_discover_tests()` requires GoogleTest to be `include()`ed before the `add_executable` call. This is satisfied since gtest is built as a subdirectory early in the CMake configuration.
+- Each test case is now individually addressable via `ctest -R <pattern>`, enabling CI to run subsets.
+- The `test_main.cpp` entry point (`Dal::RegisterAll_::Init()` + `RUN_ALL_TESTS()`) continues to work unchanged -- CTest simply runs the same binary with GoogletTest's `--gtest_list_tests` and `--gtest_filter` flags.

--- a/.claude/refactor/phase0-dependency-inventory.md
+++ b/.claude/refactor/phase0-dependency-inventory.md
@@ -1,0 +1,93 @@
+# Phase 0: Dependency Inventory
+
+## Summary
+
+All three public-layer directories (`public/src/`, `public/excel/`, `public/swig/`) have significant direct dependencies on `dal/...` internal headers. This is the key challenge for Phase 3-5 extraction: public-layer code must be refactored to go through the stable `dal_public` API instead of reaching into `dal/` internals.
+
+## public/src/ --> dal/ internal headers
+
+| Public src file               | dal/ headers included                                  |
+|-------------------------------|--------------------------------------------------------|
+| `public/src/global.hpp`       | `<dal/time/date.hpp>`                                  |
+| `public/src/globals.cpp`      | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>`, `<dal/storage/globals.hpp>` |
+| `public/src/interp.cpp`       | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>`, `<dal/math/interp/interplinear.hpp>` |
+| `public/src/interp.hpp`       | `<dal/math/vectors.hpp>`, `<dal/string/strings.hpp>`   |
+| `public/src/models.cpp`       | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>` |
+| `public/src/models.hpp`       | `<dal/model/blackscholes.hpp>`, `<dal/model/dupire.hpp>` |
+| `public/src/random.cpp`       | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>` |
+| `public/src/random.hpp`       | `<dal/string/strings.hpp>`, `<dal/math/random/sobol.hpp>`, `<dal/math/random/pseudorandom.hpp>` |
+| `public/src/repository.cpp`   | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>`, `<dal/storage/_repository.hpp>` |
+| `public/src/repository.hpp`   | `<dal/storage/storable.hpp>`, `<dal/utilities/exceptions.hpp>` |
+| `public/src/script.cpp`       | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>` |
+| `public/src/script.hpp`       | `<dal/script/event.hpp>`                               |
+| `public/src/value.cpp`        | `<dal/platform/platform.hpp>`, `<dal/platform/strict.hpp>`, `<dal/model/factory.hpp>` |
+| `public/src/value.hpp`        | `<dal/script/simulation.hpp>`                          |
+
+### Observations
+- Every .cpp file includes `<dal/platform/platform.hpp>` and `<dal/platform/strict.hpp>` -- this is a heavy internal dependency.
+- Header files expose dal/ types directly: e.g., `interp.hpp` exposes `Vector_<>` and `String_` from dal/math/vectors.hpp.
+- The `_repository.hpp` include (in repository.cpp) is from the `storage/` subdir that's explicitly excluded from `dal_library` build.
+
+## public/excel/ --> dal/ internal headers
+
+| Excel file                    | dal/ headers included                                  |
+|-------------------------------|--------------------------------------------------------|
+| `__platform.hpp`              | `<dal/platform/platform.hpp>`, `<dal/storage/_reader.hpp>`, `<dal/storage/_repository.hpp>`, `<dal/utilities/environment.hpp>`, `<dal/utilities/exceptions.hpp>` |
+| `__interp.cpp`                | `<dal/math/interp/interplinear.hpp>`, `<dal/math/interp/interp2d.hpp>`, `<dal/math/interp/interpcubic.hpp>`, `<dal/math/smooth.hpp>` |
+| `__random.cpp`                | `<dal/math/random/pseudorandom.hpp>`, `<dal/math/random/sobol.hpp>` |
+| `__repository.cpp`            | `<dal/platform/platform.hpp>`                          |
+| `__script.cpp`                | `<dal/script/event.hpp>`                               |
+| `__value.cpp`                 | `<dal/math/matrix/matrixs.hpp>`, `<dal/platform/strict.hpp>` |
+| `_excel.cpp`                  | `<dal/platform/platform.hpp>`, `<dal/platform/initall.hpp>`, `<dal/platform/strict.hpp>`, `<dal/math/cellutils.hpp>`, `<dal/storage/_repository.hpp>`, `<dal/utilities/exceptions.hpp>`, `<dal/utilities/numerics.hpp>`, `"dal/math/matrix/matrixutils.hpp"`*, `"dal/platform/optionals.hpp"`*, `"dal/string/strings.hpp"`*, `"dal/utilities/algorithms.hpp"`*, `"dal/utilities/dictionary.hpp"`* |
+| `_excel.hpp`                  | `<dal/platform/platform.hpp>`, `<dal/math/matrix/matrixs.hpp>`, `<dal/platform/optionals.hpp>`, `<dal/storage/_reader.hpp>`, `<dal/storage/storable.hpp>`, `<dal/utilities/dictionary.hpp>`, `<dal/utilities/environment.hpp>` |
+
+*Note: `_excel.cpp` uses BOTH angle-bracket and quoted includes for dal/ headers. Quoted `"dal/..."` includes (lines 84-88) are particularly unusual in a project that otherwise standardizes on `<dal/...>`.
+
+### Observations
+- `public/excel/` is the most deeply entangled layer. It includes dal/platform, dal/math, dal/script, dal/storage, and dal/utilities headers.
+- Excel `__*.cpp` files each include `<public/excel/__platform.hpp>` which pulls in even more dal/ dependencies transitively.
+- Excel files also include `public/src/*.hpp` (the public wrapper layer) -- creating a chain: excel -> public/src -> dal/
+- Excel also includes `public/auto/MG_*_public.inc` generated files for Excel function stubs.
+
+## public/swig/ --> dal/ internal headers
+
+| SWIG file                     | dal/ headers included (in `%{ %}` blocks)              |
+|-------------------------------|--------------------------------------------------------|
+| `cell.i`                      | `<dal/math/cell.hpp>`                                  |
+| `dal.i`                       | `<dal/platform/platform.hpp>`                          |
+| `date.i`                      | `<dal/time/date.hpp>`                                  |
+| `handle.i`                    | `<dal/platform/platform.hpp>`                          |
+| `init.i`                      | `<dal/platform/initall.hpp>`                           |
+| `matrix.i`                    | `<dal/math/matrix/matrixs.hpp>`                        |
+| `strings.i`                   | `<dal/string/strings.hpp>`                             |
+
+### Observations
+- SWIG files directly include dal/ headers in `%{ ... %}` (raw C++ code) blocks.
+- `dal.i` is the main entry point; it `%include`s init.i, handle.i, date.i, cell.i, global.i, strings.i, matrix.i, script.i, models.i, value.i, random.i.
+- The SWIG dependency chain is: swig -> dal/ internal headers, not swig -> public/src/. This means Python bindings currently bypass the public API layer entirely.
+
+## public/python/ --> dal/ headers
+
+**None found.** `public/python/` contains only Python packaging files (setup.py, setup.cfg, MANIFEST.in, requirements.txt, README.md) with no C++ includes.
+
+## Public-layer self-references (within public/)
+
+All `public/src/*.cpp` files reference their corresponding `.hpp` via `<public/src/...>`:
+- `globals.cpp` -> `<public/src/global.hpp>`
+- `interp.cpp` -> `<public/src/interp.hpp>`
+- `models.cpp` -> `<public/src/models.hpp>`
+- `repository.cpp` -> `<public/src/repository.hpp>`
+- `script.cpp` -> `<public/src/script.hpp>`
+- `value.cpp` -> `<public/src/value.hpp>`
+
+All `public/excel/__*.cpp` files reference `<public/excel/__platform.hpp>` and `<public/src/...>`:
+- `__global.cpp` -> `<public/excel/__platform.hpp>`, `<public/src/global.hpp>`
+- `__interp.cpp` -> `<public/excel/__platform.hpp>`, `<public/src/interp.hpp>`
+- etc.
+
+## Risk Assessment for Refactoring
+
+1. **HIGH**: `public/excel/` has 20+ distinct dal/ header dependencies -- the most entangled layer.
+2. **MEDIUM**: `public/src/` exposes dal/ types in its public headers (Vector_<>, String_, etc.), breaking the abstraction wall.
+3. **MEDIUM**: SWIG bypasses public API entirely, directly including dal/ headers.
+4. **LOW**: `public/python/` has no C++ includes -- already clean.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,38 @@ if(WIN32)
     endif()
 endif()
 
+# ---------------------------------------------------------------------------
+# Refactored workspace (feature flag, default OFF)
+# When ON, the four sub-projects (dal-cpp, dal-public, dal-python, dal-excel)
+# are added as additional CMake subdirectories alongside the legacy build.
+# ---------------------------------------------------------------------------
+option(DAL_ENABLE_REFACTORED_WORKSPACE "Enable refactored workspace targets" OFF)
+
+if(DAL_ENABLE_REFACTORED_WORKSPACE)
+    option(DAL_BUILD_CPP "Build dal-cpp" ON)
+    option(DAL_BUILD_PUBLIC "Build dal-public" ON)
+    option(DAL_BUILD_PYTHON "Build dal-python" OFF)
+    option(DAL_BUILD_EXCEL "Build dal-excel" OFF)
+
+    if(DAL_BUILD_CPP)
+        add_subdirectory(dal-cpp)
+    endif()
+
+    if(DAL_BUILD_PUBLIC)
+        add_subdirectory(dal-public)
+    endif()
+
+    if(DAL_BUILD_PYTHON)
+        add_subdirectory(dal-python)
+    endif()
+
+    if(DAL_BUILD_EXCEL)
+        add_subdirectory(dal-excel)
+    endif()
+endif()
+
+enable_testing()
+
 add_subdirectory(dal)
 
 if (DAL_BUILD_PUBLIC)

--- a/dal-cpp/CMakeLists.txt
+++ b/dal-cpp/CMakeLists.txt
@@ -1,0 +1,32 @@
+# dal-cpp: Core C++ Quant Library
+#
+# This project contains the full internal C++ implementation of the DAL library.
+# It is the foundation for all other DAL sub-projects.
+#
+# Target: dal_cpp (alias DAL::cpp)
+
+cmake_minimum_required(VERSION 3.21.0)
+
+project(dal-cpp LANGUAGES CXX
+    DESCRIPTION "DAL Core C++ Quant Library"
+    VERSION 1.0.0)
+
+message(STATUS "-- Building dal-cpp (refactored workspace)")
+
+# ---------------------------------------------------------------------------
+# User-configurable options
+# ---------------------------------------------------------------------------
+option(DAL_CPP_BUILD_TESTS "Build dal-cpp tests" ON)
+option(DAL_CPP_BUILD_EXAMPLES "Build dal-cpp examples" ON)
+
+# AAD backend selection (exactly one should be ON)
+option(DAL_CPP_USE_XAD_AAD "Use XAD AAD backend" OFF)
+option(DAL_CPP_USE_CODIPACK_AAD "Use CoDiPack AAD backend" OFF)
+option(DAL_CPP_USE_ADEPT_AAD "Use Adept AAD backend" ON)
+
+# ---------------------------------------------------------------------------
+# TODO(Phase 2): Move dal/ sources, externals, config, tests, examples here.
+# Currently this is a placeholder scaffold.
+# ---------------------------------------------------------------------------
+
+message(STATUS "  dal-cpp placeholder scaffold -- Phase 2 will add core sources")

--- a/dal-excel/CMakeLists.txt
+++ b/dal-excel/CMakeLists.txt
@@ -1,0 +1,52 @@
+# dal-excel: Excel Add-in Interface
+#
+# This project provides the Excel COM add-in interface for DAL.
+# It depends ONLY on dal-public (DAL::public), never directly on dal-cpp.
+# Build is Windows-only.
+#
+# Target: dal_excel (alias DAL::excel)
+
+cmake_minimum_required(VERSION 3.21.0)
+
+project(dal-excel
+    DESCRIPTION "DAL Excel Add-in"
+    VERSION 1.0.0)
+
+message(STATUS "-- Building dal-excel (refactored workspace)")
+
+# ---------------------------------------------------------------------------
+# User-configurable options
+# ---------------------------------------------------------------------------
+option(DAL_EXCEL_BUILD_TESTS "Build dal-excel tests" ON)
+
+# ---------------------------------------------------------------------------
+# Guard: dal-excel is Windows-only
+# ---------------------------------------------------------------------------
+if(NOT WIN32)
+    message(STATUS "  dal-excel: skipping (requires Windows)")
+    return()
+endif()
+
+# ---------------------------------------------------------------------------
+# Dependency: dal-public (DAL::public)
+# During Phase 1 scaffolding, may not be available -- be non-fatal.
+# ---------------------------------------------------------------------------
+if(TARGET DAL::public)
+    message(STATUS "  dal-excel: using sibling DAL::public target")
+else()
+    find_package(dal-public QUIET)
+    if(dal-public_FOUND)
+        message(STATUS "  dal-excel: using installed dal-public package")
+    else()
+        message(STATUS "  dal-excel: DAL::public not available yet (placeholder scaffold)")
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# TODO(Phase 5): Move public/excel/ sources here.
+# Target only links DAL::public.
+# Tests use gtest + CTest.
+# Currently this is a placeholder scaffold.
+# ---------------------------------------------------------------------------
+
+message(STATUS "  dal-excel placeholder scaffold -- Phase 5 will add Excel add-in sources")

--- a/dal-public/CMakeLists.txt
+++ b/dal-public/CMakeLists.txt
@@ -1,0 +1,44 @@
+# dal-public: Stable Public C++ API Layer
+#
+# This project wraps dal-cpp internals behind a stable, controlled public API.
+# Downstream projects (dal-python, dal-excel) depend only on this layer.
+#
+# Target: dal_public (alias DAL::public)
+
+cmake_minimum_required(VERSION 3.21.0)
+
+project(dal-public LANGUAGES CXX
+    DESCRIPTION "DAL Public C++ API"
+    VERSION 1.0.0)
+
+message(STATUS "-- Building dal-public (refactored workspace)")
+
+# ---------------------------------------------------------------------------
+# User-configurable options
+# ---------------------------------------------------------------------------
+option(DAL_PUBLIC_BUILD_TESTS "Build dal-public tests" ON)
+
+# ---------------------------------------------------------------------------
+# Dependency: dal-cpp
+#
+# In monorepo mode, DAL::cpp is available as a sibling target.
+# In installed mode, use find_package.
+# During Phase 1 scaffolding, neither may be available -- be non-fatal.
+# ---------------------------------------------------------------------------
+if(TARGET DAL::cpp)
+    message(STATUS "  dal-public: using sibling DAL::cpp target")
+else()
+    find_package(dal-cpp QUIET)
+    if(dal-cpp_FOUND)
+        message(STATUS "  dal-public: using installed dal-cpp package")
+    else()
+        message(STATUS "  dal-public: DAL::cpp not available yet (placeholder scaffold)")
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# TODO(Phase 3): Move public/src/ sources, public/auto/, config here.
+# Currently this is a placeholder scaffold.
+# ---------------------------------------------------------------------------
+
+message(STATUS "  dal-public placeholder scaffold -- Phase 3 will add public API sources")

--- a/dal-python/CMakeLists.txt
+++ b/dal-python/CMakeLists.txt
@@ -1,0 +1,44 @@
+# dal-python: Python Bindings via SWIG
+#
+# This project generates Python bindings for the DAL public API using SWIG.
+# It depends ONLY on dal-public (DAL::public), never directly on dal-cpp.
+#
+# Target: dal_python (alias DAL::python)
+
+cmake_minimum_required(VERSION 3.21.0)
+
+project(dal-python
+    DESCRIPTION "DAL Python Bindings"
+    VERSION 1.0.0)
+
+message(STATUS "-- Building dal-python (refactored workspace)")
+
+# ---------------------------------------------------------------------------
+# User-configurable options
+# ---------------------------------------------------------------------------
+option(DAL_PYTHON_BUILD_TESTS "Build dal-python tests" ON)
+option(DAL_PYTHON_BUILD_WHEEL "Build Python wheel" OFF)
+
+# ---------------------------------------------------------------------------
+# Dependency: dal-public (DAL::public)
+# During Phase 1 scaffolding, may not be available -- be non-fatal.
+# ---------------------------------------------------------------------------
+if(TARGET DAL::public)
+    message(STATUS "  dal-python: using sibling DAL::public target")
+else()
+    find_package(dal-public QUIET)
+    if(dal-public_FOUND)
+        message(STATUS "  dal-python: using installed dal-public package")
+    else()
+        message(STATUS "  dal-python: DAL::public not available yet (placeholder scaffold)")
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# TODO(Phase 4): Move public/swig/ and public/python/ here.
+# SWIG interface should only #include <dal_public/...> headers.
+# Tests use pytest.
+# Currently this is a placeholder scaffold.
+# ---------------------------------------------------------------------------
+
+message(STATUS "  dal-python placeholder scaffold -- Phase 4 will add Python bindings")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GoogleTest)
+
 file(GLOB_RECURSE TEST_FILES "*.hpp" "*.cpp")
 
 add_executable(test_suite ${TEST_FILES})
@@ -16,3 +18,5 @@ install(TARGETS test_suite
         RUNTIME DESTINATION bin
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         )
+
+gtest_discover_tests(test_suite)


### PR DESCRIPTION
## Summary

First PR in the multi-project DAL refactoring (see `doc/dal-refactor-plan.md`). This is the preparation and scaffolding phase — no code is moved or broken.

### Phase 0 — Preparation
- Document current build targets, directory ownership, and test baseline (524/524 pass)
- Inventory all `#include` dependencies from `public/src/`, `public/excel/`, `public/swig/` into core `dal/` headers
- Document the Machinist codegen pipeline (`config/dal.ifc` → `dal/auto` + `public/auto`)
- Register `gtest_discover_tests(test_suite)` in CTest — verified 524/524 tests
- Identified **duplicate compilation bug**: when `BUILD_SHARED_LIBS=OFF`, all `dal/*.cpp` are compiled into `dal_public` a second time (to be fixed in Phase 3)

### Phase 1 — Scaffolding
- Create `dal-cpp/`, `dal-public/`, `dal-python/`, `dal-excel/` directories with documented placeholder `CMakeLists.txt`
- Add `DAL_ENABLE_REFACTORED_WORKSPACE` option (default `OFF`) to top-level `CMakeLists.txt`
- Sub-project options: `DAL_BUILD_CPP`, `DAL_BUILD_PUBLIC`, `DAL_BUILD_PYTHON`, `DAL_BUILD_EXCEL`
- Old `bash ./build_linux.sh` and `bin/test_suite` continue working as before

## Test plan
- `bash ./build_linux.sh` — full build passes
- `bin/test_suite` — 524/524 tests pass
- `ctest` — 524/524 tests discovered and pass
- Top-level CMake configures with `DAL_ENABLE_REFACTORED_WORKSPACE=OFF` (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)