### PR TITLE
test: add Playwright e2e for dal-web and sync docs

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -6,16 +6,16 @@ implement → review pipeline. The orchestrator routes work between them.
 
 ## Team Roster
 
-| Role         | Agent              | Color  | Reads                            | Writes                                                  |
-|--------------|--------------------|--------|----------------------------------|---------------------------------------------------------|
-| Orchestrator | `dal-orchestrator` | purple | GitHub issues, all artifacts     | task list, PRs                                          |
-| Spec writer  | `dal-spec-writer`  | orange | issues, methodology, rules       | `.claude/specs/<slug>.md`                               |
-| Architect    | `dal-architect`    | blue   | spec, codebase, methodology      | `.claude/designs/<slug>.md`                             |
-| API designer | `dal-api-designer` | pink   | spec, design, public headers     | `.claude/api-notes/<slug>.md`                           |
-| Critic       | `dal-critic`       | red    | spec, design, api-note           | `.claude/critiques/<slug>.md`                           |
-| Implementer  | `dal-implementer`  | green  | spec, design, api-note, critique | source code, tests, TDD in worktree                     |
-| Tester       | `dal-tester`       | cyan   | source under-test, conventions   | additional `dal-cpp/tests/<module>/*` code, in worktree |
-| Reviewer     | `dal-reviewer`     | amber  | PR diff, all upstream artifacts  | review report, optional merge                           |
+| Role         | Agent              | Color  | Reads                            | Writes                                                                                     |
+|--------------|--------------------|--------|----------------------------------|--------------------------------------------------------------------------------------------|
+| Orchestrator | `dal-orchestrator` | purple | GitHub issues, all artifacts     | task list, PRs                                                                             |
+| Spec writer  | `dal-spec-writer`  | orange | issues, methodology, rules       | `.claude/specs/<slug>.md`                                                                  |
+| Architect    | `dal-architect`    | blue   | spec, codebase, methodology      | `.claude/designs/<slug>.md`                                                                |
+| API designer | `dal-api-designer` | pink   | spec, design, public headers     | `.claude/api-notes/<slug>.md`                                                              |
+| Critic       | `dal-critic`       | red    | spec, design, api-note           | `.claude/critiques/<slug>.md`                                                              |
+| Implementer  | `dal-implementer`  | green  | spec, design, api-note, critique | source code, tests, TDD in worktree                                                        |
+| Tester       | `dal-tester`       | cyan   | source under-test, conventions   | `dal-cpp/tests/<module>/*` and, for web scope, `dal-web/frontend/tests/e2e/*`, in worktree |
+| Reviewer     | `dal-reviewer`     | amber  | PR diff, all upstream artifacts  | review report, optional merge                                                              |
 
 ## Workflow
 

--- a/.claude/agents/dal-tester.md
+++ b/.claude/agents/dal-tester.md
@@ -1,10 +1,10 @@
 ---
 name: dal-tester
 description: |
-  Write Google Test unit tests and fix failing test sets for the DAL C++ quantitative finance library. Use when the user asks to write tests,
-  add test coverage, create unit tests, repair broken tests, fix failing test suites, or mentions testing for new or existing C++ code. Also trigger when
-  implementing features that need test coverage, refactoring code without tests, or when the user mentions a
-  function/class that should be tested.
+  Write DAL tests and fix failing test sets. This includes Google Test coverage for C++ modules and
+  Playwright e2e smoke tests for dal-web frontend flows when the scope includes web UI behavior.
+  Use when the user asks to write tests, add test coverage, create unit tests, repair broken tests,
+  fix failing suites, or mentions testing for new or existing C++/web code.
 
   This agent works incrementally: analyze coverage gaps across the entire codebase, pick the weakest sub-module
   under `dal-cpp/dal/`, write focused tests for just that module, build, run the full suite, style-review, then commit
@@ -55,6 +55,8 @@ You write Google Test unit tests that follow project conventions, cover edge cas
 - `dal-cpp/dal/` — core library with ~15 sub-modules
 - `dal-cpp/tests/` — one subdirectory per module, globbed into a single `dal_cpp_tests` binary
 - `dal-cpp/CMakeLists.txt` — uses `file(GLOB_RECURSE TEST_FILES "*.hpp" "*.cpp")`, so new test files are auto-detected
+- `dal-web/frontend/tests/e2e/` — Playwright e2e smoke coverage for web UI flows
+- `dal-web/scripts/setup-playwright.sh` — one-time browser/runtime setup for Playwright on Linux
 
 ## Your Process
 
@@ -151,6 +153,19 @@ For each failure:
 - Invalid holiday centers, day-counts, or other reference data strings
 - Test ordering: Google Test runs alphabetically within a file
 
+### Phase 4B: Web UI e2e (when scope includes `dal-web/`)
+
+If your changes touch the web frontend/backend contract or user-facing flows in `dal-web/`,
+run the Playwright smoke suite before style review:
+
+```bash
+$ ./dal-web/scripts/setup-playwright.sh
+$ cd dal-web/frontend
+$ npm run test:e2e
+```
+
+If e2e fails, debug with `dal-web/{backend,frontend}/.server.log`, fix root cause, and rerun.
+
 ### Phase 5: Style Review
 
 Use the `dal-code-style-review` skill to check all changed files. Fix any violations before proceeding.
