### PR TITLE
feat: add web UI start/stop scripts and async valuations

### DIFF
--- a/.claude/skills/dal-webui-setup/SKILL.md
+++ b/.claude/skills/dal-webui-setup/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: dal-webui-setup
+description: Start or stop the DAL derivatives portfolio web UI (FastAPI backend + React/Vite frontend). Use when the user says "start the web UI", "run the webui", "stop the web UI", "shut down the webui", "launch the dashboard", or anything about bringing the DAL web UI up or down.
+user-invocable: true
+---
+
+# DAL Web UI — Start / Stop
+
+Brings up or tears down the two-service web UI that sits on top of the DAL Python public API.
+
+Two scripts handle the actual work:
+
+| Command | What it does |
+|---------|--------------|
+| `./webui/scripts/start.sh` | Checks prerequisites, starts backend (uvicorn on `:8001`) and frontend (vite on `:5173`), waits for both, runs a smoke test. |
+| `./webui/scripts/stop.sh [--force]` | Stops both services (by PID file, falling back to port-based kill). Use `--force` to escalate to SIGKILL. |
+
+## When to use
+
+- **User wants to start the web UI** → run `./webui/scripts/start.sh`
+- **User wants to stop the web UI** → run `./webui/scripts/stop.sh`
+- **User wants to run tests** → the skill can also invoke the test suites directly (see below).
+
+## Startup flow
+
+When the user asks to start the web UI:
+
+```bash
+./webui/scripts/start.sh
+```
+
+The script:
+1. Verifies prerequisites (python ≥ 3.13, uv, node, npm)
+2. Reads the backend port from `webui/frontend/vite.config.ts` (currently `:8001`)
+3. Checks that both ports are free
+4. Runs `uv sync` in `webui/backend/`
+5. Starts uvicorn in the background (PID saved to `webui/backend/.server.pid`)
+6. Waits for `/api/health` to respond (up to 20s)
+7. Runs `npm install` in `webui/frontend/`
+8. Starts vite in the background (PID saved to `webui/frontend/.server.pid`)
+9. Waits for `:5173` to respond (up to 30s)
+10. Smoke-tests the proxy (frontend → backend)
+11. Prints the URLs
+
+Logs go to `webui/backend/.server.log` and `webui/frontend/.server.log`.
+
+## Shutdown flow
+
+When the user asks to stop the web UI:
+
+```bash
+./webui/scripts/stop.sh
+```
+
+The script:
+1. Reads the backend port from `vite.config.ts`
+2. Kills the backend by PID (from `.server.pid`), or by port if no PID file
+3. Kills the frontend the same way
+4. Removes PID files
+5. Verifies both ports are free
+
+If a service refuses to stop within 5s, the script warns. Re-run with `--force` to escalate to SIGKILL.
+
+## Running tests
+
+If the user asks to run tests after starting the UI:
+
+```bash
+# Backend tests (pytest, runs against the stub by default)
+cd webui/backend && uv run pytest
+
+# Frontend type-check + production build
+cd webui/frontend && npm run build
+```
+
+## Native vs. stub DAL backend
+
+By default the backend uses `dal_stub.py` (pure-Python closed-form Black-Scholes). To use the compiled SWIG bindings:
+
+1. Build `dal-python` per the repo root `README.md`.
+2. Install into the uv env: `uv pip install ../dal-python` (from `webui/backend/`).
+3. Set `DAL_REQUIRE_NATIVE=1` before starting the backend.
+
+The start script respects environment variables, so you can do:
+
+```bash
+DAL_REQUIRE_NATIVE=1 ./webui/scripts/start.sh
+```
+
+## Troubleshooting
+
+- **Port already in use** — run `./webui/scripts/stop.sh` first, or manually free the port with `sudo fuser -k <port>/tcp`.
+- **Backend fails to start** — check `webui/backend/.server.log`. Common causes: missing dependencies, port conflict, Python version mismatch.
+- **Frontend fails to start** — check `webui/frontend/.server.log`. Common causes: port conflict, node_modules out of date (try `rm -rf node_modules && npm install`).
+- **Proxy not forwarding** — verify `webui/frontend/vite.config.ts` has the correct `proxy.target` port, and that the backend is actually running.
+
+## Reference
+
+For full details on the web UI architecture, see `webui/README.md`.

--- a/.claude/skills/dal-webui-setup/SKILL.md
+++ b/.claude/skills/dal-webui-setup/SKILL.md
@@ -10,10 +10,10 @@ Brings up or tears down the two-service web UI that sits on top of the DAL Pytho
 
 Two scripts handle the actual work:
 
-| Command | What it does |
-|---------|--------------|
-| `./webui/scripts/start.sh` | Checks prerequisites, starts backend (uvicorn on `:8001`) and frontend (vite on `:5173`), waits for both, runs a smoke test. |
-| `./webui/scripts/stop.sh [--force]` | Stops both services (by PID file, falling back to port-based kill). Use `--force` to escalate to SIGKILL. |
+| Command                               | What it does                                                                                                                             |
+|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `./webui/scripts/start.sh`            | Checks prerequisites, starts backend (uvicorn on `:8001`) and frontend (vite on `:5173`), waits for both, runs a smoke test.             |
+| `./webui/scripts/stop.sh [--force]`   | Stops both services (by PID file, falling back to port-based kill). Use `--force` to escalate to SIGKILL.                                |
 
 ## When to use
 
@@ -78,7 +78,7 @@ cd webui/frontend && npm run build
 By default the backend uses `dal_stub.py` (pure-Python closed-form Black-Scholes). To use the compiled SWIG bindings:
 
 1. Build `dal-python` per the repo root `README.md`.
-2. Install into the uv env: `uv pip install ../dal-python` (from `webui/backend/`).
+2. Install into the uv env: `uv pip install ../../dal-python` (from `webui/backend/`).
 3. Set `DAL_REQUIRE_NATIVE=1` before starting the backend.
 
 The start script respects environment variables, so you can do:

--- a/README.md
+++ b/README.md
@@ -177,28 +177,58 @@ Within `dal-cpp/`:
 
 A portfolio management web application lives in [`webui/`](webui/). It is not part of the CMake workspace; it runs as a FastAPI backend plus a React + TypeScript frontend. The backend talks to DAL through the Python public API (`dal`) via `webui/backend/app/services/dal_gateway.py`, with a pure-Python development stub available when the native bindings are not installed.
 
-```bash
-# Backend API (http://127.0.0.1:8000/docs)
-cd webui/backend
-uv sync
-uv run uvicorn app.main:app --reload --port 8000
-```
+The easiest way to start and stop the UI is with the scripts in `webui/scripts/`:
 
 ```bash
-# Frontend SPA (http://localhost:5173)
-cd webui/frontend
-npm install
-npm run dev
+# Start both services
+./webui/scripts/start.sh
+
+# Stop both services
+./webui/scripts/stop.sh          # SIGTERM
+./webui/scripts/stop.sh --force  # escalate to SIGKILL if needed
 ```
 
-Useful checks:
+`start.sh` checks prerequisites (Python ≥ 3.13, uv, node, npm), verifies ports `8001` (backend) and `5173` (frontend) are free, installs dependencies (`uv sync` in `webui/backend/`, `npm install` in `webui/frontend/`), launches both servers in the background, waits for the backend `/api/health` endpoint and the frontend to become ready, then smoke-tests the vite proxy (`/api` → backend). PIDs are saved to `webui/{backend,frontend}/.server.pid` and logs to `.server.log` next to each server.
+
+`stop.sh` kills by PID from those files, verifies each port is actually free, and falls back to port-based kill if an orphaned child is holding the socket (for example when the launcher spawns a wrapper process). With `--force` it escalates to SIGKILL after 5s.
+
+Once running:
+
+- Frontend: `http://localhost:5173`
+- Backend API docs: `http://127.0.0.1:8001/docs`
+
+### Running tests
 
 ```bash
 cd webui/backend && uv run pytest
 cd webui/frontend && npm run build
 ```
 
-Set `DAL_REQUIRE_NATIVE=1` before starting the backend to require the compiled `dal` package instead of allowing the development stub.
+### Using the native DAL backend
+
+By default the backend falls back to a pure-Python development stub when the compiled `dal` package is not installed. To require the native bindings:
+
+1. Build `dal-python` per the instructions above.
+2. Install it into the backend's virtualenv: `(cd webui/backend && uv pip install ../../dal-python)`.
+3. Start the UI with `DAL_REQUIRE_NATIVE=1 ./webui/scripts/start.sh`.
+
+### Manual startup (without the scripts)
+
+If you need to start either service by hand:
+
+```bash
+# Backend (http://127.0.0.1:8001/docs)
+cd webui/backend
+uv sync
+uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8001
+
+# Frontend (http://localhost:5173)
+cd webui/frontend
+npm install
+./node_modules/.bin/vite
+```
+
+Note: run vite directly rather than `npm run dev` when launching by hand -- `npm run` wraps the command in a parent process that does not forward SIGTERM, which leaves an orphan holding the port on shutdown.
 
 ## Excel Interface
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -69,6 +69,23 @@ strict). The `/api/health` endpoint reports which backend is active.
 
 ## Running
 
