### PR TITLE
test: expand script engine unit test coverage

### DIFF
--- a/dal-cpp/tests/script/test_constcondprocessor.cpp
+++ b/dal-cpp/tests/script/test_constcondprocessor.cpp
@@ -1,0 +1,132 @@
+//
+// Created by wegam on 2026/05/30.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/script/visitor/all.hpp>
+#include <dal/script/parser.hpp>
+#include <dal/script/node.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+
+namespace {
+    // Run the full preprocessing chain that the const-condition processor depends on:
+    // variable indexing, if processing, and domain processing set the always-true / always-false
+    // flags that the const-condition processor consumes, then process from the top of every statement.
+    Event_ ParseAndConstCondProcess(const String_& event) {
+        Parser_ parser;
+        Event_ res = parser.Parse(event);
+
+        VarIndexer_ indexer;
+        for (auto& stat : res)
+            stat->Accept(indexer);
+
+        IFProcessor_ ifProc;
+        for (auto& stat : res)
+            stat->Accept(ifProc);
+
+        DomainProcessor_ domProc(indexer.VarNames().size(), false);
+        for (auto& stat : res)
+            stat->Accept(domProc);
+
+        ConstCondProcessor_ ccProc;
+        for (auto& stat : res)
+            ccProc.ProcessFromTop(stat);
+
+        return res;
+    }
+} // namespace
+
+TEST(ScriptTest, TestConstCondAlwaysTrueIfReplacedByCollection) {
+    String_ event = R"(
+        IF 2 >= 1 THEN
+            x = 1
+        END
+    )";
+    auto res = ParseAndConstCondProcess(event);
+
+    const auto* collect = dynamic_cast<const NodeCollect_*>(res[0].get());
+    ASSERT_NE(collect, nullptr);
+    ASSERT_EQ(collect->arguments_.size(), 1u);
+    ASSERT_NE(dynamic_cast<const NodeAssign_*>(collect->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestConstCondAlwaysFalseIfReplacedByElse) {
+    String_ event = R"(
+        IF 2 < 1 THEN
+            x = 1
+        ELSE
+            x = 2
+        END
+    )";
+    auto res = ParseAndConstCondProcess(event);
+
+    const auto* collect = dynamic_cast<const NodeCollect_*>(res[0].get());
+    ASSERT_NE(collect, nullptr);
+    ASSERT_EQ(collect->arguments_.size(), 1u);
+
+    const auto* assign = dynamic_cast<const NodeAssign_*>(collect->arguments_[0].get());
+    ASSERT_NE(assign, nullptr);
+    const auto* rhs = dynamic_cast<const NodeConst_*>(assign->arguments_[1].get());
+    ASSERT_NE(rhs, nullptr);
+    ASSERT_NEAR(rhs->constVal_, 2.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstCondAlwaysFalseNoElseEmptyCollection) {
+    String_ event = R"(
+        IF 2 < 1 THEN
+            x = 1
+        END
+    )";
+    auto res = ParseAndConstCondProcess(event);
+
+    const auto* collect = dynamic_cast<const NodeCollect_*>(res[0].get());
+    ASSERT_NE(collect, nullptr);
+    ASSERT_EQ(collect->arguments_.size(), 0u);
+}
+
+TEST(ScriptTest, TestConstCondAlwaysTrueConditionReplacedByTrueNode) {
+    String_ event = R"(
+        IF (2 >= 1) AND spot() >= 0 THEN
+            x = 1
+        END
+    )";
+    auto res = ParseAndConstCondProcess(event);
+
+    // The if remains, because the compound condition can still be true or false.
+    const auto* ifNode = dynamic_cast<const NodeIf_*>(res[0].get());
+    ASSERT_NE(ifNode, nullptr);
+
+    const auto* andNode = dynamic_cast<const NodeAnd_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(andNode, nullptr);
+    ASSERT_NE(dynamic_cast<const NodeTrue_*>(andNode->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestConstCondAlwaysFalseConditionReplacedByFalseNode) {
+    String_ event = R"(
+        IF (2 < 1) OR spot() >= 0 THEN
+            x = 1
+        END
+    )";
+    auto res = ParseAndConstCondProcess(event);
+
+    const auto* ifNode = dynamic_cast<const NodeIf_*>(res[0].get());
+    ASSERT_NE(ifNode, nullptr);
+
+    const auto* orNode = dynamic_cast<const NodeOr_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(orNode, nullptr);
+    ASSERT_NE(dynamic_cast<const NodeFalse_*>(orNode->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestConstCondNonConstIfUnchanged) {
+    String_ event = R"(
+        IF spot() >= 1 THEN
+            x = 1
+        END
+    )";
+    auto res = ParseAndConstCondProcess(event);
+
+    ASSERT_NE(dynamic_cast<const NodeIf_*>(res[0].get()), nullptr);
+}

--- a/dal-cpp/tests/script/test_constprocessor.cpp
+++ b/dal-cpp/tests/script/test_constprocessor.cpp
@@ -1,0 +1,207 @@
+//
+// Created by wegam on 2026/05/30.
+//
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <dal/platform/platform.hpp>
+#include <dal/script/visitor/all.hpp>
+#include <dal/script/parser.hpp>
+#include <dal/script/node.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+
+namespace {
+    // Parse, index variables, then run the constant processor over every statement.
+    Event_ ParseAndConstProcess(const String_& event) {
+        Parser_ parser;
+        Event_ res = parser.Parse(event);
+
+        VarIndexer_ indexer;
+        for (auto& stat : res)
+            stat->Accept(indexer);
+
+        ConstProcessor_ proc(indexer.VarNames().size());
+        for (auto& stat : res)
+            stat->Accept(proc);
+
+        return res;
+    }
+
+    // RHS expression of an assignment statement.
+    const ExprNode_* AssignRhs(const Statement_& stat) {
+        return dynamic_cast<const ExprNode_*>(stat->arguments_[1].get());
+    }
+} // namespace
+
+TEST(ScriptTest, TestConstProcessorFoldAddition) {
+    auto res = ParseAndConstProcess("x = 2 + 3");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_NE(dynamic_cast<const NodeAdd_*>(res[0]->arguments_[1].get()), nullptr);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, 5.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorFoldSubtraction) {
+    auto res = ParseAndConstProcess("x = 7 - 4");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, 3.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorFoldMultiplication) {
+    auto res = ParseAndConstProcess("x = 3 * 4");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, 12.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorFoldDivision) {
+    auto res = ParseAndConstProcess("x = 6 / 2");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, 3.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorFoldPowerOperator) {
+    auto res = ParseAndConstProcess("x = 2 ^ 3");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_NE(dynamic_cast<const NodePow_*>(res[0]->arguments_[1].get()), nullptr);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, 8.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorFoldMaxMin) {
+    {
+        auto res = ParseAndConstProcess("x = MAX(2, 3)");
+        const ExprNode_* rhs = AssignRhs(res[0]);
+        ASSERT_NE(dynamic_cast<const NodeMax_*>(res[0]->arguments_[1].get()), nullptr);
+        ASSERT_TRUE(rhs->isConst_);
+        ASSERT_NEAR(rhs->constVal_, 3.0, 1e-10);
+    }
+    {
+        auto res = ParseAndConstProcess("x = MIN(2, 3)");
+        const ExprNode_* rhs = AssignRhs(res[0]);
+        ASSERT_NE(dynamic_cast<const NodeMin_*>(res[0]->arguments_[1].get()), nullptr);
+        ASSERT_TRUE(rhs->isConst_);
+        ASSERT_NEAR(rhs->constVal_, 2.0, 1e-10);
+    }
+}
+
+TEST(ScriptTest, TestConstProcessorFoldFunctions) {
+    {
+        auto res = ParseAndConstProcess("x = SQRT(4)");
+        const ExprNode_* rhs = AssignRhs(res[0]);
+        ASSERT_TRUE(rhs->isConst_);
+        ASSERT_NEAR(rhs->constVal_, 2.0, 1e-10);
+    }
+    {
+        auto res = ParseAndConstProcess("x = EXP(0)");
+        const ExprNode_* rhs = AssignRhs(res[0]);
+        ASSERT_TRUE(rhs->isConst_);
+        ASSERT_NEAR(rhs->constVal_, 1.0, 1e-10);
+    }
+    {
+        auto res = ParseAndConstProcess("x = LOG(1)");
+        const ExprNode_* rhs = AssignRhs(res[0]);
+        ASSERT_TRUE(rhs->isConst_);
+        ASSERT_NEAR(rhs->constVal_, 0.0, 1e-10);
+    }
+}
+
+TEST(ScriptTest, TestConstProcessorFoldUnaryMinus) {
+    auto res = ParseAndConstProcess("x = -5");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_NE(dynamic_cast<const NodeUMinus_*>(res[0]->arguments_[1].get()), nullptr);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, -5.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorFoldNestedExpression) {
+    auto res = ParseAndConstProcess("x = (2 + 3) * 4 - 1");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_TRUE(rhs->isConst_);
+    ASSERT_NEAR(rhs->constVal_, 19.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorPropagatesConstVariable) {
+    String_ event = R"(
+        y = 2
+        x = y + 1
+    )";
+    auto res = ParseAndConstProcess(event);
+
+    const auto* add = dynamic_cast<const NodeAdd_*>(res[1]->arguments_[1].get());
+    ASSERT_NE(add, nullptr);
+    ASSERT_TRUE(add->isConst_);
+    ASSERT_NEAR(add->constVal_, 3.0, 1e-10);
+
+    const auto* var = dynamic_cast<const NodeVar_*>(add->arguments_[0].get());
+    ASSERT_NE(var, nullptr);
+    ASSERT_TRUE(var->isConst_);
+    ASSERT_NEAR(var->constVal_, 2.0, 1e-10);
+}
+
+TEST(ScriptTest, TestConstProcessorSpotNotConst) {
+    auto res = ParseAndConstProcess("x = spot() + 1");
+    const ExprNode_* rhs = AssignRhs(res[0]);
+    ASSERT_NE(dynamic_cast<const NodeAdd_*>(res[0]->arguments_[1].get()), nullptr);
+    ASSERT_FALSE(rhs->isConst_);
+}
+
+TEST(ScriptTest, TestConstProcessorMixedConstNonConst) {
+    String_ event = R"(
+        x = spot()
+        y = x + 2
+    )";
+    auto res = ParseAndConstProcess(event);
+
+    const auto* add = dynamic_cast<const NodeAdd_*>(res[1]->arguments_[1].get());
+    ASSERT_NE(add, nullptr);
+    ASSERT_FALSE(add->isConst_);
+
+    const auto* var = dynamic_cast<const NodeVar_*>(add->arguments_[0].get());
+    ASSERT_NE(var, nullptr);
+    ASSERT_FALSE(var->isConst_);
+}
+
+TEST(ScriptTest, TestConstProcessorReassignmentClearsConst) {
+    String_ event = R"(
+        x = 2
+        x = spot()
+        y = x
+    )";
+    auto res = ParseAndConstProcess(event);
+
+    const auto* var = dynamic_cast<const NodeVar_*>(res[2]->arguments_[1].get());
+    ASSERT_NE(var, nullptr);
+    ASSERT_FALSE(var->isConst_);
+}
+
+TEST(ScriptTest, TestConstProcessorConditionalAssignmentNotConst) {
+    String_ event = R"(
+        IF spot() >= 1 THEN
+            x = 2
+        END
+        y = x
+    )";
+    auto res = ParseAndConstProcess(event);
+
+    const auto* var = dynamic_cast<const NodeVar_*>(res[1]->arguments_[1].get());
+    ASSERT_NE(var, nullptr);
+    ASSERT_FALSE(var->isConst_);
+}
+
+TEST(ScriptTest, TestConstProcessorUnconditionalAssignmentStaysConst) {
+    String_ event = R"(
+        x = 2
+        y = x
+    )";
+    auto res = ParseAndConstProcess(event);
+
+    const auto* var = dynamic_cast<const NodeVar_*>(res[1]->arguments_[1].get());
+    ASSERT_NE(var, nullptr);
+    ASSERT_TRUE(var->isConst_);
+    ASSERT_NEAR(var->constVal_, 2.0, 1e-10);
+}