@@ -169,18 +184,20 @@ Once the PR is open and the user is done with the change, exit the worktree (kee
 
 ## Key Conventions at a Glance
 
-| Element           | Convention                                          |
-|-------------------|-----------------------------------------------------|
-| Test macro        | `TEST(Suite, Name)` — never `TEST_F`                |
-| Assertions        | `ASSERT_*` only — never `EXPECT_*`                  |
-| Float compare     | `ASSERT_NEAR(actual, expected, 1e-10)`              |
-| Exception test    | `ASSERT_THROW(stmt, Dal::Exception_)`               |
-| Suite names       | PascalCase (`CcyTest`, `InterpTest`)                |
-| Test names        | PascalCase with `Test` prefix (`TestNewCubic`)      |
-| File names        | lowercase, `test_` prefix (`test_currency.cpp`)     |
-| Include order     | `<gtest/gtest.h>` → DAL headers                     |
-| Namespace         | `using namespace Dal;` at file scope                |
-| State             | No mutable singletons shared with other test files  |
+| Element         | Convention                                                  |
+|-----------------|-------------------------------------------------------------|
+| Test macro      | `TEST(Suite, Name)` — never `TEST_F`                        |
+| Assertions      | `ASSERT_*` only — never `EXPECT_*`                          |
+| Float compare   | `ASSERT_NEAR(actual, expected, 1e-10)`                      |
+| Exception test  | `ASSERT_THROW(stmt, Dal::Exception_)`                       |
+| Suite names     | PascalCase (`CcyTest`, `InterpTest`)                        |
+| Test names      | PascalCase with `Test` prefix (`TestNewCubic`)              |
+| File names      | lowercase, `test_` prefix (`test_currency.cpp`)             |
+| Include order   | `<gtest/gtest.h>` → DAL headers                             |
+| Namespace       | `using namespace Dal;` at file scope                        |
+| State           | No mutable singletons shared with other test files          |
+| Web e2e files   | `dal-web/frontend/tests/e2e/*.spec.ts`                      |
+| Web e2e command | `./dal-web/scripts/setup-playwright.sh && npm run test:e2e` |
 
 ## What Not to Do
 
@@ -193,3 +210,4 @@ Once the PR is open and the user is done with the change, exit the worktree (kee
 - Don't add comments describing what the test does — test names should be self-documenting
 - Don't create a PR that mixes test changes with unrelated work unless the user asks for it
 - Don't change existing test suite names or reformat existing tests
+- Don't skip Playwright e2e when your changes impact `dal-web/` behavior

--- a/.claude/agents/dal-tester.md
+++ b/.claude/agents/dal-tester.md
@@ -184,20 +184,20 @@ Once the PR is open and the user is done with the change, exit the worktree (kee
 
 ## Key Conventions at a Glance
 
-| Element         | Convention                                                  |
-|-----------------|-------------------------------------------------------------|
-| Test macro      | `TEST(Suite, Name)` — never `TEST_F`                        |
-| Assertions      | `ASSERT_*` only — never `EXPECT_*`                          |
-| Float compare   | `ASSERT_NEAR(actual, expected, 1e-10)`                      |
-| Exception test  | `ASSERT_THROW(stmt, Dal::Exception_)`                       |
-| Suite names     | PascalCase (`CcyTest`, `InterpTest`)                        |
-| Test names      | PascalCase with `Test` prefix (`TestNewCubic`)              |
-| File names      | lowercase, `test_` prefix (`test_currency.cpp`)             |
-| Include order   | `<gtest/gtest.h>` → DAL headers                             |
-| Namespace       | `using namespace Dal;` at file scope                        |
-| State           | No mutable singletons shared with other test files          |
-| Web e2e files   | `dal-web/frontend/tests/e2e/*.spec.ts`                      |
-| Web e2e command | `./dal-web/scripts/setup-playwright.sh && npm run test:e2e` |
+| Element         | Convention                                                                           |
+|-----------------|--------------------------------------------------------------------------------------|
+| Test macro      | `TEST(Suite, Name)` — never `TEST_F`                                                 |
+| Assertions      | `ASSERT_*` only — never `EXPECT_*`                                                   |
+| Float compare   | `ASSERT_NEAR(actual, expected, 1e-10)`                                               |
+| Exception test  | `ASSERT_THROW(stmt, Dal::Exception_)`                                                |
+| Suite names     | PascalCase (`CcyTest`, `InterpTest`)                                                 |
+| Test names      | PascalCase with `Test` prefix (`TestNewCubic`)                                       |
+| File names      | lowercase, `test_` prefix (`test_currency.cpp`)                                      |
+| Include order   | `<gtest/gtest.h>` → DAL headers                                                      |
+| Namespace       | `using namespace Dal;` at file scope                                                 |
+| State           | No mutable singletons shared with other test files                                   |
+| Web e2e files   | `dal-web/frontend/tests/e2e/*.spec.ts`                                               |
+| Web e2e command | `./dal-web/scripts/setup-playwright.sh && (cd dal-web/frontend && npm run test:e2e)` |
 
 ## What Not to Do
 

--- a/.claude/rules/dal-web-design.md
+++ b/.claude/rules/dal-web-design.md
@@ -452,8 +452,8 @@ Before submitting Web UI code, check:
 
 ## References
 
-- **Design document**: `dal-web/DESIGN.md`
 - **Style file**: `dal-web/frontend/src/styles.css`
+- **Web UI overview**: `dal-web/README.md`
 - **Inspiration sources**: Bloomberg Terminal, trading desk interfaces, control room displays
 
 ---

--- a/.claude/skills/dal-web-setup/SKILL.md
+++ b/.claude/skills/dal-web-setup/SKILL.md
@@ -68,14 +68,14 @@ If the user asks to run tests after starting the UI:
 
 ```bash
 # Backend tests (pytest, runs against the stub by default)
-cd dal-web/backend && uv run pytest
+(cd dal-web/backend && uv run pytest)
 
 # Frontend type-check + production build
-cd dal-web/frontend && npm run build
+(cd dal-web/frontend && npm run build)
 
 # Frontend e2e smoke tests (Playwright; starts/stops the web UI itself)
 ./dal-web/scripts/setup-playwright.sh   # one-time browser/runtime setup
-cd dal-web/frontend && npm run test:e2e
+(cd dal-web/frontend && npm run test:e2e)
 ```
 
 ## Native vs. stub DAL backend

--- a/.claude/skills/dal-web-setup/SKILL.md
+++ b/.claude/skills/dal-web-setup/SKILL.md
@@ -10,10 +10,11 @@ Brings up or tears down the two-service web UI that sits on top of the DAL Pytho
 
 Two scripts handle the actual work:
 
-| Command                               | What it does                                                                                                                             |
-|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| `./dal-web/scripts/start.sh`            | Checks prerequisites, starts backend (uvicorn on `:8001`) and frontend (vite on `:5173`), waits for both, runs a smoke test.             |
-| `./dal-web/scripts/stop.sh [--force]`   | Stops both services (by PID file, falling back to port-based kill). Use `--force` to escalate to SIGKILL.                                |
+| Command                                 | What it does                                                                                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `./dal-web/scripts/start.sh`            | Checks prerequisites, starts backend (uvicorn on `:8001`) and frontend (vite on `:5173`), waits for both, runs a smoke test. |
+| `./dal-web/scripts/stop.sh [--force]`   | Stops both services (by PID file, falling back to port-based kill). Use `--force` to escalate to SIGKILL.                    |
+| `./dal-web/scripts/setup-playwright.sh` | One-time setup for the frontend e2e suite: downloads Chrome and its NSS runtime libraries used by Playwright.                |
 
 ## When to use
 
@@ -71,6 +72,10 @@ cd dal-web/backend && uv run pytest
 
 # Frontend type-check + production build
 cd dal-web/frontend && npm run build
+
+# Frontend e2e smoke tests (Playwright; starts/stops the web UI itself)
+./dal-web/scripts/setup-playwright.sh   # one-time browser/runtime setup
+cd dal-web/frontend && npm run test:e2e
 ```
 
 ## Native vs. stub DAL backend

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -22,11 +22,12 @@ exclude_paths:
   - 'build/**'
   - 'bin/**'
   - 'lib/**'
-  # Playwright e2e tooling — the config intentionally resolves the locally
-  # provisioned Chrome binary and its NSS libraries via fs path discovery,
-  # which trips the "non-literal fs filename" security rule. The paths are
-  # derived from the repo layout, not from user input, so this is a false
-  # positive for test-only tooling.
+  # Playwright e2e tooling — the config resolves the provisioned Chrome binary
+  # and its NSS libraries via fs path discovery, which trips the "non-literal
+  # fs filename" security rule. While the Chrome path can be overridden via
+  # the PLAYWRIGHT_CHROME_PATH environment variable, the resolved paths are
+  # constrained to the repo-local Chrome installation. This is test-only
+  # tooling run locally by developers, not exposed to untrusted input.
   - 'dal-web/frontend/playwright.config.ts'
   # Internal project documentation and agent/skill definitions.
   # The Codacy Agentlinter is designed to enforce style rules for AI-agent

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -22,6 +22,12 @@ exclude_paths:
   - 'build/**'
   - 'bin/**'
   - 'lib/**'
+  # Playwright e2e tooling — the config intentionally resolves the locally
+  # provisioned Chrome binary and its NSS libraries via fs path discovery,
+  # which trips the "non-literal fs filename" security rule. The paths are
+  # derived from the repo layout, not from user input, so this is a false
+  # positive for test-only tooling.
+  - 'dal-web/frontend/playwright.config.ts'
   # Internal project documentation and agent/skill definitions.
   # The Codacy Agentlinter is designed to enforce style rules for AI-agent
   # prompts (no undefined acronyms, no absolute rules without escape hatches,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,9 +31,10 @@ Formatting is enforced by `.clang-format` (LLVM base, 4-space indent, 150 column
 
 ### CMake presets and options
 
-`CMakePresets.json` base preset turns **everything off** (all AAD backends, examples,
-benchmarks, public/python/excel). With all AAD backends off, the native ("aadet") backend
-is used. Presets: `Release-linux`, `Debug-linux`, `Release-windows`, `Debug-windows`.
+`CMakePresets.json` base preset turns off all AAD backends, examples, benchmarks,
+and the public/python/excel sub-projects. Tests remain enabled by the source default
+(`DAL_CPP_BUILD_TESTS=ON`). With AAD backends off, the native ("aadet") backend is
+used. Presets: `Release-linux`, `Debug-linux`, `Release-windows`, `Debug-windows`.
 Override via cache vars when configuring manually:
 
 - `DAL_BUILD_PUBLIC`, `DAL_BUILD_PYTHON`, `DAL_BUILD_EXCEL` (Excel is Windows-only)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,120 @@
+# Copilot Instructions for DAL (Derivatives Algorithms Library)
+
+C++17 quantitative finance library with built-in Automatic Adjoint Differentiation (AAD),
+organized as a multi-project CMake workspace.
+
+## Build, Test, Lint
+
+```bash
+# Full build: Machinist codegen → configure → build all sub-projects → install → ctest
+bash ./build_linux.sh          # add --coverage for a coverage report
+
+# Manual build from the workspace root
+mkdir build && cd build
+cmake --preset=Release-linux -DDAL_BUILD_PUBLIC=ON .. && make -j32 && make install
+```
+
+CMake installs into the repo root: binaries in `bin/`, libs in `lib/`, headers in `include/`.
+
+Tests run through CTest. Each sub-project registers its own GoogleTest binary
+(`dal_cpp_tests`, `dal_public_tests`) via `gtest_discover_tests`.
+
+```bash
+(cd build && ctest --output-on-failure)          # all registered tests
+bin/dal_cpp_tests                                # one binary directly
+bin/dal_cpp_tests --gtest_filter=<Suite>.*       # one suite
+bin/dal_cpp_tests --gtest_filter=<Suite>.<Test>  # one test
+```
+
+Formatting is enforced by `.clang-format` (LLVM base, 4-space indent, 150 column limit,
+`T*` not `T *`, attach braces).
+
+### CMake presets and options
+
+`CMakePresets.json` base preset turns **everything off** (all AAD backends, examples,
+benchmarks, public/python/excel). With all AAD backends off, the native ("aadet") backend
+is used. Presets: `Release-linux`, `Debug-linux`, `Release-windows`, `Debug-windows`.
+Override via cache vars when configuring manually:
+
+- `DAL_BUILD_PUBLIC`, `DAL_BUILD_PYTHON`, `DAL_BUILD_EXCEL` (Excel is Windows-only)
+- `DAL_CPP_BUILD_TESTS`, `DAL_CPP_BUILD_EXAMPLES`, `DAL_CPP_BUILD_BENCHMARKS`
+- `DAL_USE_XAD_AAD` / `DAL_USE_ADEPT_AAD` / `DAL_USE_CODIPACK_AAD` — pick an AAD backend.
+  CI runs the full matrix across native/xad/codipack/adept and gcc-13/14, clang-18/19.
+
+## Architecture
+
+Dependency graph: `dal-cpp ← dal-public ← {dal-python, dal-excel}`; `dal-web` consumes
+the Python public API. Each sub-project owns its own `CMakeLists.txt` and stands alone.
+
+| Sub-project   | Target / purpose                                                  |
+|---------------|------------------------------------------------------------------|
+| `dal-cpp/`    | `DAL::cpp` — core: math, curves, models, scripting, AAD          |
+| `dal-public/` | `DAL::public` — stable public API wrapping `DAL::cpp`            |
+| `dal-python/` | SWIG Python bindings (`dal` package), depends on `DAL::public`   |
+| `dal-excel/`  | `.xll` add-in, Windows-only, depends on `DAL::public`           |
+| `dal-web/`    | FastAPI backend + React/Vite frontend portfolio app             |
+
+Core modules under `dal-cpp/dal/`: `math/` (interpolation, optimization, PDE, RNG, matrix,
+`math/aad/`), `script/` (visitor-pattern expression engine: lexer → preprocessor → parser
+→ AST → simulation), `model/`, `curve/` (yield curves, calibration), `indice/`, `risk/`,
+`concurrency/` (thread pool), `storage/`, and `auto/` (Machinist-generated, glob-included).
+
+The public API flattens everything into the `Dal::` namespace via `using` aliases.
+
+## Codegen (Machinist) — critical, non-obvious
+
+Enums are **never hand-written** as `enum class`. They are declared with Machinist markup
+in `/*IF---- ... -IF----*/` blocks placed before `namespace Dal {` in the header. Machinist
+reads `dal-cpp/config/dal.ifc` + `dal.mgl` and generates `dal-cpp/dal/auto/MG_*_enum.{hpp,inc}`
+(and `dal-excel/auto/MG_*_public.inc`). `build_linux.sh` runs Machinist twice (`-d ./dal-cpp/dal`
+and `-d ./dal-excel`). After changing markup, regenerate and **commit the generated files**:
+
+```bash
+export MACHINIST_TEMPLATE_DIR=$PWD/dal-cpp/externals/machinist/template/
+./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-cpp/dal
+./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-excel
+```
+
+Use values as `EnumName_::Value_::NAME`; `switch (obj.Switch())`; `obj == EnumName_::Value_::X`
+when the markup is `switchable`. Include `MG_*_enum.hpp` inside `namespace Dal { }` in the
+header and `MG_*_enum.inc` inside `namespace Dal { }` in the `.cpp`.
+
+Files matching `_repository.*` under `dal-cpp/dal/storage/` are excluded from the build.
+
+## Conventions
+
+Naming (see `.claude/rules/code-style.md` for the full table):
+
+- Classes/structs: PascalCase with trailing `_` (`Date_`, `ThreadPool_`); template params
+  single-letter + `_` (`T_`, `RHS_`); methods PascalCase; member vars camelCase + `_`
+  (`spot_`); locals camelCase; constants/macros UPPER_SNAKE_CASE; files lowercase with no
+  separators (`blackscholes.hpp`); test files `test_<name>.cpp`.
+- Headers: `#pragma once` (no guards); three-line `//\n// Created by <author> on <date>.\n//`
+  file header; include order system → DAL → local; most `.cpp` include `<dal/platform/platform.hpp>`.
+- Types: `using` over `typedef`; `Handle_<T_>` wraps `shared_ptr<const T_>`; `Vector_<E_>`
+  privately inherits `std::vector`; `String_` is case-insensitive; `explicit` single-arg ctors;
+  `[[nodiscard]] const` getters; `nullptr` not `NULL`; all files end with a newline.
+- Errors: custom `Exception_`; use `REQUIRE(cond, msg)` (runs in release) not debug-only
+  `ASSERT`; `THROW(msg)`; stack context via `NOTICE`/`NOTE`.
+- Patterns: CRTP (AAD expression templates), Visitor (script AST), Factory (`New*`, `Clone`),
+  RAII tape/stack scopes, thread-local `Tape()`.
+
+Tests (Google Test, `.claude/rules/unit-test-style.md`):
+
+- Always `TEST(Suite, Name)` — never `TEST_F`/fixtures. Suite PascalCase matching the module
+  (`AADTest`); test names PascalCase with `Test` prefix (`TestNumberAdd`).
+- Prefer `ASSERT_*` over `EXPECT_*`; floats via `ASSERT_NEAR(actual, expected, 1e-8..1e-10)`;
+  exceptions via `ASSERT_THROW(expr, Dal::Exception_)`; use scoped `{ }` blocks for sub-cases.
+- The core runner calls `Dal::RegisterAll_::Init()` before `RUN_ALL_TESTS()` (`tests/test_main.cpp`).
+- For AAD: `Clear(*Tape())` → setup → `NewRecording` → compute → `PropagateToStart` → assert adjoints.
+
+## Tooling notes
+
+- Python dependencies are managed with **uv** (not pip/venv directly) for both the web backend
+  and the Python public-API/SWIG build.
+- Repo AI guidance lives under `.claude/` only (rules, skills, agents). Keep markdown tables
+  column-aligned with compact separator rows. Use SSH (`git@github.com:`) URLs, not HTTPS.
+- Web UI: `./dal-web/scripts/start.sh` / `stop.sh`; frontend at http://localhost:5173,
+  API docs at http://127.0.0.1:8001/docs.
+- Web UI e2e: run `./dal-web/scripts/setup-playwright.sh` once, then
+  `cd dal-web/frontend && npm run test:e2e`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,8 +112,9 @@ Tests (Google Test, `.claude/rules/unit-test-style.md`):
 
 - Python dependencies are managed with **uv** (not pip/venv directly) for both the web backend
   and the Python public-API/SWIG build.
-- Repo AI guidance lives under `.claude/` only (rules, skills, agents). Keep markdown tables
-  column-aligned with compact separator rows. Use SSH (`git@github.com:`) URLs, not HTTPS.
+- DAL agent guidance (rules, skills, agents) lives under `.claude/`. Copilot guidance is in
+  `.github/copilot-instructions.md` (this file). Keep markdown tables column-aligned with compact
+  separator rows. Use SSH (`git@github.com:`) URLs, not HTTPS.
 - Web UI: `./dal-web/scripts/start.sh` / `stop.sh`; frontend at http://localhost:5173,
   API docs at http://127.0.0.1:8001/docs.
 - Web UI e2e: run `./dal-web/scripts/setup-playwright.sh` once, then

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/*
 bin/*
 lib/*
 include/*
+chrome/
+chrome-libs/
 coverage.info
 coverage/
 *.csv
@@ -15,6 +17,8 @@ build
 *.egg-info
 *.idb
 __pycache__
+dal-web/frontend/playwright-report/
+dal-web/frontend/test-results/
 public/lib/*
 *.xlsx
 notebooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ The top-level `CMakeLists.txt` is a thin workspace that selects sub-projects via
 - `DAL_CPP_BUILD_TESTS` (default `ON`) — build the `dal-cpp` test suite
 - `DAL_CPP_BUILD_EXAMPLES` (default `ON`) — build the `dal-cpp` example programs
 - `DAL_CPP_BUILD_BENCHMARKS` (default `ON`) — build the `dal-cpp` benchmark programs
-- `DAL_USE_ADEPT_AAD` / `DAL_USE_XAD_AAD` / `DAL_USE_CODIPACK_AAD` — pick the AAD backend (default Adept)
+- `DAL_USE_ADEPT_AAD` / `DAL_USE_XAD_AAD` / `DAL_USE_CODIPACK_AAD` — pick the AAD backend (source default: Adept; CMake presets override all three to OFF unless explicitly enabled)
 
 CMake installs to the repo root (`CMAKE_INSTALL_PREFIX=${sourceDir}`), placing binaries in `bin/`, libraries in `lib/`, and headers in `include/`.
 
@@ -109,9 +109,9 @@ The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Ea
 **Web UI (`dal-web/`, not built by CMake)** — FastAPI backend + React frontend:
 - `dal-web/backend/` — Python FastAPI application, uses `dal-python` bindings or stub
 - `dal-web/frontend/` — React + TypeScript SPA, uses Vite
-- `dal-web/scripts/` — `start.sh` and `stop.sh` for running the UI
+- `dal-web/scripts/` — `start.sh`, `stop.sh`, and `setup-playwright.sh`
 
-Start the web UI with `./dal-web/scripts/start.sh` (requires Python 3.13+, uv, Node.js 20+, npm). Frontend at http://localhost:5173, backend API docs at http://127.0.0.1:8001/docs.
+Start the web UI with `./dal-web/scripts/start.sh` (requires Python 3.13+, uv, Node.js 20+, npm). Frontend at http://localhost:5173, backend API docs at http://127.0.0.1:8001/docs. For frontend e2e, run `./dal-web/scripts/setup-playwright.sh` once, then `cd dal-web/frontend && npm run test:e2e`.
 
 **Code generation** — `dal-cpp/config/dal.ifc` is processed by the Machinist tool. `build_linux.sh` runs Machinist twice:
 - once with `-d ./dal-cpp/dal` to produce core enum and serialization files under `dal-cpp/dal/auto/`

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Portfolio management web app in `dal-web/`:
 ```bash
 ./dal-web/scripts/start.sh     # Start backend + frontend
 ./dal-web/scripts/stop.sh      # Stop services
+./dal-web/scripts/setup-playwright.sh
+cd dal-web/frontend && npm run test:e2e   # frontend e2e smoke tests
 ```
 
 - Frontend: http://localhost:5173

--- a/dal-web/README.md
+++ b/dal-web/README.md
@@ -109,7 +109,7 @@ Dependencies are managed with [uv](https://docs.astral.sh/uv/). From `dal-web/ba
 ```bash
 cd dal-web/backend
 uv sync                     # create .venv and install runtime + dev deps from uv.lock
-uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8001
+uv run python -m uvicorn app.main:app --reload --host 127.0.0.1 --port 8001
 ```
 
 `uv` provisions a matching Python interpreter automatically (downloading one if
@@ -161,7 +161,7 @@ already in use`, either free the port or run on a different one:
 fuser -k 8001/tcp
 
 # Option C — use a different port (e.g. 8002)
-uv run uvicorn app.main:app --reload --port 8002
+uv run python -m uvicorn app.main:app --reload --port 8002
 ```
 
 If you choose Option C, also update the proxy target in
@@ -211,8 +211,10 @@ uv run pytest               # runs against the in-process DAL stub
 ```
 
 ```bash
+./dal-web/scripts/setup-playwright.sh
 cd dal-web/frontend
 npm run build               # type-check + production build
+npm run test:e2e            # Playwright smoke tests (starts/stops the web UI)
 ```
 
 ## Screens

--- a/dal-web/backend/uv.lock
+++ b/dal-web/backend/uv.lock
@@ -63,7 +63,7 @@ wheels = [
 ]
 
 [[package]]
-name = "dal-webui-backend"
+name = "dal-web-backend"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [

--- a/dal-web/frontend/package-lock.json
+++ b/dal-web/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-router-dom": "^6.26.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^5.2.0",
@@ -413,6 +414,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1332,6 +1349,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/dal-web/frontend/package.json
+++ b/dal-web/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-react": "^5.2.0",
     "typescript": "^5.5.4",
     "vite": "^8.0.16"

--- a/dal-web/frontend/playwright.config.ts
+++ b/dal-web/frontend/playwright.config.ts
@@ -70,7 +70,10 @@ export default defineConfig({
       executablePath: resolveChromeExecutable(),
       env: {
         ...process.env,
-        ...(chromeLibraryPath() ? { LD_LIBRARY_PATH: chromeLibraryPath() } : {}),
+        ...((): Record<string, string> => {
+          const libPath = chromeLibraryPath();
+          return libPath ? { LD_LIBRARY_PATH: libPath } : {};
+        })(),
       },
     },
   },

--- a/dal-web/frontend/playwright.config.ts
+++ b/dal-web/frontend/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from "@playwright/test";
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BASE_URL = "http://localhost:5173";
+
+const frontendDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(frontendDir, "..", "..");
+
+// Playwright's bundled browsers are not available on every Linux distro, so
+// `dal-web/scripts/setup-playwright.sh` downloads Chrome into `<repo>/chrome`
+// and extracts its NSS runtime libraries into `<repo>/chrome-libs/extract`.
+const chromeDir = resolve(repoRoot, "chrome");
+const chromeLibDir = resolve(repoRoot, "chrome-libs", "extract", "usr", "lib", "x86_64-linux-gnu");
+
+// Locate the Chrome binary downloaded by setup-playwright.sh. The download
+// creates a versioned directory such as `chrome/linux-149.0.7827.115/...`, so
+// pick the highest version available. `PLAYWRIGHT_CHROME_PATH` overrides this.
+function resolveChromeExecutable(): string {
+  const override = process.env.PLAYWRIGHT_CHROME_PATH;
+  if (override) {
+    return override;
+  }
+
+  const candidates = existsSync(chromeDir)
+    ? readdirSync(chromeDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name.startsWith("linux-"))
+        .map((entry) => resolve(chromeDir, entry.name, "chrome-linux64", "chrome"))
+        .filter((path) => existsSync(path))
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    : [];
+
+  const executable = candidates.at(-1);
+  if (!executable) {
+    throw new Error(
+      `No Chrome binary found under ${chromeDir}. Run ./dal-web/scripts/setup-playwright.sh first.`
+    );
+  }
+
+  return executable;
+}
+
+// Prepend the extracted NSS libraries so Chrome can load libnspr4/libnss3.
+function chromeLibraryPath(): string {
+  return [chromeLibDir, process.env.LD_LIBRARY_PATH]
+    .filter((value): value is string => Boolean(value) && existsSync(value as string))
+    .join(":");
+}
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "line",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    launchOptions: {
+      executablePath: resolveChromeExecutable(),
+      env: {
+        ...process.env,
+        LD_LIBRARY_PATH: chromeLibraryPath(),
+      },
+    },
+  },
+  webServer: {
+    command: "../scripts/playwright-start.sh",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/dal-web/frontend/playwright.config.ts
+++ b/dal-web/frontend/playwright.config.ts
@@ -12,7 +12,23 @@ const repoRoot = resolve(frontendDir, "..", "..");
 // `dal-web/scripts/setup-playwright.sh` downloads Chrome into `<repo>/chrome`
 // and extracts its NSS runtime libraries into `<repo>/chrome-libs/extract`.
 const chromeDir = resolve(repoRoot, "chrome");
-const chromeLibDir = resolve(repoRoot, "chrome-libs", "extract", "usr", "lib", "x86_64-linux-gnu");
+const chromeLibBase = resolve(repoRoot, "chrome-libs", "extract", "usr", "lib");
+
+function findChromeLibDir(): string | null {
+  if (!existsSync(chromeLibBase)) return null;
+  const candidates = existsSync(chromeLibBase)
+    ? readdirSync(chromeLibBase, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name.endsWith("-linux-gnu"))
+        .map((entry) => entry.name)
+    : [];
+  // Prefer the first discovered multiarch dir; x86_64-linux-gnu is the most
+  // common and a reasonable fallback.
+  return candidates.length > 0
+    ? resolve(chromeLibBase, candidates[0])
+    : null;
+}
+
+const chromeLibDir = findChromeLibDir();
 
 // Locate the Chrome binary downloaded by setup-playwright.sh. The download
 // creates a versioned directory such as `chrome/linux-149.0.7827.115/...`, so
@@ -62,7 +78,7 @@ function resolveChromeExecutable(): string {
 // Prepend the extracted NSS libraries so Chrome can load libnspr4/libnss3.
 function chromeLibraryPath(): string {
   const parts: string[] = [];
-  if (existsSync(chromeLibDir)) {
+  if (chromeLibDir && existsSync(chromeLibDir)) {
     parts.push(chromeLibDir);
   }
   if (process.env.LD_LIBRARY_PATH) {

--- a/dal-web/frontend/playwright.config.ts
+++ b/dal-web/frontend/playwright.config.ts
@@ -20,6 +20,11 @@ const chromeLibDir = resolve(repoRoot, "chrome-libs", "extract", "usr", "lib", "
 function resolveChromeExecutable(): string {
   const override = process.env.PLAYWRIGHT_CHROME_PATH;
   if (override) {
+    if (!existsSync(override)) {
+      throw new Error(
+        `PLAYWRIGHT_CHROME_PATH points to a non-existent file: ${override}`
+      );
+    }
     return override;
   }
 
@@ -65,7 +70,7 @@ export default defineConfig({
       executablePath: resolveChromeExecutable(),
       env: {
         ...process.env,
-        LD_LIBRARY_PATH: chromeLibraryPath(),
+        ...(chromeLibraryPath() ? { LD_LIBRARY_PATH: chromeLibraryPath() } : {}),
       },
     },
   },

--- a/dal-web/frontend/playwright.config.ts
+++ b/dal-web/frontend/playwright.config.ts
@@ -43,9 +43,14 @@ function resolveChromeExecutable(): string {
 
 // Prepend the extracted NSS libraries so Chrome can load libnspr4/libnss3.
 function chromeLibraryPath(): string {
-  return [chromeLibDir, process.env.LD_LIBRARY_PATH]
-    .filter((value): value is string => Boolean(value) && existsSync(value as string))
-    .join(":");
+  const parts: string[] = [];
+  if (existsSync(chromeLibDir)) {
+    parts.push(chromeLibDir);
+  }
+  if (process.env.LD_LIBRARY_PATH) {
+    parts.push(process.env.LD_LIBRARY_PATH);
+  }
+  return parts.join(":");
 }
 
 export default defineConfig({

--- a/dal-web/frontend/playwright.config.ts
+++ b/dal-web/frontend/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
-import { existsSync, readdirSync } from "node:fs";
+import { accessSync, constants as fsConstants, existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,6 +23,19 @@ function resolveChromeExecutable(): string {
     if (!existsSync(override)) {
       throw new Error(
         `PLAYWRIGHT_CHROME_PATH points to a non-existent file: ${override}`
+      );
+    }
+    const overrideStat = statSync(override);
+    if (!overrideStat.isFile()) {
+      throw new Error(
+        `PLAYWRIGHT_CHROME_PATH is not a regular file: ${override}`
+      );
+    }
+    try {
+      accessSync(override, fsConstants.X_OK);
+    } catch {
+      throw new Error(
+        `PLAYWRIGHT_CHROME_PATH is not executable: ${override}`
       );
     }
     return override;

--- a/dal-web/frontend/tests/e2e/app.spec.ts
+++ b/dal-web/frontend/tests/e2e/app.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("shows the dashboard shell", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Portfolios" })).toBeVisible();
+  await expect(page.getByText("online")).toBeVisible();
+});
+
+test("navigates between primary pages", async ({ page }) => {
+  await page.goto("/products");
+  await expect(page.getByRole("heading", { name: "Product Builder" })).toBeVisible();
+
+  await page.goto("/models");
+  await expect(page.getByRole("heading", { name: "Models" })).toBeVisible();
+
+  await page.goto("/valuations");
+  await expect(page.getByRole("heading", { name: "Valuation Runs" })).toBeVisible();
+});

--- a/dal-web/scripts/playwright-start.sh
+++ b/dal-web/scripts/playwright-start.sh
@@ -4,13 +4,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+STARTED=false
+
 cleanup() {
-  "${REPO_ROOT}/dal-web/scripts/stop.sh" --force >/dev/null 2>&1 || true
+  if [ "${STARTED}" = true ]; then
+    "${REPO_ROOT}/dal-web/scripts/stop.sh" --force >/dev/null 2>&1 || true
+  fi
 }
 
 trap cleanup EXIT INT TERM
 
 "${REPO_ROOT}/dal-web/scripts/start.sh"
+STARTED=true
 
 # Keep the process alive so Playwright's webServer doesn't exit.
 # `sleep infinity` is not portable; use a long-sleep loop instead.

--- a/dal-web/scripts/playwright-start.sh
+++ b/dal-web/scripts/playwright-start.sh
@@ -12,4 +12,6 @@ trap cleanup EXIT INT TERM
 
 "${REPO_ROOT}/dal-web/scripts/start.sh"
 
-sleep infinity
+# Keep the process alive so Playwright's webServer doesn't exit.
+# `sleep infinity` is not portable; use a long-sleep loop instead.
+while true; do sleep 86400; done

--- a/dal-web/scripts/playwright-start.sh
+++ b/dal-web/scripts/playwright-start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cleanup() {
+  "${REPO_ROOT}/dal-web/scripts/stop.sh" --force >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT INT TERM
+
+"${REPO_ROOT}/dal-web/scripts/start.sh"
+
+sleep infinity

--- a/dal-web/scripts/setup-playwright.sh
+++ b/dal-web/scripts/setup-playwright.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CHROME_ROOT="${REPO_ROOT}/chrome"
+LIB_ROOT="${REPO_ROOT}/chrome-libs/extract"
+LIB_DIR="${LIB_ROOT}/usr/lib/x86_64-linux-gnu"
+
+find_chrome_binary() {
+  find "${CHROME_ROOT}" -path '*/chrome-linux64/chrome' -type f 2>/dev/null | sort | tail -n 1
+}
+
+CHROME_BINARY="$(find_chrome_binary)"
+
+if [ ! -x "${CHROME_BINARY}" ]; then
+  echo "Installing Chrome for Playwright..."
+  (cd "${REPO_ROOT}" && npx --yes @puppeteer/browsers install chrome@stable)
+  CHROME_BINARY="$(find_chrome_binary)"
+else
+  echo "Chrome already installed: ${CHROME_BINARY}"
+fi
+
+if [ ! -f "${LIB_DIR}/libnspr4.so" ] || [ ! -f "${LIB_DIR}/libnss3.so" ]; then
+  echo "Installing browser runtime libraries..."
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+  (cd "${TMP_DIR}" && apt-get download libnspr4 libnss3)
+  mkdir -p "${LIB_ROOT}"
+  for deb in "${TMP_DIR}"/*.deb; do
+    dpkg-deb -x "${deb}" "${LIB_ROOT}"
+  done
+else
+  echo "Browser runtime libraries already installed: ${LIB_DIR}"
+fi
+
+echo "Playwright setup complete."

--- a/dal-web/scripts/setup-playwright.sh
+++ b/dal-web/scripts/setup-playwright.sh
@@ -6,7 +6,17 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 CHROME_ROOT="${REPO_ROOT}/chrome"
 LIB_ROOT="${REPO_ROOT}/chrome-libs/extract"
-LIB_DIR="${LIB_ROOT}/usr/lib/x86_64-linux-gnu"
+# Discover the multiarch library directory (e.g. x86_64-linux-gnu, aarch64-linux-gnu)
+# instead of hard-coding x86_64 so non-amd64 Debian/Ubuntu variants work.
+LIB_DIR=""
+if [ -d "${LIB_ROOT}/usr/lib" ]; then
+  for candidate in "${LIB_ROOT}"/usr/lib/*-linux-gnu; do
+    if [ -d "${candidate}" ]; then
+      LIB_DIR="${candidate}"
+      break
+    fi
+  done
+fi
 
 find_chrome_binary() {
   # Guard against a fresh checkout where CHROME_ROOT doesn't exist yet: with
@@ -36,7 +46,7 @@ if [ ! -x "${CHROME_BINARY}" ]; then
   exit 1
 fi
 
-if [ ! -f "${LIB_DIR}/libnspr4.so" ] || [ ! -f "${LIB_DIR}/libnss3.so" ]; then
+if [ -z "${LIB_DIR}" ] || [ ! -f "${LIB_DIR}/libnspr4.so" ] || [ ! -f "${LIB_DIR}/libnss3.so" ]; then
   echo "Installing browser runtime libraries..."
   for cmd in apt-get dpkg-deb; do
     if ! command -v "${cmd}" >/dev/null 2>&1; then

--- a/dal-web/scripts/setup-playwright.sh
+++ b/dal-web/scripts/setup-playwright.sh
@@ -9,7 +9,9 @@ LIB_ROOT="${REPO_ROOT}/chrome-libs/extract"
 LIB_DIR="${LIB_ROOT}/usr/lib/x86_64-linux-gnu"
 
 find_chrome_binary() {
-  find "${CHROME_ROOT}" -path '*/chrome-linux64/chrome' -type f 2>/dev/null | sort | tail -n 1
+  # Sort by version (-V) so chrome/linux-<version> dirs pick the newest, not
+  # the lexically-last, then take that newest path.
+  find "${CHROME_ROOT}" -path '*/chrome-linux64/chrome' -type f 2>/dev/null | sort -V | tail -n 1
 }
 
 CHROME_BINARY="$(find_chrome_binary)"
@@ -20,6 +22,11 @@ if [ ! -x "${CHROME_BINARY}" ]; then
   CHROME_BINARY="$(find_chrome_binary)"
 else
   echo "Chrome already installed: ${CHROME_BINARY}"
+fi
+
+if [ ! -x "${CHROME_BINARY}" ]; then
+  echo "error: Chrome installation did not produce an executable under ${CHROME_ROOT}" >&2
+  exit 1
 fi
 
 if [ ! -f "${LIB_DIR}/libnspr4.so" ] || [ ! -f "${LIB_DIR}/libnss3.so" ]; then

--- a/dal-web/scripts/setup-playwright.sh
+++ b/dal-web/scripts/setup-playwright.sh
@@ -9,6 +9,9 @@ LIB_ROOT="${REPO_ROOT}/chrome-libs/extract"
 LIB_DIR="${LIB_ROOT}/usr/lib/x86_64-linux-gnu"
 
 find_chrome_binary() {
+  # Guard against a fresh checkout where CHROME_ROOT doesn't exist yet: with
+  # `set -euo pipefail`, a `find` on a missing directory would abort the script.
+  [ -d "${CHROME_ROOT}" ] || return 0
   # Sort by version (-V) so chrome/linux-<version> dirs pick the newest, not
   # the lexically-last, then take that newest path.
   find "${CHROME_ROOT}" -path '*/chrome-linux64/chrome' -type f 2>/dev/null | sort -V | tail -n 1
@@ -31,6 +34,13 @@ fi
 
 if [ ! -f "${LIB_DIR}/libnspr4.so" ] || [ ! -f "${LIB_DIR}/libnss3.so" ]; then
   echo "Installing browser runtime libraries..."
+  for cmd in apt-get dpkg-deb; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      echo "error: '${cmd}' is required to install the NSS runtime libraries (libnspr4, libnss3)." >&2
+      echo "       Install those packages manually for your distribution and re-run." >&2
+      exit 1
+    fi
+  done
   TMP_DIR="$(mktemp -d)"
   trap 'rm -rf "${TMP_DIR}"' EXIT
   (cd "${TMP_DIR}" && apt-get download libnspr4 libnss3)

--- a/dal-web/scripts/setup-playwright.sh
+++ b/dal-web/scripts/setup-playwright.sh
@@ -21,6 +21,10 @@ CHROME_BINARY="$(find_chrome_binary)"
 
 if [ ! -x "${CHROME_BINARY}" ]; then
   echo "Installing Chrome for Playwright..."
+  if ! command -v npx >/dev/null 2>&1; then
+    echo "error: npx is required to download Chrome. Install Node.js (>=20) first." >&2
+    exit 1
+  fi
   (cd "${REPO_ROOT}" && npx --yes @puppeteer/browsers install chrome@stable)
   CHROME_BINARY="$(find_chrome_binary)"
 else

--- a/dal-web/scripts/start.sh
+++ b/dal-web/scripts/start.sh
@@ -118,7 +118,7 @@ info "Installing backend dependencies (uv sync)..."
 info "Starting backend on port ${BACKEND_PORT}..."
 (
   cd "${BACKEND_DIR}"
-  nohup uv run uvicorn app.main:app --reload --host 127.0.0.1 --port "${BACKEND_PORT}" \
+  nohup uv run python -m uvicorn app.main:app --reload --host 127.0.0.1 --port "${BACKEND_PORT}" \
     > "${REPO_ROOT}/${BACKEND_LOG_FILE}" 2>&1 &
   echo $!
 ) > "${REPO_ROOT}/${BACKEND_PID_FILE}"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,14 +59,6 @@ git clone --recursive git@github.com:wegamekinglc/Derivatives-Algorithms-Lib.git
 cd Derivatives-Algorithms-Lib
 ```
 
-Or use HTTPS if you don't have SSH keys set up:
-
-```bash
-# HTTPS (no SSH key required)
-git clone --recursive https://github.com/wegamekinglc/Derivatives-Algorithms-Lib.git
-cd Derivatives-Algorithms-Lib
-```
-
 **Important:** The `--recursive` flag is required to fetch all git submodules (XAD, Adept, CoDiPack, Google Test, RapidJSON, Machinist).
 
 If you already cloned without `--recursive`:
@@ -139,6 +131,11 @@ make install
 - `Debug-linux` — Debug build with full symbols
 
 **CMake Options:**
+
+The table below shows source-level defaults from `CMakeLists.txt` files. Note that
+`CMakePresets.json` (`Release-linux`/`Debug-linux`) overrides several values (for
+example: all external AAD backends OFF, examples/benchmarks/public OFF) unless you
+re-enable them with `-D...` flags.
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -369,7 +366,7 @@ If you need to start services individually:
 ```bash
 cd dal-web/backend
 uv sync
-uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8001
+uv run python -m uvicorn app.main:app --reload --host 127.0.0.1 --port 8001
 ```
 
 **Frontend:**
@@ -441,6 +438,14 @@ Open http://localhost:5173 in a browser — the dashboard should load.
 ```bash
 cd dal-web/backend
 uv run pytest
+```
+
+4. Run frontend e2e smoke tests:
+
+```bash
+./dal-web/scripts/setup-playwright.sh
+cd dal-web/frontend
+npm run test:e2e
 ```
 
 ---
@@ -540,7 +545,7 @@ uv pip install -e . --no-build-isolation --force-reinstall
 
 ```bash
 cd dal-web/backend
-uv run uvicorn app.main:app --host 127.0.0.1 --port 8001
+uv run python -m uvicorn app.main:app --host 127.0.0.1 --port 8001
 ```
 
 ### Getting Help


### PR DESCRIPTION
## Summary
- Add a Playwright e2e smoke suite for the `dal-web` UI that boots backend + frontend and verifies the dashboard shell and primary-page navigation
- Add `scripts/setup-playwright.sh` (provisions Chrome + NSS runtime libs, since Playwright's bundled browsers are unavailable on this OS) and `scripts/playwright-start.sh` (Playwright `webServer` wrapper that starts/stops the UI)
- Fix `dal-web/scripts/start.sh` to launch the backend via `python -m uvicorn` so it uses the project's uv environment
- Add `.github/copilot-instructions.md` (build/test commands, architecture, Machinist codegen, conventions, web e2e workflow)
- Sync existing docs (README, CLAUDE.md, dal-web/README, docs/installation, `.claude/` agents/skills/rules) with the new e2e workflow; fix stale references (HTTPS clone snippet, dead `dal-web/DESIGN.md`, AAD preset-vs-source defaults) and normalize edited markdown tables

## Test plan
- [x] `cd dal-web/frontend && npm run test:e2e` — 2/2 Playwright tests pass
- [x] `./dal-web/scripts/setup-playwright.sh` — idempotent browser/runtime setup
- [x] `cd dal-web/backend && uv run pytest` — 20/20 backend tests pass
- [x] `cd dal-web/frontend && npm run build` — type-check + production build