### PR TITLE
refactor: remove unused self parameter from YCInstrument_::Precompute

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -213,7 +213,7 @@ namespace Dal {
                 rates_.reserve(instruments_.size());
                 marketRates_.reserve(instruments_.size());
                 for (const auto& inst : instruments_) {
-                    rates_.push_back(inst->Precompute(inst, fundingYC));
+                    rates_.push_back(inst->Precompute(fundingYC));
                     marketRates_.push_back(inst->MarketRate());
                 }
             }
@@ -238,7 +238,7 @@ namespace Dal {
         Vector_<> ModelRates(const Vector_<Handle_<YCInstrument_>>& instruments, const YieldCurve_& curve, const Handle_<YieldCurve_>& fundingCurve) {
             Vector_<> modelRates(instruments.size());
             for (int i = 0; i < static_cast<int>(instruments.size()); ++i) {
-                auto rate = instruments[i]->Precompute(instruments[i], fundingCurve);
+                auto rate = instruments[i]->Precompute(fundingCurve);
                 modelRates[i] = (*rate)(curve);
             }
             return modelRates;

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -266,8 +266,7 @@ namespace Dal {
 
     pair<Date_, Date_> Deposit_::TimeSpan() const { return {start_, maturity_}; }
 
-    Handle_<YCInstrument_::Rate_> Deposit_::Precompute(const Handle_<YCInstrument_>&,
-                                                        const Handle_<YieldCurve_>& funding_yc) const {
+    Handle_<YCInstrument_::Rate_> Deposit_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
         return Handle_<Rate_>(new DepositRate_(start_, maturity_, convention_, funding_yc));
     }
 
@@ -284,8 +283,7 @@ namespace Dal {
 
     pair<Date_, Date_> FRA_::TimeSpan() const { return {start_, maturity_}; }
 
-    Handle_<YCInstrument_::Rate_> FRA_::Precompute(const Handle_<YCInstrument_>&,
-                                                    const Handle_<YieldCurve_>& funding_yc) const {
+    Handle_<YCInstrument_::Rate_> FRA_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
         return Handle_<Rate_>(new ForwardRate_(start_, maturity_, 0.0, convention_, funding_yc));
     }
 
@@ -308,8 +306,7 @@ namespace Dal {
 
     pair<Date_, Date_> Future_::TimeSpan() const { return {start_, maturity_}; }
 
-    Handle_<YCInstrument_::Rate_> Future_::Precompute(const Handle_<YCInstrument_>&,
-                                                       const Handle_<YieldCurve_>& funding_yc) const {
+    Handle_<YCInstrument_::Rate_> Future_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
         return Handle_<Rate_>(new ForwardRate_(start_, maturity_, convexityAdjustment_, convention_, funding_yc));
     }
 
@@ -343,8 +340,7 @@ namespace Dal {
 
     pair<Date_, Date_> Swap_::TimeSpan() const { return {start_, maturity_}; }
 
-    Handle_<YCInstrument_::Rate_> Swap_::Precompute(const Handle_<YCInstrument_>&,
-                                                     const Handle_<YieldCurve_>& funding_yc) const {
+    Handle_<YCInstrument_::Rate_> Swap_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
         const auto fixedPeriods = BuildLegPeriods(start_,
                                                   maturity_,
                                                   fixedLegConvention_,
@@ -394,8 +390,7 @@ namespace Dal {
 
     pair<Date_, Date_> BasisSwap_::TimeSpan() const { return {start_, maturity_}; }
 
-    Handle_<YCInstrument_::Rate_> BasisSwap_::Precompute(const Handle_<YCInstrument_>&,
-                                                          const Handle_<YieldCurve_>& funding_yc) const {
+    Handle_<YCInstrument_::Rate_> BasisSwap_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
         const auto spreadPeriods = BuildLegPeriods(start_,
                                                    maturity_,
                                                    spreadLegConvention_,

--- a/dal-cpp/dal/curve/ycinstrument.hpp
+++ b/dal-cpp/dal/curve/ycinstrument.hpp
@@ -25,8 +25,7 @@ namespace Dal {
             virtual double operator()(const YieldCurve_& yc) const = 0;
         };
 
-        [[nodiscard]] virtual Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
-                                                        const Handle_<YieldCurve_>& funding_yc) const = 0;
+        [[nodiscard]] virtual Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const = 0;
     };
 
     class Deposit_ : public YCInstrument_ {
@@ -46,8 +45,7 @@ namespace Dal {
         [[nodiscard]] String_ Name() const override;
         [[nodiscard]] pair<Date_, Date_> TimeSpan() const override;
         [[nodiscard]] double MarketRate() const override { return marketRate_; }
-        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
-                                                const Handle_<YieldCurve_>& funding_yc) const override;
+        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const override;
     };
 
     class FRA_ : public YCInstrument_ {
@@ -66,8 +64,7 @@ namespace Dal {
         [[nodiscard]] String_ Name() const override;
         [[nodiscard]] pair<Date_, Date_> TimeSpan() const override;
         [[nodiscard]] double MarketRate() const override { return marketRate_; }
-        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
-                                                const Handle_<YieldCurve_>& funding_yc) const override;
+        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const override;
     };
 
     class Future_ : public YCInstrument_ {
@@ -88,8 +85,7 @@ namespace Dal {
         [[nodiscard]] String_ Name() const override;
         [[nodiscard]] pair<Date_, Date_> TimeSpan() const override;
         [[nodiscard]] double MarketRate() const override { return marketRate_; }
-        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
-                                                const Handle_<YieldCurve_>& funding_yc) const override;
+        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const override;
     };
 
     class Swap_ : public YCInstrument_ {
@@ -114,8 +110,7 @@ namespace Dal {
         [[nodiscard]] String_ Name() const override;
         [[nodiscard]] pair<Date_, Date_> TimeSpan() const override;
         [[nodiscard]] double MarketRate() const override { return marketRate_; }
-        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
-                                                const Handle_<YieldCurve_>& funding_yc) const override;
+        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const override;
     };
 
     class OISSwap_ : public Swap_ {
@@ -153,8 +148,7 @@ namespace Dal {
         [[nodiscard]] String_ Name() const override;
         [[nodiscard]] pair<Date_, Date_> TimeSpan() const override;
         [[nodiscard]] double MarketRate() const override { return marketRate_; }
-        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YCInstrument_>& self,
-                                                const Handle_<YieldCurve_>& funding_yc) const override;
+        [[nodiscard]] Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const override;
     };
 
     class STIR_ : public FRA_ {

--- a/dal-cpp/examples/curve_calibration/curve_calibration.cpp
+++ b/dal-cpp/examples/curve_calibration/curve_calibration.cpp
@@ -47,7 +47,7 @@ namespace {
                                            const YieldCurve_& marketCurve,
                                            const Date_& tradeDate,
                                            const Ccy_& ccy) {
-        const auto rate = prototype->Precompute(prototype, Handle_<YieldCurve_>());
+        const auto rate = prototype->Precompute(Handle_<YieldCurve_>());
 
         if (auto deposit = dynamic_cast<const Deposit_*>(prototype.get())) {
             const auto span = deposit->TimeSpan();
@@ -209,8 +209,8 @@ namespace {
                                                               libor6mIndex,
                                                               referenceLeg));
 
-        const auto futureRate = future->Precompute(future, Handle_<YieldCurve_>());
-        const auto basisSwapRate = basisSwap->Precompute(basisSwap, Handle_<YieldCurve_>());
+        const auto futureRate = future->Precompute(Handle_<YieldCurve_>());
+        const auto basisSwapRate = basisSwap->Precompute(Handle_<YieldCurve_>());
 
         std::cout << "\n"
                   << std::string(70, '=') << "\n"
@@ -429,7 +429,7 @@ namespace {
 
         std::cout << "  Total calibration elapsed: " << int(totalMs) << " ms\n\n";
 
-        const auto fraRate = fra3x6->Precompute(fra3x6, Handle_<YieldCurve_>());
+        const auto fraRate = fra3x6->Precompute(Handle_<YieldCurve_>());
         std::cout << std::fixed << std::setprecision(6);
         std::cout << "  Forward 3x6 FRA repriced on calibrated bundle: " << (*fraRate)(calibratedCurve) * 100.0 << "%\n";
     }

--- a/dal-cpp/examples/underdetermined/underdetermined.cpp
+++ b/dal-cpp/examples/underdetermined/underdetermined.cpp
@@ -57,7 +57,7 @@ int main() {
 
     CurveBlock_ calibYC(*dc);
     for (int i = 0; i < nInstruments; ++i) {
-        Handle_<YCInstrument_::Rate_> rate = instruments[i]->Precompute(instruments[i], Handle_<YieldCurve_>());
+        Handle_<YCInstrument_::Rate_> rate = instruments[i]->Precompute(Handle_<YieldCurve_>());
         double modelRate = (*rate)(calibYC);
         double mktRate = instruments[i]->MarketRate();
         std::cout << std::setw(12) << instruments[i]->Name()

--- a/dal-cpp/tests/curve/test_curveblock.cpp
+++ b/dal-cpp/tests/curve/test_curveblock.cpp
@@ -113,7 +113,7 @@ TEST(CurveBlockTest, TestFlatCurveCalibration) {
     CurveBlock_ yc(*dc);
 
     for (const auto& inst : instruments) {
-        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
+        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
         ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
@@ -151,7 +151,7 @@ TEST(CurveBlockTest, TestUpwardSlopingCurve) {
     CurveBlock_ yc(*dc);
 
     for (const auto& inst : instruments) {
-        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
+        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
         ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
@@ -228,7 +228,7 @@ TEST(CurveBlockTest, TestRoundTrip) {
     CurveBlock_ yc(*calibDc);
 
     for (const auto& inst : instruments) {
-        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
+        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
         ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
@@ -261,7 +261,7 @@ TEST(CurveBlockTest, TestCalibrationWithSTIR) {
     CurveBlock_ yc(*dc);
 
     for (const auto& inst : instruments) {
-        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(inst, Handle_<YieldCurve_>());
+        Handle_<YCInstrument_::Rate_> rate = inst->Precompute(Handle_<YieldCurve_>());
         double modelRate = (*rate)(yc);
         ASSERT_NEAR(modelRate, inst->MarketRate(), 1e-8);
     }
@@ -366,10 +366,10 @@ TEST(CurveBlockTest, TestSequentialMultiCurveCalibration) {
                                                ibor3m,
                                                floatLeg));
 
-    const auto oisDepositRate = oisDeposit->Precompute(oisDeposit, Handle_<YieldCurve_>());
-    const auto oisSwapRate = oisSwap->Precompute(oisSwap, Handle_<YieldCurve_>());
-    const auto fraRate = fra->Precompute(fra, Handle_<YieldCurve_>());
-    const auto irsRate = irs->Precompute(irs, Handle_<YieldCurve_>());
+    const auto oisDepositRate = oisDeposit->Precompute(Handle_<YieldCurve_>());
+    const auto oisSwapRate = oisSwap->Precompute(Handle_<YieldCurve_>());
+    const auto fraRate = fra->Precompute(Handle_<YieldCurve_>());
+    const auto irsRate = irs->Precompute(Handle_<YieldCurve_>());
 
     CurveCalibrationSpec_ oisStage;
     oisStage.today_ = today;

--- a/dal-cpp/tests/curve/test_ycinstrument.cpp
+++ b/dal-cpp/tests/curve/test_ycinstrument.cpp
@@ -119,7 +119,7 @@ TEST(YCInstrumentTest, TestDepositPrecomputeMatchesDiscountCurve) {
     ASSERT_EQ(deposit->TimeSpan().first, today);
     ASSERT_EQ(deposit->TimeSpan().second, maturity);
 
-    const Handle_<YCInstrument_::Rate_> rate = deposit->Precompute(deposit, Handle_<YieldCurve_>());
+    const Handle_<YCInstrument_::Rate_> rate = deposit->Precompute(Handle_<YieldCurve_>());
     const double expected = ExpectedSimpleRate(*dc, today, maturity, basis);
     ASSERT_NEAR((*rate)(curve), expected, 1e-12);
 }
@@ -131,7 +131,7 @@ TEST(YCInstrumentTest, TestDepositUsesFallbackDiscountCurveWhenPrimaryMissingCon
     const Handle_<DiscountCurve_> dc = MakeFlatDiscountCurve("ois", "USD", today, 0.02);
     const Handle_<YieldCurve_> fallback(new CurveBlock_(dc, basis));
     const Handle_<YCInstrument_> deposit(new Deposit_(today, maturity, 0.021, basis));
-    const Handle_<YCInstrument_::Rate_> rate = deposit->Precompute(deposit, fallback);
+    const Handle_<YCInstrument_::Rate_> rate = deposit->Precompute(fallback);
     const MissingYieldCurve_ primary;
 
     const double expected = ExpectedSimpleRate(*dc, today, maturity, basis);
@@ -150,7 +150,7 @@ TEST(YCInstrumentTest, TestSwapPrecomputeMatchesParRate) {
     ASSERT_EQ(swap->TimeSpan().first, today);
     ASSERT_EQ(swap->TimeSpan().second, maturity);
 
-    const Handle_<YCInstrument_::Rate_> rate = swap->Precompute(swap, Handle_<YieldCurve_>());
+    const Handle_<YCInstrument_::Rate_> rate = swap->Precompute(Handle_<YieldCurve_>());
     const double expected = ExpectedSwapRate(*dc, today, maturity, 6, basis);
     ASSERT_NEAR((*rate)(curve), expected, 1e-12);
 }
@@ -175,7 +175,7 @@ TEST(YCInstrumentTest, TestOISSwapUsesFallbackDiscountCurveWhenPrimaryMissingCon
     floatLeg.dayBasis_ = basis;
 
     const Handle_<YCInstrument_> swap(new OISSwap_(today, today, maturity, 0.0, fixedLeg, overnightConvention, floatLeg));
-    const Handle_<YCInstrument_::Rate_> rate = swap->Precompute(swap, fallback);
+    const Handle_<YCInstrument_::Rate_> rate = swap->Precompute(fallback);
     const MissingYieldCurve_ primary;
 
     ASSERT_EQ(swap->Name(), "OISSwap");
@@ -197,7 +197,7 @@ TEST(YCInstrumentTest, TestSTIRPrecomputeMatchesForwardRate) {
     ASSERT_EQ(stir->TimeSpan().first, start);
     ASSERT_EQ(stir->TimeSpan().second, maturity);
 
-    const Handle_<YCInstrument_::Rate_> rate = stir->Precompute(stir, Handle_<YieldCurve_>());
+    const Handle_<YCInstrument_::Rate_> rate = stir->Precompute(Handle_<YieldCurve_>());
     const double expected = ExpectedSimpleRate(*dc, start, maturity, basis);
     ASSERT_NEAR((*rate)(curve), expected, 1e-12);
 }
@@ -222,7 +222,7 @@ TEST(YCInstrumentTest, TestFraUsesTenorSpecificForwardCurve) {
     convention.collateral_ = CollateralType_(CollateralType_::Value_::OIS);
     const Handle_<YCInstrument_> fra(new FRA_(today, start, maturity, 0.0, convention));
 
-    const Handle_<YCInstrument_::Rate_> rate = fra->Precompute(fra, Handle_<YieldCurve_>());
+    const Handle_<YCInstrument_::Rate_> rate = fra->Precompute(Handle_<YieldCurve_>());
     const double expected = ExpectedSimpleRate(*libor3m, start, maturity, basis);
     ASSERT_NEAR((*rate)(curve), expected, 1e-12);
 }
@@ -248,7 +248,7 @@ TEST(YCInstrumentTest, TestFraUsesFallbackProjectionCurveWhenPrimaryMissingConte
     convention.collateral_ = CollateralType_(CollateralType_::Value_::OIS);
 
     const Handle_<YCInstrument_> fra(new FRA_(today, start, maturity, 0.0, convention));
-    const Handle_<YCInstrument_::Rate_> rate = fra->Precompute(fra, fallback);
+    const Handle_<YCInstrument_::Rate_> rate = fra->Precompute(fallback);
     const MissingYieldCurve_ primary;
 
     const double expected = ExpectedSimpleRate(*libor3m, start, maturity, basis);
@@ -267,7 +267,7 @@ TEST(YCInstrumentTest, TestFutureAppliesConvexityAdjustment) {
     convention.dayBasis_ = basis;
     const Handle_<YCInstrument_> future(new Future_(today, start, maturity, 0.0, convention, 0.0015));
 
-    const Handle_<YCInstrument_::Rate_> rate = future->Precompute(future, Handle_<YieldCurve_>());
+    const Handle_<YCInstrument_::Rate_> rate = future->Precompute(Handle_<YieldCurve_>());
     const double expected = ExpectedSimpleRate(*dc, start, maturity, basis) - 0.0015;
     ASSERT_NEAR((*rate)(curve), expected, 1e-12);
 }
@@ -304,7 +304,7 @@ TEST(YCInstrumentTest, TestBasisSwapUsesSeparateForwardCurves) {
     const Handle_<YCInstrument_> basisSwap(
         new BasisSwap_(today, today, maturity, 0.0, spreadConvention, spreadLeg, referenceConvention, referenceLeg));
 
-    const Handle_<YCInstrument_::Rate_> rate = basisSwap->Precompute(basisSwap, Handle_<YieldCurve_>());
+    const Handle_<YCInstrument_::Rate_> rate = basisSwap->Precompute(Handle_<YieldCurve_>());
     const double expected = ExpectedBasisSpread(*ois, *libor3m, *libor6m, today, maturity, 3, 6, basis, basis);
     ASSERT_NEAR((*rate)(curve), expected, 1e-12);
 }
@@ -342,7 +342,7 @@ TEST(YCInstrumentTest, TestBasisSwapUsesFallbackCurvesWhenPrimaryMissingContext)
 
     const Handle_<YCInstrument_> basisSwap(
         new BasisSwap_(today, today, maturity, 0.0, spreadConvention, spreadLeg, referenceConvention, referenceLeg));
-    const Handle_<YCInstrument_::Rate_> rate = basisSwap->Precompute(basisSwap, fallback);
+    const Handle_<YCInstrument_::Rate_> rate = basisSwap->Precompute(fallback);
     const MissingYieldCurve_ primary;
 
     const double expected = ExpectedBasisSpread(*ois, *libor3m, *libor6m, today, maturity, 3, 6, basis, basis);


### PR DESCRIPTION
## Summary
- Remove the unused `self` (first `Handle_<YCInstrument_>&`) parameter from `Precompute` across the entire `YCInstrument_` hierarchy
- Affects base class and 5 derived classes: `Deposit_`, `FRA_`, `Future_`, `Swap_`, `BasisSwap_`
- Update all 19 call sites in calibration, examples, and tests

## Test plan
- [x] `bin/dal_cpp_tests` — 678/678 passed
- [x] `bin/dal_public_tests` — 2/2 passed
- [x] `curve_calibration` example builds and runs
- [x] `xccy_curve_calibration` example builds and runs