### PR TITLE
ci: build and test all public sub-projects

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -129,6 +129,7 @@ jobs:
           CXXFLAGS: -O2
           CC: gcc-14
           CXX: g++-14
+          VERBOSE: 1
           ADDITIONAL_CMAKE_FLAGS: -DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off -DDAL_USE_ADEPT_AAD=off -DDAL_BUILD_PYTHON=ON
         run: |
           bash -e ./build_linux.sh

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -93,3 +93,29 @@ jobs:
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Extended build: dal-cpp + dal-public + dal-python.
+  # Lives in a separate job so the main 16-job compiler×backend matrix
+  # stays lean — the Python bindings are backend-agnostic, so testing
+  # them against one representative configuration is sufficient.
+  build-extended:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          submodules: recursive
+
+      - name: Setup
+        run: |
+          sudo apt install -y gcc-14 g++-14 swig \
+            libc++-dev make cmake libpython3-dev \
+            autotools-dev autoconf libtool
+
+      - name: Compile and test
+        env:
+          CXXFLAGS: -O2
+          CC: gcc-14
+          CXX: g++-14
+          ADDITIONAL_CMAKE_FLAGS: -DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off -DDAL_USE_ADEPT_AAD=off -DDAL_BUILD_PYTHON=ON
+        run: |
+          bash -e ./build_linux.sh

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -116,7 +116,7 @@ jobs:
       # Configure step so cmake's find_package(Python3) picks up the
       # venv's interpreter — otherwise dal_python_pytest runs against
       # the system python, which doesn't have pytest.
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # @v3
 
       - name: Set up Python venv
         run: |

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -108,9 +108,21 @@ jobs:
       - name: Setup
         run: |
           sudo apt install -y gcc-14 g++-14 swig \
-            libc++-dev make cmake libpython3-dev \
-            autotools-dev autoconf libtool \
-            python3-pytest python3-numpy
+            libc++-dev make cmake \
+            autotools-dev autoconf libtool
+
+      # Python env: uv-managed venv, matching the convention in
+      # dal-python/run_tests.sh. The venv must be on PATH *before* the
+      # Configure step so cmake's find_package(Python3) picks up the
+      # venv's interpreter — otherwise dal_python_pytest runs against
+      # the system python, which doesn't have pytest.
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python venv
+        run: |
+          uv venv .venv --python 3.12
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          uv pip install pytest numpy
 
       - name: Compile and test
         env:

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           sudo apt install -y gcc-14 g++-14 swig \
             libc++-dev make cmake libpython3-dev \
-            autotools-dev autoconf libtool
+            autotools-dev autoconf libtool \
+            python3-pytest python3-numpy
 
       - name: Compile and test
         env:

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -96,10 +96,16 @@ jobs:
         shell: pwsh
         run: |
           uv venv .venv --python 3.12
-          # .venv\Scripts must precede the system Python on PATH so cmake
-          # finds the venv's interpreter at configure time.
           $venvScripts = (Resolve-Path .\.venv\Scripts).Path
+          $pythonExe = Join-Path $venvScripts "python.exe"
+          # Add venv Scripts to PATH so subprocesses (including cmake's
+          # FindPython3 on some platforms) pick up the venv's python.
           Add-Content -Path $env:GITHUB_PATH -Value $venvScripts
+          # Also set Python3_EXECUTABLE explicitly because cmake's
+          # FindPython3 on Windows prefers the registry / highest-version
+          # interpreter over PATH order. Point it at the venv's python
+          # so dal_python_pytest can find pytest.
+          Add-Content -Path $env:GITHUB_ENV -Value "Python3_EXECUTABLE=$pythonExe"
           uv pip install pytest numpy
 
       - name: Build Machinist
@@ -129,7 +135,8 @@ jobs:
           rm -rf build
           mkdir -p build
           cd build
-          cmake --preset Release-windows -DDAL_BUILD_PUBLIC=ON -DDAL_CPP_BUILD_EXAMPLES=ON ${ADDITIONAL_CMAKE_FLAGS} ..
+          cmake --preset Release-windows -DDAL_BUILD_PUBLIC=ON -DDAL_CPP_BUILD_EXAMPLES=ON ${ADDITIONAL_CMAKE_FLAGS} \
+            ${Python3_EXECUTABLE:+-DPython3_EXECUTABLE="$Python3_EXECUTABLE"} ..
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -90,7 +90,7 @@ jobs:
       # Configure step so cmake's find_package(Python3) picks up the
       # venv's interpreter — otherwise dal_python_pytest runs against
       # the system python, which doesn't have pytest.
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf # @v3
 
       - name: Set up Python venv
         shell: pwsh

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -144,4 +144,4 @@ jobs:
         shell: bash
         run: |
           cd build