--- a/dal-cpp/tests/script/test_domain.cpp
+++ b/dal-cpp/tests/script/test_domain.cpp
@@ -1,0 +1,559 @@
+//
+// Created by wegam on 2026/05/30.
+//
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <dal/platform/platform.hpp>
+#include <dal/script/visitor/domain.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+
+TEST(ScriptTest, TestBoundRealAccessors) {
+    Bound_ b(3.5);
+    ASSERT_FALSE(b.IsInfinite());
+    ASSERT_FALSE(b.IsPlusInf());
+    ASSERT_FALSE(b.IsMinusInf());
+    ASSERT_NEAR(b.Val(), 3.5, 1e-10);
+
+    Bound_ d;
+    ASSERT_TRUE(d.IsZero());
+    ASSERT_NEAR(d.Val(), 0.0, 1e-10);
+}
+
+TEST(ScriptTest, TestBoundPlusInfinity) {
+    Bound_ b(Bound_::plusInfinity_);
+    ASSERT_TRUE(b.IsInfinite());
+    ASSERT_TRUE(b.IsPlusInf());
+    ASSERT_FALSE(b.IsMinusInf());
+    ASSERT_TRUE(b.IsPositive());
+    ASSERT_TRUE(b.IsPositive(true));
+    ASSERT_FALSE(b.IsZero());
+}
+
+TEST(ScriptTest, TestBoundMinusInfinity) {
+    Bound_ b(Bound_::minusInfinity_);
+    ASSERT_TRUE(b.IsInfinite());
+    ASSERT_TRUE(b.IsMinusInf());
+    ASSERT_FALSE(b.IsPlusInf());
+    ASSERT_TRUE(b.IsNegative());
+    ASSERT_TRUE(b.IsNegative(true));
+    ASSERT_FALSE(b.IsZero());
+}
+
+TEST(ScriptTest, TestBoundZeroSignSemantics) {
+    Bound_ z(0.0);
+    ASSERT_TRUE(z.IsPositive(false));
+    ASSERT_FALSE(z.IsPositive(true));
+    ASSERT_TRUE(z.IsNegative(false));
+    ASSERT_FALSE(z.IsNegative(true));
+    ASSERT_TRUE(z.IsZero());
+}
+
+TEST(ScriptTest, TestBoundAssignment) {
+    Bound_ b(1.0);
+    b = 5.0;
+    ASSERT_NEAR(b.Val(), 5.0, 1e-10);
+    ASSERT_FALSE(b.IsInfinite());
+
+    b = Bound_::plusInfinity_;
+    ASSERT_TRUE(b.IsPlusInf());
+
+    b = Bound_::minusInfinity_;
+    ASSERT_TRUE(b.IsMinusInf());
+
+    Bound_ c(3.0);
+    b = c;
+    ASSERT_EQ(b, Bound_(3.0));
+}
+
+TEST(ScriptTest, TestBoundComparison) {
+    ASSERT_TRUE(Bound_(1.0) == Bound_(1.0));
+    ASSERT_TRUE(Bound_(1.0) != Bound_(2.0));
+    ASSERT_TRUE(Bound_(1.0) < Bound_(2.0));
+    ASSERT_TRUE(Bound_(2.0) > Bound_(1.0));
+    ASSERT_TRUE(Bound_(2.0) <= Bound_(2.0));
+    ASSERT_TRUE(Bound_(2.0) >= Bound_(2.0));
+    ASSERT_FALSE(Bound_(2.0) < Bound_(2.0));
+}
+
+TEST(ScriptTest, TestBoundComparisonWithInfinities) {
+    Bound_ pInf(Bound_::plusInfinity_);
+    Bound_ mInf(Bound_::minusInfinity_);
+    ASSERT_TRUE(mInf < Bound_(0.0));
+    ASSERT_TRUE(Bound_(0.0) < pInf);
+    ASSERT_TRUE(mInf < pInf);
+    ASSERT_TRUE(pInf == Bound_(Bound_::plusInfinity_));
+    ASSERT_TRUE(mInf == Bound_(Bound_::minusInfinity_));
+    ASSERT_TRUE(pInf > mInf);
+}
+
+TEST(ScriptTest, TestBoundNegation) {
+    ASSERT_EQ(-Bound_(3.0), Bound_(-3.0));
+    ASSERT_TRUE((-Bound_(Bound_::plusInfinity_)).IsMinusInf());
+    ASSERT_TRUE((-Bound_(Bound_::minusInfinity_)).IsPlusInf());
+}
+
+TEST(ScriptTest, TestBoundMultiplicationReal) {
+    ASSERT_EQ(Bound_(2.0) * Bound_(3.0), Bound_(6.0));
+    ASSERT_EQ(Bound_(-2.0) * Bound_(3.0), Bound_(-6.0));
+}
+
+TEST(ScriptTest, TestBoundMultiplicationWithInfinity) {
+    Bound_ pInf(Bound_::plusInfinity_);
+    Bound_ mInf(Bound_::minusInfinity_);
+
+    ASSERT_TRUE((pInf * Bound_(2.0)).IsPlusInf());
+    ASSERT_TRUE((pInf * Bound_(-2.0)).IsMinusInf());
+    ASSERT_TRUE((mInf * Bound_(2.0)).IsMinusInf());
+    ASSERT_TRUE((mInf * Bound_(-2.0)).IsPlusInf());
+    ASSERT_TRUE((pInf * mInf).IsMinusInf());
+    ASSERT_TRUE((pInf * pInf).IsPlusInf());
+
+    ASSERT_TRUE((pInf * Bound_(0.0)).IsPlusInf());
+    ASSERT_TRUE((Bound_(0.0) * mInf).IsMinusInf());
+}
+
+TEST(ScriptTest, TestBoundWrite) {
+    ASSERT_EQ(Bound_(Bound_::plusInfinity_).Write(), "+INF");
+    ASSERT_EQ(Bound_(Bound_::minusInfinity_).Write(), "-INF");
+}
+
+TEST(ScriptTest, TestIntervalSingleton) {
+    Interval_ i(4.0);
+    double val;
+    ASSERT_TRUE(i.IsSingleton(&val));
+    ASSERT_NEAR(val, 4.0, 1e-10);
+    ASSERT_FALSE(i.IsContinuous());
+    ASSERT_EQ(i.Left(), Bound_(4.0));
+    ASSERT_EQ(i.Right(), Bound_(4.0));
+    ASSERT_FALSE(i.IsInfinite());
+}
+
+TEST(ScriptTest, TestIntervalZeroSingleton) {
+    Interval_ i(0.0);
+    ASSERT_TRUE(i.IsZero());
+    ASSERT_TRUE(i.IsSingleton());
+}
+
+TEST(ScriptTest, TestIntervalContinuous) {
+    Interval_ i(Bound_(1.0), Bound_(2.0));
+    ASSERT_FALSE(i.IsSingleton());
+    ASSERT_TRUE(i.IsContinuous());
+    ASSERT_FALSE(i.IsZero());
+}
+
+TEST(ScriptTest, TestIntervalInconsistentBoundsThrow) {
+    ASSERT_THROW(Interval_(Bound_(2.0), Bound_(1.0)), Dal::Exception_);
+    ASSERT_THROW(Interval_(Bound_(Bound_::plusInfinity_), Bound_(1.0)), Dal::Exception_);
+    ASSERT_THROW(Interval_(Bound_(1.0), Bound_(Bound_::minusInfinity_)), Dal::Exception_);
+}
+
+TEST(ScriptTest, TestIntervalSignChecks) {
+    Interval_ pos(Bound_(1.0), Bound_(2.0));
+    ASSERT_TRUE(pos.IsPositive());
+    ASSERT_TRUE(pos.IsPositive(true));
+    ASSERT_FALSE(pos.IsNegative());
+    ASSERT_TRUE(pos.IsPosOrNeg());
+
+    Interval_ neg(Bound_(-2.0), Bound_(-1.0));
+    ASSERT_TRUE(neg.IsNegative());
+    ASSERT_TRUE(neg.IsNegative(true));
+    ASSERT_FALSE(neg.IsPositive());
+
+    Interval_ straddle(Bound_(-1.0), Bound_(1.0));
+    ASSERT_FALSE(straddle.IsPositive(true));
+    ASSERT_FALSE(straddle.IsNegative(true));
+    ASSERT_FALSE(straddle.IsPosOrNeg(true));
+}
+
+TEST(ScriptTest, TestIntervalInfinite) {
+    Interval_ i(Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_));
+    ASSERT_TRUE(i.IsInfinite());
+    ASSERT_TRUE(i.Includes(0.0));
+    ASSERT_TRUE(i.Includes(1e20));
+}
+
+TEST(ScriptTest, TestIntervalAddition) {
+    Interval_ a(Bound_(1.0), Bound_(2.0));
+    Interval_ b(Bound_(3.0), Bound_(4.0));
+    Interval_ c = a + b;
+    ASSERT_EQ(c.Left(), Bound_(4.0));
+    ASSERT_EQ(c.Right(), Bound_(6.0));
+
+    Interval_ withInf(Bound_(Bound_::minusInfinity_), Bound_(5.0));
+    Interval_ d = a + withInf;
+    ASSERT_TRUE(d.Left().IsMinusInf());
+    ASSERT_EQ(d.Right(), Bound_(7.0));
+}
+
+TEST(ScriptTest, TestIntervalSubtraction) {
+    Interval_ a(Bound_(5.0), Bound_(7.0));
+    Interval_ b(Bound_(1.0), Bound_(2.0));
+    Interval_ c = a - b;
+    ASSERT_EQ(c.Left(), Bound_(3.0));
+    ASSERT_EQ(c.Right(), Bound_(6.0));
+}
+
+TEST(ScriptTest, TestIntervalUnaryMinus) {
+    Interval_ a(Bound_(1.0), Bound_(3.0));
+    Interval_ n = -a;
+    ASSERT_EQ(n.Left(), Bound_(-3.0));
+    ASSERT_EQ(n.Right(), Bound_(-1.0));
+}
+
+TEST(ScriptTest, TestIntervalMultiplication) {
+    Interval_ a(Bound_(2.0), Bound_(3.0));
+    Interval_ b(Bound_(4.0), Bound_(5.0));
+    Interval_ c = a * b;
+    ASSERT_EQ(c.Left(), Bound_(8.0));
+    ASSERT_EQ(c.Right(), Bound_(15.0));
+
+    Interval_ straddle(Bound_(-2.0), Bound_(3.0));
+    Interval_ d = straddle * Interval_(Bound_(-1.0), Bound_(4.0));
+    ASSERT_EQ(d.Left(), Bound_(-8.0));
+    ASSERT_EQ(d.Right(), Bound_(12.0));
+}
+
+TEST(ScriptTest, TestIntervalMultiplicationByZero) {
+    Interval_ a(Bound_(2.0), Bound_(3.0));
+    Interval_ z(0.0);
+    Interval_ c = a * z;
+    ASSERT_TRUE(c.IsZero());
+}
+
+TEST(ScriptTest, TestIntervalInverseSingleton) {
+    Interval_ a(4.0);
+    Interval_ inv = a.Inverse();
+    double val;
+    ASSERT_TRUE(inv.IsSingleton(&val));
+    ASSERT_NEAR(val, 0.25, 1e-10);
+}
+
+TEST(ScriptTest, TestIntervalInverseContinuous) {
+    Interval_ a(Bound_(2.0), Bound_(4.0));
+    Interval_ inv = a.Inverse();
+    ASSERT_NEAR(inv.Left().Val(), 0.25, 1e-10);
+    ASSERT_NEAR(inv.Right().Val(), 0.5, 1e-10);
+}
+
+TEST(ScriptTest, TestIntervalInverseZeroThrows) {
+    Interval_ z(0.0);
+    ASSERT_THROW(z.Inverse(), Dal::Exception_);
+}
+
+TEST(ScriptTest, TestIntervalDivision) {
+    Interval_ a(Bound_(2.0), Bound_(4.0));
+    Interval_ b(Bound_(2.0), Bound_(2.0));
+    Interval_ c = a / b;
+    ASSERT_NEAR(c.Left().Val(), 1.0, 1e-10);
+    ASSERT_NEAR(c.Right().Val(), 2.0, 1e-10);
+}
+
+TEST(ScriptTest, TestIntervalMinMax) {
+    Interval_ a(Bound_(1.0), Bound_(4.0));
+    Interval_ b(Bound_(2.0), Bound_(3.0));
+
+    Interval_ mn = a.IMin(b);
+    ASSERT_EQ(mn.Left(), Bound_(1.0));
+    ASSERT_EQ(mn.Right(), Bound_(3.0));
+
+    Interval_ mx = a.IMax(b);
+    ASSERT_EQ(mx.Left(), Bound_(2.0));
+    ASSERT_EQ(mx.Right(), Bound_(4.0));
+}
+
+TEST(ScriptTest, TestIntervalIncludes) {
+    Interval_ a(Bound_(1.0), Bound_(5.0));
+    ASSERT_TRUE(a.Includes(3.0));
+    ASSERT_TRUE(a.Includes(1.0));
+    ASSERT_TRUE(a.Includes(5.0));
+    ASSERT_FALSE(a.Includes(6.0));
+    ASSERT_FALSE(a.Includes(0.0));
+
+    Interval_ inner(Bound_(2.0), Bound_(4.0));
+    ASSERT_TRUE(a.Includes(inner));
+    ASSERT_TRUE(inner.IsIncludedIn(a));
+    ASSERT_FALSE(inner.Includes(a));
+}
+
+TEST(ScriptTest, TestIntervalComparison) {
+    Interval_ a(Bound_(1.0), Bound_(2.0));
+    Interval_ b(Bound_(1.0), Bound_(3.0));
+    Interval_ c(Bound_(2.0), Bound_(3.0));
+
+    ASSERT_TRUE(a == a);
+    ASSERT_TRUE(a < b);
+    ASSERT_TRUE(b < c);
+    ASSERT_TRUE(c > a);
+    ASSERT_TRUE(a <= a);
+    ASSERT_TRUE(a >= a);
+}
+
+TEST(ScriptTest, TestIntervalAdjacent) {
+    Interval_ a(Bound_(1.0), Bound_(2.0));
+    Interval_ b(Bound_(2.0), Bound_(3.0));
+    ASSERT_EQ(a.IsAdjacent(b), 1u);
+    ASSERT_EQ(b.IsAdjacent(a), 2u);
+
+    Interval_ c(Bound_(5.0), Bound_(6.0));
+    ASSERT_EQ(a.IsAdjacent(c), 0u);
+}
+
+TEST(ScriptTest, TestIntervalIntersect) {
+    Interval_ a(Bound_(1.0), Bound_(4.0));
+    Interval_ b(Bound_(3.0), Bound_(6.0));
+    Interval_ sect;
+    ASSERT_TRUE(Intersect(a, b, &sect));
+    ASSERT_EQ(sect.Left(), Bound_(3.0));
+    ASSERT_EQ(sect.Right(), Bound_(4.0));
+
+    Interval_ c(Bound_(10.0), Bound_(12.0));
+    ASSERT_FALSE(Intersect(a, c));
+}
+
+TEST(ScriptTest, TestIntervalMerge) {
+    Interval_ a(Bound_(1.0), Bound_(4.0));
+    Interval_ b(Bound_(3.0), Bound_(6.0));
+    Interval_ merged;
+    ASSERT_TRUE(Merge(a, b, &merged));
+    ASSERT_EQ(merged.Left(), Bound_(1.0));
+    ASSERT_EQ(merged.Right(), Bound_(6.0));
+
+    Interval_ c(Bound_(10.0), Bound_(12.0));
+    ASSERT_FALSE(Merge(a, c));
+}
+
+TEST(ScriptTest, TestIntervalWrite) {
+    ASSERT_EQ(Interval_(2.0).Write(), "{2}");
+}
+
+TEST(ScriptTest, TestDomainEmpty) {
+    Domain_ d;
+    ASSERT_TRUE(d.IsEmpty());
+    ASSERT_EQ(d.Size(), 0u);
+    ASSERT_TRUE(d.MinBound().IsMinusInf());
+    ASSERT_TRUE(d.MaxBound().IsPlusInf());
+}
+
+TEST(ScriptTest, TestDomainSingleton) {
+    Domain_ d(3.0);
+    ASSERT_FALSE(d.IsEmpty());
+    ASSERT_EQ(d.Size(), 1u);
+    ASSERT_TRUE(d.IsDiscrete());
+    ASSERT_FALSE(d.IsContinuous());
+    double val;
+    ASSERT_TRUE(d.IsConstant(&val));
+    ASSERT_NEAR(val, 3.0, 1e-10);
+    ASSERT_EQ(d.MinBound(), Bound_(3.0));
+    ASSERT_EQ(d.MaxBound(), Bound_(3.0));
+}
+
+TEST(ScriptTest, TestDomainAddDisjointSingletons) {
+    Domain_ d;
+    d.AddSingleton(1.0);
+    d.AddSingleton(3.0);
+    ASSERT_EQ(d.Size(), 2u);
+    ASSERT_TRUE(d.IsDiscrete());
+
+    auto singletons = d.GetSingletons();
+    ASSERT_EQ(singletons.size(), 2u);
+    ASSERT_NEAR(singletons[0], 1.0, 1e-10);
+    ASSERT_NEAR(singletons[1], 3.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainMergesOverlappingIntervals) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(4.0)));
+    d.AddInterval(Interval_(Bound_(3.0), Bound_(6.0)));
+    ASSERT_EQ(d.Size(), 1u);
+    ASSERT_EQ(d.MinBound(), Bound_(1.0));
+    ASSERT_EQ(d.MaxBound(), Bound_(6.0));
+}
+
+TEST(ScriptTest, TestDomainKeepsDisjointIntervals) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(2.0)));
+    d.AddInterval(Interval_(Bound_(5.0), Bound_(6.0)));
+    ASSERT_EQ(d.Size(), 2u);
+    ASSERT_EQ(d.MinBound(), Bound_(1.0));
+    ASSERT_EQ(d.MaxBound(), Bound_(6.0));
+}
+
+TEST(ScriptTest, TestDomainRealSpaceCollapse) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(2.0)));
+    d.AddInterval(Interval_(Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_)));
+    ASSERT_EQ(d.Size(), 1u);
+    ASSERT_TRUE(d.IsInfinite());
+    ASSERT_TRUE(d.MinBound().IsMinusInf());
+    ASSERT_TRUE(d.MaxBound().IsPlusInf());
+}
+
+TEST(ScriptTest, TestDomainBoolean) {
+    Domain_ d;
+    d.AddSingleton(0.0);
+    d.AddSingleton(1.0);
+    pair<double, double> vals;
+    ASSERT_TRUE(d.IsBoolean(&vals));
+    ASSERT_NEAR(vals.first, 0.0, 1e-10);
+    ASSERT_NEAR(vals.second, 1.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainPositiveNegative) {
+    Domain_ pos;
+    pos.AddInterval(Interval_(Bound_(1.0), Bound_(2.0)));
+    pos.AddSingleton(5.0);
+    ASSERT_TRUE(pos.IsPositive());
+    ASSERT_FALSE(pos.IsNegative());
+
+    Domain_ neg;
+    neg.AddInterval(Interval_(Bound_(-3.0), Bound_(-1.0)));
+    ASSERT_TRUE(neg.IsNegative());
+    ASSERT_FALSE(neg.IsPositive());
+}
+
+TEST(ScriptTest, TestDomainGetContinuous) {
+    Domain_ d;
+    d.AddSingleton(0.0);
+    d.AddInterval(Interval_(Bound_(2.0), Bound_(4.0)));
+    Domain_ cont = d.GetContinuous();
+    ASSERT_EQ(cont.Size(), 1u);
+    ASSERT_TRUE(cont.IsContinuous());
+    ASSERT_EQ(cont.MinBound(), Bound_(2.0));
+}
+
+TEST(ScriptTest, TestDomainAddition) {
+    Domain_ a(2.0);
+    Domain_ b(3.0);
+    Domain_ c = a + b;
+    double val;
+    ASSERT_TRUE(c.IsConstant(&val));
+    ASSERT_NEAR(val, 5.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainNegation) {
+    Domain_ a;
+    a.AddInterval(Interval_(Bound_(1.0), Bound_(3.0)));
+    Domain_ n = -a;
+    ASSERT_EQ(n.MinBound(), Bound_(-3.0));
+    ASSERT_EQ(n.MaxBound(), Bound_(-1.0));
+}
+
+TEST(ScriptTest, TestDomainSubtraction) {
+    Domain_ a(5.0);
+    Domain_ b(2.0);
+    Domain_ c = a - b;
+    double val;
+    ASSERT_TRUE(c.IsConstant(&val));
+    ASSERT_NEAR(val, 3.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainMultiplication) {
+    Domain_ a(4.0);
+    Domain_ b(3.0);
+    Domain_ c = a * b;
+    double val;
+    ASSERT_TRUE(c.IsConstant(&val));
+    ASSERT_NEAR(val, 12.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainShiftInPlace) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(2.0)));
+    d += 3.0;
+    ASSERT_EQ(d.MinBound(), Bound_(4.0));
+    ASSERT_EQ(d.MaxBound(), Bound_(5.0));
+    d -= 1.0;
+    ASSERT_EQ(d.MinBound(), Bound_(3.0));
+    ASSERT_EQ(d.MaxBound(), Bound_(4.0));
+}
+
+TEST(ScriptTest, TestDomainMinMax) {
+    Domain_ a;
+    a.AddInterval(Interval_(Bound_(1.0), Bound_(4.0)));
+    Domain_ b;
+    b.AddInterval(Interval_(Bound_(2.0), Bound_(3.0)));
+
+    Domain_ mn = a.DMin(b);
+    ASSERT_EQ(mn.MinBound(), Bound_(1.0));
+    ASSERT_EQ(mn.MaxBound(), Bound_(3.0));
+
+    Domain_ mx = a.DMax(b);
+    ASSERT_EQ(mx.MinBound(), Bound_(2.0));
+    ASSERT_EQ(mx.MaxBound(), Bound_(4.0));
+}
+
+TEST(ScriptTest, TestDomainIncludes) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(3.0)));
+    d.AddSingleton(7.0);
+    ASSERT_TRUE(d.Includes(2.0));
+    ASSERT_TRUE(d.Includes(7.0));
+    ASSERT_FALSE(d.Includes(5.0));
+}
+
+TEST(ScriptTest, TestDomainFuzzyZeroShortcuts) {
+    Domain_ zero(0.0);
+    ASSERT_TRUE(zero.CanBeZero());
+    ASSERT_FALSE(zero.CanBeNonZero());
+    ASSERT_TRUE(zero.ZeroIsDiscrete());
+    ASSERT_FALSE(zero.ZeroIsCont());
+
+    Domain_ around;
+    around.AddInterval(Interval_(Bound_(-1.0), Bound_(1.0)));
+    ASSERT_TRUE(around.CanBeZero());
+    ASSERT_TRUE(around.CanBeNonZero());
+    ASSERT_FALSE(around.ZeroIsDiscrete());
+    ASSERT_TRUE(around.ZeroIsCont());
+
+    Domain_ nonZero(5.0);
+    ASSERT_FALSE(nonZero.CanBeZero());
+    ASSERT_TRUE(nonZero.CanBeNonZero());
+}
+
+TEST(ScriptTest, TestDomainCanBePositiveNegative) {
+    Domain_ pos;
+    pos.AddInterval(Interval_(Bound_(1.0), Bound_(2.0)));
+    ASSERT_TRUE(pos.CanBePositive(true));
+    ASSERT_FALSE(pos.CanBeNegative(true));
+
+    Domain_ straddle;
+    straddle.AddInterval(Interval_(Bound_(-2.0), Bound_(3.0)));
+    ASSERT_TRUE(straddle.CanBePositive(true));
+    ASSERT_TRUE(straddle.CanBeNegative(true));
+
+    Domain_ empty;
+    ASSERT_FALSE(empty.CanBePositive(true));
+    ASSERT_FALSE(empty.CanBeNegative(true));
+}
+
+TEST(ScriptTest, TestDomainSmallestPosLb) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(-2.0), Bound_(-1.0)));
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(3.0)));
+    double res;
+    ASSERT_TRUE(d.SmallestPosLb(res));
+    ASSERT_NEAR(res, 1.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainBiggestNegRb) {
+    Domain_ d;
+    d.AddInterval(Interval_(Bound_(-3.0), Bound_(-1.0)));
+    d.AddInterval(Interval_(Bound_(1.0), Bound_(2.0)));
+    double res;
+    ASSERT_TRUE(d.BiggestNegRb(res));
+    ASSERT_NEAR(res, -1.0, 1e-10);
+}
+
+TEST(ScriptTest, TestDomainAddDomain) {
+    Domain_ a;
+    a.AddSingleton(1.0);
+    Domain_ b;
+    b.AddSingleton(2.0);
+    a.AddDomain(b);
+    ASSERT_EQ(a.Size(), 2u);
+    ASSERT_TRUE(a.Includes(1.0));
+    ASSERT_TRUE(a.Includes(2.0));
+}

