### PR TITLE
feat: make AnalyticJacobian work on all four AAD backends

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -253,11 +253,14 @@ namespace Dal {
                 new Tape::DiscountLogDF_<T_>(name, ccy, knotDates, logDF, dayCount, logDfScheme, baseCurve));
         }
 
-        // RAII tape scope: Clear on entry, Clear on exit (even on throw). Phase A owns exactly one
-        // AAD cycle per solver restart -- the recording, sweep, and harvest all live inside this
-        // scope. The tape must be clean before the next Gradient call (or the next F call which,
-        // while it does not touch the tape, would inherit any state if a future change ever reads
-        // the tape from F). Phase A is single-threaded today; thread-local Tape_ isolates
+        // RAII tape scope: Clear on entry, Clear on exit (even on throw). AnalyticJacobian owns
+        // exactly one AAD cycle per solver restart -- the recording, sweep, and harvest all live
+        // inside this scope. NewRecording is opened by AnalyticJacobian AFTER RegisterIndependent,
+        // not here: XAD requires inputs registered before the recording window opens (its canonical
+        // idiom), and opening the recording before registration silently drops the inputs and yields
+        // an all-zero Jacobian. The tape must be clean before the next Gradient call (or the next
+        // F call which, while it does not touch the tape, would inherit any state if a future change
+        // ever reads the tape from F). Single-threaded today; thread-local Tape_ isolates
         // per-worker state if calibration ever becomes parallel, but the residual loop itself must
         // stay serial until a parallel-residual design exists.
         struct TapeGuard_ {
@@ -273,19 +276,6 @@ namespace Dal {
             TapeGuard_(const TapeGuard_&) = delete;
             TapeGuard_& operator=(const TapeGuard_&) = delete;
         };
-
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-        // Zero every node's adjoint on the tape, leaving the recorded graph intact. Used between
-        // single-result reverse sweeps so each row's seed propagates from a clean slate. The tape
-        // does not expose a one-shot "zero adjoints" helper, so we walk the nodes blocklist. This
-        // reaches into the native Dal::AAD::Tape_::nodes_ block list, which only the native backend
-        // exposes -- third-party AAD backends (XAD/CoDiPack/Adept) take the bumped Jacobian path
-        // instead, so the whole Phase A reverse-sweep machinery is native-only.
-        void ZeroAllAdjoints(Dal::AAD::Tape_& tape) {
-            for (auto it = tape.nodes_.Begin(); it != tape.nodes_.End(); ++it)
-                it->Adjoint() = 0.0;
-        }
-#endif
 
         class YieldCurveCalibrationFunc_ : public Underdetermined::Function_ {
             String_ ccy_;
@@ -355,25 +345,20 @@ namespace Dal {
                 return CurveBlock_(curveName_, ccy_, discountCurves, forwardCurves, liborBasis_);
             }
 
-            // Sparse Jacobian (LOG_DISCOUNT free-node log-DF unknowns). Returns the Phase A
-            // reverse-mode AAD Jacobian (native Number_ tape) when EligibleForAnalyticJacobian(); otherwise
-            // returns nullptr so the solver dense-bumps. The residual is modelRate - marketRate, so
-            // dResidual_i/dx_j = dModelRate_i/dx_j (marketRate is constant, contributes nothing).
+            // Sparse Jacobian (LOG_DISCOUNT free-node log-DF unknowns). Returns the reverse-mode AAD
+            // Jacobian (single-result sweep on the active Number_ tape) when EligibleForAnalyticJacobian();
+            // otherwise returns nullptr so the solver dense-bumps. The residual is modelRate -
+            // marketRate, so dResidual_i/dx_j = dModelRate_i/dx_j (marketRate is constant, contributes
+            // nothing). Backend-neutral: the same path runs under native, XAD, CoDiPack, and Adept via
+            // the Dal::AAD facade (RegisterIndependent, ZeroAdjoints, Adjoint, PropagateToStart).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
                 if (EligibleForAnalyticJacobian())
                     return AnalyticJacobian(x, f);
                 // Ineligible: NOTICE was emitted by EligibleForAnalyticJacobian (names the offending
                 // condition); return nullptr so the solver dense-bumps.
-                return nullptr;
-#else
-                // The Phase A analytic Jacobian is native-AAD-only (it walks Dal::AAD::Tape_::nodes_
-                // for single-result reverse sweeps, which third-party backends do not expose). Under
-                // XAD/CoDiPack/Adept return nullptr so the solver dense-bumps -- identical numerics.
                 static_cast<void>(x);
                 static_cast<void>(f);
                 return nullptr;
-#endif
             }
 
             // Phase A eligibility predicate (per .claude/designs/aad-analytic-jacobian-selector-api.md
@@ -478,27 +463,35 @@ namespace Dal {
             }
         };
 
-        // Phase A body. The structure mirrors .claude/designs/aad-analytic-jacobian-phase-a-plan.md
-        // §3.2: TapeGuard on entry/exit, build Number_-typed curve, build Number_-typed rates via
-        // PrecomputeT<Number_>, compute residuals, single-result reverse loop. The column map is
-        // solver col j = storage node j+1, so Adjoint(logDF[j+1]) reads the sensitivity to x[j].
-        // Native-AAD-only: the reverse sweep walks Dal::AAD::Tape_::nodes_ (via ZeroAllAdjoints),
-        // which third-party backends do not expose; under those, Gradient() never calls this.
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
+        // AnalyticJacobian body. TapeGuard on entry/exit (Clear + NewRecording), build Number_-typed
+        // curve, build Number_-typed rates via PrecomputeT<Number_>, compute residuals, single-result
+        // reverse loop. The column map is solver col j = storage node j+1, so Adjoint(logDF[j+1])
+        // reads the sensitivity to x[j]. Backend-neutral: RegisterIndependent, ZeroAdjoints, Adjoint,
+        // and PropagateToStart are all Dal::AAD facade primitives, so the same loop runs unchanged
+        // under native, XAD, CoDiPack, and Adept.
         Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
             static_cast<void>(f); // the residual values themselves are unused; we recompute on the tape
 
             // Independents: free-node log(DF) values. Anchor (node 0) is pinned at 0 and is NOT an