-          ctest --output-on-failure -C Release
+          ctest --output-on-failure --verbose -C Release

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -85,11 +85,22 @@ jobs:
           # choco installs to C:\ProgramData\chocolatey\bin which is on PATH
           swig -version
 
-      - name: Install Python test dependencies
+      # Python env: uv-managed venv, matching the convention in
+      # dal-python/run_tests.sh. The venv must be on PATH *before* the
+      # Configure step so cmake's find_package(Python3) picks up the
+      # venv's interpreter — otherwise dal_python_pytest runs against
+      # the system python, which doesn't have pytest.
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python venv
         shell: pwsh
         run: |
-          # dal_python_pytest uses `python -m pytest`; numpy is imported by several tests.
-          python -m pip install --disable-pip-version-check pytest numpy
+          uv venv .venv --python 3.12
+          # .venv\Scripts must precede the system Python on PATH so cmake
+          # finds the venv's interpreter at configure time.
+          $venvScripts = (Resolve-Path .\.venv\Scripts).Path
+          Add-Content -Path $env:GITHUB_PATH -Value $venvScripts
+          uv pip install pytest numpy
 
       - name: Build Machinist
         shell: bash

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -71,7 +71,19 @@ jobs:
             adept)
               FLAGS="-DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off -DDAL_USE_ADEPT_AAD=on" ;;
           esac
+          # dal-python (SWIG bindings) and dal-excel (Windows-only COM add-in)
+          # are built on every matrix combination — the matrix is small
+          # (3 jobs) and the bindings are backend-agnostic.
+          FLAGS="$FLAGS -DDAL_BUILD_PYTHON=ON -DDAL_BUILD_EXCEL=ON"
           echo "ADDITIONAL_CMAKE_FLAGS=$FLAGS" >> $GITHUB_ENV
+
+      - name: Install SWIG
+        shell: pwsh
+        run: |
+          # windows-latest runners ship with Python 3.x but not SWIG.
+          choco install swig --no-progress --yes
+          # choco installs to C:\ProgramData\chocolatey\bin which is on PATH
+          swig -version
 
       - name: Build Machinist
         shell: bash

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -85,6 +85,12 @@ jobs:
           # choco installs to C:\ProgramData\chocolatey\bin which is on PATH
           swig -version
 
+      - name: Install Python test dependencies
+        shell: pwsh
+        run: |
+          # dal_python_pytest uses `python -m pytest`; numpy is imported by several tests.
+          python -m pip install --disable-pip-version-check pytest numpy
+
       - name: Build Machinist
         shell: bash
         run: |

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -65,9 +65,15 @@ if [ $? -ne 0 ]; then
 fi
 
 # Run all tests via CTest
+# VERBOSE=1 shows full test output (useful for seeing Python/Excel test details)
+CTEST_FLAGS="--output-on-failure"
+if [ "${VERBOSE:-0}" = "1" ]; then
+    CTEST_FLAGS="$CTEST_FLAGS --verbose"
+fi
+
 (
 cd build || exit
-ctest --output-on-failure
+ctest $CTEST_FLAGS
 )
 
 if [ $? -ne 0 ]; then

--- a/dal-excel/CMakeLists.txt
+++ b/dal-excel/CMakeLists.txt
@@ -98,7 +98,13 @@ add_library(dal_excel SHARED ${EXCEL_FILES})
 add_library(DAL::excel ALIAS dal_excel)
 
 if(MSVC)
-    target_compile_definitions(dal_excel PRIVATE IS_BASE)
+    target_compile_definitions(dal_excel PRIVATE
+        IS_BASE
+        # Windows.h defines min/max as macros, which breaks AAD headers
+        # (XAD, Adept) that use std::numeric_limits<...>::max() and
+        # std::min/max. NOMINMAX suppresses those macros.
+        NOMINMAX
+    )
 endif()
 
 # Excel COM compile definitions (mirrors original)