+### Quick Start (both services)
+
+```bash
+# Terminal 1 — Backend (start first so the frontend proxy can reach it)
+cd webui/backend
+uv sync
+uv run uvicorn app.main:app --reload --port 8000
+
+# Terminal 2 — Frontend
+cd webui/frontend
+npm install
+npm run dev
+```
+
+Then open **http://localhost:5173** in your browser. The Vite dev server proxies
+`/api` requests to the backend automatically.
+
 ### Backend (Python >= 3.13)
 
 Dependencies are managed with [uv](https://docs.astral.sh/uv/). From `webui/backend`:
@@ -94,6 +111,35 @@ cd webui/frontend
 npm install
 npm run dev                 # http://localhost:5173 (proxies /api to :8000)
 ```
+
+The Vite dev server proxies all `/api` requests to the backend URL configured in
+`vite.config.ts` (default: `http://127.0.0.1:8000`). If you change the backend
+port, update the `proxy.target` in that file and restart the frontend.
+
+### Stopping
+
+Press `Ctrl+C` in each terminal to stop the services.
+
+### Troubleshooting
+
+**Port 8000 already in use.** If the backend fails with `[Errno 98] Address
+already in use`, either free the port or run on a different one:
+
+```bash
+# Option A — find and kill whatever is using port 8000
+fuser -k 8000/tcp
+
+# Option B — use a different port (e.g. 8001)
+uv run uvicorn app.main:app --reload --port 8001
+```
+
+If you choose Option B, also update the proxy target in
+`webui/frontend/vite.config.ts` to match (`http://127.0.0.1:8001`) and restart
+the frontend.
+
+**Frontend can't reach the backend.** Make sure the backend starts *before* the
+frontend. If you see proxy errors in the browser console, check that the backend
+is running and the port in `vite.config.ts` matches.
 
 ### Tests
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -11,6 +11,9 @@ Derivatives Algorithms Library (DAL).
 
 ```
 webui/
+├── scripts/
+│   ├── start.sh             start both services (backend + frontend)
+│   └── stop.sh              stop both services (with optional --force)
 ├── backend/                 FastAPI service
 │   ├── app/
 │   │   ├── main.py          app factory + router wiring
@@ -71,20 +74,33 @@ strict). The `/api/health` endpoint reports which backend is active.
 
 ### Quick Start (both services)
 
-```bash
-# Terminal 1 — Backend (start first so the frontend proxy can reach it)
-cd webui/backend
-uv sync
-uv run uvicorn app.main:app --reload --port 8000
+The easiest way to start and stop the web UI is with the scripts in `webui/scripts/`:
 
-# Terminal 2 — Frontend
-cd webui/frontend
-npm install
-npm run dev
+```bash
+# Start both services
+./webui/scripts/start.sh
+
+# Stop both services
+./webui/scripts/stop.sh          # SIGTERM
+./webui/scripts/stop.sh --force  # escalate to SIGKILL if needed
 ```
 
-Then open **http://localhost:5173** in your browser. The Vite dev server proxies
-`/api` requests to the backend automatically.
+`start.sh` checks prerequisites (Python ≥ 3.13, uv, node, npm), verifies ports
+`8001` (backend) and `5173` (frontend) are free, installs dependencies
+(`uv sync` in `webui/backend/`, `npm install` in `webui/frontend/`), launches
+both servers in the background, waits for the backend `/api/health` endpoint and
+the frontend to become ready, then smoke-tests the vite proxy (`/api` → backend).
+PIDs are saved to `webui/{backend,frontend}/.server.pid` and logs to
+`.server.log` next to each server.
+
+`stop.sh` kills by PID from those files, verifies each port is actually free,
+and falls back to port-based kill if an orphaned child is holding the socket
+(for example when the launcher spawns a wrapper process). With `--force` it
+escalates to SIGKILL after 5s.
+
+Once running, open **http://localhost:5173** in your browser. The Vite dev
+server proxies `/api` requests to the backend automatically (target port is
+`8001`, configured in `vite.config.ts`).
 
 ### Backend (Python >= 3.13)
 
@@ -93,12 +109,12 @@ Dependencies are managed with [uv](https://docs.astral.sh/uv/). From `webui/back
 ```bash
 cd webui/backend
 uv sync                     # create .venv and install runtime + dev deps from uv.lock
-uv run uvicorn app.main:app --reload --port 8000
+uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8001
 ```
 
 `uv` provisions a matching Python interpreter automatically (downloading one if
 needed) and resolves dependencies from the committed `uv.lock`. API docs are then
-available at <http://127.0.0.1:8000/docs>.
+available at <http://127.0.0.1:8001/docs>.
 
 > To run against the compiled native `dal` package instead of the dev stub,
 > install it into the uv environment (`uv pip install /path/to/dal`) and start
@@ -109,37 +125,83 @@ available at <http://127.0.0.1:8000/docs>.
 ```bash
 cd webui/frontend
 npm install
-npm run dev                 # http://localhost:5173 (proxies /api to :8000)
+./node_modules/.bin/vite    # http://localhost:5173 (proxies /api to :8001)
 ```
 
 The Vite dev server proxies all `/api` requests to the backend URL configured in
-`vite.config.ts` (default: `http://127.0.0.1:8000`). If you change the backend
+`vite.config.ts` (default: `http://127.0.0.1:8001`). If you change the backend
 port, update the `proxy.target` in that file and restart the frontend.
+
+> **Note:** Run vite directly rather than `npm run dev` when launching by hand.
+> `npm run` wraps the command in a parent process that does not forward SIGTERM,
+> which leaves an orphan holding the port on shutdown. The `start.sh` script
+> already does this for you.
 
 ### Stopping
 
-Press `Ctrl+C` in each terminal to stop the services.
+If you started the services with `start.sh`, stop them with:
+
+```bash
+./webui/scripts/stop.sh
+```
+
+If you started them manually, press `Ctrl+C` in each terminal, or use the stop
+script (it will fall back to port-based kill if no PID files exist).
 
 ### Troubleshooting
 
-**Port 8000 already in use.** If the backend fails with `[Errno 98] Address
+**Port 8001 already in use.** If the backend fails with `[Errno 98] Address
 already in use`, either free the port or run on a different one:
 
 ```bash
-# Option A — find and kill whatever is using port 8000
-fuser -k 8000/tcp
+# Option A — stop any running web UI
+./webui/scripts/stop.sh
 
-# Option B — use a different port (e.g. 8001)
-uv run uvicorn app.main:app --reload --port 8001
+# Option B — find and kill whatever is using port 8001
+fuser -k 8001/tcp
+
+# Option C — use a different port (e.g. 8002)
+uv run uvicorn app.main:app --reload --port 8002
 ```
 
-If you choose Option B, also update the proxy target in
-`webui/frontend/vite.config.ts` to match (`http://127.0.0.1:8001`) and restart
+If you choose Option C, also update the proxy target in
+`webui/frontend/vite.config.ts` to match (`http://127.0.0.1:8002`) and restart
 the frontend.
 
 **Frontend can't reach the backend.** Make sure the backend starts *before* the
 frontend. If you see proxy errors in the browser console, check that the backend
 is running and the port in `vite.config.ts` matches.
+
+## API
+
+The backend exposes a REST-ish API under `/api`. Full OpenAPI docs are served at
+`/docs` once the backend is running. Highlights beyond the standard CRUD:
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET /api/health` | Reports which DAL backend is active (native vs. stub). |
+| `POST /api/products`, `PUT /api/products/{id}` | Create / partially update a scripted product. |
+| `POST /api/products/debug` | Render the DAL `Product_Debug` dump for arbitrary rows. |
+| `POST /api/models`, `PUT /api/models/{id}` | Black-Scholes or Dupire model data. |
+| `POST /api/trades`, `PUT /api/trades/{id}` | Link a product + model + notional. |
+| `POST /api/portfolios/{id}/trades/{tid}` | Add a trade to a portfolio. |
+| `POST /api/trades/{id}/value` | Start an **async** single-trade valuation (returns `status: "running"`). |
+| `POST /api/portfolios/{id}/value` | Start an **async** portfolio valuation (returns `status: "running"`). |
+| `GET /api/valuations/{id}` | Poll until `status` becomes `"completed"` or `"failed"`. |
+
+### Delete guards
+
+Deleting a product or model that is still referenced by any trade returns
+`409 Conflict` with a detail message naming the referencing trade. Delete the
+trade first (which cascades out of any portfolios) and then the product/model.
+
+### Async valuation
+
+Valuation endpoints now return a pending `ValuationResult` with
+`status: "running"` immediately. Pricing runs in a FastAPI background task, and
+the result is updated in-place once it completes. The frontend polls
+`GET /api/valuations/{id}` at 300ms intervals until the status becomes
+`"completed"` or `"failed"`.
 
 ### Tests
 
@@ -155,12 +217,18 @@ npm run build               # type-check + production build
 
 ## Screens
 
-* **Dashboard** -- portfolio counts, latest PV, recent valuation runs.
+* **Dashboard** -- portfolio counts, latest PV, recent valuation runs (with
+  per-run status indicator: running / completed / failed).
 * **Portfolios** -- group trades into books, add/remove trades, price the book.
-* **Trades** -- link a product + model + notional; price a single trade.
+  Delete buttons require confirmation; portfolios cascade-delete their trades
+  from the book.
+* **Trades** -- link a product + model + notional; price a single trade. Trades
+  are updated in place via `PUT /api/trades/{id}`.
 * **Product Builder** -- compose DAL scripted products as a schedule of
   (date/label, event) rows; load templates (European, up-and-out call, snowball);
-  render the DAL product debug dump.
-* **Models** -- create Black-Scholes model data.
-* **Valuation Runs** -- reproducible history of every Monte Carlo run with PV and
-  Greeks.
+  render the DAL product debug dump. Saved products can be **loaded** back into
+  the editor for iteration.
+* **Models** -- create Black-Scholes or Dupire model data (vol surface entered
+  as a whitespace-separated matrix).
+* **Valuation Runs** -- reproducible history of every Monte Carlo run with PV,
+  Greeks, and per-run status.

--- a/webui/backend/app/routers/models.py
+++ b/webui/backend/app/routers/models.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app.dependencies import store_dependency
 from app.schemas import ModelCreate, ModelDefinition, ModelUpdate
-from app.services.store import NotFoundError, Store
+from app.services.store import ConflictError, NotFoundError, Store
 
 router = APIRouter(prefix="/api/models", tags=["models"])
 
@@ -46,7 +46,7 @@ def update_model(
     payload: ModelUpdate,
     store: Store = Depends(store_dependency),
 ) -> ModelDefinition:
-    patch = payload.model_dump(exclude_unset=True)
+    patch = payload.model_dump(exclude_none=True)
     try:
         return store.update_model(model_id, patch)
     except NotFoundError as exc:
@@ -60,5 +60,5 @@ def update_model(
 def delete_model(model_id: str, store: Store = Depends(store_dependency)) -> None:
     try:
         store.delete_model(model_id)
-    except NotFoundError as exc:
+    except ConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/webui/backend/app/routers/models.py
+++ b/webui/backend/app/routers/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.dependencies import store_dependency
-from app.schemas import ModelCreate, ModelDefinition
+from app.schemas import ModelCreate, ModelDefinition, ModelUpdate
 from app.services.store import NotFoundError, Store
 
 router = APIRouter(prefix="/api/models", tags=["models"])
@@ -40,6 +40,25 @@ def get_model(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@router.put("/{model_id}", response_model=ModelDefinition)
+def update_model(
+    model_id: str,
+    payload: ModelUpdate,
+    store: Store = Depends(store_dependency),
+) -> ModelDefinition:
+    patch = payload.model_dump(exclude_unset=True)
+    try:
+        return store.update_model(model_id, patch)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        # model.dal_kind_and_params() validation failure (e.g. kind=BS but no bs params)
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
 @router.delete("/{model_id}", status_code=204)
 def delete_model(model_id: str, store: Store = Depends(store_dependency)) -> None:
-    store.delete_model(model_id)
+    try:
+        store.delete_model(model_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/webui/backend/app/routers/portfolios.py
+++ b/webui/backend/app/routers/portfolios.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from app.dependencies import gateway_dependency, store_dependency
 from app.schemas import (
@@ -14,7 +14,10 @@ from app.schemas import (
 )
 from app.services.dal_gateway import DalGateway
 from app.services.store import NotFoundError, Store
-from app.services.valuation import value_portfolio
+from app.services.valuation import (
+    _run_portfolio_pricing,
+    value_portfolio_async,
+)
 
 router = APIRouter(prefix="/api/portfolios", tags=["portfolios"])
 
@@ -90,11 +93,23 @@ def remove_trade(
 def value_portfolio_endpoint(
     portfolio_id: str,
     config: ValuationConfig,
+    background_tasks: BackgroundTasks,
     store: Store = Depends(store_dependency),
     gateway: DalGateway = Depends(gateway_dependency),
 ) -> ValuationResult:
+    """Start a portfolio valuation asynchronously.
+
+    Returns a pending ``ValuationResult`` immediately with ``status="running"``.
+    Pricing runs in a background task; poll ``GET /api/valuations/{id}`` until
+    ``status`` becomes ``"completed"`` or ``"failed"``.
+    """
     try:
         store.get_portfolio(portfolio_id)
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return value_portfolio(store, gateway, portfolio_id, config)
+
+    pending = value_portfolio_async(store, gateway, portfolio_id, config)
+    background_tasks.add_task(
+        _run_portfolio_pricing, store, gateway, pending.id, portfolio_id, config
+    )
+    return pending

--- a/webui/backend/app/routers/products.py
+++ b/webui/backend/app/routers/products.py
@@ -13,7 +13,7 @@ from app.schemas import (
     ProductUpdate,
 )
 from app.services.dal_gateway import DalGateway
-from app.services.store import NotFoundError, Store
+from app.services.store import ConflictError, NotFoundError, Store
 from app.services.templates import product_templates
 
 router = APIRouter(prefix="/api/products", tags=["products"])
@@ -55,7 +55,7 @@ def update_product(
     payload: ProductUpdate,
     store: Store = Depends(store_dependency),
 ) -> ProductDefinition:
-    patch = payload.model_dump(exclude_unset=True)
+    patch = payload.model_dump(exclude_none=True)
     try:
         return store.update_product(product_id, patch)
     except NotFoundError as exc:
@@ -66,7 +66,7 @@ def update_product(
 def delete_product(product_id: str, store: Store = Depends(store_dependency)) -> None:
     try:
         store.delete_product(product_id)
-    except NotFoundError as exc:
+    except ConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 

--- a/webui/backend/app/routers/products.py
+++ b/webui/backend/app/routers/products.py
@@ -10,6 +10,7 @@ from app.schemas import (
     ProductDebugRequest,
     ProductDebugResponse,
     ProductDefinition,
+    ProductUpdate,
 )
 from app.services.dal_gateway import DalGateway
 from app.services.store import NotFoundError, Store
@@ -48,9 +49,25 @@ def get_product(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@router.put("/{product_id}", response_model=ProductDefinition)
+def update_product(
+    product_id: str,
+    payload: ProductUpdate,
+    store: Store = Depends(store_dependency),
+) -> ProductDefinition:
+    patch = payload.model_dump(exclude_unset=True)
+    try:
+        return store.update_product(product_id, patch)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @router.delete("/{product_id}", status_code=204)
 def delete_product(product_id: str, store: Store = Depends(store_dependency)) -> None:
-    store.delete_product(product_id)
+    try:
+        store.delete_product(product_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post("/debug", response_model=ProductDebugResponse)

--- a/webui/backend/app/routers/trades.py
+++ b/webui/backend/app/routers/trades.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from app.dependencies import gateway_dependency, store_dependency
 from app.schemas import (
     Trade,
     TradeCreate,
+    TradeUpdate,
     ValuationConfig,
     ValuationResult,
 )
 from app.services.dal_gateway import DalGateway
 from app.services.store import NotFoundError, Store
-from app.services.valuation import value_single_trade
+from app.services.valuation import (
+    _run_trade_pricing,
+    value_single_trade_async,
+)
 
 router = APIRouter(prefix="/api/trades", tags=["trades"])
 
@@ -43,6 +47,19 @@ def get_trade(trade_id: str, store: Store = Depends(store_dependency)) -> Trade:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@router.put("/{trade_id}", response_model=Trade)
+def update_trade(
+    trade_id: str,
+    payload: TradeUpdate,
+    store: Store = Depends(store_dependency),
+) -> Trade:
+    patch = payload.model_dump(exclude_unset=True)
+    try:
+        return store.update_trade(trade_id, patch)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @router.delete("/{trade_id}", status_code=204)
 def delete_trade(trade_id: str, store: Store = Depends(store_dependency)) -> None:
     store.delete_trade(trade_id)
@@ -52,10 +69,23 @@ def delete_trade(trade_id: str, store: Store = Depends(store_dependency)) -> Non
 def value_trade_endpoint(
     trade_id: str,
     config: ValuationConfig,
+    background_tasks: BackgroundTasks,
     store: Store = Depends(store_dependency),
     gateway: DalGateway = Depends(gateway_dependency),
 ) -> ValuationResult:
+    """Start a single-trade valuation asynchronously.
+
+    Returns a pending ``ValuationResult`` immediately with ``status="running"``.
+    Pricing runs in a background task; poll ``GET /api/valuations/{id}`` until
+    ``status`` becomes ``"completed"`` or ``"failed"``.
+    """
     try:
-        return value_single_trade(store, gateway, trade_id, config)
+        store.get_trade(trade_id)
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    pending = value_single_trade_async(store, gateway, trade_id, config)
+    background_tasks.add_task(
+        _run_trade_pricing, store, gateway, pending.id, trade_id, config
+    )
+    return pending

--- a/webui/backend/app/routers/trades.py
+++ b/webui/backend/app/routers/trades.py
@@ -53,7 +53,7 @@ def update_trade(
     payload: TradeUpdate,
     store: Store = Depends(store_dependency),
 ) -> Trade:
-    patch = payload.model_dump(exclude_unset=True)
+    patch = payload.model_dump(exclude_none=True)
     try:
         return store.update_trade(trade_id, patch)
     except NotFoundError as exc:

--- a/webui/backend/app/schemas/__init__.py
+++ b/webui/backend/app/schemas/__init__.py
@@ -65,6 +65,13 @@ class ProductCreate(BaseModel):
     rows: list[EventRow]
 
 
+class ProductUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    template: str | None = None
+    rows: list[EventRow] | None = None
+
+
 # ---------------------------------------------------------------------------
 # Model definitions (map onto DAL model data)
 # ---------------------------------------------------------------------------
@@ -110,6 +117,13 @@ class ModelCreate(BaseModel):
     dupire: DupireModelParams | None = None
 
 
+class ModelUpdate(BaseModel):
+    name: str | None = None
+    kind: Literal["BSModelData_", "DupireModelData_"] | None = None
+    bs: BSModelParams | None = None
+    dupire: DupireModelParams | None = None
+
+
 # ---------------------------------------------------------------------------
 # Portfolio / trade hierarchy
 # ---------------------------------------------------------------------------
@@ -136,6 +150,17 @@ class TradeCreate(BaseModel):
     product_id: str
     model_id: str
     tags: list[str] = Field(default_factory=list)
+
+
+class TradeUpdate(BaseModel):
+    name: str | None = None
+    book: str | None = None
+    counterparty: str | None = None
+    notional: float | None = None
+    quantity: float | None = None
+    product_id: str | None = None
+    model_id: str | None = None
+    tags: list[str] | None = None
 
 
 class Portfolio(BaseModel):
@@ -184,6 +209,7 @@ class ValuationResult(BaseModel):
     total_greeks: dict[str, float] = Field(default_factory=dict)
     trades: list[TradeValuation] = Field(default_factory=list)
     created_at: str
+    status: Literal["running", "completed", "failed"] = "completed"
 
 
 class ProductDebugRequest(BaseModel):

--- a/webui/backend/app/schemas/__init__.py
+++ b/webui/backend/app/schemas/__init__.py
@@ -210,6 +210,7 @@ class ValuationResult(BaseModel):
     trades: list[TradeValuation] = Field(default_factory=list)
     created_at: str
     status: Literal["running", "completed", "failed"] = "completed"
+    error_message: str | None = None
 
 
 class ProductDebugRequest(BaseModel):

--- a/webui/backend/app/services/dal_stub.py
+++ b/webui/backend/app/services/dal_stub.py
@@ -109,12 +109,18 @@ def DupireModelData_New(  # noqa: N802
     times: list[float],
     vols: Any,
 ) -> _ModelHandle:
-    # Use the mid vol of the surface as a flat approximation for the stub.
+    # Use the average vol of the surface as a flat approximation for the stub.
+    # Handle both 2D list (normal case) and scalar (edge case) inputs.
     flat_vol = 0.2
-    try:
-        flat_vol = float(vols)  # in case a scalar slipped through
-    except (TypeError, ValueError):
-        pass
+    if isinstance(vols, list) and vols and isinstance(vols[0], list):
+        total = sum(sum(row) for row in vols)
+        count = sum(len(row) for row in vols)
+        flat_vol = total / count if count > 0 else 0.2
+    else:
+        try:
+            flat_vol = float(vols)
+        except (TypeError, ValueError):
+            pass
     return _ModelHandle(
         "DupireModelData_",
         {"spot": spot, "rate": rate, "div": repo, "vol": flat_vol},

--- a/webui/backend/app/services/store.py
+++ b/webui/backend/app/services/store.py
@@ -51,7 +51,25 @@ class Store:
 
     def delete_product(self, product_id: str) -> None:
         with self._lock:
-            self._products.pop(product_id, None)
+            if product_id not in self._products:
+                return
+            # Guard against orphaning trades that still reference this product.
+            for trade in self._trades.values():
+                if trade.product_id == product_id:
+                    raise NotFoundError(
+                        f"Cannot delete product {product_id}: still referenced by trade {trade.id}"
+                    )
+            del self._products[product_id]
+
+    def update_product(self, product_id: str, patch: dict) -> ProductDefinition:
+        """Merge a partial update into an existing product definition."""
+        with self._lock:
+            product = self.get_product(product_id)
+            updated_data = product.model_dump()
+            updated_data.update(patch)
+            updated = ProductDefinition(**updated_data)
+            self._products[product_id] = updated
+            return updated
 
     # -- models ----------------------------------------------------------
 
@@ -73,7 +91,27 @@ class Store:
 
     def delete_model(self, model_id: str) -> None:
         with self._lock:
-            self._models.pop(model_id, None)
+            if model_id not in self._models:
+                return
+            # Guard against orphaning trades that still reference this model.
+            for trade in self._trades.values():
+                if trade.model_id == model_id:
+                    raise NotFoundError(
+                        f"Cannot delete model {model_id}: still referenced by trade {trade.id}"
+                    )
+            del self._models[model_id]
+
+    def update_model(self, model_id: str, patch: dict) -> ModelDefinition:
+        """Merge a partial update into an existing model definition."""
+        with self._lock:
+            model = self.get_model(model_id)
+            updated_data = model.model_dump()
+            updated_data.update(patch)
+            updated = ModelDefinition(**updated_data)
+            # Validate params match kind (same check as create_model)
+            updated.dal_kind_and_params()
+            self._models[model_id] = updated
+            return updated
 
     # -- trades ----------------------------------------------------------
 
@@ -98,10 +136,30 @@ class Store:
 
     def delete_trade(self, trade_id: str) -> None:
         with self._lock:
-            self._trades.pop(trade_id, None)
+            if trade_id not in self._trades:
+                return
+            del self._trades[trade_id]
+            # Cascade: remove from any portfolios that still reference it.
             for pf in self._portfolios.values():
                 if trade_id in pf.trade_ids:
                     pf.trade_ids.remove(trade_id)
+
+    def update_trade(self, trade_id: str, patch: dict) -> Trade:
+        """Merge a partial update into an existing trade.
+
+        If product_id or model_id are changed, validates they exist.
+        """
+        with self._lock:
+            trade = self.get_trade(trade_id)
+            if "product_id" in patch:
+                self.get_product(patch["product_id"])
+            if "model_id" in patch:
+                self.get_model(patch["model_id"])
+            updated_data = trade.model_dump()
+            updated_data.update(patch)
+            updated = Trade(**updated_data)
+            self._trades[trade_id] = updated
+            return updated
 
     # -- portfolios ------------------------------------------------------
 
@@ -164,6 +222,16 @@ class Store:
                 return self._valuations[valuation_id]
             except KeyError as exc:
                 raise NotFoundError(f"valuation {valuation_id}") from exc
+
+    def update_valuation(self, valuation_id: str, patch: dict) -> ValuationResult:
+        """Atomically update fields on a valuation (used by async pricing)."""
+        with self._lock:
+            valuation = self.get_valuation(valuation_id)
+            updated_data = valuation.model_dump()
+            updated_data.update(patch)
+            updated = ValuationResult(**updated_data)
+            self._valuations[valuation_id] = updated
+            return updated
 
 
 # Process-wide singleton stored in a mutable container so get_store()

--- a/webui/backend/app/services/store.py
+++ b/webui/backend/app/services/store.py
@@ -22,6 +22,10 @@ class NotFoundError(KeyError):
     """Raised when an entity id cannot be resolved."""
 
 
+class ConflictError(Exception):
+    """Raised when an operation conflicts with existing state (e.g., references)."""
+
+
 class Store:
     def __init__(self) -> None:
         self._lock = threading.RLock()
@@ -56,7 +60,7 @@ class Store:
             # Guard against orphaning trades that still reference this product.
             for trade in self._trades.values():
                 if trade.product_id == product_id:
-                    raise NotFoundError(
+                    raise ConflictError(
                         f"Cannot delete product {product_id}: still referenced by trade {trade.id}"
                     )
             del self._products[product_id]
@@ -96,7 +100,7 @@ class Store:
             # Guard against orphaning trades that still reference this model.
             for trade in self._trades.values():
                 if trade.model_id == model_id:
-                    raise NotFoundError(
+                    raise ConflictError(
                         f"Cannot delete model {model_id}: still referenced by trade {trade.id}"
                     )
             del self._models[model_id]

--- a/webui/backend/app/services/valuation.py
+++ b/webui/backend/app/services/valuation.py
@@ -11,7 +11,6 @@ updates the result in-place when done (status: running -> completed / failed).
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from uuid import uuid4
 
 from app.schemas import (
     Trade,

--- a/webui/backend/app/services/valuation.py
+++ b/webui/backend/app/services/valuation.py
@@ -1,8 +1,17 @@
-"""Valuation service: orchestrates trade / portfolio pricing via the gateway."""
+"""Valuation service: orchestrates trade / portfolio pricing via the gateway.
+
+Supports both synchronous and asynchronous pricing.  The synchronous path
+(``value_trade``, ``value_portfolio``, ``value_single_trade``) blocks until
+pricing completes and returns the result directly.  The asynchronous path
+(``value_portfolio_async``, ``value_single_trade_async``) creates a pending
+``ValuationResult`` in the store, runs pricing in a background task, and
+updates the result in-place when done (status: running -> completed / failed).
+"""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from uuid import uuid4
 
 from app.schemas import (
     Trade,
@@ -18,13 +27,17 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def value_trade(
+def _price_trade(
     store: Store,
     gateway: DalGateway,
     trade: Trade,
     config: ValuationConfig,
 ) -> TradeValuation:
-    """Price a single trade and scale the PV/Greeks by notional * quantity."""
+    """Price a single trade and scale the PV/Greeks by notional * quantity.
+
+    Per-trade failures are caught and returned as ``TradeValuation(error=...)``
+    so that a single failing trade does not abort an entire portfolio valuation.
+    """
     product = store.get_product(trade.product_id)
     model = store.get_model(trade.model_id)
     event_dates, events = product.event_dates_and_events()
@@ -72,6 +85,27 @@ def value_trade(
     )
 
 
+# Backwards-compatible alias (the old public name).
+value_trade = _price_trade
+
+
+def _aggregate_trade_valuations(
+    trade_valuations: list[TradeValuation],
+) -> tuple[float, dict[str, float]]:
+    """Sum scaled PVs and merge per-trade Greeks into portfolio totals."""
+    total_pv = sum(tv.scaled_pv for tv in trade_valuations)
+    total_greeks: dict[str, float] = {}
+    for tv in trade_valuations:
+        for name, value in tv.greeks.items():
+            total_greeks[name] = total_greeks.get(name, 0.0) + value
+    return total_pv, total_greeks
+
+
+# ---------------------------------------------------------------------------
+# Synchronous pricing (legacy path — blocks until done)
+# ---------------------------------------------------------------------------
+
+
 def value_portfolio(
     store: Store,
     gateway: DalGateway,
@@ -79,12 +113,8 @@ def value_portfolio(
     config: ValuationConfig,
 ) -> ValuationResult:
     trades = store.portfolio_trades(portfolio_id)
-    trade_valuations = [value_trade(store, gateway, t, config) for t in trades]
-    total_pv = sum(tv.scaled_pv for tv in trade_valuations)
-    total_greeks: dict[str, float] = {}
-    for tv in trade_valuations:
-        for name, value in tv.greeks.items():
-            total_greeks[name] = total_greeks.get(name, 0.0) + value
+    trade_valuations = [_price_trade(store, gateway, t, config) for t in trades]
+    total_pv, total_greeks = _aggregate_trade_valuations(trade_valuations)
 
     result = ValuationResult(
         target_kind="portfolio",
@@ -107,7 +137,7 @@ def value_single_trade(
     config: ValuationConfig,
 ) -> ValuationResult:
     trade = store.get_trade(trade_id)
-    tv = value_trade(store, gateway, trade, config)
+    tv = _price_trade(store, gateway, trade, config)
     result = ValuationResult(
         target_kind="trade",
         target_id=trade_id,
@@ -120,3 +150,113 @@ def value_single_trade(
         created_at=_utc_now(),
     )
     return store.add_valuation(result)
+
+
+# ---------------------------------------------------------------------------
+# Asynchronous pricing (creates a pending result, runs in background task)
+# ---------------------------------------------------------------------------
+
+
+def _run_portfolio_pricing(
+    store: Store,
+    gateway: DalGateway,
+    valuation_id: str,
+    portfolio_id: str,
+    config: ValuationConfig,
+) -> None:
+    """Background task: price a portfolio and update the ValuationResult in-place."""
+    try:
+        trades = store.portfolio_trades(portfolio_id)
+        trade_valuations = [_price_trade(store, gateway, t, config) for t in trades]
+        total_pv, total_greeks = _aggregate_trade_valuations(trade_valuations)
+        store.update_valuation(
+            valuation_id,
+            {
+                "total_pv": total_pv,
+                "total_greeks": total_greeks,
+                "trades": trade_valuations,
+                "status": "completed",
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 - mark the valuation as failed
+        store.update_valuation(
+            valuation_id,
+            {"status": "failed", "total_greeks": {"error": 1.0}, "total_pv": 0.0},
+        )
+
+
+def _run_trade_pricing(
+    store: Store,
+    gateway: DalGateway,
+    valuation_id: str,
+    trade_id: str,
+    config: ValuationConfig,
+) -> None:
+    """Background task: price a single trade and update the ValuationResult in-place."""
+    try:
+        trade = store.get_trade(trade_id)
+        tv = _price_trade(store, gateway, trade, config)
+        store.update_valuation(
+            valuation_id,
+            {
+                "total_pv": tv.scaled_pv,
+                "total_greeks": dict(tv.greeks),
+                "trades": [tv],
+                "status": "completed",
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 - mark the valuation as failed
+        store.update_valuation(
+            valuation_id,
+            {"status": "failed", "total_greeks": {"error": 1.0}, "total_pv": 0.0},
+        )
+
+
+def value_portfolio_async(
+    store: Store,
+    gateway: DalGateway,
+    portfolio_id: str,
+    config: ValuationConfig,
+) -> ValuationResult:
+    """Create a pending ValuationResult and return immediately.
+
+    Pricing runs in a FastAPI BackgroundTasks task.  The caller polls
+    ``GET /api/valuations/{id}`` until ``status == "completed"`` or ``"failed"``.
+    """
+    pending = ValuationResult(
+        target_kind="portfolio",
+        target_id=portfolio_id,
+        backend=gateway.backend_name,
+        is_native=gateway.is_native,
+        config=config,
+        total_pv=0.0,
+        trades=[],
+        created_at=_utc_now(),
+        status="running",
+    )
+    return store.add_valuation(pending)
+
+
+def value_single_trade_async(
+    store: Store,
+    gateway: DalGateway,
+    trade_id: str,
+    config: ValuationConfig,
+) -> ValuationResult:
+    """Create a pending ValuationResult and return immediately.
+
+    Pricing runs in a FastAPI BackgroundTasks task.  The caller polls
+    ``GET /api/valuations/{id}`` until ``status == "completed"`` or ``"failed"``.
+    """
+    pending = ValuationResult(
+        target_kind="trade",
+        target_id=trade_id,
+        backend=gateway.backend_name,
+        is_native=gateway.is_native,
+        config=config,
+        total_pv=0.0,
+        trades=[],
+        created_at=_utc_now(),
+        status="running",
+    )
+    return store.add_valuation(pending)

--- a/webui/backend/app/services/valuation.py
+++ b/webui/backend/app/services/valuation.py
@@ -10,6 +10,7 @@ updates the result in-place when done (status: running -> completed / failed).
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 from app.schemas import (
@@ -20,6 +21,8 @@ from app.schemas import (
 )
 from app.services.dal_gateway import DalGateway, ValuationRequest
 from app.services.store import Store
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> str:
@@ -178,9 +181,15 @@ def _run_portfolio_pricing(
             },
         )
     except Exception as exc:  # noqa: BLE001 - mark the valuation as failed
+        logger.exception("Portfolio valuation %s failed", valuation_id)
         store.update_valuation(
             valuation_id,
-            {"status": "failed", "total_greeks": {"error": 1.0}, "total_pv": 0.0},
+            {
+                "status": "failed",
+                "error_message": str(exc),
+                "total_pv": 0.0,
+                "total_greeks": {},
+            },
         )
 
 
@@ -205,9 +214,15 @@ def _run_trade_pricing(
             },
         )
     except Exception as exc:  # noqa: BLE001 - mark the valuation as failed
+        logger.exception("Trade valuation %s failed", valuation_id)
         store.update_valuation(
             valuation_id,
-            {"status": "failed", "total_greeks": {"error": 1.0}, "total_pv": 0.0},
+            {
+                "status": "failed",
+                "error_message": str(exc),
+                "total_pv": 0.0,
+                "total_greeks": {},
+            },
         )
 
 

--- a/webui/backend/tests/conftest.py
+++ b/webui/backend/tests/conftest.py
@@ -17,11 +17,13 @@ def client():
     from fastapi.testclient import TestClient
 
     # Reset singletons so each test starts from a clean store/gateway.
+    # The singletons are stored in list wrappers (_gateway_box, _store_box)
+    # to avoid `global` statements in the getter functions.
     import app.services.dal_gateway as gw
     import app.services.store as st
 
-    gw._gateway = None
-    st._store = None
+    gw._gateway_box[0] = None
+    st._store_box[0] = None
 
     from app.main import create_app
 

--- a/webui/backend/tests/test_api.py
+++ b/webui/backend/tests/test_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 
 def test_health_reports_stub_backend(client):
     resp = client.get("/api/health")
@@ -56,6 +58,7 @@ def _wait_for_valuation(client, valuation_id: str, max_polls: int = 20) -> dict:
         body = resp.json()
         if body["status"] != "running":
             return body
+        time.sleep(0.1)
     raise AssertionError(f"Valuation {valuation_id} did not complete within {max_polls} polls")
 
 

--- a/webui/backend/tests/test_api.py
+++ b/webui/backend/tests/test_api.py
@@ -48,6 +48,17 @@ def _create_bs_model(client) -> str:
     return resp.json()["id"]
 
 
+def _wait_for_valuation(client, valuation_id: str, max_polls: int = 20) -> dict:
+    """Poll a valuation until it is no longer 'running' (background task completed)."""
+    for _ in range(max_polls):
+        resp = client.get(f"/api/valuations/{valuation_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        if body["status"] != "running":
+            return body
+    raise AssertionError(f"Valuation {valuation_id} did not complete within {max_polls} polls")
+
+
 def test_full_workflow_value_portfolio(client):
     product_id = _create_european_product(client)
     model_id = _create_bs_model(client)
@@ -79,8 +90,13 @@ def test_full_workflow_value_portfolio(client):
         json={"num_paths": 1024, "enable_aad": True, "evaluation_date": "2022-09-15"},
     )
     assert val_resp.status_code == 200
-    body = val_resp.json()
-    assert body["target_kind"] == "portfolio"
+    pending = val_resp.json()
+    assert pending["status"] == "running"
+    assert pending["target_kind"] == "portfolio"
+
+    # Poll until the background pricing completes.
+    body = _wait_for_valuation(client, pending["id"])
+    assert body["status"] == "completed"
     assert body["total_pv"] > 0.0
     assert "d_spot" in body["total_greeks"]
     # PV is scaled by notional
@@ -106,7 +122,11 @@ def test_trade_value_endpoint(client):
         json={"num_paths": 512, "enable_aad": True, "evaluation_date": "2022-09-15"},
     )
     assert val_resp.status_code == 200
-    body = val_resp.json()
+    pending = val_resp.json()
+    assert pending["status"] == "running"
+
+    body = _wait_for_valuation(client, pending["id"])
+    assert body["status"] == "completed"
     assert 7.0 < body["total_pv"] < 9.0
 
 
@@ -135,3 +155,139 @@ def test_create_trade_with_unknown_product_fails(client):
         json={"name": "bad", "product_id": "missing", "model_id": model_id},
     )
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Delete guards — cannot delete products/models still referenced by trades
+# ---------------------------------------------------------------------------
+
+
+def test_delete_product_referenced_by_trade_fails(client):
+    product_id = _create_european_product(client)
+    model_id = _create_bs_model(client)
+    client.post(
+        "/api/trades",
+        json={"name": "t", "product_id": product_id, "model_id": model_id},
+    )
+    resp = client.delete(f"/api/products/{product_id}")
+    assert resp.status_code == 409
+    assert "referenced by trade" in resp.json()["detail"]
+
+
+def test_delete_model_referenced_by_trade_fails(client):
+    product_id = _create_european_product(client)
+    model_id = _create_bs_model(client)
+    client.post(
+        "/api/trades",
+        json={"name": "t", "product_id": product_id, "model_id": model_id},
+    )
+    resp = client.delete(f"/api/models/{model_id}")
+    assert resp.status_code == 409
+    assert "referenced by trade" in resp.json()["detail"]
+
+
+def test_delete_product_without_references_succeeds(client):
+    product_id = _create_european_product(client)
+    resp = client.delete(f"/api/products/{product_id}")
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# PUT (update) endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_update_product(client):
+    product_id = _create_european_product(client)
+    resp = client.put(
+        f"/api/products/{product_id}",
+        json={"name": "Renamed Call"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed Call"
+
+
+def test_update_model(client):
+    model_id = _create_bs_model(client)
+    resp = client.put(
+        f"/api/models/{model_id}",
+        json={"bs": {"spot": 110.0, "vol": 0.25, "rate": 0.01, "div": 0.0}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["bs"]["spot"] == 110.0
+
+
+def test_update_trade(client):
+    product_id = _create_european_product(client)
+    model_id = _create_bs_model(client)
+    trade_resp = client.post(
+        "/api/trades",
+        json={"name": "orig", "product_id": product_id, "model_id": model_id},
+    )
+    trade_id = trade_resp.json()["id"]
+    resp = client.put(
+        f"/api/trades/{trade_id}",
+        json={"name": "renamed", "notional": 2_000_000.0},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "renamed"
+    assert resp.json()["notional"] == 2_000_000.0
+
+
+def test_update_trade_with_missing_product_fails(client):
+    product_id = _create_european_product(client)
+    model_id = _create_bs_model(client)
+    trade_resp = client.post(
+        "/api/trades",
+        json={"name": "t", "product_id": product_id, "model_id": model_id},
+    )
+    trade_id = trade_resp.json()["id"]
+    resp = client.put(
+        f"/api/trades/{trade_id}",
+        json={"product_id": "nonexistent"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Async valuation status
+# ---------------------------------------------------------------------------
+
+
+def test_valuation_returns_running_then_completed(client):
+    product_id = _create_european_product(client)
+    model_id = _create_bs_model(client)
+    trade_resp = client.post(
+        "/api/trades",
+        json={"name": "t", "product_id": product_id, "model_id": model_id, "notional": 1.0},
+    )
+    trade_id = trade_resp.json()["id"]
+    val_resp = client.post(
+        f"/api/trades/{trade_id}/value",
+        json={"num_paths": 256, "enable_aad": False, "evaluation_date": "2022-09-15"},
+    )
+    pending = val_resp.json()
+    assert pending["status"] == "running"
+    assert pending["total_pv"] == 0.0
+
+    body = _wait_for_valuation(client, pending["id"])
+    assert body["status"] == "completed"
+    assert body["total_pv"] > 0.0
+
+
+def test_delete_unused_product_and_model(client):
+    """End-to-end: after deleting a trade, its product/model can be deleted."""
+    product_id = _create_european_product(client)
+    model_id = _create_bs_model(client)
+    trade_resp = client.post(
+        "/api/trades",
+        json={"name": "t", "product_id": product_id, "model_id": model_id},
+    )
+    trade_id = trade_resp.json()["id"]
+    # Can't delete while trade exists.
+    assert client.delete(f"/api/products/{product_id}").status_code == 409
+    # Delete the trade (cascades out of portfolios too).
+    assert client.delete(f"/api/trades/{trade_id}").status_code == 204
+    # Now product and model can be deleted.
+    assert client.delete(f"/api/products/{product_id}").status_code == 204
+    assert client.delete(f"/api/models/{model_id}").status_code == 204

--- a/webui/backend/tests/test_dal_gateway.py
+++ b/webui/backend/tests/test_dal_gateway.py
@@ -54,3 +54,47 @@ def test_value_european_call_matches_black_scholes():
     assert 0.4 < res["d_spot"] < 0.6
     # vega is positive
     assert res["d_vol"] > 0.0
+
+
+def test_dupire_stub_uses_average_vol_surface():
+    """The stub should average the 2D vol surface, not hard-code 0.2."""
+    gw = make_gateway()
+    # A surface where the average vol is clearly 0.30 (not 0.2).
+    request = ValuationRequest(
+        event_dates=["STRIKE", {"date": "2023-09-15"}],
+        events=["100.0", "call pays MAX(spot() - STRIKE, 0.0)"],
+        model_kind="DupireModelData_",
+        model_params={
+            "spot": 100.0,
+            "rate": 0.0,
+            "repo": 0.0,
+            "spots": [90.0, 100.0, 110.0],
+            "times": [0.5, 1.0],
+            "vols": [[0.30, 0.30], [0.30, 0.30], [0.30, 0.30]],
+        },
+        num_paths=512,
+        enable_aad=False,
+        evaluation_date=(2022, 9, 15),
+    )
+    res_30 = gw.value(request)
+    # Now the same surface but with average vol 0.40 — should give a higher price.
+    request_40 = ValuationRequest(
+        event_dates=request.event_dates,
+        events=request.events,
+        model_kind="DupireModelData_",
+        model_params={
+            "spot": 100.0,
+            "rate": 0.0,
+            "repo": 0.0,
+            "spots": [90.0, 100.0, 110.0],
+            "times": [0.5, 1.0],
+            "vols": [[0.40, 0.40], [0.40, 0.40], [0.40, 0.40]],
+        },
+        num_paths=512,
+        enable_aad=False,
+        evaluation_date=(2022, 9, 15),
+    )
+    res_40 = gw.value(request_40)
+    # Both surfaces are non-zero and 0.40-vol > 0.30-vol in price.
+    assert res_30["PV"] > 0.0
+    assert res_40["PV"] > res_30["PV"]

--- a/webui/frontend/src/api/client.ts
+++ b/webui/frontend/src/api/client.ts
@@ -91,6 +91,7 @@ export interface ValuationResult {
   total_greeks: Record<string, number>;
   trades: TradeValuation[];
   created_at: string;
+  status: "running" | "completed" | "failed";
 }
 
 export interface Health {
@@ -161,6 +162,11 @@ export const api = {
   listProducts: () => request<ProductDefinition[]>("/products"),
   createProduct: (body: Omit<ProductDefinition, "id">) =>
     request<ProductDefinition>("/products", { method: "POST", body: JSON.stringify(body) }),
+  updateProduct: (id: string, patch: Partial<Omit<ProductDefinition, "id">>) =>
+    request<ProductDefinition>(`/products/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(patch),
+    }),
   deleteProduct: (id: string) =>
     request<undefined>(`/products/${id}`, { method: "DELETE" }),
   debugProduct: (rows: EventRow[]) =>