-            // independent -- the solver's x vector has NX() = nNodes-1 entries, matching.
+            // independent -- the solver's x vector has NX() = nNodes-1 entries, matching. RegisterIndependent
+            // registers each node with the active tape on every backend; the anchor stays a plain
+            // assignment because routing it through RegisterIndependent would add a phantom input column.
             const int nNodes = static_cast<int>(knotDates_.size());
             REQUIRE(static_cast<int>(x.size()) == nNodes - 1,
-                    "Phase A: x vector length must equal nNodes - 1 (anchor excluded)");
+                    "AnalyticJacobian: x vector length must equal nNodes - 1 (anchor excluded)");
             Vector_<Dal::AAD::Number_> logDF(nNodes);
-            logDF[0] = 0.0; // pinned; records a constant node (harmless -- adjoint never read)
+            logDF[0] = 0.0; // pinned anchor; deliberately NOT registered (adjoint never read)
             for (int i = 0; i < static_cast<int>(x.size()); ++i)
-                logDF[i + 1] = x[i]; // native backend: Number_(double) registers an independent
+                Dal::AAD::RegisterIndependent(logDF[i + 1], x[i]);
+
+            // Open the recording AFTER registering the independents and BEFORE the forward pass.
+            // XAD's canonical contract requires inputs registered before newRecording; opening the
+            // recording earlier silently drops them and yields an all-zero Jacobian (the B2 class).
+            // On native NewRecording is a no-op, so this is invisible there; on CoDiPack/Adept it
+            // anchors the sweep bounds to this point, which is exactly what PropagateToStart sweeps.
+            Dal::AAD::NewRecording(*tape);
 
             // Build the Number_-typed calibrated curve directly with the tape-registered logDF.
             std::unique_ptr<Tape::DiscountCurve_<Dal::AAD::Number_>> dc(
@@ -519,13 +512,13 @@ namespace Dal {
             const int nCols = nNodes - 1;
             Matrix_<> j(nRows, nCols, 0.0);
 
-            // Single-result reverse sweep. TODO: replace with SetNumResultsForAAD(true, nRows) for
-            // a single PropagateToStart walk producing all nRows adjoint vectors simultaneously --
-            // the multi-result path is a ~nRows-x speedup. The single-result path is simpler and
-            // mirrors test_tape.cpp; defer the multi-result optimization until the single-result
-            // path is validated.
+            // Single-result reverse sweep. One PropagateToStart per residual row; ZeroAdjoints clears
+            // the propagated adjoints between rows so each seed lands on a clean slate. The multi-result
+            // path (SetNumResultsForAAD(true, nRows), one sweep for all rows) is a ~nRows-x speedup and
+            // remains a profiling-driven follow-up; the single-result path is simpler and runs identically
+            // on every backend.
             for (int i = 0; i < nRows; ++i) {
-                ZeroAllAdjoints(*tape);
+                Dal::AAD::ZeroAdjoints(*tape);
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
                 Dal::AAD::PropagateToStart(*tape);
                 for (int col = 0; col < nCols; ++col)
@@ -533,7 +526,6 @@ namespace Dal {
             }
             return new XCurveJacobian_(std::move(j));
         }
-#endif // native AAD backend (Phase A Jacobian)
 
         Vector_<> ModelRates(const Vector_<Handle_<YCInstrument_>>& instruments, const YieldCurve_& curve, const Handle_<YieldCurve_>& fundingCurve) {
             Vector_<> modelRates(instruments.size());

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -232,7 +232,7 @@ namespace Dal {
 
         // Phase A templated curve builder. Handles ONLY LOG_DISCOUNT -- the only parameterization
         // the AAD path supports. The other parameterizations REQUIRE(false) in the Number_
-        // instantiation; this is unreachable because EligibleForPhaseA rejects non-LOG_DISCOUNT
+        // instantiation; this is unreachable because EligibleForAnalyticJacobian rejects non-LOG_DISCOUNT
         // before constructing any templated object.
         template <class T_>
         std::unique_ptr<Tape::DiscountCurve_<T_>> BuildDiscountCurveT(const String_& name,
@@ -356,14 +356,14 @@ namespace Dal {
             }
 
             // Sparse Jacobian (LOG_DISCOUNT free-node log-DF unknowns). Returns the Phase A
-            // reverse-mode AAD Jacobian (native Number_ tape) when EligibleForPhaseA(); otherwise
+            // reverse-mode AAD Jacobian (native Number_ tape) when EligibleForAnalyticJacobian(); otherwise
             // returns nullptr so the solver dense-bumps. The residual is modelRate - marketRate, so
             // dResidual_i/dx_j = dModelRate_i/dx_j (marketRate is constant, contributes nothing).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-                if (EligibleForPhaseA())
-                    return PhaseAJacobian_NativeAAD(x, f);
-                // Ineligible: NOTICE was emitted by EligibleForPhaseA (names the offending
+                if (EligibleForAnalyticJacobian())
+                    return AnalyticJacobian(x, f);
+                // Ineligible: NOTICE was emitted by EligibleForAnalyticJacobian (names the offending
                 // condition); return nullptr so the solver dense-bumps.
                 return nullptr;
 #else
@@ -382,7 +382,7 @@ namespace Dal {
             // a NOTICE + return nullptr (solver dense-bumps) instead of failing. Each fall-through
             // path emits a NOTICE that names the offending condition so the user can see why the
             // AAD Jacobian did not engage.
-            [[nodiscard]] bool EligibleForPhaseA() const {
+            [[nodiscard]] bool EligibleForAnalyticJacobian() const {
                 if (parameterization_ != CurveParameterization_::Value_::LOG_DISCOUNT) {
                     const String_ msg = String_("AAD Jacobian requires CurveParameterization_::LOG_DISCOUNT, got ")
                                         + parameterization_.String() + "; falling back to bumped";
@@ -400,7 +400,7 @@ namespace Dal {
                 // fine for Phase A (the templated Tape::SwapRate_ reads DF(tradeDate_, p) directly), but
                 // requires anchor alignment so every instrument starts at knotDates_.front().
                 for (int i = 0; i < static_cast<int>(instruments_.size()); ++i)
-                    if (!InstrumentEligibleForPhaseA(instruments_[i].get()))
+                    if (!InstrumentEligibleForAnalyticJacobian(instruments_[i].get()))
                         return false;
                 return true;
             }
@@ -423,7 +423,7 @@ namespace Dal {
             // Per-instrument Phase A eligibility. Returns true iff the instrument has a templated
             // rate, uses no projection curve (forecast == discount), and starts at the curve anchor.
             // Emits a NOTICE naming the offending condition on each fall-through.
-            [[nodiscard]] bool InstrumentEligibleForPhaseA(const YCInstrument_* inst) const {
+            [[nodiscard]] bool InstrumentEligibleForAnalyticJacobian(const YCInstrument_* inst) const {
                 const String_ name = inst->Name();
                 const RateIndexConvention_* floatConv = PhaseAFloatConvention(inst);
                 if (!floatConv) {
@@ -458,11 +458,11 @@ namespace Dal {
             // Gradient call, nRows reverse sweeps (one per residual), harvest adjoints column by
             // column. Returns XCurveJacobian_ (a dense Jacobian subclass: storage is dense,
             // assembly is sparse-by-row because AAD produces exact structural zeros).
-            [[nodiscard]] Underdetermined::Jacobian_* PhaseAJacobian_NativeAAD(const Vector_<>& x, const Vector_<>& f) const;
+            [[nodiscard]] Underdetermined::Jacobian_* AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const;
 
             // Downcast instrument i to its concrete type and dispatch to PrecomputeT<T_>. Returns
             // an empty handle if the instrument type is not supported (Phase A scope is Deposit,
-            // FRA, Future, vanilla Swap); EligibleForPhaseA rejects such calibrations before this
+            // FRA, Future, vanilla Swap); EligibleForAnalyticJacobian rejects such calibrations before this
             // is ever called, so the empty-handle branch is unreachable in practice.
             template <class T_> [[nodiscard]] Handle_<Tape::Rate_<T_>> PhaseARateAt(int i) const {
                 const auto* inst = instruments_[i].get();
@@ -485,7 +485,7 @@ namespace Dal {
         // Native-AAD-only: the reverse sweep walks Dal::AAD::Tape_::nodes_ (via ZeroAllAdjoints),
         // which third-party backends do not expose; under those, Gradient() never calls this.
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-        Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::PhaseAJacobian_NativeAAD(const Vector_<>& x, const Vector_<>& f) const {
+        Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
             static_cast<void>(f); // the residual values themselves are unused; we recompute on the tape

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -463,12 +463,13 @@ namespace Dal {
             }
         };
 
-        // AnalyticJacobian body. TapeGuard on entry/exit (Clear + NewRecording), build Number_-typed
+        // AnalyticJacobian body. TapeGuard on entry/exit (Clear only), build Number_-typed
         // curve, build Number_-typed rates via PrecomputeT<Number_>, compute residuals, single-result
-        // reverse loop. The column map is solver col j = storage node j+1, so Adjoint(logDF[j+1])
-        // reads the sensitivity to x[j]. Backend-neutral: RegisterIndependent, ZeroAdjoints, Adjoint,
-        // and PropagateToStart are all Dal::AAD facade primitives, so the same loop runs unchanged
-        // under native, XAD, CoDiPack, and Adept.
+        // reverse loop. NewRecording is opened explicitly after RegisterIndependent (XAD requires
+        // inputs registered before newRecording). The column map is solver col j = storage node j+1,
+        // so Adjoint(logDF[j+1]) reads the sensitivity to x[j]. Backend-neutral: RegisterIndependent,
+        // ZeroAdjoints, Adjoint, and PropagateToStart are all Dal::AAD facade primitives, so the same
+        // loop runs unchanged under native, XAD, CoDiPack, and Adept.
         Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -346,7 +346,7 @@ namespace Dal {
             T_ operator()(const YCCtx_<T_>& ctx) const override {
                 // Phase A eligibility guarantees forecast == discount == ctx.curve_ (the calibrated
                 // target curve), so we read every DF from ctx.curve_. tradeDate_ == anchor is also
-                // guaranteed by EligibleForPhaseA, so DF(anchor, p) = ctx.curve_(tradeDate_, p).
+                // guaranteed by EligibleForAnalyticJacobian, so DF(anchor, p) = ctx.curve_(tradeDate_, p).
                 const DiscountCurve_<T_>& discount = ctx.curve_;
                 T_ annuity(static_cast<double>(0.0));
                 for (const auto& period : fixedPeriods_)

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -9,6 +9,7 @@
 #include <dal/curve/yc.hpp>
 #include <dal/curve/ycinstrument.hpp>
 #include <dal/curve/yclogdf.hpp>
+#include <dal/math/aad/aad.hpp>
 #include <dal/protocol/accrualperiod.hpp>
 #include <dal/string/strings.hpp>
 #include <dal/time/schedules.hpp>

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -351,7 +351,9 @@ namespace Dal {
                 T_ annuity(static_cast<double>(0.0));
                 for (const auto& period : fixedPeriods_)
                     annuity += static_cast<double>(period.accrual_.dcf_) * discount(tradeDate_, period.schedule_.paymentDate_);
-                REQUIRE(static_cast<double>(annuity) > 0.0, "Swap pricing requires positive fixed-leg annuity");
+                // Dal::AAD::Value extracts the primal on every backend; static_cast<double> would
+                // only work on native and CoDiPack (XAD/Adept have no conversion operator).
+                REQUIRE(Dal::AAD::Value(annuity) > 0.0, "Swap pricing requires positive fixed-leg annuity");
 
                 T_ floatPv(static_cast<double>(0.0));
                 for (const auto& period : floatPeriods_) {
@@ -502,18 +504,17 @@ namespace Dal {
         return Handle_<Tape::Rate_<T_>>(new Tape::SwapRate_<T_>(tradeDate_, fixedPeriods, floatPeriods, floatIndexConvention_));
     }
 
-    // Explicit instantiation of PrecomputeT<Dal::AAD::Number_> on each Phase A instrument so the
-    // linker finds the symbol when calibration.cpp calls it. double is implicitly instantiated at
-    // every use site (rare) but we also force it here for symmetry. Gated on the native backend
-    // because the Number_ templated rate bodies use native-tape conversions (static_cast<double>)
-    // the external AAD backends' active types do not provide; under those backends Phase A compiles
-    // away and the solver dense-bumps instead.
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
+    // Explicit instantiation of PrecomputeT<Dal::AAD::Number_> on each instrument so the linker
+    // finds the symbol when calibration.cpp's AnalyticJacobian calls it. The Number_-typed rate
+    // bodies forward arithmetic and value extraction to the Dal::AAD facade, so they compile and
+    // run under every AAD backend. These were previously gated to the native backend because the
+    // analytic Jacobian reached into the native-only Dal::AAD::Tape_::nodes_ member; that reach is
+    // gone (zeroing now goes through the backend-neutral Dal::AAD::ZeroAdjoints), so the gate is
+    // gone too and the instantiation is needed under every backend.
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> Deposit_::PrecomputeT<Dal::AAD::Number_>() const;
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> FRA_::PrecomputeT<Dal::AAD::Number_>() const;
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> Future_::PrecomputeT<Dal::AAD::Number_>() const;
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> Swap_::PrecomputeT<Dal::AAD::Number_>() const;
-#endif // native AAD backend (Phase A rates)
 
     OISSwap_::OISSwap_(const Date_& tradeDate,
                        const Date_& start,

--- a/dal-cpp/dal/curve/ycinstrument.hpp
+++ b/dal-cpp/dal/curve/ycinstrument.hpp
@@ -51,7 +51,7 @@ namespace Dal {
         // yield context. Declared only on the concrete instruments that have a Phase A templated
         // rate (Deposit_/FRA_/Future_/Swap_, plus their derived OISSwap_/STIR_); PhaseARateAt
         // dispatches via dynamic_cast to those types, so there is no base-class entry point.
-        // Instruments without a templated rate (e.g. BasisSwap_) make EligibleForPhaseA reject the
+        // Instruments without a templated rate (e.g. BasisSwap_) make EligibleForAnalyticJacobian reject the
         // whole calibration and the solver dense-bumps instead.
     };
 

--- a/dal-cpp/dal/curve/yclogdf.cpp
+++ b/dal-cpp/dal/curve/yclogdf.cpp
@@ -245,7 +245,7 @@ namespace Dal {
         // path does NOT consult interp_ (it accumulates basis weights against logDF_ directly).
         Vector_<> logDFDouble(yf_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
-            logDFDouble[i] = static_cast<double>(logDF_[i]);
+            logDFDouble[i] = Dal::AAD::Value(logDF_[i]);
         interp_ = BuildLogDfInterpFromYf(this->Name(), scheme_, yf_, logDFDouble);
         RebuildBasisAux();
     }
@@ -431,10 +431,12 @@ namespace Dal {
 
     template <class T_>
     void DiscountLogDF_<T_>::Write(Archive::Store_& dst) const {
-        // Serialisation is double-only; the Number_ path never persists. Extract via static_cast.
+        // Serialisation is double-only; the Number_ path never persists. Extract the primal value
+        // via the backend-neutral Dal::AAD::Value facade (static_cast<double> works on native and
+        // CoDiPack but not on XAD/Adept, which have no conversion operator).
         Vector_<> logDFDouble(logDF_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
-            logDFDouble[i] = static_cast<double>(logDF_[i]);
+            logDFDouble[i] = Dal::AAD::Value(logDF_[i]);
         DiscountLogDF_v2::XWrite(dst,
                                  this->Name(),
                                  this->ccy_.String(),
@@ -455,7 +457,7 @@ namespace Dal {
     Vector_<> DiscountLogDF_<T_>::NodeDF() const {
         Vector_<> retval(logDF_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
-            retval[i] = std::exp(static_cast<double>(logDF_[i]));
+            retval[i] = std::exp(Dal::AAD::Value(logDF_[i]));
         return retval;
     }
 
@@ -468,20 +470,20 @@ namespace Dal {
         // missing the public surface a caller might assume.
         Vector_<> retval(logDF_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
-            retval[i] = static_cast<double>(logDF_[i]);
+            retval[i] = Dal::AAD::Value(logDF_[i]);
         return retval;
     }
 
     // Explicit instantiations. DiscountLogDF_<double> is the hot path (F loop, bumped fallback,
-    // serialisation). DiscountLogDF_<Dal::AAD::Number_> is instantiated only under the native
-    // backend; it pulls in the AAD-aware branches via if constexpr and is linked into the Phase A
-    // Gradient override in calibration.cpp. The external AAD backends' active types do not provide
-    // the native-tape conversions (static_cast<double>) the Number_ body relies on, so the Number_
-    // instantiation is gated out and Phase A compiles away.
+    // serialisation). DiscountLogDF_<Dal::AAD::Number_> is linked into the AnalyticJacobian override
+    // in calibration.cpp; the Number_-typed body forwards to the Dal::AAD facade (exp/log/value via
+    // ADL), so it compiles and runs under every AAD backend. These instantiations were previously
+    // gated to the native backend because the analytic Jacobian zeroed adjoints by walking the
+    // native-only Dal::AAD::Tape_::nodes_ member; zeroing now goes through the backend-neutral
+    // Dal::AAD::ZeroAdjoints facade primitive, so the gate is gone and the instantiation is needed
+    // under every backend.
     template class DiscountLogDF_<double>;
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
     template class DiscountLogDF_<Dal::AAD::Number_>;
-#endif // native AAD backend (Phase A log-DF curve)
 
     } // namespace Tape
 

--- a/dal-cpp/dal/math/aad/aad.hpp
+++ b/dal-cpp/dal/math/aad/aad.hpp
@@ -39,8 +39,20 @@ namespace Dal::AAD {
         return Clear(*tape);
     }
 
+    // Register n as a tape-tracked independent holding value v. Native: Number_::operator=(double)
+    // (expr.hpp) records a fresh node -- that IS the registration. Mirrors the curve calibration
+    // independent-registration step behind a backend-neutral name.
+    FORCE_INLINE void RegisterIndependent(Number_& n, double v) { n = v; }
+
+    // Zero every node's adjoint, leaving the recorded graph intact. Used between single-result
+    // reverse sweeps so each row's seed propagates from a clean slate.
+    FORCE_INLINE void ZeroAdjoints(Tape_& tape) {
+        for (auto it = tape.nodes_.Begin(); it != tape.nodes_.End(); ++it)
+            it->Adjoint() = 0.0;
+    }
+
 } // namespace Dal::AAD
-#else
+#elif defined(DAL_USE_ADEPT_AAD)
 
 #include <algorithm>
 
@@ -53,6 +65,71 @@ namespace Dal::AAD {
     FORCE_INLINE void Clear(Tape_* tape) {
         return Clear(*tape);
     }
+
+    // Register n as an independent holding value v. Adept records the assignment as a statement on
+    // the active stack; no separate registerInput call is needed.
+    FORCE_INLINE void RegisterIndependent(Number_& n, double v) { n = v; }
+
+    // Zero every gradient between single-result sweeps. NOT a no-op on Adept: the compute_adjoint
+    // override (tape.hpp) zeroes only each consumed statement's LHS, then accumulates into operands
+    // whose gradients are never cleared -- row 2's seed would land on row 1's residue and corrupt
+    // the Jacobian. ZeroGradientArray clears the live gradient array while keeping
+    // gradients_initialized_ true so the override's THROW guard stays satisfied.
+    FORCE_INLINE void ZeroAdjoints(Tape_& tape) { tape.ZeroGradientArray(); }
+
+} // namespace Dal::AAD
+#elif defined(DAL_USE_XAD_AAD)
+
+#include <algorithm>
+#include <dal/utilities/exceptions.hpp>
+
+namespace Dal::AAD {
+
+    template <class IT_> FORCE_INLINE void PutOnTape(IT_ begin, IT_ end) {
+        std::for_each(begin, end, [](Number_& n) { PutOnTape(n); });
+    }
+
+    FORCE_INLINE void Clear(Tape_* tape) {
+        return Clear(*tape);
+    }
+
+    // Register n as an independent holding value v. XAD requires registerInput to run BEFORE the
+    // recording window opens (NewRecording): registering an input AFTER NewRecording silently drops
+    // it and yields an all-zero Jacobian column, so callers must RegisterIndependent first, then
+    // NewRecording, then the forward pass. The facade asserts the tape is active (clearAll does not
+    // deactivate a tape constructed with activate=true), so a passive tape fails loud here.
+    FORCE_INLINE void RegisterIndependent(Number_& n, double v) {
+        auto* t = Tape();
+        REQUIRE(t->tape_.isActive(), "Dal::AAD::RegisterIndependent: XAD tape is not active");
+        t->tape_.registerInput(n);
+        xad::value(n) = v;
+    }
+
+    FORCE_INLINE void ZeroAdjoints(Tape_& tape) { tape.tape_.clearDerivatives(); }
+
+} // namespace Dal::AAD
+#elif defined(DAL_USE_CODIPACK_AAD)
+
+#include <algorithm>
+
+namespace Dal::AAD {
+
+    template <class IT_> FORCE_INLINE void PutOnTape(IT_ begin, IT_ end) {
+        std::for_each(begin, end, [](Number_& n) { PutOnTape(n); });
+    }
+
+    FORCE_INLINE void Clear(Tape_* tape) {
+        return Clear(*tape);
+    }
+
+    // Register n as an independent holding value v on the active CoDiPack tape.
+    FORCE_INLINE void RegisterIndependent(Number_& n, double v) {
+        Tape()->tape_.registerInput(n);
+        n.setValue(v);
+    }
+
+    // Zero every adjoint (no-arg clearAdjoints zeroes up to the largest created index), graph intact.
+    FORCE_INLINE void ZeroAdjoints(Tape_& tape) { tape.tape_.clearAdjoints(); }
 
 } // namespace Dal::AAD
 #endif

--- a/dal-cpp/dal/math/aad/tape.hpp
+++ b/dal-cpp/dal/math/aad/tape.hpp
@@ -119,6 +119,17 @@ namespace Dal::AAD {
                 }
             }
         }
+
+        // Zero the live gradient array, leaving gradients_initialized_ true and the statement graph
+        // intact. compute_adjoint above zeroes only each consumed statement's LHS, then accumulates
+        // into operands whose gradients are never cleared; in a single-result reverse-sweep loop row
+        // 2's seed would land on row 1's operand residue and corrupt the Jacobian. Called by the
+        // Dal::AAD::ZeroAdjoints facade between sweeps. initialize_gradients() (protected on
+        // adept::Stack, reachable because Tape_ inherits it publicly) allocates gradient_ to
+        // max_gradient_ on first call and zeroes every entry on every call -- it touches only
+        // gradient_, n_allocated_gradients_, and gradients_initialized_, never the statement graph,
+        // so it is safe to call between sweeps and satisfies the compute_adjoint THROW guard above.
+        void ZeroGradientArray() { initialize_gradients(); }
     };
 
     void Clear(Tape_& tape);

--- a/dal-cpp/tests/curve/test_analytic_jacobian.cpp
+++ b/dal-cpp/tests/curve/test_analytic_jacobian.cpp
@@ -25,14 +25,14 @@ using namespace Dal;
 // not expose. Under those backends TestOnly::AnalyticJacobianAt returns an empty matrix and the
 // solver dense-bumps, so the tests that assert the exact AAD Jacobian are skipped there.
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-#define DAL_PHASE_A_NATIVE_AAD 1
+#define DAL_HAS_CURVE_ANALYTIC_JACOBIAN 1
 #else
-#define DAL_PHASE_A_NATIVE_AAD 0
+#define DAL_HAS_CURVE_ANALYTIC_JACOBIAN 0
 #endif
 
-#define SKIP_IF_NOT_NATIVE_AAD() \
+#define SKIP_IF_NO_ANALYTIC_JACOBIAN() \
     do { \
-        if (!DAL_PHASE_A_NATIVE_AAD) \
+        if (!DAL_HAS_CURVE_ANALYTIC_JACOBIAN) \
             GTEST_SKIP() << "Phase A analytic Jacobian is native-AAD-only; external backends dense-bump."; \
     } while (false)
 
@@ -159,8 +159,8 @@ namespace {
 // Each non-zero entry must match a two-sided central difference of F(x) at step
 // 1e-6 within 1e-9.
 
-TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceLogLinear) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogLinear) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::LOG_LINEAR);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     ASSERT_EQ(static_cast<int>(x.size()), 5);
@@ -195,8 +195,8 @@ TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceLogLinear) {
 // must have at least one exactly-zero entry for a column beyond the instrument's
 // cashflow support.
 
-TEST(PhaseAAADJacobianTest, TestStructuralZerosAreExactlyZero) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestStructuralZerosAreExactlyZero) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec();
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
@@ -214,7 +214,7 @@ TEST(PhaseAAADJacobianTest, TestStructuralZerosAreExactlyZero) {
 // ============================================================================
 // We do NOT assert iteration count (linesearch varies), only that the residual converges.
 
-TEST(PhaseAAADJacobianTest, TestSolveConvergesLogLinear) {
+TEST(AnalyticJacobianTest, TestSolveConvergesLogLinear) {
     auto specAAD = MakePhaseASpec();
 
     const auto rAAD = CalibrateYieldCurve(specAAD);
@@ -229,13 +229,13 @@ TEST(PhaseAAADJacobianTest, TestSolveConvergesLogLinear) {
 // ============================================================================
 // Category 4: Ineligibility -- the AAD Jacobian falls back to bumping with a NOTICE
 // ============================================================================
-// Phase A is ineligible for non-LOG_DISCOUNT parameterizations. EligibleForPhaseA
+// Phase A is ineligible for non-LOG_DISCOUNT parameterizations. EligibleForAnalyticJacobian
 // returns false, Gradient returns nullptr (the solver dense-bumps), and a NOTICE
 // fires. We cannot easily assert the NOTICE text from a unit test, but we CAN assert
 // the fallback behavior: TestOnly::AnalyticJacobianAt returns an EMPTY matrix on a
 // non-LOG_DISCOUNT spec (Gradient returned nullptr).
 
-TEST(PhaseAAADJacobianTest, TestIneligibleParameterizationFallsBack) {
+TEST(AnalyticJacobianTest, TestIneligibleParameterizationFallsBack) {
     auto spec = MakePhaseASpec();
     spec.parameterization_ = CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD;
     // Knot 0 must be > today for non-LOG_DISCOUNT.
@@ -248,9 +248,9 @@ TEST(PhaseAAADJacobianTest, TestIneligibleParameterizationFallsBack) {
 }
 
 // A FORECAST-target calibration (calibrateDiscountCurve_ == false) is ineligible for the AAD
-// Jacobian. EligibleForPhaseA returns false, Gradient returns nullptr, and
+// Jacobian. EligibleForAnalyticJacobian returns false, Gradient returns nullptr, and
 // TestOnly::AnalyticJacobianAt returns an EMPTY matrix (the solver dense-bumps instead).
-TEST(PhaseAAADJacobianTest, TestIneligibleForecastTargetFallsBack) {
+TEST(AnalyticJacobianTest, TestIneligibleForecastTargetFallsBack) {
     auto spec = MakePhaseASpec();
     spec.calibrateDiscountCurve_ = false;
     spec.targetTenor_ = PeriodLength_("3M");
@@ -278,7 +278,7 @@ TEST(PhaseAAADJacobianTest, TestIneligibleForecastTargetFallsBack) {
 // EMPTY matrix (the solver dense-bumps). We construct one such swap alongside an eligible one
 // to confirm the whole calibration falls back when ANY instrument is ineligible.
 
-TEST(PhaseAAADJacobianTest, TestTradeDateNotStartRejected) {
+TEST(AnalyticJacobianTest, TestTradeDateNotStartRejected) {
     auto spec = MakePhaseASpec();
     const auto fixedLeg = AnnualLegPA();
     const auto floatIdx = AnnualIndexPA();
@@ -303,8 +303,8 @@ TEST(PhaseAAADJacobianTest, TestTradeDateNotStartRejected) {
 // non-empty analytic Jacobian only exists on native AAD; on external backends the analytic path
 // is gated out and AnalyticJacobianAt returns an empty matrix regardless of eligibility, so this
 // assertion is skipped there (the eligibility predicate itself is covered by the native run).
-TEST(PhaseAAADJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec();
     spec.instruments_ = {
         Handle_<YCInstrument_>(new Swap_(spec.today_, spec.today_, Date_(2023, 1, 1), 0.012, AnnualLegPA(), AnnualIndexPA(), AnnualLegPA())),
@@ -322,7 +322,7 @@ TEST(PhaseAAADJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
 // the first call's residuals and produce wrong numbers. We assert the second
 // call reproduces the first exactly.
 
-TEST(PhaseAAADJacobianTest, TestTapeIsolationAcrossCalls) {
+TEST(AnalyticJacobianTest, TestTapeIsolationAcrossCalls) {
     auto spec = MakePhaseASpec();
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     const Matrix_<> J1 = TestOnly::AnalyticJacobianAt(spec, x);
@@ -342,15 +342,15 @@ TEST(PhaseAAADJacobianTest, TestTapeIsolationAcrossCalls) {
 // these two tests cover LOG_CUBIC_NATURAL and MIXED, exercising the natural-cubic and
 // mixed-cutoff spline branches of the AAD path.
 
-TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceLogCubicNatural) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogCubicNatural) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::LOG_CUBIC_NATURAL);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
 }
 
-TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceMixed) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceMixed) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::MIXED);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
@@ -365,8 +365,8 @@ TEST(PhaseAAADJacobianTest, TestMatchesCentralDifferenceMixed) {
 // the single row matches a central difference for every node column, and that the columns the
 // deposit does NOT touch (beyond its maturity) are EXACTLY zero (AAD structural zero, not noise).
 
-TEST(PhaseAAADJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     CurveCalibrationSpec_ spec;
     spec.today_ = Date_(2022, 1, 1);
     spec.ccy_ = "USD";
@@ -412,8 +412,8 @@ TEST(PhaseAAADJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
 // still match central differences row by row, and structural zeros must appear for instruments
 // whose cashflows end before later nodes.
 
-TEST(PhaseAAADJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifference) {
-    SKIP_IF_NOT_NATIVE_AAD();
+TEST(AnalyticJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifference) {
+    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     CurveCalibrationSpec_ spec;
     spec.today_ = Date_(2022, 1, 1);
     spec.ccy_ = "USD";

--- a/dal-cpp/tests/curve/test_analytic_jacobian.cpp
+++ b/dal-cpp/tests/curve/test_analytic_jacobian.cpp
@@ -20,21 +20,11 @@
 
 using namespace Dal;
 
-// The Phase A analytic Jacobian is native-AAD-only: it walks Dal::AAD::Tape_::nodes_ for the
-// single-result reverse sweeps, an internal the third-party AAD backends (XAD/CoDiPack/Adept) do
-// not expose. Under those backends TestOnly::AnalyticJacobianAt returns an empty matrix and the
-// solver dense-bumps, so the tests that assert the exact AAD Jacobian are skipped there.
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-#define DAL_HAS_CURVE_ANALYTIC_JACOBIAN 1
-#else
-#define DAL_HAS_CURVE_ANALYTIC_JACOBIAN 0
-#endif
-
-#define SKIP_IF_NO_ANALYTIC_JACOBIAN() \
-    do { \
-        if (!DAL_HAS_CURVE_ANALYTIC_JACOBIAN) \
-            GTEST_SKIP() << "Phase A analytic Jacobian is native-AAD-only; external backends dense-bump."; \
-    } while (false)
+// The analytic Jacobian is backend-neutral: it runs the single-result reverse-sweep loop under
+// every AAD backend (native, XAD, CoDiPack, Adept) via the Dal::AAD facade (RegisterIndependent,
+// ZeroAdjoints, Adjoint, PropagateToStart). Every test below runs on every backend; there is no
+// skip machinery. The eligibility/fallback tests still assert an empty matrix (nullptr Gradient)
+// for ineligible calibrations -- that is the fallback behavior, not a backend skip.
 
 namespace {
     RateLegConvention_ AnnualLegPA() {
@@ -160,7 +150,6 @@ namespace {
 // 1e-6 within 1e-9.
 
 TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogLinear) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::LOG_LINEAR);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     ASSERT_EQ(static_cast<int>(x.size()), 5);
@@ -196,7 +185,6 @@ TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogLinear) {
 // cashflow support.
 
 TEST(AnalyticJacobianTest, TestStructuralZerosAreExactlyZero) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec();
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
@@ -299,12 +287,9 @@ TEST(AnalyticJacobianTest, TestTradeDateNotStartRejected) {
 }
 
 // Sanity check the symmetric case: when tradeDate == start == anchor the same shape is still
-// admitted (one swap, non-empty Jacobian), guarding against an over-broad rejection. The
-// non-empty analytic Jacobian only exists on native AAD; on external backends the analytic path
-// is gated out and AnalyticJacobianAt returns an empty matrix regardless of eligibility, so this
-// assertion is skipped there (the eligibility predicate itself is covered by the native run).
+// admitted (one swap, non-empty Jacobian), guarding against an over-broad rejection. Runs on every
+// backend now that the analytic path is backend-neutral.
 TEST(AnalyticJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec();
     spec.instruments_ = {
         Handle_<YCInstrument_>(new Swap_(spec.today_, spec.today_, Date_(2023, 1, 1), 0.012, AnnualLegPA(), AnnualIndexPA(), AnnualLegPA())),
@@ -343,14 +328,12 @@ TEST(AnalyticJacobianTest, TestTapeIsolationAcrossCalls) {
 // mixed-cutoff spline branches of the AAD path.
 
 TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceLogCubicNatural) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::LOG_CUBIC_NATURAL);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
 }
 
 TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceMixed) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     auto spec = MakePhaseASpec(LogDfScheme_::Value_::MIXED);
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
@@ -366,7 +349,6 @@ TEST(AnalyticJacobianTest, TestMatchesCentralDifferenceMixed) {
 // deposit does NOT touch (beyond its maturity) are EXACTLY zero (AAD structural zero, not noise).
 
 TEST(AnalyticJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     CurveCalibrationSpec_ spec;
     spec.today_ = Date_(2022, 1, 1);
     spec.ccy_ = "USD";
@@ -413,7 +395,6 @@ TEST(AnalyticJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
 // whose cashflows end before later nodes.
 
 TEST(AnalyticJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifference) {
-    SKIP_IF_NO_ANALYTIC_JACOBIAN();
     CurveCalibrationSpec_ spec;
     spec.today_ = Date_(2022, 1, 1);
     spec.ccy_ = "USD";
@@ -457,4 +438,106 @@ TEST(AnalyticJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifferenc
         ASSERT_EQ(J(0, c), 0.0) << "deposit row col " << c << " = " << J(0, c);
     for (int c = 2; c < 5; ++c)
         ASSERT_EQ(J(1, c), 0.0) << "fra row col " << c << " = " << J(1, c);
+}
+
+// ============================================================================
+// Category 10: B2 sentinel -- every row has a non-trivial Jacobian
+// ============================================================================
+// The signature failure mode for a missed registerInput / broken recording window (the B2 class)
+// is an ALL-ZERO Jacobian row: the tape never learned the input is an independent, so the reverse
+// sweep propagates nothing and the harvested row is zero. This invariant trips that failure on the
+// AAD result alone, before any FD comparison: for every row i, at least one column j must satisfy
+// |jac(i, j)| > 1e-6. Runs on every backend; the FD oracle above is the deeper check.
+
+TEST(AnalyticJacobianTest, TestEveryRowHasNonTrivialJacobian) {
+    auto spec = MakePhaseASpec();
+    const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
+    const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
+    ASSERT_EQ(J.Rows(), 5);
+    ASSERT_EQ(J.Cols(), 5);
+    for (int r = 0; r < 5; ++r) {
+        double maxAbs = 0.0;
+        for (int c = 0; c < 5; ++c)
+            maxAbs = std::max(maxAbs, std::abs(J(r, c)));
+        ASSERT_GT(maxAbs, 1.0e-6) << "row " << r << " is all-zero (B2 sentinel: missed registerInput?)";
+    }
+}
+
+// ============================================================================
+// Category 11: B1 sentinel -- later rows stay clean of earlier rows' residue
+// ============================================================================
+// On Adept the compute_adjoint override zeroes only each consumed statement's LHS and accumulates
+// into operands whose gradients are never cleared between single-result sweeps. If ZeroAdjoints
+// were a no-op (the B1 bug), row 1's seed would leave operand residue that row 2's sweep inherits,
+// and row 2's harvested Jacobian would be wrong -- specifically its structural zeros would no
+// longer be exactly zero, and its non-zero entries would disagree with a finite difference. This
+// test runs the full 5-row ladder (each row's cashflow support is a strict prefix of the columns)
+// and asserts BOTH that every entry matches a central difference AND that the structural zeros in
+// LATER rows stay exactly zero despite EARLIER rows having populated those same columns. A
+// ZeroAdjoints leak makes the later-row zeros non-zero.
+
+TEST(AnalyticJacobianTest, TestLaterRowsCleanOfEarlierResidue) {
+    auto spec = MakePhaseASpec();
+    const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
+    const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
+    ASSERT_EQ(J.Rows(), 5);
+    ASSERT_EQ(J.Cols(), 5);
+
+    // Row 0 is the 3M swap (cashflow at column 0 only): J(0, 1..4) must be EXACTLY zero. Row 1 is
+    // the 6M swap (cashflow at columns 0..1): J(1, 2..4) must be exactly zero. These zeros are the
+    // B1 falsifier: row 1 sweeps AFTER row 0, and if row 0's residue leaked, row 1's structural
+    // zeros would be non-zero. The columns that ARE non-zero must also agree with a central
+    // difference (the residue would shift them off FD too).
+    for (int c = 1; c < 5; ++c)
+        ASSERT_EQ(J(0, c), 0.0) << "row 0 col " << c << " = " << J(0, c) << " (B1 sentinel: residue from no prior row, must be structural zero)";
+    for (int c = 2; c < 5; ++c)
+        ASSERT_EQ(J(1, c), 0.0) << "row 1 col " << c << " = " << J(1, c) << " (B1 sentinel: row-0 residue leaked into row-1 structural zero?)";
+
+    // Every non-structural entry must match a central difference. A residue leak would push a
+    // later row off its FD value.
+    const double h = 1.0e-6;
+    for (int c = 0; c < 5; ++c) {
+        Vector_<> xUp = x;
+        Vector_<> xDn = x;
+        xUp[c] += h;
+        xDn[c] -= h;
+        const Vector_<> fUp = EvalResiduals(spec, xUp);
+        const Vector_<> fDn = EvalResiduals(spec, xDn);
+        for (int r = 0; r < 5; ++r) {
+            const double fd = (fUp[r] - fDn[r]) / (2.0 * h);
+            const double an = J(r, c);
+            if (std::abs(fd) < 1e-9) {
+                ASSERT_NEAR(an, 0.0, 1e-9) << "row=" << r << " col=" << c;
+            } else {
+                ASSERT_NEAR(an, fd, 1e-9 * std::max(1.0, std::abs(fd))) << "row=" << r << " col=" << c;
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Category 12: Structural asymmetry guard (defense against a future Jacobian-layout transpose)
+// ============================================================================
+// A multi-result fast path (e.g. Adept stack.jacobian(), deferred) could transpose the Jacobian
+// layout if its dep/indep offset bookkeeping is wrong. The LOG_DISCOUNT swap ladder is provably
+// non-symmetric: swap i (maturing at knot i+1) has cashflow support over columns 0..i, so
+// J(i, j>i) == 0 structurally while J(j, i) for j>i can be non-zero. This test names an explicit
+// asymmetric pair -- J(2,0) non-zero, J(0,2) exactly zero -- so a transposed layout is falsifiable
+// even without re-running the full FD oracle.
+
+TEST(AnalyticJacobianTest, TestNonSymmetricLayoutAsymmetricPair) {
+    auto spec = MakePhaseASpec();
+    const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
+    AssertMatchesCentralDifference(spec, x, 1.0e-6, 1.0e-9);
+    const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
+    ASSERT_EQ(J.Rows(), 5);
+    ASSERT_EQ(J.Cols(), 5);
+    // Annual-coupon swaps only touch the 2023/2024/2025 nodes (columns 2, 3, 4); the 2022-04 and
+    // 2022-07 nodes (columns 0, 1) are touched only by the shorter swaps. Row 4 is the 5Y swap
+    // (matures 2025-01-01): it HAS exposure to column 2 (the 2023 node its first coupon lands on).
+    ASSERT_NE(J(4, 2), 0.0) << "5Y swap must have exposure to the 2023 node (col 2)";
+    // Row 2 is the 1Y swap (matures 2023-01-01): its only coupon is at column 2, so it has NO
+    // exposure to column 4 (the 2025 node). A transposed layout would swap these and the FD oracle
+    // above would fail first; this assertion names the asymmetry directly.
+    ASSERT_EQ(J(2, 4), 0.0) << "1Y swap must have no exposure to the 2025 node (col 4)";
 }


### PR DESCRIPTION
## Summary
**PR2 of the AAD analytic-Jacobian redesign** (`.claude/designs/aad-analytic-jacobian-redesign.md`, Goal 2). Stacks on #108 (the rename).

Makes `AnalyticJacobian` **backend-neutral**: the exact AAD reverse-sweep Jacobian now runs on **all four backends** (native, XAD, CoDiPack, Adept) instead of being compile-gated to native. The native-only `#if` gate is dropped from the curve layer; the AAD-foundation backend selector (`dal/math/aad/`) is untouched — it's what makes four-backend support possible.

Changed (6 files, +261/−95):
- **`aad.hpp`** — two facade primitives, `RegisterIndependent(Number_&, double)` and `ZeroAdjoints(Tape_&)`, defined per-backend in the existing `#if`/`#elif` selector blocks. XAD's `RegisterIndependent` REQUIREs an active tape (loud, not silent).
- **`tape.hpp`** — Adept `Tape_::ZeroGradientArray()` helper (B1 fix).
- **`calibration.cpp`** — seam 1 (`RegisterIndependent` for node log-DFs), seam 2 (`ZeroAdjoints` in the sweep loop), drop the three native-only gates, `TapeGuard_` does `Clear` only with `NewRecording` opened after registrations.
- **`yclogdf.cpp` / `ycinstrument.cpp`** — seam 3: drop the `#if` explicit-instantiation gates (factually-wrong justification), rewrite comments; 5 `static_cast<double>(Number_)` sites → `Dal::AAD::Value`.
- **`test_analytic_jacobian.cpp`** — removed the skip machinery so the analytic path RUNS on every backend; added 3 sentinel tests.

## Three places the design's assumptions didn't hold (correctness-critical — please review)
1. **XAD recording window.** The design specified `Clear → NewRecording → RegisterIndependent`; XAD requires `registerInput` *before* `newRecording`, else the input is silently dropped (empirically confirmed: all-zero Jacobian). Working order on all four backends: **`Clear → RegisterIndependent ×N → NewRecording → forward → sweep`**. Native `NewRecording` is a no-op, so this is invisible there.
2. **Adept `ZeroGradientArray`.** `gradient_` is a raw `Real*` (`ADEPT_STACK_STORAGE_STL` is undefined in DAL's build, so the design's `std::fill` won't compile) and is not allocated until `initialize_gradients()` runs lazily (so a manual loop hangs on the first call). The helper calls `initialize_gradients()` (allocates to `max_gradient_`, zeroes, sets `gradients_initialized_=true`) — safe between sweeps and satisfies the `compute_adjoint` THROW guard.
3. **`static_cast<double>(Number_)`** compiles only on native + CoDiPack; XAD and Adept have no `operator double()`. Converted the 5 forward-path sites to `Dal::AAD::Value`.

## Test plan
Local clean-state runs (CI is authoritative):

| Backend             | AnalyticJacobianTest | Full dal_cpp_tests |
|---------------------|----------------------|--------------------|
| Native              | 15/15 pass           | 711/711 pass       |
| XAD (B2 canary)     | 15/15 pass, no skips | 711/711 pass       |
| CoDiPack            | 15/15 pass, no skips | 711/711 pass       |
| Adept (B1 canary)   | 15/15 pass, no skips | 711/711 pass       |

- [x] Finite-difference oracle (`AssertMatchesCentralDifference`) passes on all four backends
- [x] B2 sentinel (`TestEveryRowHasNonTrivialJacobian`) — catches XAD all-zero columns
- [x] B1 sentinel (`TestLaterRowsCleanOfEarlierResidue`) — catches Adept cross-row residue
- [x] Structural-asymmetry guard passes on all four
- [ ] CI green across the build matrix (clang-18/19, gcc-13/14, msvc × aadet/adept/codipack/xad)

Out of scope (deferred to PR3): the runtime `CurveJacobianMode_` on/off flag and once-per-call NOTICE caching.