--- a/dal-excel/src/__global.cpp
+++ b/dal-excel/src/__global.cpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/global.hpp>
 
 /*IF--------------------------------------------------------------------------

--- a/dal-excel/src/__interp.cpp
+++ b/dal-excel/src/__interp.cpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/interp.hpp>
 #include <dal/math/interp/interplinear.hpp>
 #include <dal/math/interp/interp2d.hpp>

--- a/dal-excel/src/__models.cpp
+++ b/dal-excel/src/__models.cpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/models.hpp>
 
 /*IF--------------------------------------------------------------------------

--- a/dal-excel/src/__platform.hpp
+++ b/dal-excel/src/__platform.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/_excel.hpp>
+#include "_excel.hpp"
 #include <dal/platform/platform.hpp>
 #include <dal/storage/_reader.hpp>
 #include <dal/storage/_repository.hpp>

--- a/dal-excel/src/__random.cpp
+++ b/dal-excel/src/__random.cpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/random.hpp>
 #include <dal/math/random/pseudorandom.hpp>
 #include <dal/math/random/sobol.hpp>

--- a/dal-excel/src/__repository.cpp
+++ b/dal-excel/src/__repository.cpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <dal/platform/platform.hpp>
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/repository.hpp>
 
 /*IF--------------------------------------------------------------------------

--- a/dal-excel/src/__script.cpp
+++ b/dal-excel/src/__script.cpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/script.hpp>
 #include <dal/script/event.hpp>
 

--- a/dal-excel/src/__value.cpp
+++ b/dal-excel/src/__value.cpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <public/excel/__platform.hpp>
+#include "__platform.hpp"
 #include <dal-public/src/value.hpp>
 #include <dal/math/matrix/matrixs.hpp>
 #include <dal/platform/strict.hpp>

--- a/dal-python/CMakeLists.txt
+++ b/dal-python/CMakeLists.txt
@@ -221,9 +221,21 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/dal/
 
 # ---------------------------------------------------------------------------
 # Python tests (pytest)
+#
+# The in-build-tree `dal/` directory only contains SWIG's generated
+# `dal.py` and the compiled `_dal.*.pyd` / `_dal.*.so`. The hand-written
+# package files (`__init__.py`, `api.py`) live in `src/dal/` and are
+# normally copied only at install time. Copy them into the build tree at
+# configure time too, so CTest can `import dal` from the build directory
+# without a separate `pip install -e .` step.
 # ---------------------------------------------------------------------------
 if(DAL_PYTHON_BUILD_TESTS)
     enable_testing()
+
+    file(COPY
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/dal/__init__.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/dal/api.py
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/dal)
 
     add_test(NAME dal_python_pytest
              COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/tests -v


### PR DESCRIPTION
## Summary
- **Linux (`cmake-linux.yml`)**: add a `build-extended` job (gcc-14, aadet backend) that enables `DAL_BUILD_PYTHON=ON`, installs SWIG, sets up a uv-managed Python venv with pytest + numpy, and runs `ctest` end-to-end.
- **Windows (`cmake-windows.yml`)**: enable `DAL_BUILD_PYTHON=ON` and `DAL_BUILD_EXCEL=ON` on every matrix combination (msvc × 3 AAD backends). Install SWIG (Chocolatey), set up a uv-managed venv, and pin cmake's `Python3_EXECUTABLE` to the venv's interpreter.
- **Python env via uv** — matches the convention in `dal-python/run_tests.sh`. On both platforms: install uv → create `.venv` → put venv on PATH → `uv pip install pytest numpy`.
- **Bug fix (`dal-python/CMakeLists.txt`)**: the existing `add_test(NAME dal_python_pytest ...)` was broken — the in-build-tree `dal/` package only contained SWIG's generated files; the hand-written `__init__.py` and `api.py` were copied at install time only, so `import dal` failed when CTest ran pytest from the build directory. Add a `file(COPY ...)` at configure time.
- **Bug fix (`dal-excel/src/__platform.hpp` + 7 `__*.cpp` files)**: Excel sources included `<public/excel/__platform.hpp>` and `<public/excel/_excel.hpp>`, but those files moved to `dal-excel/src/` during the multi-project refactor. The code was broken but never caught because Excel wasn't in CI. Fixed by switching to same-directory quoted includes.
- **Bug fix (`dal-excel/CMakeLists.txt`)**: `dal_excel` sources include `<Windows.h>`, which defines `min`/`max` as macros. These break AAD headers (XAD, Adept) that use `std::numeric_limits<...>::max()` and `std::min/max`. Added `NOMINMAX` compile definition for MSVC.
- **Codacy fix**: pin `astral-sh/setup-uv` to full commit SHA instead of tag (`@v3` → `@8d55fbecc...`).

## Coverage matrix (build + test)

| Sub-project | Linux CI | Windows CI |
|-------------|----------|------------|
| dal-cpp     | ✅ 4 compilers × 4 backends | ✅ msvc × 3 backends |
| dal-public  | ✅ same matrix | ✅ same matrix |
| dal-python  | ✅ 1 extended job (build + pytest) | ✅ 3 combos (build + pytest) |
| dal-excel   | — (Windows-only) | ✅ 3 combos (build + gtest) |

**Total: 20/20 CI checks passing** (17 Linux + 3 Windows).

## Code quality
- ✅ Codacy: Your pull request is up to standards!
- ✅ Copilot review: All threads resolved
- ✅ All CI jobs green

## Notes

- `dal-excel` sources only need `<Windows.h>`, not Office COM headers, so the build works on a stock `windows-latest` runner.
- `dal_excel_tests` is currently a stub (`ASSERT_TRUE(true)`) and passes.
- `setup-uv@v3` is pinned to the v3 tag's full SHA (`8d55fbecc275b1c35dbe060458839f8d30439ccf`) for supply-chain security.