@@ -173,12 +179,19 @@ export const api = {
   listModels: () => request<ModelDefinition[]>("/models"),
   createModel: (body: Omit<ModelDefinition, "id">) =>
     request<ModelDefinition>("/models", { method: "POST", body: JSON.stringify(body) }),
+  updateModel: (id: string, patch: Partial<Omit<ModelDefinition, "id">>) =>
+    request<ModelDefinition>(`/models/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(patch),
+    }),
   deleteModel: (id: string) => request<undefined>(`/models/${id}`, { method: "DELETE" }),
 
   // trades
   listTrades: () => request<Trade[]>("/trades"),
   createTrade: (body: Omit<Trade, "id" | "tags"> & { tags?: string[] }) =>
     request<Trade>("/trades", { method: "POST", body: JSON.stringify(body) }),
+  updateTrade: (id: string, patch: Partial<Omit<Trade, "id">>) =>
+    request<Trade>(`/trades/${id}`, { method: "PUT", body: JSON.stringify(patch) }),
   deleteTrade: (id: string) => request<undefined>(`/trades/${id}`, { method: "DELETE" }),
   valueTrade: (id: string, config: ValuationConfig) =>
     request<ValuationResult>(`/trades/${id}/value`, {
@@ -205,4 +218,5 @@ export const api = {
 
   // valuations
   listValuations: () => request<ValuationResult[]>("/valuations"),
+  getValuation: (id: string) => request<ValuationResult>(`/valuations/${id}`),
 };

--- a/webui/frontend/src/components/ValuationPanel.tsx
+++ b/webui/frontend/src/components/ValuationPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ValuationConfig, ValuationResult } from "../api/client";
+import { api, type ValuationConfig, type ValuationResult } from "../api/client";
 import { css, fmtMoney, fmtNum, inlineStyle } from "../format";
 
 interface Props {
@@ -8,6 +8,8 @@ interface Props {
 }
 
 const PATH_CHOICES = [10, 12, 14, 16, 18, 20];
+const POLL_INTERVAL_MS = 300;
+const MAX_POLL_ATTEMPTS = 200;
 
 export default function ValuationPanel({ onRun, title = "Run valuation" }: Props) {
   const [pathsPow, setPathsPow] = useState(16);
@@ -18,10 +20,12 @@ export default function ValuationPanel({ onRun, title = "Run valuation" }: Props
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ValuationResult | null>(null);
+  const [statusLabel, setStatusLabel] = useState<string | null>(null);
 
   async function run() {
     setBusy(true);
     setError(null);
+    setStatusLabel("submitting…");
     try {
       const request: ValuationConfig = {
         num_paths: 2 ** pathsPow,
@@ -31,9 +35,27 @@ export default function ValuationPanel({ onRun, title = "Run valuation" }: Props
         smooth: 0.01,
         evaluation_date: evalDate || null,
       };
-      setResult(await onRun(request));
+      // Backend now returns a pending result with status="running".
+      const pending = await onRun(request);
+      setResult(pending);
+      setStatusLabel("pricing…");
+
+      // Poll the backend until the background pricing task completes.
+      let current = pending;
+      for (let i = 0; i < MAX_POLL_ATTEMPTS && current.status === "running"; i++) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+        current = await api.getValuation(pending.id);
+        setResult(current);
+      }
+      if (current.status === "running") {
+        setError("Valuation timed out — check the Valuations page for progress.");
+      } else if (current.status === "failed") {
+        setError("Valuation failed on the server. Check the backend logs.");
+      }
+      setStatusLabel(null);
     } catch (e: unknown) {
       setError(String(e));
+      setStatusLabel(null);
     } finally {
       setBusy(false);
     }
@@ -115,11 +137,11 @@ export default function ValuationPanel({ onRun, title = "Run valuation" }: Props
           }}
           disabled={busy}
         >
-          {busy ? "Pricing…" : "Run valuation"}
+          {busy ? (statusLabel ?? "Pricing…") : "Run valuation"}
         </button>
       </div>
 
-      {result && (
+      {result && result.status !== "running" && (
         <div>
           <div {...css("cards")} {...inlineStyle({ marginBottom: 12 })}>
             <div {...css("card")}>

--- a/webui/frontend/src/pages/Dashboard.tsx
+++ b/webui/frontend/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ export default function Dashboard() {
   const [portfolios, setPortfolios] = useState<Portfolio[]>([]);
   const [trades, setTrades] = useState<Trade[]>([]);
   const [valuations, setValuations] = useState<ValuationResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -16,9 +17,9 @@ export default function Dashboard() {
         setLoading(false);
       }
     };
-    void api.listPortfolios().then(setPortfolios).finally(done);
-    void api.listTrades().then(setTrades).finally(done);
-    void api.listValuations().then(setValuations).finally(done);
+    void api.listPortfolios().then(setPortfolios).catch((e: unknown) => setError(String(e))).finally(done);
+    void api.listTrades().then(setTrades).catch((e: unknown) => setError(String(e))).finally(done);
+    void api.listValuations().then(setValuations).catch((e: unknown) => setError(String(e))).finally(done);
   }, []);
 
   const lastByTarget = new Map<string, ValuationResult>();
@@ -40,6 +41,8 @@ export default function Dashboard() {
           <p>Portfolio overview and recent valuation activity.</p>
         </div>
       </div>
+
+      {error && <div {...css("error")}>{error}</div>}
 
       <div {...css("cards")} {...inlineStyle({ marginBottom: 24 })}>
         <div {...css("card")}>

--- a/webui/frontend/src/pages/Dashboard.tsx
+++ b/webui/frontend/src/pages/Dashboard.tsx
@@ -15,9 +15,9 @@ export default function Dashboard() {
       api.listTrades().then((t) => { setTrades(t); }),
       api.listValuations().then((v) => { setValuations(v); }),
     ]).then((results) => {
-      const error = results.find((r) => r.status === 'rejected');
-      if (error && error.status === 'rejected') {
-        setError(String(error.reason));
+      const rejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (rejected) {
+        setError(String(rejected.reason));
       }
       setLoading(false);
     });

--- a/webui/frontend/src/pages/Dashboard.tsx
+++ b/webui/frontend/src/pages/Dashboard.tsx
@@ -11,15 +11,15 @@ export default function Dashboard() {
 
   useEffect(() => {
     let pending = 3;
-    const done = () => {
+    const checkDone = () => {
       pending -= 1;
       if (pending === 0) {
         setLoading(false);
       }
     };
-    void api.listPortfolios().then((p) => { setPortfolios(p); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
-    void api.listTrades().then((t) => { setTrades(t); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
-    void api.listValuations().then((v) => { setValuations(v); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
+    void api.listPortfolios().then((p) => { setPortfolios(p); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { checkDone(); });
+    void api.listTrades().then((t) => { setTrades(t); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { checkDone(); });
+    void api.listValuations().then((v) => { setValuations(v); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { checkDone(); });
   }, []);
 
   const lastByTarget = new Map<string, ValuationResult>();

--- a/webui/frontend/src/pages/Dashboard.tsx
+++ b/webui/frontend/src/pages/Dashboard.tsx
@@ -17,9 +17,9 @@ export default function Dashboard() {
         setLoading(false);
       }
     };
-    void api.listPortfolios().then(setPortfolios).catch((e: unknown) => setError(String(e))).finally(done);
-    void api.listTrades().then(setTrades).catch((e: unknown) => setError(String(e))).finally(done);
-    void api.listValuations().then(setValuations).catch((e: unknown) => setError(String(e))).finally(done);
+    void api.listPortfolios().then((p) => { setPortfolios(p); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
+    void api.listTrades().then((t) => { setTrades(t); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
+    void api.listValuations().then((v) => { setValuations(v); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
   }, []);
 
   const lastByTarget = new Map<string, ValuationResult>();

--- a/webui/frontend/src/pages/Dashboard.tsx
+++ b/webui/frontend/src/pages/Dashboard.tsx
@@ -6,11 +6,19 @@ export default function Dashboard() {
   const [portfolios, setPortfolios] = useState<Portfolio[]>([]);
   const [trades, setTrades] = useState<Trade[]>([]);
   const [valuations, setValuations] = useState<ValuationResult[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    void api.listPortfolios().then(setPortfolios);
-    void api.listTrades().then(setTrades);
-    void api.listValuations().then(setValuations);
+    let pending = 3;
+    const done = () => {
+      pending -= 1;
+      if (pending === 0) {
+        setLoading(false);
+      }
+    };
+    void api.listPortfolios().then(setPortfolios).finally(done);
+    void api.listTrades().then(setTrades).finally(done);
+    void api.listValuations().then(setValuations).finally(done);
   }, []);
 
   const lastByTarget = new Map<string, ValuationResult>();
@@ -56,7 +64,9 @@ export default function Dashboard() {
 
       <div {...css("panel")}>
         <h2>Recent valuation runs</h2>
-        {valuations.length === 0 ? (
+        {loading ? (
+          <p {...css("muted")}>Loading…</p>
+        ) : valuations.length === 0 ? (
           <p {...css("muted")}>No valuations yet. Price a portfolio or trade to begin.</p>
         ) : (
           <table>
@@ -73,7 +83,11 @@ export default function Dashboard() {
               {valuations.slice(0, 8).map((v) => (
                 <tr key={v.id}>
                   <td {...css("mono")}>{new Date(v.created_at).toLocaleString()}</td>
-                  <td>{v.target_kind}</td>
+                  <td>
+                    {v.target_kind}
+                    {v.status === "running" && <span {...css("muted")}> (running)</span>}
+                    {v.status === "failed" && <span {...css("error-inline")}> (failed)</span>}
+                  </td>
                   <td>
                     {v.backend}
                     {v.is_native ? "" : " (stub)"}

--- a/webui/frontend/src/pages/Dashboard.tsx
+++ b/webui/frontend/src/pages/Dashboard.tsx
@@ -10,16 +10,17 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    let pending = 3;
-    const checkDone = () => {
-      pending -= 1;
-      if (pending === 0) {
-        setLoading(false);
+    void Promise.allSettled([
+      api.listPortfolios().then((p) => { setPortfolios(p); }),
+      api.listTrades().then((t) => { setTrades(t); }),
+      api.listValuations().then((v) => { setValuations(v); }),
+    ]).then((results) => {
+      const error = results.find((r) => r.status === 'rejected');
+      if (error && error.status === 'rejected') {
+        setError(String(error.reason));
       }
-    };
-    void api.listPortfolios().then((p) => { setPortfolios(p); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { checkDone(); });
-    void api.listTrades().then((t) => { setTrades(t); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { checkDone(); });
-    void api.listValuations().then((v) => { setValuations(v); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { checkDone(); });
+      setLoading(false);
+    });
   }, []);
 
   const lastByTarget = new Map<string, ValuationResult>();

--- a/webui/frontend/src/pages/Models.tsx
+++ b/webui/frontend/src/pages/Models.tsx
@@ -1,32 +1,77 @@
 import { useEffect, useState } from "react";
-import { api, type ModelDefinition } from "../api/client";
-import { css, fmtNum } from "../format";
+import { api, type ModelDefinition, type ModelKind } from "../api/client";
+import { css, fmtNum, inlineStyle } from "../format";
 
 export default function Models() {
   const [models, setModels] = useState<ModelDefinition[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Shared fields
   const [name, setName] = useState("BS spot=100 vol=20%");
+  const [kind, setKind] = useState<ModelKind>("BSModelData_");
+
+  // Black-Scholes params
   const [spot, setSpot] = useState(100);
   const [vol, setVol] = useState(0.2);
   const [rate, setRate] = useState(0.0);
   const [div, setDiv] = useState(0.0);
 
+  // Dupire params
+  const [dupireSpot, setDupireSpot] = useState(100);
+  const [dupireRate, setDupireRate] = useState(0.0);
+  const [dupireRepo, setDupireRepo] = useState(0.0);
+  const [dupireSpotsText, setDupireSpotsText] = useState("90, 100, 110");
+  const [dupireTimesText, setDupireTimesText] = useState("0.25, 0.5, 1.0");
+  const [dupireVolsText, setDupireVolsText] = useState("0.22, 0.20, 0.19\n0.21, 0.20, 0.20\n0.19, 0.20, 0.22");
+
   function refresh() {
-    void api.listModels().then(setModels).catch((e: unknown) => {
+    return api.listModels().then(setModels).catch((e: unknown) => {
       setError(String(e));
     });
   }
 
-  useEffect(refresh, []);
+  useEffect(() => {
+    void refresh().finally(() => setLoading(false));
+  }, []);
+
+  function parseNumberList(text: string): number[] {
+    return text
+      .split(/[,\s]+/)
+      .filter((s) => s.length > 0)
+      .map(Number);
+  }
+
+  function parseMatrix(text: string): number[][] {
+    return text
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => parseNumberList(line));
+  }
 
   async function create() {
     setError(null);
     try {
-      await api.createModel({
-        name,
-        kind: "BSModelData_",
-        bs: { spot, vol, rate, div },
-      });
+      if (kind === "BSModelData_") {
+        await api.createModel({
+          name,
+          kind: "BSModelData_",
+          bs: { spot, vol, rate, div },
+        });
+      } else {
+        await api.createModel({
+          name,
+          kind: "DupireModelData_",
+          dupire: {
+            spot: dupireSpot,
+            rate: dupireRate,
+            repo: dupireRepo,
+            spots: parseNumberList(dupireSpotsText),
+            times: parseNumberList(dupireTimesText),
+            vols: parseMatrix(dupireVolsText),
+          },
+        });
+      }
       refresh();
     } catch (e: unknown) {
       setError(String(e));
@@ -34,8 +79,16 @@ export default function Models() {
   }
 
   async function remove(id: string) {
-    await api.deleteModel(id);
-    refresh();
+    const model = models.find((m) => m.id === id);
+    if (!window.confirm(`Delete model "${model?.name ?? id}"? This cannot be undone.`)) {
+      return;
+    }
+    try {
+      await api.deleteModel(id);
+      refresh();
+    } catch (e: unknown) {
+      setError(String(e));
+    }
   }
 
   return (
@@ -49,8 +102,14 @@ export default function Models() {
 
       {error && <div {...css("error")}>{error}</div>}
 
+      {loading ? (
+        <div {...css("panel")}>
+          <p {...css("muted")}>Loading models…</p>
+        </div>
+      ) : (
+      <>
       <div {...css("panel")}>
-        <h2>New Black-Scholes model</h2>
+        <h2>New model</h2>
         <div {...css("field")}>
           <label htmlFor="model-name">Name</label>
           <input
@@ -61,54 +120,138 @@ export default function Models() {
             }}
           />
         </div>
-        <div {...css("row")}>
-          <div>
-            <label htmlFor="model-spot">Spot</label>
-            <input
-              id="model-spot"
-              type="number"
-              value={spot}
-              onChange={(e) => {
-                setSpot(Number(e.target.value));
-              }}
-            />
+        <div {...css("field")}>
+          <label htmlFor="model-kind">Model kind</label>
+          <select
+            id="model-kind"
+            value={kind}
+            onChange={(e) => {
+              setKind(e.target.value as ModelKind);
+            }}
+            {...inlineStyle({ maxWidth: 320 })}
+          >
+            <option value="BSModelData_">Black-Scholes</option>
+            <option value="DupireModelData_">Dupire (local vol surface)</option>
+          </select>
+        </div>
+
+        {kind === "BSModelData_" ? (
+          <div {...css("row")}>
+            <div>
+              <label htmlFor="model-spot">Spot</label>
+              <input
+                id="model-spot"
+                type="number"
+                value={spot}
+                onChange={(e) => {
+                  setSpot(Number(e.target.value));
+                }}
+              />
+            </div>
+            <div>
+              <label htmlFor="model-vol">Vol</label>
+              <input
+                id="model-vol"
+                type="number"
+                step="0.01"
+                value={vol}
+                onChange={(e) => {
+                  setVol(Number(e.target.value));
+                }}
+              />
+            </div>
+            <div>
+              <label htmlFor="model-rate">Rate</label>
+              <input
+                id="model-rate"
+                type="number"
+                step="0.01"
+                value={rate}
+                onChange={(e) => {
+                  setRate(Number(e.target.value));
+                }}
+              />
+            </div>
+            <div>
+              <label htmlFor="model-dividend">Dividend</label>
+              <input
+                id="model-dividend"
+                type="number"
+                step="0.01"
+                value={div}
+                onChange={(e) => {
+                  setDiv(Number(e.target.value));
+                }}
+              />
+            </div>
           </div>
+        ) : (
           <div>
-            <label htmlFor="model-vol">Vol</label>
-            <input
-              id="model-vol"
-              type="number"
-              step="0.01"
-              value={vol}
-              onChange={(e) => {
-                setVol(Number(e.target.value));
-              }}
-            />
+            <p {...css("muted")} {...inlineStyle({ marginTop: 0, marginBottom: 12 })}>
+              Dupire uses a local volatility surface σ(S, t). Enter spot strikes
+              (one row), times (one row), and a vols matrix (one row per strike,
+              one column per time).
+            </p>
+            <div {...css("row")}>
+              <div>
+                <label htmlFor="dupire-spot">Spot</label>
+                <input
+                  id="dupire-spot"
+                  type="number"
+                  value={dupireSpot}
+                  onChange={(e) => setDupireSpot(Number(e.target.value))}
+                />
+              </div>
+              <div>
+                <label htmlFor="dupire-rate">Rate</label>
+                <input
+                  id="dupire-rate"
+                  type="number"
+                  step="0.01"
+                  value={dupireRate}
+                  onChange={(e) => setDupireRate(Number(e.target.value))}
+                />
+              </div>
+              <div>
+                <label htmlFor="dupire-repo">Repo</label>
+                <input
+                  id="dupire-repo"
+                  type="number"
+                  step="0.01"
+                  value={dupireRepo}
+                  onChange={(e) => setDupireRepo(Number(e.target.value))}
+                />
+              </div>
+            </div>
+            <div {...css("field")}>
+              <label htmlFor="dupire-spots">Spot strikes (comma-separated)</label>
+              <input
+                id="dupire-spots"
+                value={dupireSpotsText}
+                onChange={(e) => setDupireSpotsText(e.target.value)}
+              />
+            </div>
+            <div {...css("field")}>
+              <label htmlFor="dupire-times">Times in years (comma-separated)</label>
+              <input
+                id="dupire-times"
+                value={dupireTimesText}
+                onChange={(e) => setDupireTimesText(e.target.value)}
+              />
+            </div>
+            <div {...css("field")}>
+              <label htmlFor="dupire-vols">Vols matrix (one row per strike, whitespace-separated)</label>
+              <textarea
+                id="dupire-vols"
+                value={dupireVolsText}
+                onChange={(e) => setDupireVolsText(e.target.value)}
+                rows={4}
+              />
+            </div>
           </div>
-          <div>
-            <label htmlFor="model-rate">Rate</label>
-            <input
-              id="model-rate"
-              type="number"
-              step="0.01"
-              value={rate}
-              onChange={(e) => {
-                setRate(Number(e.target.value));
-              }}
-            />
-          </div>
-          <div>
-            <label htmlFor="model-dividend">Dividend</label>
-            <input
-              id="model-dividend"
-              type="number"
-              step="0.01"
-              value={div}
-              onChange={(e) => {
-                setDiv(Number(e.target.value));
-              }}
-            />
-          </div>
+        )}
+
+        <div {...inlineStyle({ marginTop: 12 })}>
           <button
             type="button"
             onClick={() => {
@@ -128,7 +271,7 @@ export default function Models() {
             <th {...css("num")}>Spot</th>
             <th {...css("num")}>Vol</th>
             <th {...css("num")}>Rate</th>
-            <th {...css("num")}>Div</th>
+            <th {...css("num")}>Div/Repo</th>
             <th></th>
           </tr>
         </thead>
@@ -137,10 +280,22 @@ export default function Models() {
             <tr key={m.id}>
               <td>{m.name}</td>
               <td {...css("mono")}>{m.kind}</td>
-              <td {...css("num")}>{m.bs ? fmtNum(m.bs.spot, 2) : "-"}</td>
-              <td {...css("num")}>{m.bs ? fmtNum(m.bs.vol, 4) : "-"}</td>
-              <td {...css("num")}>{m.bs ? fmtNum(m.bs.rate, 4) : "-"}</td>
-              <td {...css("num")}>{m.bs ? fmtNum(m.bs.div, 4) : "-"}</td>
+              <td {...css("num")}>
+                {m.bs ? fmtNum(m.bs.spot, 2) : m.dupire ? fmtNum(m.dupire.spot, 2) : "-"}
+              </td>
+              <td {...css("num")}>
+                {m.bs
+                  ? fmtNum(m.bs.vol, 4)
+                  : m.dupire
+                  ? "(surface)"
+                  : "-"}
+              </td>
+              <td {...css("num")}>
+                {m.bs ? fmtNum(m.bs.rate, 4) : m.dupire ? fmtNum(m.dupire.rate, 4) : "-"}
+              </td>
+              <td {...css("num")}>
+                {m.bs ? fmtNum(m.bs.div, 4) : m.dupire ? fmtNum(m.dupire.repo, 4) : "-"}
+              </td>
               <td>
                 <button
                   type="button"
@@ -156,6 +311,8 @@ export default function Models() {
           ))}
         </tbody>
       </table>
+      </>
+      )}
     </div>
   );
 }

--- a/webui/frontend/src/pages/Models.tsx
+++ b/webui/frontend/src/pages/Models.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api, type ModelDefinition, type ModelKind } from "../api/client";
 import { css, fmtNum, inlineStyle } from "../format";
 
@@ -25,15 +25,15 @@ export default function Models() {
   const [dupireTimesText, setDupireTimesText] = useState("0.25, 0.5, 1.0");
   const [dupireVolsText, setDupireVolsText] = useState("0.22, 0.20, 0.19\n0.21, 0.20, 0.20\n0.19, 0.20, 0.22");
 
-  function refresh() {
-    return api.listModels().then(setModels).catch((e: unknown) => {
+  const refresh = useCallback(() => {
+    return api.listModels().then((m) => { setModels(m); }).catch((e: unknown) => {
       setError(String(e));
     });
-  }
+  }, []);
 
   useEffect(() => {
-    void refresh().finally(() => setLoading(false));
-  }, []);
+    void refresh().finally(() => { setLoading(false); });
+  }, [refresh]);
 
   function parseNumberList(text: string): number[] {
     return text

--- a/webui/frontend/src/pages/Models.tsx
+++ b/webui/frontend/src/pages/Models.tsx
@@ -199,7 +199,7 @@ export default function Models() {
                   id="dupire-spot"
                   type="number"
                   value={dupireSpot}
-                  onChange={(e) => setDupireSpot(Number(e.target.value))}
+                  onChange={(e) => { setDupireSpot(Number(e.target.value)); }}
                 />
               </div>
               <div>
@@ -209,7 +209,7 @@ export default function Models() {
                   type="number"
                   step="0.01"
                   value={dupireRate}
-                  onChange={(e) => setDupireRate(Number(e.target.value))}
+                  onChange={(e) => { setDupireRate(Number(e.target.value)); }}
                 />
               </div>
               <div>
@@ -219,7 +219,7 @@ export default function Models() {
                   type="number"
                   step="0.01"
                   value={dupireRepo}
-                  onChange={(e) => setDupireRepo(Number(e.target.value))}
+                  onChange={(e) => { setDupireRepo(Number(e.target.value)); }}
                 />
               </div>
             </div>
@@ -228,7 +228,7 @@ export default function Models() {
               <input
                 id="dupire-spots"
                 value={dupireSpotsText}
-                onChange={(e) => setDupireSpotsText(e.target.value)}
+                onChange={(e) => { setDupireSpotsText(e.target.value); }}
               />
             </div>
             <div {...css("field")}>
@@ -236,7 +236,7 @@ export default function Models() {
               <input
                 id="dupire-times"
                 value={dupireTimesText}
-                onChange={(e) => setDupireTimesText(e.target.value)}
+                onChange={(e) => { setDupireTimesText(e.target.value); }}
               />
             </div>
             <div {...css("field")}>
@@ -244,7 +244,7 @@ export default function Models() {
               <textarea
                 id="dupire-vols"
                 value={dupireVolsText}
-                onChange={(e) => setDupireVolsText(e.target.value)}
+                onChange={(e) => { setDupireVolsText(e.target.value); }}
                 rows={4}
               />
             </div>

--- a/webui/frontend/src/pages/Models.tsx
+++ b/webui/frontend/src/pages/Models.tsx
@@ -121,7 +121,7 @@ export default function Models() {
           />
         </div>
         <div {...css("field")}>
-          <label htmlFor="model-kind">Model kind</label>
+          <label>Model kind</label>
           <select
             id="model-kind"
             value={kind}
@@ -194,7 +194,7 @@ export default function Models() {
             </p>
             <div {...css("row")}>
               <div>
-                <label htmlFor="dupire-spot">Spot</label>
+                <label>Spot</label>
                 <input
                   id="dupire-spot"
                   type="number"
@@ -203,7 +203,7 @@ export default function Models() {
                 />
               </div>
               <div>
-                <label htmlFor="dupire-rate">Rate</label>
+                <label>Rate</label>
                 <input
                   id="dupire-rate"
                   type="number"
@@ -213,7 +213,7 @@ export default function Models() {
                 />
               </div>
               <div>
-                <label htmlFor="dupire-repo">Repo</label>
+                <label>Repo</label>
                 <input
                   id="dupire-repo"
                   type="number"
@@ -224,7 +224,7 @@ export default function Models() {
               </div>
             </div>
             <div {...css("field")}>
-              <label htmlFor="dupire-spots">Spot strikes (comma-separated)</label>
+              <label>Spot strikes (comma-separated)</label>
               <input
                 id="dupire-spots"
                 value={dupireSpotsText}
@@ -232,7 +232,7 @@ export default function Models() {
               />
             </div>
             <div {...css("field")}>
-              <label htmlFor="dupire-times">Times in years (comma-separated)</label>
+              <label>Times in years (comma-separated)</label>
               <input
                 id="dupire-times"
                 value={dupireTimesText}
@@ -240,7 +240,7 @@ export default function Models() {
               />
             </div>
             <div {...css("field")}>
-              <label htmlFor="dupire-vols">Vols matrix (one row per strike, whitespace-separated)</label>
+              <label>Vols matrix (one row per strike, whitespace-separated)</label>
               <textarea
                 id="dupire-vols"
                 value={dupireVolsText}

--- a/webui/frontend/src/pages/Models.tsx
+++ b/webui/frontend/src/pages/Models.tsx
@@ -121,18 +121,20 @@ export default function Models() {
           />
         </div>
         <div {...css("field")}>
-          <label>Model kind</label>
-          <select
-            id="model-kind"
-            value={kind}
-            onChange={(e) => {
-              setKind(e.target.value as ModelKind);
-            }}
-            {...inlineStyle({ maxWidth: 320 })}
-          >
-            <option value="BSModelData_">Black-Scholes</option>
-            <option value="DupireModelData_">Dupire (local vol surface)</option>
-          </select>
+          <label>
+            Model kind
+            <select
+              id="model-kind"
+              value={kind}
+              onChange={(e) => {
+                setKind(e.target.value as ModelKind);
+              }}
+              {...inlineStyle({ maxWidth: 320 })}
+            >
+              <option value="BSModelData_">Black-Scholes</option>
+              <option value="DupireModelData_">Dupire (local vol surface)</option>
+            </select>
+          </label>
         </div>
 
         {kind === "BSModelData_" ? (
@@ -194,59 +196,71 @@ export default function Models() {
             </p>
             <div {...css("row")}>
               <div>
-                <label>Spot</label>
-                <input
-                  id="dupire-spot"
-                  type="number"
-                  value={dupireSpot}
-                  onChange={(e) => { setDupireSpot(Number(e.target.value)); }}
-                />
+                <label>
+                  Spot
+                  <input
+                    id="dupire-spot"
+                    type="number"
+                    value={dupireSpot}
+                    onChange={(e) => { setDupireSpot(Number(e.target.value)); }}
+                  />
+                </label>
               </div>
               <div>
-                <label>Rate</label>
-                <input
-                  id="dupire-rate"
-                  type="number"
-                  step="0.01"
-                  value={dupireRate}
-                  onChange={(e) => { setDupireRate(Number(e.target.value)); }}
-                />
+                <label>
+                  Rate
+                  <input
+                    id="dupire-rate"
+                    type="number"
+                    step="0.01"
+                    value={dupireRate}
+                    onChange={(e) => { setDupireRate(Number(e.target.value)); }}
+                  />
+                </label>
               </div>
               <div>
-                <label>Repo</label>
-                <input
-                  id="dupire-repo"
-                  type="number"
-                  step="0.01"
-                  value={dupireRepo}
-                  onChange={(e) => { setDupireRepo(Number(e.target.value)); }}
-                />
+                <label>
+                  Repo
+                  <input
+                    id="dupire-repo"
+                    type="number"
+                    step="0.01"
+                    value={dupireRepo}
+                    onChange={(e) => { setDupireRepo(Number(e.target.value)); }}
+                  />
+                </label>
               </div>
             </div>
             <div {...css("field")}>
-              <label>Spot strikes (comma-separated)</label>
-              <input
-                id="dupire-spots"
-                value={dupireSpotsText}
-                onChange={(e) => { setDupireSpotsText(e.target.value); }}
-              />
+              <label>
+                Spot strikes (comma-separated)
+                <input
+                  id="dupire-spots"
+                  value={dupireSpotsText}
+                  onChange={(e) => { setDupireSpotsText(e.target.value); }}
+                />
+              </label>
             </div>
             <div {...css("field")}>
-              <label>Times in years (comma-separated)</label>
-              <input
-                id="dupire-times"
-                value={dupireTimesText}
-                onChange={(e) => { setDupireTimesText(e.target.value); }}
-              />
+              <label>
+                Times in years (comma-separated)
+                <input
+                  id="dupire-times"
+                  value={dupireTimesText}
+                  onChange={(e) => { setDupireTimesText(e.target.value); }}
+                />
+              </label>
             </div>
             <div {...css("field")}>
-              <label>Vols matrix (one row per strike, whitespace-separated)</label>
-              <textarea
-                id="dupire-vols"
-                value={dupireVolsText}
-                onChange={(e) => { setDupireVolsText(e.target.value); }}
-                rows={4}
-              />
+              <label>
+                Vols matrix (one row per strike, whitespace-separated)
+                <textarea
+                  id="dupire-vols"
+                  value={dupireVolsText}
+                  onChange={(e) => { setDupireVolsText(e.target.value); }}
+                  rows={4}
+                />
+              </label>
             </div>
           </div>
         )}

--- a/webui/frontend/src/pages/Portfolios.tsx
+++ b/webui/frontend/src/pages/Portfolios.tsx
@@ -53,22 +53,30 @@ export default function Portfolios() {
     if (!selected) {
       return;
     }
-    const pf = await api.removeTradeFromPortfolio(selected.id, tid);
-    setSelected(pf);
-    setMembers(await api.portfolioTrades(pf.id));
-    refresh();
+    try {
+      const pf = await api.removeTradeFromPortfolio(selected.id, tid);
+      setSelected(pf);
+      setMembers(await api.portfolioTrades(pf.id));
+      await refresh();
+    } catch (e: unknown) {
+      setError(String(e));
+    }
   }
 
   async function deletePortfolio(id: string) {
     if (!window.confirm("Delete this portfolio? This cannot be undone.")) {
       return;
     }
-    await api.deletePortfolio(id);
-    if (selected?.id === id) {
-      setSelected(null);
-      setMembers([]);
+    try {
+      await api.deletePortfolio(id);
+      if (selected?.id === id) {
+        setSelected(null);
+        setMembers([]);
+      }
+      await refresh();
+    } catch (e: unknown) {
+      setError(String(e));
     }
-    refresh();
   }
 
   return (

--- a/webui/frontend/src/pages/Portfolios.tsx
+++ b/webui/frontend/src/pages/Portfolios.tsx
@@ -21,7 +21,7 @@ export default function Portfolios() {
   }
 
   useEffect(() => {
-    void refresh().finally(() => setLoading(false));
+    void refresh().catch((e: unknown) => setError(String(e))).finally(() => setLoading(false));
   }, []);
 
   async function selectPortfolio(pf: Portfolio) {

--- a/webui/frontend/src/pages/Portfolios.tsx
+++ b/webui/frontend/src/pages/Portfolios.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api, type Portfolio, type Trade } from "../api/client";
 import { css, fmtMoney, inlineStyle } from "../format";
 import ValuationPanel from "../components/ValuationPanel";
@@ -13,16 +13,16 @@ export default function Portfolios() {
   const [addTradeId, setAddTradeId] = useState("");
   const [loading, setLoading] = useState(true);
 
-  function refresh() {
+  const refresh = useCallback(() => {
     return Promise.all([
-      api.listPortfolios().then(setPortfolios),
-      api.listTrades().then(setAllTrades),
+      api.listPortfolios().then((p) => { setPortfolios(p); }),
+      api.listTrades().then((t) => { setAllTrades(t); }),
     ]);
-  }
+  }, []);
 
   useEffect(() => {
-    void refresh().catch((e: unknown) => setError(String(e))).finally(() => setLoading(false));
-  }, []);
+    void refresh().catch((e: unknown) => { setError(String(e)); }).finally(() => { setLoading(false); });
+  }, [refresh]);
 
   async function selectPortfolio(pf: Portfolio) {
     setSelected(pf);

--- a/webui/frontend/src/pages/Portfolios.tsx
+++ b/webui/frontend/src/pages/Portfolios.tsx
@@ -11,13 +11,18 @@ export default function Portfolios() {
   const [name, setName] = useState("New Portfolio");
   const [error, setError] = useState<string | null>(null);
   const [addTradeId, setAddTradeId] = useState("");
+  const [loading, setLoading] = useState(true);
 
   function refresh() {
-    void api.listPortfolios().then(setPortfolios);
-    void api.listTrades().then(setAllTrades);
+    return Promise.all([
+      api.listPortfolios().then(setPortfolios),
+      api.listTrades().then(setAllTrades),
+    ]);
   }
 
-  useEffect(refresh, []);
+  useEffect(() => {
+    void refresh().finally(() => setLoading(false));
+  }, []);
 
   async function selectPortfolio(pf: Portfolio) {
     setSelected(pf);
@@ -54,6 +59,18 @@ export default function Portfolios() {
     refresh();
   }
 
+  async function deletePortfolio(id: string) {
+    if (!window.confirm("Delete this portfolio? This cannot be undone.")) {
+      return;
+    }
+    await api.deletePortfolio(id);
+    if (selected?.id === id) {
+      setSelected(null);
+      setMembers([]);
+    }
+    refresh();
+  }
+
   return (
     <div>
       <div {...css("page-header")}>
@@ -65,6 +82,11 @@ export default function Portfolios() {
 
       {error && <div {...css("error")}>{error}</div>}
 
+      {loading ? (
+        <div {...css("panel")}>
+          <p {...css("muted")}>Loading portfolios…</p>
+        </div>
+      ) : (
       <div {...css("grid-2")}>
         <div {...css("panel")}>
           <h2>Books</h2>
@@ -89,7 +111,9 @@ export default function Portfolios() {
             <thead>
               <tr>
                 <th>Name</th>
+                <th>Description</th>
                 <th {...css("num")}># trades</th>
+                <th></th>
                 <th></th>
               </tr>
             </thead>
@@ -97,6 +121,7 @@ export default function Portfolios() {
               {portfolios.map((pf) => (
                 <tr key={pf.id}>
                   <td>{pf.name}</td>
+                  <td {...css("muted")}>{pf.description}</td>
                   <td {...css("num")}>{pf.trade_ids.length}</td>
                   <td>
                     <button
@@ -107,6 +132,17 @@ export default function Portfolios() {
                       }}
                     >
                       Open
+                    </button>
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      {...css("danger")}
+                      onClick={() => {
+                        void deletePortfolio(pf.id);
+                      }}
+                    >
+                      Delete
                     </button>
                   </td>
                 </tr>
@@ -166,7 +202,9 @@ export default function Portfolios() {
                           type="button"
                           {...css("danger")}
                           onClick={() => {
-                            void removeTrade(t.id);
+                            if (window.confirm(`Remove ${t.name} from this portfolio?`)) {
+                              void removeTrade(t.id);
+                            }
                           }}
                         >
                           Remove
@@ -180,6 +218,7 @@ export default function Portfolios() {
           )}
         </div>
       </div>
+      )}
 
       {selected && (
         <ValuationPanel

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -40,9 +40,9 @@ export default function ProductBuilder() {
       api.listTemplates().then((t) => { setTemplates(t); }),
       refresh(),
     ]).then((results) => {
-      const error = results.find((r) => r.status === 'rejected');
-      if (error && error.status === 'rejected') {
-        setError(String(error.reason));
+      const rejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (rejected) {
+        setError(String(rejected.reason));
       }
       setLoading(false);
     });

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -36,15 +36,16 @@ export default function ProductBuilder() {
   }, []);
 
   useEffect(() => {
-    let pending = 2;
-    const done = () => {
-      pending -= 1;
-      if (pending === 0) {
-        setLoading(false);
+    void Promise.allSettled([
+      api.listTemplates().then((t) => { setTemplates(t); }),
+      refresh(),
+    ]).then((results) => {
+      const error = results.find((r) => r.status === 'rejected');
+      if (error && error.status === 'rejected') {
+        setError(String(error.reason));
       }
-    };
-    void api.listTemplates().then((t) => { setTemplates(t); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
-    void refresh().catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
+      setLoading(false);
+    });
   }, [refresh]);
 
   function loadSavedProduct(product: ProductDefinition) {

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -32,7 +32,7 @@ export default function ProductBuilder() {
   }
 
   const refresh = useCallback(() => {
-    return api.listProducts().then(setProducts);
+    return api.listProducts().then((p) => { setProducts(p); });
   }, []);
 
   useEffect(() => {
@@ -43,8 +43,8 @@ export default function ProductBuilder() {
         setLoading(false);
       }
     };
-    void api.listTemplates().then(setTemplates).catch((e: unknown) => setError(String(e))).finally(done);
-    void refresh().catch((e: unknown) => setError(String(e))).finally(done);
+    void api.listTemplates().then((t) => { setTemplates(t); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
+    void refresh().catch((e: unknown) => { setError(String(e)); }).finally(done);
   }, [refresh]);
 
   function loadSavedProduct(product: ProductDefinition) {

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -93,7 +93,7 @@ export default function ProductBuilder() {
     setError(null);
     try {
       await api.createProduct({ name, description, template: null, rows: apiRows() });
-      refresh();
+      await refresh();
     } catch (e: unknown) {
       setError(String(e));
     }
@@ -106,7 +106,7 @@ export default function ProductBuilder() {
     }
     try {
       await api.deleteProduct(id);
-      refresh();
+      await refresh();
     } catch (e: unknown) {
       setError(String(e));
     }

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -20,6 +20,7 @@ export default function ProductBuilder() {
   const [rows, setRows] = useState<EditorRow[]>([makeRow()]);
   const [debug, setDebug] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   function apiRows(): EventRow[] {
     return rows.map((r) => ({
@@ -31,13 +32,28 @@ export default function ProductBuilder() {
   }
 
   const refresh = useCallback(() => {
-    void api.listProducts().then(setProducts);
+    return api.listProducts().then(setProducts);
   }, []);
 
   useEffect(() => {
-    void api.listTemplates().then(setTemplates);
-    refresh();
+    let pending = 2;
+    const done = () => {
+      pending -= 1;
+      if (pending === 0) {
+        setLoading(false);
+      }
+    };
+    void api.listTemplates().then(setTemplates).finally(done);
+    void refresh().finally(done);
   }, [refresh]);
+
+  function loadSavedProduct(product: ProductDefinition) {
+    setName(product.name);
+    setDescription(product.description);
+    setRows(product.rows.map((r) => makeRow(r)));
+    setDebug("");
+    setError(null);
+  }
 
   function loadTemplate(key: string) {
     const tpl = templates.find((t) => t.key === key);
@@ -83,8 +99,16 @@ export default function ProductBuilder() {
   }
 
   async function removeProduct(id: string) {
-    await api.deleteProduct(id);
-    refresh();
+    const product = products.find((p) => p.id === id);
+    if (!window.confirm(`Delete product "${product?.name ?? id}"? This cannot be undone.`)) {
+      return;
+    }
+    try {
+      await api.deleteProduct(id);
+      refresh();
+    } catch (e: unknown) {
+      setError(String(e));
+    }
   }
 
   return (
@@ -98,6 +122,12 @@ export default function ProductBuilder() {
 
       {error && <div {...css("error")}>{error}</div>}
 
+      {loading ? (
+        <div {...css("panel")}>
+          <p {...css("muted")}>Loading products…</p>
+        </div>
+      ) : (
+      <>
       <div {...css("toolbar")}>
         <span {...css("muted")}>Start from template:</span>
         {templates.map((t) => (
@@ -224,37 +254,55 @@ export default function ProductBuilder() {
 
       <div {...css("panel")}>
         <h2>Saved products</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Description</th>
-              <th {...css("num")}># rows</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {products.map((p) => (
-              <tr key={p.id}>
-                <td>{p.name}</td>
-                <td {...css("muted")}>{p.description}</td>
-                <td {...css("num")}>{p.rows.length}</td>
-                <td>
-                  <button
-                    type="button"
-                    {...css("danger")}
-                    onClick={() => {
-                      void removeProduct(p.id);
-                    }}
-                  >
-                    Delete
-                  </button>
-                </td>
+        {products.length === 0 ? (
+          <p {...css("muted")}>No saved products yet. Build one above and click Save.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th {...css("num")}># rows</th>
+                <th></th>
+                <th></th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {products.map((p) => (
+                <tr key={p.id}>
+                  <td>{p.name}</td>
+                  <td {...css("muted")}>{p.description}</td>
+                  <td {...css("num")}>{p.rows.length}</td>
+                  <td>
+                    <button
+                      type="button"
+                      {...css("ghost")}
+                      onClick={() => {
+                        loadSavedProduct(p);
+                      }}
+                    >
+                      Load
+                    </button>
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      {...css("danger")}
+                      onClick={() => {
+                        void removeProduct(p.id);
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
+      </>
+      )}
     </div>
   );
 }

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -43,8 +43,8 @@ export default function ProductBuilder() {
         setLoading(false);
       }
     };
-    void api.listTemplates().then(setTemplates).finally(done);
-    void refresh().finally(done);
+    void api.listTemplates().then(setTemplates).catch((e: unknown) => setError(String(e))).finally(done);
+    void refresh().catch((e: unknown) => setError(String(e))).finally(done);
   }, [refresh]);
 
   function loadSavedProduct(product: ProductDefinition) {

--- a/webui/frontend/src/pages/ProductBuilder.tsx
+++ b/webui/frontend/src/pages/ProductBuilder.tsx
@@ -43,8 +43,8 @@ export default function ProductBuilder() {
         setLoading(false);
       }
     };
-    void api.listTemplates().then((t) => { setTemplates(t); }).catch((e: unknown) => { setError(String(e)); }).finally(done);
-    void refresh().catch((e: unknown) => { setError(String(e)); }).finally(done);
+    void api.listTemplates().then((t) => { setTemplates(t); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
+    void refresh().catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
   }, [refresh]);
 
   function loadSavedProduct(product: ProductDefinition) {

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -14,6 +14,7 @@ export default function Trades() {
   const [models, setModels] = useState<ModelDefinition[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   const [name, setName] = useState("New Trade");
   const [book, setBook] = useState("EQ-EXOTICS");
@@ -24,23 +25,30 @@ export default function Trades() {
   const [modelId, setModelId] = useState("");
 
   const refresh = useCallback(() => {
-    void api.listTrades().then(setTrades);
+    return api.listTrades().then(setTrades);
   }, []);
 
   useEffect(() => {
-    refresh();
+    let pending = 3;
+    const done = () => {
+      pending -= 1;
+      if (pending === 0) {
+        setLoading(false);
+      }
+    };
+    refresh().finally(done);
     void api.listProducts().then((p) => {
       setProducts(p);
       if (p[0]) {
         setProductId(p[0].id);
       }
-    });
+    }).finally(done);
     void api.listModels().then((m) => {
       setModels(m);
       if (m[0]) {
         setModelId(m[0].id);
       }
-    });
+    }).finally(done);
   }, [refresh]);
 
   async function create() {
@@ -62,8 +70,19 @@ export default function Trades() {
   }
 
   async function remove(id: string) {
-    await api.deleteTrade(id);
-    refresh();
+    const trade = trades.find((t) => t.id === id);
+    if (!window.confirm(`Delete trade "${trade?.name ?? id}"? This cannot be undone.`)) {
+      return;
+    }
+    try {
+      await api.deleteTrade(id);
+      if (selected === id) {
+        setSelected(null);
+      }
+      refresh();
+    } catch (e: unknown) {
+      setError(String(e));
+    }
   }
 
   interface NamedItem {
@@ -87,6 +106,12 @@ export default function Trades() {
 
       {error && <div {...css("error")}>{error}</div>}
 
+      {loading ? (
+        <div {...css("panel")}>
+          <p {...css("muted")}>Loading trades…</p>
+        </div>
+      ) : (
+      <>
       <div {...css("panel")}>
         <h2>New trade</h2>
         <div {...css("row")} {...inlineStyle({ marginBottom: 12 })}>
@@ -239,6 +264,8 @@ export default function Trades() {
             onRun={(config) => api.valueTrade(selected, config)}
           />
         </div>
+      )}
+      </>
       )}
     </div>
   );

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -36,19 +36,19 @@ export default function Trades() {
         setLoading(false);
       }
     };
-    refresh().finally(done);
+    refresh().catch((e: unknown) => setError(String(e))).finally(done);
     void api.listProducts().then((p) => {
       setProducts(p);
       if (p[0]) {
         setProductId(p[0].id);
       }
-    }).finally(done);
+    }).catch((e: unknown) => setError(String(e))).finally(done);
     void api.listModels().then((m) => {
       setModels(m);
       if (m[0]) {
         setModelId(m[0].id);
       }
-    }).finally(done);
+    }).catch((e: unknown) => setError(String(e))).finally(done);
   }, [refresh]);
 
   async function create() {

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -64,7 +64,7 @@ export default function Trades() {
         product_id: productId,
         model_id: modelId,
       });
-      refresh();
+      await refresh();
     } catch (e: unknown) {
       setError(String(e));
     }
@@ -80,7 +80,7 @@ export default function Trades() {
       if (selected === id) {
         setSelected(null);
       }
-      refresh();
+      await refresh();
     } catch (e: unknown) {
       setError(String(e));
     }

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -44,9 +44,9 @@ export default function Trades() {
         }
       }),
     ]).then((results) => {
-      const error = results.find((r) => r.status === 'rejected');
-      if (error && error.status === 'rejected') {
-        setError(String(error.reason));
+      const rejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (rejected) {
+        setError(String(rejected.reason));
       }
       setLoading(false);
     });

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -36,19 +36,19 @@ export default function Trades() {
         setLoading(false);
       }
     };
-    refresh().catch((e: unknown) => { setError(String(e)); }).finally(done);
+    refresh().catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
     void api.listProducts().then((p) => {
       setProducts(p);
       if (p[0]) {
         setProductId(p[0].id);
       }
-    }).catch((e: unknown) => { setError(String(e)); }).finally(done);
+    }).catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
     void api.listModels().then((m) => {
       setModels(m);
       if (m[0]) {
         setModelId(m[0].id);
       }
-    }).catch((e: unknown) => { setError(String(e)); }).finally(done);
+    }).catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
   }, [refresh]);
 
   async function create() {

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -29,26 +29,27 @@ export default function Trades() {
   }, []);
 
   useEffect(() => {
-    let pending = 3;
-    const done = () => {
-      pending -= 1;
-      if (pending === 0) {
-        setLoading(false);
+    void Promise.allSettled([
+      refresh(),
+      api.listProducts().then((p) => {
+        setProducts(p);
+        if (p[0]) {
+          setProductId(p[0].id);
+        }
+      }),
+      api.listModels().then((m) => {
+        setModels(m);
+        if (m[0]) {
+          setModelId(m[0].id);
+        }
+      }),
+    ]).then((results) => {
+      const error = results.find((r) => r.status === 'rejected');
+      if (error && error.status === 'rejected') {
+        setError(String(error.reason));
       }
-    };
-    refresh().catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
-    void api.listProducts().then((p) => {
-      setProducts(p);
-      if (p[0]) {
-        setProductId(p[0].id);
-      }
-    }).catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
-    void api.listModels().then((m) => {
-      setModels(m);
-      if (m[0]) {
-        setModelId(m[0].id);
-      }
-    }).catch((e: unknown) => { setError(String(e)); }).finally(() => { done(); });
+      setLoading(false);
+    });
   }, [refresh]);
 
   async function create() {

--- a/webui/frontend/src/pages/Trades.tsx
+++ b/webui/frontend/src/pages/Trades.tsx
@@ -25,7 +25,7 @@ export default function Trades() {
   const [modelId, setModelId] = useState("");
 
   const refresh = useCallback(() => {
-    return api.listTrades().then(setTrades);
+    return api.listTrades().then((t) => { setTrades(t); });
   }, []);
 
   useEffect(() => {
@@ -36,19 +36,19 @@ export default function Trades() {
         setLoading(false);
       }
     };
-    refresh().catch((e: unknown) => setError(String(e))).finally(done);
+    refresh().catch((e: unknown) => { setError(String(e)); }).finally(done);
     void api.listProducts().then((p) => {
       setProducts(p);
       if (p[0]) {
         setProductId(p[0].id);
       }
-    }).catch((e: unknown) => setError(String(e))).finally(done);
+    }).catch((e: unknown) => { setError(String(e)); }).finally(done);
     void api.listModels().then((m) => {
       setModels(m);
       if (m[0]) {
         setModelId(m[0].id);
       }
-    }).catch((e: unknown) => setError(String(e))).finally(done);
+    }).catch((e: unknown) => { setError(String(e)); }).finally(done);
   }, [refresh]);
 
   async function create() {

--- a/webui/frontend/src/pages/Valuations.tsx
+++ b/webui/frontend/src/pages/Valuations.tsx
@@ -5,9 +5,10 @@ import { css, fmtMoney, fmtNum, inlineStyle } from "../format";
 export default function Valuations() {
   const [runs, setRuns] = useState<ValuationResult[]>([]);
   const [open, setOpen] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    void api.listValuations().then(setRuns);
+    void api.listValuations().then(setRuns).finally(() => setLoading(false));
   }, []);
 
   return (
@@ -19,7 +20,9 @@ export default function Valuations() {
         </div>
       </div>
 
-      {runs.length === 0 ? (
+      {loading ? (
+        <p {...css("muted")}>Loading valuations…</p>
+      ) : runs.length === 0 ? (
         <p {...css("muted")}>No valuation runs recorded yet.</p>
       ) : (
         <table>
@@ -27,6 +30,7 @@ export default function Valuations() {
             <tr>
               <th>When</th>
               <th>Target</th>
+              <th>Status</th>
               <th>Backend</th>
               <th {...css("num")}># paths</th>
               <th>AAD</th>
@@ -41,6 +45,17 @@ export default function Valuations() {
                   <td {...css("mono")}>{new Date(r.created_at).toLocaleString()}</td>
                   <td>{r.target_kind}</td>
                   <td>
+                    {r.status === "running" && (
+                      <span {...css("status-running")}>running…</span>
+                    )}
+                    {r.status === "completed" && (
+                      <span {...css("status-completed")}>completed</span>
+                    )}
+                    {r.status === "failed" && (
+                      <span {...css("status-failed")}>failed</span>
+                    )}
+                  </td>
+                  <td>
                     {r.backend}
                     {r.is_native ? "" : " (stub)"}
                   </td>
@@ -51,17 +66,22 @@ export default function Valuations() {
                     <button
                       type="button"
                       {...css("ghost")}
+                      disabled={r.status === "running"}
                       onClick={() => {
                         setOpen(open === r.id ? null : r.id);
                       }}
                     >
-                      {open === r.id ? "Hide" : "Details"}
+                      {r.status === "running"
+                        ? "—"
+                        : open === r.id
+                        ? "Hide"
+                        : "Details"}
                     </button>
                   </td>
                 </tr>
-                {open === r.id && (
+                {open === r.id && r.status === "completed" && (
                   <tr key={`${r.id}-detail`}>
-                    <td colSpan={7}>
+                    <td colSpan={8}>
                       <div {...css("panel")} {...inlineStyle({ margin: 0 })}>
                         <h2>Greeks</h2>
                         {Object.keys(r.total_greeks).length === 0 ? (

--- a/webui/frontend/src/pages/Valuations.tsx
+++ b/webui/frontend/src/pages/Valuations.tsx
@@ -9,7 +9,7 @@ export default function Valuations() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    void api.listValuations().then(setRuns).catch((e: unknown) => setError(String(e))).finally(() => setLoading(false));
+    void api.listValuations().then((r) => { setRuns(r); }).catch((e: unknown) => { setError(String(e)); }).finally(() => { setLoading(false); });
   }, []);
 
   return (

--- a/webui/frontend/src/pages/Valuations.tsx
+++ b/webui/frontend/src/pages/Valuations.tsx
@@ -5,10 +5,11 @@ import { css, fmtMoney, fmtNum, inlineStyle } from "../format";
 export default function Valuations() {
   const [runs, setRuns] = useState<ValuationResult[]>([]);
   const [open, setOpen] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    void api.listValuations().then(setRuns).finally(() => setLoading(false));
+    void api.listValuations().then(setRuns).catch((e: unknown) => setError(String(e))).finally(() => setLoading(false));
   }, []);
 
   return (
@@ -19,6 +20,8 @@ export default function Valuations() {
           <p>Reproducible history of every Monte Carlo valuation.</p>
         </div>
       </div>
+
+      {error && <div {...css("error")}>{error}</div>}
 
       {loading ? (
         <p {...css("muted")}>Loading valuations…</p>

--- a/webui/frontend/src/styles.css
+++ b/webui/frontend/src/styles.css
@@ -313,6 +313,24 @@ label {
   font-size: 13px;
 }
 
+.error-inline {
+  color: var(--red);
+  font-weight: 500;
+}
+
+.status-running {
+  color: var(--amber);
+  font-style: italic;
+}
+
+.status-completed {
+  color: var(--green);
+}
+
+.status-failed {
+  color: var(--red);
+}
+
 .muted {
   color: var(--text-dim);
 }

--- a/webui/frontend/vite.config.ts
+++ b/webui/frontend/vite.config.ts
@@ -1,14 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Vite dev server proxies /api to the FastAPI backend on :8000.
+// Vite dev server proxies /api to the FastAPI backend on :8001.
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8000",
+        target: "http://127.0.0.1:8001",
         changeOrigin: true,
       },
     },

--- a/webui/scripts/start.sh
+++ b/webui/scripts/start.sh
@@ -42,7 +42,7 @@ if ! command -v grep >/dev/null 2>&1; then
   echo "error: grep is required but not found" >&2
   exit 1
 fi
-BACKEND_PORT="$(grep -oP 'target.*?:(\K\d+)' "${FRONTEND_DIR}/vite.config.ts" 2>/dev/null || true)"
+BACKEND_PORT="$(grep -E 'target.*http.*127\.0\.0\.1:[0-9]+' "${FRONTEND_DIR}/vite.config.ts" 2>/dev/null | grep -oE ':[0-9]+' | tr -d ':' || true)"
 BACKEND_PORT="${BACKEND_PORT:-8001}"
 
 # PID and log files
@@ -81,6 +81,9 @@ check_cmd python3   || FAILED_PREREQS=1
 check_cmd uv        || FAILED_PREREQS=1
 check_cmd node      || FAILED_PREREQS=1
 check_cmd npm       || FAILED_PREREQS=1
+check_cmd curl      || FAILED_PREREQS=1
+check_cmd ss        || FAILED_PREREQS=1
+check_cmd nohup     || FAILED_PREREQS=1
 [ "${FAILED_PREREQS}" -eq 0 ] || exit 1
 
 PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"

--- a/webui/scripts/start.sh
+++ b/webui/scripts/start.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Start the DAL web UI (FastAPI backend + React/Vite frontend).
+#
+# Usage:
+#   ./webui/scripts/start.sh
+#
+# What it does:
+#   1. Verifies prerequisites (python 3.13+, uv, node, npm).
+#   2. Reads the backend port from webui/frontend/vite.config.ts.
+#   3. Checks that both ports (backend + 5173) are free.
+#   4. Starts the backend (uvicorn) in the background.
+#   5. Starts the frontend (vite) in the background.
+#   6. Waits for both to be ready, then runs a smoke test.
+#   7. Prints the URLs.
+#
+# Logs are written to webui/backend/.server.log and
+# webui/frontend/.server.log. PIDs are stored in .server.pid next to
+# the respective server directory, so stop.sh can kill them cleanly.
+#
+# Exit codes:
+#   0  both services started successfully
+#   1  prerequisites missing or ports already in use
+#   2  backend failed to start
+#   3  frontend failed to start
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve repo root (this script lives in webui/scripts/)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+BACKEND_DIR="webui/backend"
+FRONTEND_DIR="webui/frontend"
+FRONTEND_PORT=5173
+
+# Read backend port from vite.config.ts proxy target.
+# Matches lines like: target: "http://127.0.0.1:8001"
+if ! command -v grep >/dev/null 2>&1; then
+  echo "error: grep is required but not found" >&2
+  exit 1
+fi
+BACKEND_PORT="$(grep -oP 'target.*?:(\K\d+)' "${FRONTEND_DIR}/vite.config.ts" 2>/dev/null || true)"
+BACKEND_PORT="${BACKEND_PORT:-8001}"
+
+# PID and log files
+BACKEND_PID_FILE="${BACKEND_DIR}/.server.pid"
+BACKEND_LOG_FILE="${BACKEND_DIR}/.server.log"
+FRONTEND_PID_FILE="${FRONTEND_DIR}/.server.pid"
+FRONTEND_LOG_FILE="${FRONTEND_DIR}/.server.log"
+
+# ---------------------------------------------------------------------------
+# Colours and helpers
+# ---------------------------------------------------------------------------
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+
+info()  { printf "%s[info]%s  %s\n" "${GREEN}"  "${NC}" "$*"; }
+warn()  { printf "%s[warn]%s  %s\n" "${YELLOW}" "${NC}" "$*"; }
+error() { printf "%s[error]%s %s\n" "${RED}"    "${NC}" "$*" >&2; }
+
+port_busy() {
+  ss -tlnp 2>/dev/null | grep -qE ":${1}(\s|$)"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisites
+# ---------------------------------------------------------------------------
+info "Checking prerequisites..."
+
+check_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "$1 is not installed. Please install it and retry."
+    return 1
+  fi
+}
+
+FAILED_PREREQS=0
+check_cmd python3   || FAILED_PREREQS=1
+check_cmd uv        || FAILED_PREREQS=1
+check_cmd node      || FAILED_PREREQS=1
+check_cmd npm       || FAILED_PREREQS=1
+[ "${FAILED_PREREQS}" -eq 0 ] || exit 1
+
+PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYTHON_MAJOR="$(echo "${PYTHON_VERSION}" | cut -d. -f1)"
+PYTHON_MINOR="$(echo "${PYTHON_VERSION}" | cut -d. -f2)"
+if [ "${PYTHON_MAJOR}" -lt 3 ] || { [ "${PYTHON_MAJOR}" -eq 3 ] && [ "${PYTHON_MINOR}" -lt 13 ]; }; then
+  error "Python >= 3.13 is required (found ${PYTHON_VERSION})"
+  exit 1
+fi
+info "  python ${PYTHON_VERSION}, uv $(uv --version | awk '{print $2}'), node $(node --version), npm $(npm --version)"
+
+# ---------------------------------------------------------------------------
+# 2. Check ports are free
+# ---------------------------------------------------------------------------
+info "Checking ports (backend=${BACKEND_PORT}, frontend=${FRONTEND_PORT})..."
+
+if port_busy "${BACKEND_PORT}"; then
+  error "Port ${BACKEND_PORT} is already in use. Run webui/scripts/stop.sh first, or pick a different port in ${FRONTEND_DIR}/vite.config.ts."
+  exit 1
+fi
+if port_busy "${FRONTEND_PORT}"; then
+  error "Port ${FRONTEND_PORT} is already in use. Run webui/scripts/stop.sh first."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Backend setup
+# ---------------------------------------------------------------------------
+info "Installing backend dependencies (uv sync)..."
+(cd "${BACKEND_DIR}" && uv sync --quiet)
+
+info "Starting backend on port ${BACKEND_PORT}..."
+(
+  cd "${BACKEND_DIR}"
+  nohup uv run uvicorn app.main:app --reload --host 127.0.0.1 --port "${BACKEND_PORT}" \
+    > "${REPO_ROOT}/${BACKEND_LOG_FILE}" 2>&1 &
+  echo $!
+) > "${REPO_ROOT}/${BACKEND_PID_FILE}"
+BACKEND_PID="$(cat "${REPO_ROOT}/${BACKEND_PID_FILE}")"
+info "  backend PID ${BACKEND_PID}, log: ${BACKEND_LOG_FILE}"
+
+# Wait for backend to accept connections (up to 20s).
+info "Waiting for backend health check..."
+for i in $(seq 1 40); do
+  if curl -sf "http://127.0.0.1:${BACKEND_PORT}/api/health" >/dev/null 2>&1; then
+    info "  backend is up"
+    break
+  fi
+  if ! kill -0 "${BACKEND_PID}" 2>/dev/null; then
+    error "Backend process exited before becoming healthy. Check ${BACKEND_LOG_FILE}:"
+    tail -n 20 "${REPO_ROOT}/${BACKEND_LOG_FILE}" >&2 || true
+    rm -f "${REPO_ROOT}/${BACKEND_PID_FILE}"
+    exit 2
+  fi
+  sleep 0.5
+done
+if ! curl -sf "http://127.0.0.1:${BACKEND_PORT}/api/health" >/dev/null 2>&1; then
+  error "Backend did not become healthy within 20s. Check ${BACKEND_LOG_FILE}."
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Frontend setup
+# ---------------------------------------------------------------------------
+info "Installing frontend dependencies (npm install)..."
+(cd "${FRONTEND_DIR}" && npm install --silent --no-audit --no-fund >/dev/null)
+
+info "Starting frontend on port ${FRONTEND_PORT}..."
+(
+  cd "${FRONTEND_DIR}"
+  # Run vite directly rather than `npm run dev` so the PID we save is the
+  # actual node process holding the port. npm wraps the script in a parent
+  # process that doesn't forward SIGTERM to its child, which previously
+  # left orphaned node processes behind on stop.
+  nohup ./node_modules/.bin/vite > "${REPO_ROOT}/${FRONTEND_LOG_FILE}" 2>&1 &
+  echo $!
+) > "${REPO_ROOT}/${FRONTEND_PID_FILE}"
+FRONTEND_PID="$(cat "${REPO_ROOT}/${FRONTEND_PID_FILE}")"
+info "  frontend PID ${FRONTEND_PID}, log: ${FRONTEND_LOG_FILE}"
+
+# Wait for frontend to accept connections (up to 30s).
+info "Waiting for frontend to be ready..."
+for i in $(seq 1 60); do
+  if curl -sf "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
+    info "  frontend is up"
+    break
+  fi
+  if ! kill -0 "${FRONTEND_PID}" 2>/dev/null; then
+    error "Frontend process exited before becoming healthy. Check ${FRONTEND_LOG_FILE}:"
+    tail -n 20 "${REPO_ROOT}/${FRONTEND_LOG_FILE}" >&2 || true
+    rm -f "${REPO_ROOT}/${FRONTEND_PID_FILE}"
+    exit 3
+  fi
+  sleep 0.5
+done
+if ! curl -sf "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
+  error "Frontend did not become ready within 30s. Check ${FRONTEND_LOG_FILE}."
+  exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Smoke test — proxy should forward /api to the backend
+# ---------------------------------------------------------------------------
+info "Smoke test (frontend -> backend proxy)..."
+HEALTH="$(curl -sf "http://localhost:${FRONTEND_PORT}/api/health" || echo "")"
+if [ -z "${HEALTH}" ]; then
+  warn "Frontend is up but /api proxy is not forwarding to the backend. Check vite.config.ts."
+else
+  info "  /api/health via proxy -> ${HEALTH}"
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+printf "%s✓ DAL web UI is running%s\n" "${GREEN}" "${NC}"
+echo ""
+echo "  Frontend:  http://localhost:${FRONTEND_PORT}"
+echo "  Backend:   http://127.0.0.1:${BACKEND_PORT}"
+echo "  API docs:  http://127.0.0.1:${BACKEND_PORT}/docs"
+echo "  Backend:   PID ${BACKEND_PID}"
+echo "  Frontend:  PID ${FRONTEND_PID}"
+echo ""
+echo "To stop:     ./webui/scripts/stop.sh"
+echo "Logs:        ${BACKEND_LOG_FILE}, ${FRONTEND_LOG_FILE}"

--- a/webui/scripts/start.sh
+++ b/webui/scripts/start.sh
@@ -127,7 +127,7 @@ info "  backend PID ${BACKEND_PID}, log: ${BACKEND_LOG_FILE}"
 
 # Wait for backend to accept connections (up to 20s).
 info "Waiting for backend health check..."
-for i in $(seq 1 40); do
+for _ in $(seq 1 40); do
   if curl -sf "http://127.0.0.1:${BACKEND_PORT}/api/health" >/dev/null 2>&1; then
     info "  backend is up"
     break

--- a/webui/scripts/start.sh
+++ b/webui/scripts/start.sh
@@ -166,7 +166,7 @@ info "  frontend PID ${FRONTEND_PID}, log: ${FRONTEND_LOG_FILE}"
 
 # Wait for frontend to accept connections (up to 30s).
 info "Waiting for frontend to be ready..."
-for i in $(seq 1 60); do
+for _ in $(seq 1 60); do
   if curl -sf "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
     info "  frontend is up"
     break

--- a/webui/scripts/start.sh
+++ b/webui/scripts/start.sh
@@ -142,6 +142,10 @@ for _ in $(seq 1 40); do
 done
 if ! curl -sf "http://127.0.0.1:${BACKEND_PORT}/api/health" >/dev/null 2>&1; then
   error "Backend did not become healthy within 20s. Check ${BACKEND_LOG_FILE}."
+  # Clean up the backend process to avoid leaving a zombie server
+  kill "${BACKEND_PID}" 2>/dev/null || true
+  wait "${BACKEND_PID}" 2>/dev/null || true
+  rm -f "${REPO_ROOT}/${BACKEND_PID_FILE}"
   exit 2
 fi
 
@@ -181,6 +185,12 @@ for _ in $(seq 1 60); do
 done
 if ! curl -sf "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
   error "Frontend did not become ready within 30s. Check ${FRONTEND_LOG_FILE}."
+  # Clean up both backend and frontend to avoid leaving zombie servers
+  kill "${FRONTEND_PID}" 2>/dev/null || true
+  wait "${FRONTEND_PID}" 2>/dev/null || true
+  kill "${BACKEND_PID}" 2>/dev/null || true
+  wait "${BACKEND_PID}" 2>/dev/null || true
+  rm -f "${REPO_ROOT}/${FRONTEND_PID_FILE}" "${REPO_ROOT}/${BACKEND_PID_FILE}"
   exit 3
 fi
 

--- a/webui/scripts/stop.sh
+++ b/webui/scripts/stop.sh
@@ -43,23 +43,6 @@ FORCE=0
 [ "${1:-}" = "--force" ] && FORCE=1
 
 # ---------------------------------------------------------------------------
-# Prerequisites
-# ---------------------------------------------------------------------------
-check_cmd() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    error "$1 is not installed. Please install it and retry."
-    return 1
-  fi
-}
-
-FAILED_PREREQS=0
-check_cmd grep      || FAILED_PREREQS=1
-check_cmd ss        || FAILED_PREREQS=1
-check_cmd lsof      || FAILED_PREREQS=1
-check_cmd xargs     || FAILED_PREREQS=1
-[ "${FAILED_PREREQS}" -eq 0 ] || exit 1
-
-# ---------------------------------------------------------------------------
 # Colours and helpers
 # ---------------------------------------------------------------------------
 RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
@@ -128,6 +111,23 @@ kill_by_port() {
     fi
   fi
 }
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+check_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "$1 is not installed. Please install it and retry."
+    return 1
+  fi
+}
+
+FAILED_PREREQS=0
+check_cmd grep      || FAILED_PREREQS=1
+check_cmd ss        || FAILED_PREREQS=1
+check_cmd lsof      || FAILED_PREREQS=1
+check_cmd xargs     || FAILED_PREREQS=1
+[ "${FAILED_PREREQS}" -eq 0 ] || exit 1
 
 # ---------------------------------------------------------------------------
 # 1. Check current state

--- a/webui/scripts/stop.sh
+++ b/webui/scripts/stop.sh
@@ -32,7 +32,7 @@ FRONTEND_DIR="webui/frontend"
 FRONTEND_PORT=5173
 
 # Read backend port from vite.config.ts proxy target.
-BACKEND_PORT="$(grep -oP 'target.*?:(\K\d+)' "${FRONTEND_DIR}/vite.config.ts" 2>/dev/null || true)"
+BACKEND_PORT="$(grep -E 'target.*http.*127\.0\.0\.1:[0-9]+' "${FRONTEND_DIR}/vite.config.ts" 2>/dev/null | grep -oE ':[0-9]+' | tr -d ':' || true)"
 BACKEND_PORT="${BACKEND_PORT:-8001}"
 
 # PID and log files
@@ -41,6 +41,23 @@ FRONTEND_PID_FILE="${FRONTEND_DIR}/.server.pid"
 
 FORCE=0
 [ "${1:-}" = "--force" ] && FORCE=1
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+check_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "$1 is not installed. Please install it and retry."
+    return 1
+  fi
+}
+
+FAILED_PREREQS=0
+check_cmd grep      || FAILED_PREREQS=1
+check_cmd ss        || FAILED_PREREQS=1
+check_cmd lsof      || FAILED_PREREQS=1
+check_cmd xargs     || FAILED_PREREQS=1
+[ "${FAILED_PREREQS}" -eq 0 ] || exit 1
 
 # ---------------------------------------------------------------------------
 # Colours and helpers

--- a/webui/scripts/stop.sh
+++ b/webui/scripts/stop.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Stop the DAL web UI (FastAPI backend + React/Vite frontend).
+#
+# Usage:
+#   ./webui/scripts/stop.sh [--force]
+#
+# What it does:
+#   1. Reads the backend port from webui/frontend/vite.config.ts.
+#   2. Kills each service by PID (from the .server.pid files written by
+#      start.sh), falling back to killing by port if no PID file exists.
+#   3. Removes the PID files.
+#   4. Verifies that both ports are free.
+#
+# With --force, escalates from SIGTERM to SIGKILL if a process refuses
+# to die within 5 seconds.
+#
+# Exit codes:
+#   0  services stopped successfully (or were already stopped)
+#   1  a service could not be stopped even with --force
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve repo root (this script lives in webui/scripts/)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+BACKEND_DIR="webui/backend"
+FRONTEND_DIR="webui/frontend"
+FRONTEND_PORT=5173
+
+# Read backend port from vite.config.ts proxy target.
+BACKEND_PORT="$(grep -oP 'target.*?:(\K\d+)' "${FRONTEND_DIR}/vite.config.ts" 2>/dev/null || true)"
+BACKEND_PORT="${BACKEND_PORT:-8001}"
+
+# PID and log files
+BACKEND_PID_FILE="${BACKEND_DIR}/.server.pid"
+FRONTEND_PID_FILE="${FRONTEND_DIR}/.server.pid"
+
+FORCE=0
+[ "${1:-}" = "--force" ] && FORCE=1
+
+# ---------------------------------------------------------------------------
+# Colours and helpers
+# ---------------------------------------------------------------------------
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; NC=$'\033[0m'
+
+info()  { printf "%s[info]%s  %s\n" "${GREEN}"  "${NC}" "$*"; }
+warn()  { printf "%s[warn]%s  %s\n" "${YELLOW}" "${NC}" "$*"; }
+error() { printf "%s[error]%s %s\n" "${RED}"    "${NC}" "$*" >&2; }
+
+port_busy() {
+  ss -tlnp 2>/dev/null | grep -qE ":${1}(\s|$)"
+}
+
+# Kill a process by PID with SIGTERM, waiting up to TIMEOUT seconds.
+# Returns 0 on success, 1 if the process is still alive.
+kill_graceful() {
+  local pid="$1" name="$2" timeout="${3:-5}"
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    # Process is already gone.
+    return 0
+  fi
+  info "Sending SIGTERM to ${name} (PID ${pid})..."
+  kill -TERM "${pid}" 2>/dev/null || true
+  for _ in $(seq 1 $(( timeout * 2 ))); do
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
+# Kill a process by PID with SIGKILL (last resort).
+kill_hard() {
+  local pid="$1" name="$2"
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    return 0
+  fi
+  warn "Sending SIGKILL to ${name} (PID ${pid})..."
+  kill -KILL "${pid}" 2>/dev/null || true
+  sleep 1
+  if kill -0 "${pid}" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
+# Kill anything listening on a given port (fallback when no PID file).
+kill_by_port() {
+  local port="$1" name="$2"
+  local pids
+  pids="$(lsof -ti:"${port}" 2>/dev/null || true)"
+  if [ -z "${pids}" ]; then
+    return 0
+  fi
+  info "Killing ${name} by port ${port} (PIDs: ${pids//$'\n'/, })..."
+  echo "${pids}" | xargs -r kill 2>/dev/null || true
+  sleep 1
+  if port_busy "${port}"; then
+    if [ "${FORCE}" -eq 1 ]; then
+      warn "Port ${port} still busy; escalating to SIGKILL..."
+      echo "${pids}" | xargs -r kill -KILL 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Check current state
+# ---------------------------------------------------------------------------
+BACKEND_RUNNING=0
+FRONTEND_RUNNING=0
+port_busy "${BACKEND_PORT}"   && BACKEND_RUNNING=1
+port_busy "${FRONTEND_PORT}"  && FRONTEND_RUNNING=1
+
+if [ "${BACKEND_RUNNING}" -eq 0 ] && [ "${FRONTEND_RUNNING}" -eq 0 ]; then
+  info "No DAL web UI services are running (ports ${BACKEND_PORT} and ${FRONTEND_PORT} are both free)."
+  # Clean up any stale PID files.
+  rm -f "${REPO_ROOT}/${BACKEND_PID_FILE}" "${REPO_ROOT}/${FRONTEND_PID_FILE}"
+  exit 0
+fi
+
+# Kill a service. Try PID-based first (if the PID file exists), then verify
+# the port is actually free. Some launchers (notably `npm run <script>`)
+# spawn a child process that inherits the listening socket; killing the
+# parent PID we tracked can leave that child alive and the port still
+# bound. The post-PID port check catches those orphans and anything else
+# that slipped through.
+stop_service() {
+  local port="$1" name="$2" pid_file="$3"
+
+  if [ -f "${REPO_ROOT}/${pid_file}" ]; then
+    local pid
+    pid="$(cat "${REPO_ROOT}/${pid_file}")"
+    if ! kill_graceful "${pid}" "${name}" 5; then
+      if [ "${FORCE}" -eq 1 ]; then
+        kill_hard "${pid}" "${name}" || error "${name} PID ${pid} could not be killed."
+      else
+        warn "${name} (PID ${pid}) did not stop within 5s. Re-run with --force to escalate."
+      fi
+    fi
+    rm -f "${REPO_ROOT}/${pid_file}"
+  else
+    warn "No ${name} PID file found."
+  fi
+
+  # Defense in depth: the tracked PID may be gone while a child it spawned
+  # still holds the port. Fall back to port-based kill in that case.
+  if port_busy "${port}"; then
+    warn "${name} port ${port} still busy after PID kill; falling back to port-based kill..."
+    kill_by_port "${port}" "${name}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 2. Stop backend
+# ---------------------------------------------------------------------------
+if [ "${BACKEND_RUNNING}" -eq 1 ]; then
+  stop_service "${BACKEND_PORT}" "backend" "${BACKEND_PID_FILE}"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Stop frontend
+# ---------------------------------------------------------------------------
+if [ "${FRONTEND_RUNNING}" -eq 1 ]; then
+  stop_service "${FRONTEND_PORT}" "frontend" "${FRONTEND_PID_FILE}"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Final verification
+# ---------------------------------------------------------------------------
+sleep 1
+REMAINING=0
+if port_busy "${BACKEND_PORT}"; then
+  error "Backend is still listening on port ${BACKEND_PORT}."
+  REMAINING=1
+fi
+if port_busy "${FRONTEND_PORT}"; then
+  error "Frontend is still listening on port ${FRONTEND_PORT}."
+  REMAINING=1
+fi
+
+if [ "${REMAINING}" -eq 0 ]; then
+  printf "%s✓ DAL web UI stopped.%s  Ports ${BACKEND_PORT} and ${FRONTEND_PORT} are free.\n" "${GREEN}" "${NC}"
+  exit 0
+else
+  error "Some services could not be stopped. Try: ./webui/scripts/stop.sh --force"
+  error "Or manually: sudo fuser -k ${BACKEND_PORT}/tcp; sudo fuser -k ${FRONTEND_PORT}/tcp"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `webui/scripts/start.sh` and `stop.sh` for managing both services.
  `start.sh` checks prerequisites, verifies ports 8001/5173 are free, installs
  deps, launches both servers in the background, waits for health checks, and
  smoke-tests the vite proxy. `stop.sh` kills by PID with SIGTERM, verifies
  ports are actually free, and falls back to port-based kill to catch orphaned
  child processes. With `--force`, escalates to SIGKILL after 5s.
- Add async valuation endpoints (`POST /api/trades/{id}/value`,
  `POST /api/portfolios/{id}/value`) that return pending results and update via
  FastAPI background tasks. Frontend polls `GET /api/valuations/{id}` until
  completed or failed.
- Add `PUT` update endpoints for products, models, and trades, plus delete
  guards (409 Conflict when deleting a referenced product/model).
- Add Dupire model support: backend schema + gateway, frontend UI with matrix
  input for vol surface.
- Improve frontend pages: loading states, better styling, async valuation
  status indicators, inline edit forms.
- Update root `README.md` and `webui/README.md` to document the scripts as the
  primary way to start/stop the web UI, fix port references (8000 → 8001), and
  note that vite should run directly (not via `npm run dev`) to avoid orphans.
- Add `.claude/skills/dal-webui-setup/SKILL.md` for Claude Code integration.

## Test plan
- [x] `./webui/scripts/start.sh` → both services come up, `/api/health` via proxy returns OK
- [x] `./webui/scripts/stop.sh` → both services stop cleanly, no orphans, ports free
- [x] `cd webui/backend && uv run pytest` — backend tests pass
- [x] `cd webui/frontend && npm run build` — frontend type-check + production build
- [x] Full `bin/dal_cpp_tests` to confirm no C++ regressions (no C++ changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)