### PR TITLE
refactor: rename Phase A Jacobian symbols to AnalyticJacobian

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -232,7 +232,7 @@ namespace Dal {
 
         // Phase A templated curve builder. Handles ONLY LOG_DISCOUNT -- the only parameterization
         // the AAD path supports. The other parameterizations REQUIRE(false) in the Number_
-        // instantiation; this is unreachable because EligibleForPhaseA rejects non-LOG_DISCOUNT
+        // instantiation; this is unreachable because EligibleForAnalyticJacobian rejects non-LOG_DISCOUNT
         // before constructing any templated object.
         template <class T_>
         std::unique_ptr<Tape::DiscountCurve_<T_>> BuildDiscountCurveT(const String_& name,
@@ -356,14 +356,14 @@ namespace Dal {
             }
 
             // Sparse Jacobian (LOG_DISCOUNT free-node log-DF unknowns). Returns the Phase A
-            // reverse-mode AAD Jacobian (native Number_ tape) when EligibleForPhaseA(); otherwise
+            // reverse-mode AAD Jacobian (native Number_ tape) when EligibleForAnalyticJacobian(); otherwise
             // returns nullptr so the solver dense-bumps. The residual is modelRate - marketRate, so
             // dResidual_i/dx_j = dModelRate_i/dx_j (marketRate is constant, contributes nothing).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-                if (EligibleForPhaseA())
-                    return PhaseAJacobian_NativeAAD(x, f);
-                // Ineligible: NOTICE was emitted by EligibleForPhaseA (names the offending
+                if (EligibleForAnalyticJacobian())
+                    return AnalyticJacobian(x, f);
+                // Ineligible: NOTICE was emitted by EligibleForAnalyticJacobian (names the offending
                 // condition); return nullptr so the solver dense-bumps.
                 return nullptr;
 #else
@@ -382,7 +382,7 @@ namespace Dal {
             // a NOTICE + return nullptr (solver dense-bumps) instead of failing. Each fall-through
             // path emits a NOTICE that names the offending condition so the user can see why the
             // AAD Jacobian did not engage.
-            [[nodiscard]] bool EligibleForPhaseA() const {
+            [[nodiscard]] bool EligibleForAnalyticJacobian() const {
                 if (parameterization_ != CurveParameterization_::Value_::LOG_DISCOUNT) {
                     const String_ msg = String_("AAD Jacobian requires CurveParameterization_::LOG_DISCOUNT, got ")
                                         + parameterization_.String() + "; falling back to bumped";
@@ -400,7 +400,7 @@ namespace Dal {
                 // fine for Phase A (the templated Tape::SwapRate_ reads DF(tradeDate_, p) directly), but
                 // requires anchor alignment so every instrument starts at knotDates_.front().
                 for (int i = 0; i < static_cast<int>(instruments_.size()); ++i)
-                    if (!InstrumentEligibleForPhaseA(instruments_[i].get()))
+                    if (!InstrumentEligibleForAnalyticJacobian(instruments_[i].get()))
                         return false;
                 return true;
             }
@@ -423,7 +423,7 @@ namespace Dal {
             // Per-instrument Phase A eligibility. Returns true iff the instrument has a templated
             // rate, uses no projection curve (forecast == discount), and starts at the curve anchor.
             // Emits a NOTICE naming the offending condition on each fall-through.
-            [[nodiscard]] bool InstrumentEligibleForPhaseA(const YCInstrument_* inst) const {
+            [[nodiscard]] bool InstrumentEligibleForAnalyticJacobian(const YCInstrument_* inst) const {
                 const String_ name = inst->Name();
                 const RateIndexConvention_* floatConv = PhaseAFloatConvention(inst);
                 if (!floatConv) {
@@ -458,11 +458,11 @@ namespace Dal {
             // Gradient call, nRows reverse sweeps (one per residual), harvest adjoints column by
             // column. Returns XCurveJacobian_ (a dense Jacobian subclass: storage is dense,
             // assembly is sparse-by-row because AAD produces exact structural zeros).
-            [[nodiscard]] Underdetermined::Jacobian_* PhaseAJacobian_NativeAAD(const Vector_<>& x, const Vector_<>& f) const;
+            [[nodiscard]] Underdetermined::Jacobian_* AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const;
 
             // Downcast instrument i to its concrete type and dispatch to PrecomputeT<T_>. Returns
             // an empty handle if the instrument type is not supported (Phase A scope is Deposit,
-            // FRA, Future, vanilla Swap); EligibleForPhaseA rejects such calibrations before this
+            // FRA, Future, vanilla Swap); EligibleForAnalyticJacobian rejects such calibrations before this
             // is ever called, so the empty-handle branch is unreachable in practice.
             template <class T_> [[nodiscard]] Handle_<Tape::Rate_<T_>> PhaseARateAt(int i) const {
                 const auto* inst = instruments_[i].get();
@@ -485,7 +485,7 @@ namespace Dal {
         // Native-AAD-only: the reverse sweep walks Dal::AAD::Tape_::nodes_ (via ZeroAllAdjoints),
         // which third-party backends do not expose; under those, Gradient() never calls this.
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-        Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::PhaseAJacobian_NativeAAD(const Vector_<>& x, const Vector_<>& f) const {
+        Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
             static_cast<void>(f); // the residual values themselves are unused; we recompute on the tape

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -346,7 +346,7 @@ namespace Dal {
             T_ operator()(const YCCtx_<T_>& ctx) const override {
                 // Phase A eligibility guarantees forecast == discount == ctx.curve_ (the calibrated
                 // target curve), so we read every DF from ctx.curve_. tradeDate_ == anchor is also
-                // guaranteed by EligibleForPhaseA, so DF(anchor, p) = ctx.curve_(tradeDate_, p).
+                // guaranteed by EligibleForAnalyticJacobian, so DF(anchor, p) = ctx.curve_(tradeDate_, p).
                 const DiscountCurve_<T_>& discount = ctx.curve_;
                 T_ annuity(static_cast<double>(0.0));
                 for (const auto& period : fixedPeriods_)

--- a/dal-cpp/dal/curve/ycinstrument.hpp
+++ b/dal-cpp/dal/curve/ycinstrument.hpp
@@ -51,7 +51,7 @@ namespace Dal {
         // yield context. Declared only on the concrete instruments that have a Phase A templated
         // rate (Deposit_/FRA_/Future_/Swap_, plus their derived OISSwap_/STIR_); PhaseARateAt
         // dispatches via dynamic_cast to those types, so there is no base-class entry point.
-        // Instruments without a templated rate (e.g. BasisSwap_) make EligibleForPhaseA reject the
+        // Instruments without a templated rate (e.g. BasisSwap_) make EligibleForAnalyticJacobian reject the
         // whole calibration and the solver dense-bumps instead.
     };
 

--- a/dal-cpp/tests/curve/test_analytic_jacobian.cpp
+++ b/dal-cpp/tests/curve/test_analytic_jacobian.cpp
@@ -25,14 +25,14 @@ using namespace Dal;
 // not expose. Under those backends TestOnly::AnalyticJacobianAt returns an empty matrix and the
 // solver dense-bumps, so the tests that assert the exact AAD Jacobian are skipped there.
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-#define DAL_PHASE_A_NATIVE_AAD 1
+#define DAL_HAS_CURVE_ANALYTIC_JACOBIAN 1
 #else
-#define DAL_PHASE_A_NATIVE_AAD 0
+#define DAL_HAS_CURVE_ANALYTIC_JACOBIAN 0
 #endif
 
-#define SKIP_IF_NOT_NATIVE_AAD() \
+#define SKIP_IF_NO_ANALYTIC_JACOBIAN() \
     do { \
-        if (!DAL_PHASE_A_NATIVE_AAD) \
+        if (!DAL_HAS_CURVE_ANALYTIC_JACOBIAN) \
             GTEST_SKIP() << "Phase A analytic Jacobian is native-AAD-only; external backends dense-bump."; \
     } while (false)
 
@@ -159,8 +159,8 @@ namespace {
 // Each non-zero entry must match a two-sided central difference of F(x) at step
 // 1e-6 within 1e-9.
 
-TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceLogLinear) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogLinear) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::LOG_LINEAR);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     ASSERT_EQ(static_cast<int>(x.size()), 5);
@@ -195,8 +195,8 @@ TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceLogLinear) {
 // must have at least one exactly-zero entry for a column beyond the instrument's
 // cashflow support.
 
-TEST(PhaseAAADJacobianTest, TestStructuralZerosAreExactlyZero) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestStructuralZerosAreExactlyZero) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec();
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
@@ -214,7 +214,7 @@ TEST(PhaseAAADJacobianTest, TestStructuralZerosAreExactlyZero) {
 // ============================================================================
 // We do NOT assert iteration count (linesearch varies), only that the residual converges.
 
-TEST(PhaseAAADJacobianTest, TestSolveConvergesLogLinear) {
+TEST(AnalyticJacobianTest, TestSolveConvergesLogLinear) {
     auto specAAD = MakePhaseASpec();
 
     const auto rAAD = CalibrateYieldCurve(specAAD);
@@ -229,13 +229,13 @@ TEST(PhaseAAADJacobianTest, TestSolveConvergesLogLinear) {
 // ============================================================================
 // Category 4: Ineligibility -- the AAD Jacobian falls back to bumping with a NOTICE
 // ============================================================================
-// Phase A is ineligible for non-LOG_DISCOUNT parameterizations. EligibleForPhaseA
+// Phase A is ineligible for non-LOG_DISCOUNT parameterizations. EligibleForAnalyticJacobian
 // returns false, Gradient returns nullptr (the solver dense-bumps), and a NOTICE
 // fires. We cannot easily assert the NOTICE text from a unit test, but we CAN assert
 // the fallback behavior: TestOnly::AnalyticJacobianAt returns an EMPTY matrix on a
 // non-LOG_DISCOUNT spec (Gradient returned nullptr).
 
-TEST(PhaseAAADJacobianTest, TestIneligibleParameterizationFallsBack) {
+TEST(AnalyticJacobianTest, TestIneligibleParameterizationFallsBack) {
     auto spec = MakePhaseASpec();
     spec.parameterization_ = CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD;
     // Knot 0 must be > today for non-LOG_DISCOUNT.
@@ -248,9 +248,9 @@ TEST(PhaseAAADJacobianTest, TestIneligibleParameterizationFallsBack) {
 }
 
 // A FORECAST-target calibration (calibrateDiscountCurve_ == false) is ineligible for the AAD
-// Jacobian. EligibleForPhaseA returns false, Gradient returns nullptr, and
+// Jacobian. EligibleForAnalyticJacobian returns false, Gradient returns nullptr, and
 // TestOnly::AnalyticJacobianAt returns an EMPTY matrix (the solver dense-bumps instead).
-TEST(PhaseAAADJacobianTest, TestIneligibleForecastTargetFallsBack) {
+TEST(AnalyticJacobianTest, TestIneligibleForecastTargetFallsBack) {
     auto spec = MakePhaseASpec();
     spec.calibrateDiscountCurve_ = false;
     spec.targetTenor_ = PeriodLength_("3M");
@@ -278,7 +278,7 @@ TEST(PhaseAAADJacobianTest, TestIneligibleForecastTargetFallsBack) {
 // EMPTY matrix (the solver dense-bumps). We construct one such swap alongside an eligible one
 // to confirm the whole calibration falls back when ANY instrument is ineligible.
 
-TEST(PhaseAAADJacobianTest, TestTradeDateNotStartRejected) {
+TEST(AnalyticJacobianTest, TestTradeDateNotStartRejected) {
     auto spec = MakePhaseASpec();
     const auto fixedLeg = AnnualLegPA();
     const auto floatIdx = AnnualIndexPA();
@@ -303,8 +303,8 @@ TEST(PhaseAAADJacobianTest, TestTradeDateNotStartRejected) {
 // non-empty analytic Jacobian only exists on native AAD; on external backends the analytic path
 // is gated out and AnalyticJacobianAt returns an empty matrix regardless of eligibility, so this
 // assertion is skipped there (the eligibility predicate itself is covered by the native run).
-TEST(PhaseAAADJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec();
     spec.instruments_ = {
         Handle_<YCInstrument_>(new Swap_(spec.today_, spec.today_, Date_(2023, 1, 1), 0.012, AnnualLegPA(), AnnualIndexPA(), AnnualLegPA())),
@@ -322,7 +322,7 @@ TEST(PhaseAAADJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
 // the first call's residuals and produce wrong numbers. We assert the second
 // call reproduces the first exactly.
 
-TEST(PhaseAAADJacobianTest, TestTapeIsolationAcrossCalls) {
+TEST(AnalyticJacobianTest, TestTapeIsolationAcrossCalls) {
     auto spec = MakePhaseASpec();
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     const Matrix_<> J1 = TestOnly::AnalyticJacobianAt(spec, x);
@@ -342,15 +342,15 @@ TEST(PhaseAAADJacobianTest, TestTapeIsolationAcrossCalls) {
 // these two tests cover LOG_CUBIC_NATURAL and MIXED, exercising the natural-cubic and
 // mixed-cutoff spline branches of the AAD path.
 
-TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceLogCubicNatural) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogCubicNatural) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::LOG_CUBIC_NATURAL);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
 }
 
-TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceMixed) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceMixed) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::MIXED);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
@@ -365,8 +365,8 @@ TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceMixed) {
 // the single row matches a central difference for every node column, and that the columns the
 // deposit does NOT touch (beyond its maturity) are EXACTLY zero (AAD structural zero, not noise).
 
-TEST(PhaseAAADJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     CurveCalibrationSpec_ spec;
     spec.today_ = Date_(2022, 1, 1);
     spec.ccy_ = "USD";
@@ -412,8 +412,8 @@ TEST(PhaseAAADJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
 // still match central differences row by row, and structural zeros must appear for instruments
 // whose cashflows end before later nodes.
 
-TEST(PhaseAAADJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifference) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifference) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     CurveCalibrationSpec_ spec;
     spec.today_ = Date_(2022, 1, 1);
     spec.ccy_ = "USD";


### PR DESCRIPTION
## Summary
Pure mechanical rename of the curve-calibration analytic-Jacobian symbols so the names say WHAT (the analytic Jacobian) instead of HOW (native AAD) or WHEN ("Phase A" plan-jargon). No behavior change, no API break.

This is **PR1** of the approved redesign (`.claude/designs/aad-analytic-jacobian-redesign.md`, Goal 1). Symbols only.

Renames (lockstep):
- `PhaseAJacobian_NativeAAD` → `AnalyticJacobian` (declaration, body, `Gradient()` call site). Aligns with the existing `TestOnly::AnalyticJacobianAt` test hook.
- `EligibleForPhaseA` → `EligibleForAnalyticJacobian`; `InstrumentEligibleForPhaseA` → `InstrumentEligibleForAnalyticJacobian` (declarations, every call site, and inline comment references in `ycinstrument.{cpp,hpp}`).
- Test file `test_phase_a_jacobian.cpp` → `test_analytic_jacobian.cpp` (`git mv`, history preserved).
- Test macros `DAL_PHASE_A_NATIVE_AAD` → `DAL_HAS_CURVE_ANALYTIC_JACOBIAN`; `SKIP_IF_NOT_NATIVE_AAD()` → `SKIP_IF_NO_ANALYTIC_JACOBIAN()`.
- GTest suite `PhaseAAADJacobianTest` → `AnalyticJacobianTest`.

Explicitly deferred (to keep the diff purely mechanical): user-facing NOTICE text (already says "AAD Jacobian"), "Phase A" prose comments, methodology/experimental docs, and any enum/Machinist changes.

## Test plan
- [x] Renamed suite: `bin/dal_cpp_tests --gtest_filter=AnalyticJacobianTest.*` → 12/12 pass
- [x] Full suite: `bin/dal_cpp_tests` → 708/708 pass, no regressions
- [x] `git grep` confirms no stale old-symbol references remain in `dal-cpp/`
- [ ] CI green across the build matrix (clang-18/19, gcc-13/14, msvc × aadet/adept/codipack/xad)