--- a/dal-cpp/tests/script/test_domain.cpp
+++ b/dal-cpp/tests/script/test_domain.cpp
@@ -169,7 +169,7 @@ TEST(ScriptTest, TestIntervalSignChecks) {
 }
 
 TEST(ScriptTest, TestIntervalInfinite) {
-    Interval_ i(Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_));
+    Interval_ i{Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_)};
     ASSERT_TRUE(i.IsInfinite());
     ASSERT_TRUE(i.Includes(0.0));
     ASSERT_TRUE(i.Includes(1e20));

--- a/dal-cpp/tests/script/test_parser.cpp
+++ b/dal-cpp/tests/script/test_parser.cpp
@@ -136,3 +136,210 @@ TEST(ScriptTest, TestParserWithConflictVariableName) {
     )";
     ASSERT_THROW(parser.Parse(event), ScriptError_);
 }
+
+TEST(ScriptTest, TestParsePrecedenceAddMul) {
+    Parser_ parser;
+    String_ event = "x = 2 + 3 * 4";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto add = dynamic_cast<NodeAdd_*>(assign->arguments_[1].get());
+    ASSERT_NE(add, nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(add->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodeMulti_*>(add->arguments_[1].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParsePrecedenceMulAdd) {
+    Parser_ parser;
+    String_ event = "x = 2 * 3 + 4";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto add = dynamic_cast<NodeAdd_*>(assign->arguments_[1].get());
+    ASSERT_NE(add, nullptr);
+    ASSERT_NE(dynamic_cast<NodeMulti_*>(add->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(add->arguments_[1].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParsePrecedencePowOverMul) {
+    Parser_ parser;
+    String_ event = "x = 2 * 3 ^ 4";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto mul = dynamic_cast<NodeMulti_*>(assign->arguments_[1].get());
+    ASSERT_NE(mul, nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(mul->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodePow_*>(mul->arguments_[1].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseParenthesesOverridePrecedence) {
+    Parser_ parser;
+    String_ event = "x = (2 + 3) * 4";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto mul = dynamic_cast<NodeMulti_*>(assign->arguments_[1].get());
+    ASSERT_NE(mul, nullptr);
+    ASSERT_NE(dynamic_cast<NodeAdd_*>(mul->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(mul->arguments_[1].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseUnaryMinus) {
+    Parser_ parser;
+    String_ event = "x = -3";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto uminus = dynamic_cast<NodeUMinus_*>(assign->arguments_[1].get());
+    ASSERT_NE(uminus, nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(uminus->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseUnaryPlus) {
+    Parser_ parser;
+    String_ event = "x = +3";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto uplus = dynamic_cast<NodeUPlus_*>(assign->arguments_[1].get());
+    ASSERT_NE(uplus, nullptr);
+}
+
+
+TEST(ScriptTest, TestParseMin) {
+    Parser_ parser;
+    String_ event = "x = MIN(2, 3)";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto min = dynamic_cast<NodeMin_*>(assign->arguments_[1].get());
+    ASSERT_NE(min, nullptr);
+    ASSERT_EQ(min->arguments_.size(), 2);
+}
+
+TEST(ScriptTest, TestParseMax) {
+    Parser_ parser;
+    String_ event = "x = MAX(2, 3, 4)";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto max = dynamic_cast<NodeMax_*>(assign->arguments_[1].get());
+    ASSERT_NE(max, nullptr);
+    ASSERT_EQ(max->arguments_.size(), 3);
+}
+
+TEST(ScriptTest, TestParseMinWrongArgCountThrows) {
+    Parser_ parser;
+    String_ event = "x = MIN(2)";
+    ASSERT_THROW(parser.Parse(event), ScriptError_);
+}
+
+TEST(ScriptTest, TestParsePow) {
+    Parser_ parser;
+    String_ event = "x = 2 ^ 3";
+    auto res = parser.Parse(event);
+    auto assign = dynamic_cast<NodeAssign_*>(res[0].get());
+    auto pow = dynamic_cast<NodePow_*>(assign->arguments_[1].get());
+    ASSERT_NE(pow, nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(pow->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodeConst_*>(pow->arguments_[1].get()), nullptr);
+}
+
+
+TEST(ScriptTest, TestParseCondGreater) {
+    Parser_ parser;
+    String_ event = "IF x > 2 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    ASSERT_NE(dynamic_cast<NodeSup_*>(ifNode->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseCondLess) {
+    Parser_ parser;
+    String_ event = "IF x < 2 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    ASSERT_NE(dynamic_cast<NodeSup_*>(ifNode->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseCondLessEqual) {
+    Parser_ parser;
+    String_ event = "IF x <= 2 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    ASSERT_NE(dynamic_cast<NodeSupEqual_*>(ifNode->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseCondEqual) {
+    Parser_ parser;
+    String_ event = "IF x = 2 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    ASSERT_NE(dynamic_cast<NodeEqual_*>(ifNode->arguments_[0].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseCondNotEqual) {
+    Parser_ parser;
+    String_ event = "IF x != 2 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    auto notNode = dynamic_cast<NodeNot_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(notNode, nullptr);
+    ASSERT_NE(dynamic_cast<NodeEqual_*>(notNode->arguments_[0].get()), nullptr);
+}
+
+
+TEST(ScriptTest, TestParseCondAnd) {
+    Parser_ parser;
+    String_ event = "IF x > 2 AND x < 5 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    auto andNode = dynamic_cast<NodeAnd_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(andNode, nullptr);
+    ASSERT_NE(dynamic_cast<NodeSup_*>(andNode->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodeSup_*>(andNode->arguments_[1].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseCondOr) {
+    Parser_ parser;
+    String_ event = "IF x > 2 OR x < 5 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    auto orNode = dynamic_cast<NodeOr_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(orNode, nullptr);
+}
+
+TEST(ScriptTest, TestParseCondAndBindsTighterThanOr) {
+    Parser_ parser;
+    String_ event = "IF x > 1 OR x > 2 AND x > 3 THEN y = 1 END";
+    auto res = parser.Parse(event);
+    auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
+    auto orNode = dynamic_cast<NodeOr_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(orNode, nullptr);
+    ASSERT_NE(dynamic_cast<NodeSup_*>(orNode->arguments_[0].get()), nullptr);
+    ASSERT_NE(dynamic_cast<NodeAnd_*>(orNode->arguments_[1].get()), nullptr);
+}
+
+TEST(ScriptTest, TestParseUnbalancedParenThrows) {
+    Parser_ parser;
+    String_ event = "x = (2 + 3";
+    ASSERT_THROW(parser.Parse(event), ScriptError_);
+}
+
+TEST(ScriptTest, TestParseDanglingPlusThrows) {
+    Parser_ parser;
+    String_ event = "x = 2 +";
+    ASSERT_THROW(parser.Parse(event), ScriptError_);
+}
+
+
+TEST(ScriptTest, TestParseIfWithoutThenThrows) {
+    Parser_ parser;
+    String_ event = "IF x > 2 y = 1 END";
+    ASSERT_THROW(parser.Parse(event), ScriptError_);
+}
+
+TEST(ScriptTest, TestParseStatementWithoutInstructionThrows) {
+    Parser_ parser;
+    String_ event = "x 2";
+    ASSERT_THROW(parser.Parse(event), ScriptError_);
+}
+
+TEST(ScriptTest, TestParseCondInvalidComparatorThrows) {
+    Parser_ parser;
+    String_ event = "IF x + 2 THEN y = 1 END";
+    ASSERT_THROW(parser.Parse(event), ScriptError_);
+}

--- a/dal-cpp/tests/script/test_parser.cpp
+++ b/dal-cpp/tests/script/test_parser.cpp
@@ -11,6 +11,27 @@
 using namespace Dal;
 using namespace Dal::Script;
 
+namespace {
+    // Validate the operand order of the NodeSub_ inside a comparison node.
+    // The parser encodes both `<` and `>` as NodeSup_ (and both `<=`/`>=` as
+    // NodeSupEqual_), distinguishing them only by swapping the subtraction
+    // operands: `x > 2` becomes `x - 2`, while `x < 2` becomes `2 - x`. With
+    // constFirst=true the subtraction is `c - v`; otherwise it is `v - c`.
+    void AssertCmpSubOrder(const Node_* cmp, bool constFirst, double c, const String_& v) {
+        ASSERT_NE(cmp, nullptr);
+        auto sub = dynamic_cast<const NodeSub_*>(cmp->arguments_[0].get());
+        ASSERT_NE(sub, nullptr);
+        const Node_* lhs = sub->arguments_[0].get();
+        const Node_* rhs = sub->arguments_[1].get();
+        auto cn = dynamic_cast<const NodeConst_*>(constFirst ? lhs : rhs);
+        auto vn = dynamic_cast<const NodeVar_*>(constFirst ? rhs : lhs);
+        ASSERT_NE(cn, nullptr);
+        ASSERT_NE(vn, nullptr);
+        ASSERT_DOUBLE_EQ(cn->constVal_, c);
+        ASSERT_EQ(vn->name_, v);
+    }
+} // namespace
+
 TEST(ScriptTest, TestParseAssign) {
     Parser_ parser;
     String_ event = "x = 2";
@@ -252,7 +273,9 @@ TEST(ScriptTest, TestParseCondLess) {
     String_ event = "IF x < 2 THEN y = 1 END";
     auto res = parser.Parse(event);
     auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
-    ASSERT_NE(dynamic_cast<NodeSup_*>(ifNode->arguments_[0].get()), nullptr);
+    auto sup = dynamic_cast<NodeSup_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(sup, nullptr);
+    AssertCmpSubOrder(sup, true, 2.0, "x"); // x < 2  ->  2 - x > 0
 }
 
 TEST(ScriptTest, TestParseCondLessEqual) {
@@ -260,7 +283,9 @@ TEST(ScriptTest, TestParseCondLessEqual) {
     String_ event = "IF x <= 2 THEN y = 1 END";
     auto res = parser.Parse(event);
     auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
-    ASSERT_NE(dynamic_cast<NodeSupEqual_*>(ifNode->arguments_[0].get()), nullptr);
+    auto supEq = dynamic_cast<NodeSupEqual_*>(ifNode->arguments_[0].get());
+    ASSERT_NE(supEq, nullptr);
+    AssertCmpSubOrder(supEq, true, 2.0, "x"); // x <= 2  ->  2 - x >= 0
 }
 
 TEST(ScriptTest, TestParseCondEqual) {
@@ -289,8 +314,12 @@ TEST(ScriptTest, TestParseCondAnd) {
     auto ifNode = dynamic_cast<NodeIf_*>(res[0].get());
     auto andNode = dynamic_cast<NodeAnd_*>(ifNode->arguments_[0].get());
     ASSERT_NE(andNode, nullptr);
-    ASSERT_NE(dynamic_cast<NodeSup_*>(andNode->arguments_[0].get()), nullptr);
-    ASSERT_NE(dynamic_cast<NodeSup_*>(andNode->arguments_[1].get()), nullptr);
+    auto greater = dynamic_cast<NodeSup_*>(andNode->arguments_[0].get());
+    auto less = dynamic_cast<NodeSup_*>(andNode->arguments_[1].get());
+    ASSERT_NE(greater, nullptr);
+    ASSERT_NE(less, nullptr);
+    AssertCmpSubOrder(greater, false, 2.0, "x"); // x > 2  ->  x - 2 > 0
+    AssertCmpSubOrder(less, true, 5.0, "x");      // x < 5  ->  5 - x > 0
 }
 
 TEST(ScriptTest, TestParseCondOr) {

--- a/dal-cpp/tests/script/visitor/test_evaluator.cpp
+++ b/dal-cpp/tests/script/visitor/test_evaluator.cpp
@@ -26,7 +26,7 @@ namespace {
         std::map<String_, double> out;
         auto names = indexer.VarNames();
         auto vals = eval.VarVals();
-        for (auto i = 0; i < names.size(); ++i)
+        for (size_t i = 0; i < names.size(); ++i)
             out[names[i]] = vals[i];
         return out;
     }

--- a/dal-cpp/tests/script/visitor/test_evaluator.cpp
+++ b/dal-cpp/tests/script/visitor/test_evaluator.cpp
@@ -3,13 +3,35 @@
 //
 
 #include <gtest/gtest.h>
+#include <map>
 #include <dal/platform/platform.hpp>
 #include <dal/script/node.hpp>
+#include <dal/script/parser.hpp>
 #include <dal/script/visitor/all.hpp>
 #include <dal/script/visitor/evaluator.hpp>
 
 using namespace Dal;
 using namespace Dal::Script;
+
+namespace {
+    std::map<String_, double> ParseIndexEval(const String_& src) {
+        Parser_ parser;
+        auto event = parser.Parse(src);
+        VarIndexer_ indexer;
+        for (auto& stat : event)
+            stat->Accept(indexer);
+        Evaluator_<double> eval(Vector_<>(indexer.VarNames().size(), 0.0));
+        for (auto& stat : event)
+            stat->Accept(eval);
+        std::map<String_, double> out;
+        auto names = indexer.VarNames();
+        auto vals = eval.VarVals();
+        for (auto i = 0; i < names.size(); ++i)
+            out[names[i]] = vals[i];
+        return out;
+    }
+} // namespace
+
 
 TEST(ScriptTest, TestEvaluator) {
     Expression_ const1 = MakeBaseNode<NodeConst_>(20.0);
@@ -73,4 +95,175 @@ TEST(ScriptTest, TestEvaluatorWithExp) {
     assignExpr->Accept(visitor1);
     assignExpr->Accept(visitor2);
     ASSERT_DOUBLE_EQ(visitor2.VarVals()[0], 7.3890560989306504);
+}
+
+TEST(ScriptTest, TestEvaluatorAdd) {
+    auto vars = ParseIndexEval("x = 2 + 3");
+    ASSERT_NEAR(vars["x"], 5.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorSub) {
+    auto vars = ParseIndexEval("x = 10 - 4");
+    ASSERT_NEAR(vars["x"], 6.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorMul) {
+    auto vars = ParseIndexEval("x = 6 * 7");
+    ASSERT_NEAR(vars["x"], 42.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorDiv) {
+    auto vars = ParseIndexEval("x = 20 / 8");
+    ASSERT_NEAR(vars["x"], 2.5, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorPrecedence) {
+    auto vars = ParseIndexEval("x = 2 + 3 * 4");
+    ASSERT_NEAR(vars["x"], 14.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorParentheses) {
+    auto vars = ParseIndexEval("x = (2 + 3) * 4");
+    ASSERT_NEAR(vars["x"], 20.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorPow) {
+    auto vars = ParseIndexEval("x = 2 ^ 10");
+    ASSERT_NEAR(vars["x"], 1024.0, 1e-10);
+}
+
+
+TEST(ScriptTest, TestEvaluatorMin) {
+    auto vars = ParseIndexEval("x = MIN(3, 7)");
+    ASSERT_NEAR(vars["x"], 3.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorMax) {
+    auto vars = ParseIndexEval("x = MAX(3, 7)");
+    ASSERT_NEAR(vars["x"], 7.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorMaxThreeArgs) {
+    auto vars = ParseIndexEval("x = MAX(3, 7, 5)");
+    ASSERT_NEAR(vars["x"], 7.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorUnaryMinus) {
+    auto vars = ParseIndexEval("x = -5");
+    ASSERT_NEAR(vars["x"], -5.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorAssignReassign) {
+    auto vars = ParseIndexEval(R"(
+        x = 2
+        x = x + 10
+    )");
+    ASSERT_NEAR(vars["x"], 12.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorVariableReference) {
+    auto vars = ParseIndexEval(R"(
+        x = 4
+        y = x * 3
+    )");
+    ASSERT_NEAR(vars["x"], 4.0, 1e-10);
+    ASSERT_NEAR(vars["y"], 12.0, 1e-10);
+}
+
+
+TEST(ScriptTest, TestEvaluatorIfTrueBranch) {
+    auto vars = ParseIndexEval(R"(
+        x = 5
+        y = 0
+        IF x >= 2 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 1.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorIfFalseBranch) {
+    auto vars = ParseIndexEval(R"(
+        x = 1
+        y = 0
+        IF x >= 2 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 2.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorIfNoElseSkips) {
+    auto vars = ParseIndexEval(R"(
+        x = 1
+        y = 9
+        IF x >= 2 THEN
+            y = 1
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 9.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorConditionAnd) {
+    auto vars = ParseIndexEval(R"(
+        x = 3
+        y = 0
+        IF x > 2 AND x < 5 THEN
+            y = 1
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 1.0, 1e-10);
+}
+
+
+TEST(ScriptTest, TestEvaluatorConditionOr) {
+    auto vars = ParseIndexEval(R"(
+        x = 10
+        y = 0
+        IF x < 2 OR x > 5 THEN
+            y = 1
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 1.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorConditionNotEqual) {
+    auto vars = ParseIndexEval(R"(
+        x = 3
+        y = 0
+        IF x != 2 THEN
+            y = 1
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 1.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorConditionEqualFalse) {
+    auto vars = ParseIndexEval(R"(
+        x = 3
+        y = 0
+        IF x = 2 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 2.0, 1e-10);
+}
+
+TEST(ScriptTest, TestEvaluatorConditionLess) {
+    auto vars = ParseIndexEval(R"(
+        x = 1
+        y = 0
+        IF x < 2 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+    )");
+    ASSERT_NEAR(vars["y"], 1.0, 1e-10);
 }


### PR DESCRIPTION
## Summary
- Add `test_domain.cpp` — 54 tests for the script engine's `Bound_`/`Interval_`/`Domain_` value types (±infinity handling, degenerate/singleton intervals, bound ordering, set operations, fuzzy-zero shortcut accessors), which previously had no direct coverage.
- Add `test_constprocessor.cpp` (15) and `test_constcondprocessor.cpp` (6) — const-folding / constant-propagation visitors and always-true/false `IF` collapsing, both previously at zero coverage.
- Extend `test_parser.cpp` (+23) — operator precedence, unary minus, `^` power, `MIN`/`MAX`, comparison operators, `AND`/`OR` boolean conditions, parenthesization, and malformed-input throw paths.
- Extend `visitor/test_evaluator.cpp` (+21) — arithmetic ops, pow, min/max, `IF`/`ELSE` branch selection, comparison results, and variable assignment/reassignment.
- Full suite: 524 → 643 tests (+119), no regressions.

## Test plan
- [x] `bin/dal_cpp_tests --gtest_filter=ScriptTest.*` — all 158 ScriptTest cases pass
- [x] Full `bin/dal_cpp_tests` — 643 tests pass, zero regressions