### PR TITLE
feat: add CurveJacobianMode flag for analytic Jacobian on/off

### DIFF
--- a/dal-cpp/dal/auto/MG_CurveJacobianMode_enum.hpp
+++ b/dal-cpp/dal/auto/MG_CurveJacobianMode_enum.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+class  CurveJacobianMode_
+{
+public:
+    enum class Value_ : char
+    {
+     _NOT_SET=-1,
+     BUMPED,
+     ANALYTIC,
+     _N_VALUES
+    } val_;
+      
+    CurveJacobianMode_(Value_ val) : val_(val) {
+        REQUIRE(val < Value_::_N_VALUES, "val is not valid");
+    }
+private:
+    friend bool operator==(const CurveJacobianMode_& lhs, const CurveJacobianMode_& rhs);
+    friend struct ReadStringCurveJacobianMode_;
+    friend Vector_<CurveJacobianMode_> CurveJacobianModeListAll();
+    friend bool operator<(const CurveJacobianMode_& lhs, const CurveJacobianMode_& rhs) {
+        return lhs.val_ < rhs.val_;
+    }
+public:
+    explicit CurveJacobianMode_(const String_& src);
+    const char* String() const;
+    Value_ Switch() const {return val_;}
+    CurveJacobianMode_() : val_(Value_::_NOT_SET) {};
+};
+
+Vector_<CurveJacobianMode_> CurveJacobianModeListAll();
+
+bool operator==(const CurveJacobianMode_& lhs, const CurveJacobianMode_& rhs);
+inline bool operator!=(const CurveJacobianMode_& lhs, const CurveJacobianMode_& rhs) {return !(lhs == rhs);}
+inline bool operator==(const CurveJacobianMode_& lhs, CurveJacobianMode_::Value_ rhs) {return lhs.Switch() == rhs;}
+inline bool operator!=(const CurveJacobianMode_& lhs, CurveJacobianMode_::Value_ rhs) {return lhs.Switch() != rhs;}

--- a/dal-cpp/dal/auto/MG_CurveJacobianMode_enum.inc
+++ b/dal-cpp/dal/auto/MG_CurveJacobianMode_enum.inc
@@ -1,0 +1,61 @@
+
+bool operator==(const CurveJacobianMode_& lhs, const CurveJacobianMode_& rhs) {return lhs.val_ == rhs.val_;}
+namespace {
+    Vector_<CurveJacobianMode_>& TheCurveJacobianModeList() {
+        RETURN_STATIC(Vector_<CurveJacobianMode_>);
+    }
+}    // leave local
+
+Vector_<CurveJacobianMode_> CurveJacobianModeListAll() {
+   if (TheCurveJacobianModeList().empty()) {
+        TheCurveJacobianModeList().emplace_back(CurveJacobianMode_::Value_::BUMPED);
+        TheCurveJacobianModeList().emplace_back(CurveJacobianMode_::Value_::ANALYTIC);
+   }
+   return TheCurveJacobianModeList();
+}
+
+
+const char* CurveJacobianMode_::String() const {
+    switch (val_)
+    {
+    default:
+    case Value_::_NOT_SET:
+        return 0;
+        case Value_::BUMPED:
+        return "BUMPED";
+    case Value_::ANALYTIC:
+        return "ANALYTIC";
+        
+    }}
+
+struct ReadStringCurveJacobianMode_
+{
+    ReadStringCurveJacobianMode_() {}
+
+    bool operator()(const String_& src, CurveJacobianMode_::Value_* val) const    // returns true iff recognized input
+    {
+        bool ret_val = true;
+        if (0);	// otiose code to allow regular else-if structure
+        else if (src.empty())
+        { ret_val = false; }
+        
+	else if (String::Equivalent(src, "BUMPED"))
+        *val = CurveJacobianMode_::Value_::BUMPED;
+
+	else if (String::Equivalent(src, "ANALYTIC"))
+        *val = CurveJacobianMode_::Value_::ANALYTIC;
+        else
+            ret_val = false;
+        return ret_val;
+    }
+};
+
+CurveJacobianMode_::CurveJacobianMode_(const String_& src) {
+    static const ReadStringCurveJacobianMode_ READ_FIXED;    // allows precomputation for speed, in constructor
+    if (READ_FIXED(src, &val_))
+        return;
+    THROW("'" + src + "' is not a recognizable CurveJacobianMode");
+}
+
+
+

--- a/dal-cpp/dal/auto/java/CurveJacobianMode.java
+++ b/dal-cpp/dal/auto/java/CurveJacobianMode.java
@@ -1,0 +1,12 @@
+
+package types;
+
+public class CurveJacobianMode
+{
+    public enum Value
+    {
+		BUMPED,
+		ANALYTIC,
+        N_VALUES
+    }
+}

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -365,9 +365,11 @@ namespace Dal {
             // native, XAD, CoDiPack, and Adept via the Dal::AAD facade (RegisterIndependent,
             // ZeroAdjoints, Adjoint, PropagateToStart).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
-                // BUMPED short-circuit: the user asked for finite-difference bumping, so do no tape
-                // work, no eligibility check, no NOTICE. This is the byte-for-byte pre-analytic path.
-                if (jacobianMode_ == CurveJacobianMode_::Value_::BUMPED) {
+                // Engage the analytic Jacobian IFF the mode is explicitly ANALYTIC. Both BUMPED and
+                // _NOT_SET (default-constructed / uninitialized) route to nullptr so the solver
+                // dense-bumps -- this matches the contract "analytic iff mode == ANALYTIC && eligible"
+                // and keeps a stray _NOT_SET off the analytic path.
+                if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC) {
                     static_cast<void>(x);
                     static_cast<void>(f);
                     return nullptr;
@@ -680,6 +682,93 @@ namespace Dal {
         }
     }
 
+    namespace {
+        // Build the initial-guess vector for the solver. Split out of CalibrateYieldCurve to keep
+        // its cyclomatic complexity under the Codacy limit. Behavior is byte-for-byte identical to
+        // the inlined version that previously lived in CalibrateYieldCurve.
+        Vector_<> BuildCalibrationGuess(const CurveCalibrationSpec_& spec, const Vector_<Date_>& knotDates, bool anchorIsToday, int nParams) {
+            const int nKnots = static_cast<int>(knotDates.size());
+            Vector_<> guess(nParams);
+            if (anchorIsToday) {
+                if (spec.initialGuessPerNode_.empty()) {
+                    // R4 default seed: flat-2% rate mapped through yf_365F from the anchor.
+                    const Date_& anchor = knotDates.front();
+                    for (int i = 1; i < nKnots; ++i)
+                        guess[i - 1] = -FLAT_SEED_RATE * spec.liborBasis_(anchor, knotDates[i], nullptr);
+                } else {
+                    std::copy(spec.initialGuessPerNode_.begin(), spec.initialGuessPerNode_.end(), guess.begin());
+                }
+            } else {
+                std::fill(guess.begin(), guess.end(), spec.initialGuess_);
+            }
+            return guess;
+        }
+
+        // Run the EXACT or APPROXIMATE solver and return {result, effJacobianInverse}. Split out so
+        // the solveMode branch does not count against CalibrateYieldCurve's cyclomatic complexity.
+        struct SolverOutput_ {
+            Vector_<> result_;
+            Matrix_<> effJacobianInverse_;
+        };
+        SolverOutput_ RunCalibrationSolver(const CurveCalibrationSpec_& spec,
+                                           const Underdetermined::Function_& func,
+                                           const Vector_<>& guess,
+                                           const Vector_<>& tol,
+                                           const Sparse::TriDiagonal_& weights) {
+            Dictionary_ ctrlDict;
+            ctrlDict.Insert(KEY_MAX_EVALUATIONS, Cell_(static_cast<double>(spec.maxEvaluations_)));
+            ctrlDict.Insert(KEY_MAX_RESTARTS, Cell_(static_cast<double>(spec.maxRestarts_)));
+            UnderdeterminedControls_ controls(ctrlDict);
+
+            SolverOutput_ out;
+            if (spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
+                std::unique_ptr<Sparse::SymmetricDecomposition_> wDecomp(weights.DecomposeSymmetric());
+                out.result_ = Underdetermined::Find(func, guess, tol, *wDecomp, controls, &out.effJacobianInverse_);
+            } else {
+                out.result_ = Underdetermined::Approximate(func, guess, tol, spec.fitTolerance_, weights, controls);
+            }
+            return out;
+        }
+
+        // Assemble the CurveCalibrationResult_ from the solver output. Split out so the
+        // parameterization / diagnostics branches do not count against CalibrateYieldCurve's
+        // cyclomatic complexity. Behavior is byte-for-byte identical to the inlined version.
+        CurveCalibrationResult_ AssembleCalibrationResult(const CurveCalibrationSpec_& spec,
+                                                          const Vector_<Handle_<YCInstrument_>>& instruments,
+                                                          const Vector_<Date_>& knotDates,
+                                                          const Vector_<>& result,
+                                                          const Matrix_<>& effJacobianInverse) {
+            CurveCalibrationResult_ retval;
+            retval.curve_ = BuildDiscountCurve(spec.curveName_, spec.ccy_, spec.parameterization_, spec.logDfScheme_, knotDates, result, spec.liborBasis_,
+                                               spec.baseCurve_);
+            // For LOG_DISCOUNT the anchor knot equals today_ and would fail the strict > today check;
+            // validate the free knots only.
+            if (spec.parameterization_ == CurveParameterization_::Value_::LOG_DISCOUNT) {
+                Vector_<Date_> freeKnots;
+                for (int i = 1; i < static_cast<int>(knotDates.size()); ++i)
+                    freeKnots.push_back(knotDates[i]);
+                ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, freeKnots);
+            } else {
+                ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, knotDates);
+            }
+            Handle_<DiscountCurve_> diagnosticsCurve(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), retval.curve_.get()));
+            auto discountCurves = spec.discountCurves_;
+            auto forwardCurves = spec.forwardCurves_;
+            if (spec.calibrateDiscountCurve_)
+                discountCurves[spec.targetCollateral_] = diagnosticsCurve;
+            else
+                forwardCurves[spec.targetTenor_] = diagnosticsCurve;
+            CurveBlock_ curveView(spec.curveName_, spec.ccy_, discountCurves, forwardCurves, spec.liborBasis_);
+            Handle_<YieldCurve_> fundingCurve;
+            if (!spec.discountCurves_.empty())
+                fundingCurve.reset(new CurveBlock_(spec.curveName_, spec.ccy_, spec.discountCurves_, spec.forwardCurves_, spec.liborBasis_));
+            retval.diagnostics_ =
+                BuildDiagnostics(spec.curveName_, instruments, curveView, fundingCurve, spec.solveMode_ == CurveSolveMode_::Value_::APPROXIMATE,
+                                 spec.solveMode_ == CurveSolveMode_::Value_::EXACT ? &effJacobianInverse : nullptr);
+            return retval;
+        }
+    } // namespace
+
     CurveCalibrationResult_ CalibrateYieldCurve(const CurveCalibrationSpec_& spec) {
         // Default-constructed options -> jacobianMode_ == BUMPED -> byte-for-byte pre-analytic path.
         return CalibrateYieldCurve(spec, CurveCalibrationOptions_());
@@ -696,20 +785,8 @@ namespace Dal {
         const int nFreeKnots = anchorIsToday ? nKnots - 1 : nKnots;
         const int nParams = paramsPerKnot * nFreeKnots;
 
-        Vector_<> guess(nParams);
-        if (anchorIsToday) {
-            if (spec.initialGuessPerNode_.empty()) {
-                // R4 default seed: flat-2% rate mapped through yf_365F from the anchor.
-                const Date_& anchor = knotDates.front();
-                for (int i = 1; i < nKnots; ++i)
-                    guess[i - 1] = -FLAT_SEED_RATE * spec.liborBasis_(anchor, knotDates[i], nullptr);
-            } else {
-                std::copy(spec.initialGuessPerNode_.begin(), spec.initialGuessPerNode_.end(), guess.begin());
-            }
-        } else {
-            std::fill(guess.begin(), guess.end(), spec.initialGuess_);
-        }
-        Vector_<> tol(instruments.size(), spec.tolerance_);
+        const Vector_<> guess = BuildCalibrationGuess(spec, knotDates, anchorIsToday, nParams);
+        const Vector_<> tol(instruments.size(), spec.tolerance_);
         Vector_<Date_> weightKnots;
         if (anchorIsToday) {
             // LOG_DISCOUNT: parameter vector excludes the anchor; weights metric must match its dimension.
@@ -720,51 +797,12 @@ namespace Dal {
         }
         std::unique_ptr<Sparse::TriDiagonal_> weights(BuildCurveCalibrationWeights(weightKnots, paramsPerKnot, spec.smoothingWeight_));
 
-        Dictionary_ ctrlDict;
-        ctrlDict.Insert(KEY_MAX_EVALUATIONS, Cell_(static_cast<double>(spec.maxEvaluations_)));
-        ctrlDict.Insert(KEY_MAX_RESTARTS, Cell_(static_cast<double>(spec.maxRestarts_)));
-        UnderdeterminedControls_ controls(ctrlDict);
-
         YieldCurveCalibrationFunc_ func(spec.ccy_, spec.curveName_, spec.parameterization_, instruments, knotDates, spec.discountCurves_,
                                         spec.forwardCurves_, spec.baseCurve_, spec.targetCollateral_, spec.targetTenor_, spec.calibrateDiscountCurve_,
                                         spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_);
-        Vector_<> result;
-        Matrix_<> effJacobianInverse;
-        if (spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
-            std::unique_ptr<Sparse::SymmetricDecomposition_> wDecomp(weights->DecomposeSymmetric());
-            result = Underdetermined::Find(func, guess, tol, *wDecomp, controls, &effJacobianInverse);
-        } else {
-            result = Underdetermined::Approximate(func, guess, tol, spec.fitTolerance_, *weights, controls);
-        }
 
-        CurveCalibrationResult_ retval;
-        retval.curve_ = BuildDiscountCurve(spec.curveName_, spec.ccy_, spec.parameterization_, spec.logDfScheme_, knotDates, result, spec.liborBasis_,
-                                           spec.baseCurve_);
-        // For LOG_DISCOUNT the anchor knot equals today_ and would fail the strict > today check;
-        // validate the free knots only.
-        if (spec.parameterization_ == CurveParameterization_::Value_::LOG_DISCOUNT) {
-            Vector_<Date_> freeKnots;
-            for (int i = 1; i < static_cast<int>(knotDates.size()); ++i)
-                freeKnots.push_back(knotDates[i]);
-            ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, freeKnots);
-        } else {
-            ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, knotDates);
-        }
-        Handle_<DiscountCurve_> diagnosticsCurve(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), retval.curve_.get()));
-        auto discountCurves = spec.discountCurves_;
-        auto forwardCurves = spec.forwardCurves_;
-        if (spec.calibrateDiscountCurve_)
-            discountCurves[spec.targetCollateral_] = diagnosticsCurve;
-        else
-            forwardCurves[spec.targetTenor_] = diagnosticsCurve;
-        CurveBlock_ curveView(spec.curveName_, spec.ccy_, discountCurves, forwardCurves, spec.liborBasis_);
-        Handle_<YieldCurve_> fundingCurve;
-        if (!spec.discountCurves_.empty())
-            fundingCurve.reset(new CurveBlock_(spec.curveName_, spec.ccy_, spec.discountCurves_, spec.forwardCurves_, spec.liborBasis_));
-        retval.diagnostics_ =
-            BuildDiagnostics(spec.curveName_, instruments, curveView, fundingCurve, spec.solveMode_ == CurveSolveMode_::Value_::APPROXIMATE,
-                             spec.solveMode_ == CurveSolveMode_::Value_::EXACT ? &effJacobianInverse : nullptr);
-        return retval;
+        const SolverOutput_ solved = RunCalibrationSolver(spec, func, guess, tol, *weights);
+        return AssembleCalibrationResult(spec, instruments, knotDates, solved.result_, solved.effJacobianInverse_);
     }
 
     MultiCurveCalibrationResult_ CalibrateMultiCurve(const MultiCurveCalibrationSpec_& spec) {

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -31,6 +31,7 @@ namespace Dal {
 #include <dal/auto/MG_CurveSolveMode_enum.inc>
 #include <dal/auto/MG_CurveParameterization_enum.inc>
 #include <dal/auto/MG_CurveKnotPolicy_enum.inc>
+#include <dal/auto/MG_CurveJacobianMode_enum.inc>
 #include <dal/auto/MG_LogDfScheme_enum.inc>
 
     // Stores the LOG_DISCOUNT calibration Jacobian dense and assembles sparse. The method
@@ -278,6 +279,13 @@ namespace Dal {
         };
 
         class YieldCurveCalibrationFunc_ : public Underdetermined::Function_ {
+            // Cached eligibility verdict for the AAD analytic Jacobian. EligibleForAnalyticJacobian()
+            // is expensive (walks every instrument) and emits NOTICEs on fall-through, and Gradient is
+            // called per solver iteration (up to maxEvaluations_ * maxRestarts_). Evaluating the
+            // predicate once and caching the verdict bounds every NOTICE to at most one per
+            // CalibrateYieldCurve call (H1 NOTICE-frequency contract).
+            enum class Eligibility_ { Unknown, Eligible, Ineligible };
+
             String_ ccy_;
             String_ curveName_;
             CurveParameterization_ parameterization_;
@@ -293,6 +301,8 @@ namespace Dal {
             bool calibrateDiscountCurve_;
             DayBasis_ liborBasis_;
             LogDfScheme_ logDfScheme_;
+            CurveJacobianMode_ jacobianMode_;
+            mutable Eligibility_ cachedEligibility_ = Eligibility_::Unknown;
 
         public:
             YieldCurveCalibrationFunc_(const String_& ccy,
@@ -307,10 +317,12 @@ namespace Dal {
                                        const PeriodLength_& targetTenor,
                                        bool calibrateDiscountCurve,
                                        const DayBasis_& liborBasis,
-                                       LogDfScheme_ logDfScheme)
+                                       LogDfScheme_ logDfScheme,
+                                       CurveJacobianMode_ jacobianMode)
                 : ccy_(ccy), curveName_(curveName), parameterization_(parameterization), instruments_(instruments), knotDates_(knotDates),
                   discountCurves_(discountCurves), forwardCurves_(forwardCurves), baseCurve_(baseCurve), targetCollateral_(targetCollateral),
-                  targetTenor_(targetTenor), calibrateDiscountCurve_(calibrateDiscountCurve), liborBasis_(liborBasis), logDfScheme_(logDfScheme) {
+                  targetTenor_(targetTenor), calibrateDiscountCurve_(calibrateDiscountCurve), liborBasis_(liborBasis), logDfScheme_(logDfScheme),
+                  jacobianMode_(jacobianMode) {
                 Handle_<YieldCurve_> fundingYC;
                 if (!discountCurves_.empty())
                     fundingYC.reset(new CurveBlock_(curveName_, ccy_, discountCurves_, forwardCurves_, liborBasis_));
@@ -346,19 +358,42 @@ namespace Dal {
             }
 
             // Sparse Jacobian (LOG_DISCOUNT free-node log-DF unknowns). Returns the reverse-mode AAD
-            // Jacobian (single-result sweep on the active Number_ tape) when EligibleForAnalyticJacobian();
-            // otherwise returns nullptr so the solver dense-bumps. The residual is modelRate -
-            // marketRate, so dResidual_i/dx_j = dModelRate_i/dx_j (marketRate is constant, contributes
-            // nothing). Backend-neutral: the same path runs under native, XAD, CoDiPack, and Adept via
-            // the Dal::AAD facade (RegisterIndependent, ZeroAdjoints, Adjoint, PropagateToStart).
+            // Jacobian (single-result sweep on the active Number_ tape) when the mode is ANALYTIC and
+            // EligibleForAnalyticJacobian() holds; otherwise returns nullptr so the solver dense-bumps.
+            // The residual is modelRate - marketRate, so dResidual_i/dx_j = dModelRate_i/dx_j
+            // (marketRate is constant, contributes nothing). Backend-neutral: the same path runs under
+            // native, XAD, CoDiPack, and Adept via the Dal::AAD facade (RegisterIndependent,
+            // ZeroAdjoints, Adjoint, PropagateToStart).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
-                if (EligibleForAnalyticJacobian())
+                // BUMPED short-circuit: the user asked for finite-difference bumping, so do no tape
+                // work, no eligibility check, no NOTICE. This is the byte-for-byte pre-analytic path.
+                if (jacobianMode_ == CurveJacobianMode_::Value_::BUMPED) {
+                    static_cast<void>(x);
+                    static_cast<void>(f);
+                    return nullptr;
+                }
+                // ANALYTIC: engage the AAD Jacobian iff the cached eligibility verdict is Eligible.
+                // The verdict is evaluated once (EvaluateEligibilityOnce) and cached, so the NOTICEs
+                // inside EligibleForAnalyticJacobian fire at most once per CalibrateYieldCurve call.
+                EvaluateEligibilityOnce();
+                if (cachedEligibility_ == Eligibility_::Eligible)
                     return AnalyticJacobian(x, f);
-                // Ineligible: NOTICE was emitted by EligibleForAnalyticJacobian (names the offending
-                // condition); return nullptr so the solver dense-bumps.
+                // Ineligible: NOTICE was emitted once inside EvaluateEligibilityOnce; return nullptr so
+                // the solver dense-bumps. ANALYTIC never throws -- it is a best-effort hint.
                 static_cast<void>(x);
                 static_cast<void>(f);
                 return nullptr;
+            }
+
+            // Evaluate EligibleForAnalyticJacobian() exactly once per func lifetime and cache the
+            // verdict. Gradient is called per solver iteration; without this guard the predicate (and
+            // its NOTICEs) would re-fire thousands of times per CalibrateYieldCurve call. The NOTICEs
+            // naming the offending condition live inside EligibleForAnalyticJacobian and fire on the
+            // single uncached evaluation.
+            void EvaluateEligibilityOnce() const {
+                if (cachedEligibility_ != Eligibility_::Unknown)
+                    return;
+                cachedEligibility_ = EligibleForAnalyticJacobian() ? Eligibility_::Eligible : Eligibility_::Ineligible;
             }
 
             // Phase A eligibility predicate (per .claude/designs/aad-analytic-jacobian-selector-api.md
@@ -646,6 +681,11 @@ namespace Dal {
     }
 
     CurveCalibrationResult_ CalibrateYieldCurve(const CurveCalibrationSpec_& spec) {
+        // Default-constructed options -> jacobianMode_ == BUMPED -> byte-for-byte pre-analytic path.
+        return CalibrateYieldCurve(spec, CurveCalibrationOptions_());
+    }
+
+    CurveCalibrationResult_ CalibrateYieldCurve(const CurveCalibrationSpec_& spec, const CurveCalibrationOptions_& options) {
         ValidateCurveCalibrationSpec(spec);
 
         const Vector_<Handle_<YCInstrument_>> instruments = OrderInstruments(spec.instruments_);
@@ -687,7 +727,7 @@ namespace Dal {
 
         YieldCurveCalibrationFunc_ func(spec.ccy_, spec.curveName_, spec.parameterization_, instruments, knotDates, spec.discountCurves_,
                                         spec.forwardCurves_, spec.baseCurve_, spec.targetCollateral_, spec.targetTenor_, spec.calibrateDiscountCurve_,
-                                        spec.liborBasis_, spec.logDfScheme_);
+                                        spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_);
         Vector_<> result;
         Matrix_<> effJacobianInverse;
         if (spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
@@ -746,7 +786,8 @@ namespace Dal {
             const Vector_<Date_> knotDates = BuildCurveCalibrationKnots(spec.today_, instruments, spec.knotDates_, spec.knotPolicy_);
             YieldCurveCalibrationFunc_ func(spec.ccy_, spec.curveName_, spec.parameterization_, instruments, knotDates,
                                             spec.discountCurves_, spec.forwardCurves_, spec.baseCurve_, spec.targetCollateral_,
-                                            spec.targetTenor_, spec.calibrateDiscountCurve_, spec.liborBasis_, spec.logDfScheme_);
+                                            spec.targetTenor_, spec.calibrateDiscountCurve_, spec.liborBasis_, spec.logDfScheme_,
+                                            CurveJacobianMode_::Value_::ANALYTIC);
             const Vector_<> f = func.F(x);
             std::unique_ptr<Underdetermined::Jacobian_> j(func.Gradient(x, f));
             Matrix_<> retval;

--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -93,17 +93,10 @@ namespace Dal {
         LogDfScheme_ logDfScheme_ = LogDfScheme_::Value_::LOG_LINEAR;
     };
 
-    // Solver-side options for curve calibration. These are NOT serialized with the spec: the spec
-    // describes WHAT to calibrate (instruments, knots, curves, tolerances); the options describe
-    // HOW to solve (Jacobian construction, and future solver toggles). A default-constructed
-    // CurveCalibrationOptions_ reproduces the pre-analytic bumped path byte-for-byte.
+    // Solver-side options, NOT serialized with the spec: the spec describes WHAT to calibrate,
+    // these describe HOW to solve. Default-constructed options reproduce the pre-analytic bumped
+    // path byte-for-byte.
     struct CurveCalibrationOptions_ {
-        // Jacobian construction for the calibration solver.
-        //   BUMPED   -- finite-difference bumping of each free node. Default; byte-for-byte
-        //               identical to the pre-analytic path. Always available.
-        //   ANALYTIC -- AAD-derived dense Jacobian. Engages only when EligibleForAnalyticJacobian()
-        //               is true; otherwise falls back to BUMPED with a NOTICE (at most once per
-        //               CalibrateYieldCurve call; never throws).
         CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
     };
 

--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -35,6 +35,20 @@ alternative INSTRUMENTS
 alternative AUGMENTED
 -IF-------------------------------------------------------------------------*/
 
+/*IF--------------------------------------------------------------------------
+enumeration CurveJacobianMode
+    Jacobian construction mode for curve calibration
+switchable
+alternative BUMPED
+    Finite-difference bumping of each free node. Default; byte-for-byte
+    identical to the pre-analytic path. Always available.
+alternative ANALYTIC
+    AAD-derived dense Jacobian. Engages only when EligibleForAnalyticJacobian()
+    is true (LOG_DISCOUNT + DISCOUNT-target + forecast==discount + vanilla
+    swap/deposit/FRA/Future + tradeDate == anchor); otherwise falls back to
+    BUMPED with a NOTICE. ANALYTIC never throws -- it is a best-effort hint.
+-IF-------------------------------------------------------------------------*/
+
 #include <memory>
 #include <map>
 #include <dal/platform/platform.hpp>
@@ -51,6 +65,7 @@ namespace Dal {
 #include <dal/auto/MG_CurveSolveMode_enum.hpp>
 #include <dal/auto/MG_CurveParameterization_enum.hpp>
 #include <dal/auto/MG_CurveKnotPolicy_enum.hpp>
+#include <dal/auto/MG_CurveJacobianMode_enum.hpp>
 
     struct CurveCalibrationSpec_ {
         Date_ today_;
@@ -76,6 +91,20 @@ namespace Dal {
         CurveKnotPolicy_ knotPolicy_ = CurveKnotPolicy_::Value_::INPUT;
         Vector_<double> initialGuessPerNode_;
         LogDfScheme_ logDfScheme_ = LogDfScheme_::Value_::LOG_LINEAR;
+    };
+
+    // Solver-side options for curve calibration. These are NOT serialized with the spec: the spec
+    // describes WHAT to calibrate (instruments, knots, curves, tolerances); the options describe
+    // HOW to solve (Jacobian construction, and future solver toggles). A default-constructed
+    // CurveCalibrationOptions_ reproduces the pre-analytic bumped path byte-for-byte.
+    struct CurveCalibrationOptions_ {
+        // Jacobian construction for the calibration solver.
+        //   BUMPED   -- finite-difference bumping of each free node. Default; byte-for-byte
+        //               identical to the pre-analytic path. Always available.
+        //   ANALYTIC -- AAD-derived dense Jacobian. Engages only when EligibleForAnalyticJacobian()
+        //               is true; otherwise falls back to BUMPED with a NOTICE (at most once per
+        //               CalibrateYieldCurve call; never throws).
+        CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
     };
 
     struct CurveCalibrationDiagnostics_ {
@@ -118,6 +147,7 @@ namespace Dal {
     void ValidateCurveCalibrationSpec(const CurveCalibrationSpec_& spec);
     void ValidatePositiveDiscountFactors(const DiscountCurve_& curve, const Date_& today, const Vector_<Date_>& checkDates);
     CurveCalibrationResult_ CalibrateYieldCurve(const CurveCalibrationSpec_& spec);
+    CurveCalibrationResult_ CalibrateYieldCurve(const CurveCalibrationSpec_& spec, const CurveCalibrationOptions_& options);
     MultiCurveCalibrationResult_ CalibrateMultiCurve(const MultiCurveCalibrationSpec_& spec);
 
     namespace TestOnly {

--- a/dal-cpp/tests/curve/test_analytic_jacobian.cpp
+++ b/dal-cpp/tests/curve/test_analytic_jacobian.cpp
@@ -27,7 +27,7 @@ using namespace Dal;
 // for ineligible calibrations -- that is the fallback behavior, not a backend skip.
 
 namespace {
-    RateLegConvention_ AnnualLegPA() {
+    RateLegConvention_ AnnualLeg() {
         RateLegConvention_ leg;
         leg.paymentLag_ = 0;
         leg.paymentFrequency_ = PeriodLength_("12M");
@@ -39,7 +39,7 @@ namespace {
         return leg;
     }
 
-    RateIndexConvention_ AnnualIndexPA() {
+    RateIndexConvention_ AnnualIndex() {
         RateIndexConvention_ idx;
         idx.forecastTenor_ = PeriodLength_("12M");
         idx.dayBasis_ = DayBasis_("ACT_365F");
@@ -73,9 +73,9 @@ namespace {
             Date_(2024, 1, 1), Date_(2025, 1, 1),
         };
 
-        const auto fixedLeg = AnnualLegPA();
-        const auto floatIdx = AnnualIndexPA();
-        const auto floatLeg = AnnualLegPA();
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
         const auto mkSwap = [&](const Date_& start, const Date_& end, double parPct) {
             return Handle_<YCInstrument_>(new Swap_(spec.today_, start, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
         };
@@ -268,9 +268,9 @@ TEST(AnalyticJacobianTest, TestIneligibleForecastTargetFallsBack) {
 
 TEST(AnalyticJacobianTest, TestTradeDateNotStartRejected) {
     auto spec = MakePhaseASpec();
-    const auto fixedLeg = AnnualLegPA();
-    const auto floatIdx = AnnualIndexPA();
-    const auto floatLeg = AnnualLegPA();
+    const auto fixedLeg = AnnualLeg();
+    const auto floatIdx = AnnualIndex();
+    const auto floatLeg = AnnualLeg();
     // Spot-started swap: tradeDate is two days before the anchor start. start_ stays at the
     // anchor so TimeSpan().first == anchor -- the exact shape the old (buggy) gate admitted.
     spec.instruments_ = {
@@ -292,7 +292,7 @@ TEST(AnalyticJacobianTest, TestTradeDateNotStartRejected) {
 TEST(AnalyticJacobianTest, TestTradeDateEqualsStartStillAdmitted) {
     auto spec = MakePhaseASpec();
     spec.instruments_ = {
-        Handle_<YCInstrument_>(new Swap_(spec.today_, spec.today_, Date_(2023, 1, 1), 0.012, AnnualLegPA(), AnnualIndexPA(), AnnualLegPA())),
+        Handle_<YCInstrument_>(new Swap_(spec.today_, spec.today_, Date_(2023, 1, 1), 0.012, AnnualLeg(), AnnualIndex(), AnnualLeg())),
     };
     const Vector_<> x = {-0.005, -0.012, -0.025, -0.04, -0.06};
     const Matrix_<> J = TestOnly::AnalyticJacobianAt(spec, x);
@@ -368,7 +368,7 @@ TEST(AnalyticJacobianTest, TestSingleDepositTapeMatchesCentralDifference) {
     };
 
     // One 3M deposit starting at the anchor. Its cashflow lands at 2022-04-01 (knot column 0).
-    RateIndexConvention_ idx = AnnualIndexPA();
+    RateIndexConvention_ idx = AnnualIndex();
     spec.instruments_ = {Handle_<YCInstrument_>(
         new Deposit_(spec.today_, spec.today_, Date_(2022, 4, 1), 0.011, idx))};
 
@@ -414,9 +414,9 @@ TEST(AnalyticJacobianTest, TestMixedInstrumentCalibrationMatchesCentralDifferenc
     };
 
     // All three instruments start at the anchor (eligibility requires span.first == anchor).
-    const RateIndexConvention_ idx = AnnualIndexPA();
-    const auto fixedLeg = AnnualLegPA();
-    const auto floatLeg = AnnualLegPA();
+    const RateIndexConvention_ idx = AnnualIndex();
+    const auto fixedLeg = AnnualLeg();
+    const auto floatLeg = AnnualLeg();
     spec.instruments_ = {
         // Deposit 3M -> cashflow at 2022-04-01 (column 0).
         Handle_<YCInstrument_>(new Deposit_(spec.today_, spec.today_, Date_(2022, 4, 1), 0.011, idx)),

--- a/dal-cpp/tests/curve/test_curve_jacobian_mode.cpp
+++ b/dal-cpp/tests/curve/test_curve_jacobian_mode.cpp
@@ -1,0 +1,38 @@
+//
+// Created by dal-implementer on 2026/6/18.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/curve/calibration.hpp>
+
+using namespace Dal;
+
+// CurveJacobianMode_ is the runtime on/off flag for the curve-calibration AAD analytic Jacobian
+// (PR3 of the analytic-Jacobian redesign). It is a Machinist-generated, switchable enum with
+// exactly two values: BUMPED (the byte-for-byte pre-analytic baseline, the default) and ANALYTIC
+// (the AAD-derived dense Jacobian, best-effort hint that never throws). These tests pin the
+// enum shape, the default-constructed value, and the round-trip string mapping.
+
+TEST(CurveJacobianModeTest, TestHasBumpedAndAnalyticValues) {
+    const CurveJacobianMode_ bumped = CurveJacobianMode_::Value_::BUMPED;
+    const CurveJacobianMode_ analytic = CurveJacobianMode_::Value_::ANALYTIC;
+    ASSERT_EQ(bumped.Switch(), CurveJacobianMode_::Value_::BUMPED);
+    ASSERT_EQ(analytic.Switch(), CurveJacobianMode_::Value_::ANALYTIC);
+    ASSERT_NE(bumped, analytic);
+}
+
+TEST(CurveJacobianModeTest, TestStringRoundTrip) {
+    ASSERT_STREQ(CurveJacobianMode_(CurveJacobianMode_::Value_::BUMPED).String(), "BUMPED");
+    ASSERT_STREQ(CurveJacobianMode_(CurveJacobianMode_::Value_::ANALYTIC).String(), "ANALYTIC");
+    ASSERT_EQ(CurveJacobianMode_(String_("BUMPED")).Switch(), CurveJacobianMode_::Value_::BUMPED);
+    ASSERT_EQ(CurveJacobianMode_(String_("ANALYTIC")).Switch(), CurveJacobianMode_::Value_::ANALYTIC);
+}
+
+TEST(CurveJacobianModeTest, TestOptionsDefaultIsBumped) {
+    // CurveCalibrationOptions_ is a peer of CurveCalibrationSpec_ (NOT serialized with the spec).
+    // A default-constructed CurveCalibrationOptions_ has jacobianMode_ == BUMPED, reproducing the
+    // pre-analytic bumped path byte-for-byte. This is the migration gate's foundation.
+    const CurveCalibrationOptions_ options;
+    ASSERT_EQ(options.jacobianMode_.Switch(), CurveJacobianMode_::Value_::BUMPED);
+}

--- a/dal-cpp/tests/curve/test_curve_jacobian_mode.cpp
+++ b/dal-cpp/tests/curve/test_curve_jacobian_mode.cpp
@@ -22,6 +22,13 @@ TEST(CurveJacobianModeTest, TestHasBumpedAndAnalyticValues) {
     ASSERT_NE(bumped, analytic);
 }
 
+// The Machinist-generated enum carries a _NOT_SET sentinel that the default ctor assigns. Gradient
+// defends against this sentinel (it engages analytic ONLY on explicit ANALYTIC, so a default-
+// constructed / uninitialized mode routes to bumped like BUMPED). This pins the sentinel value.
+TEST(CurveJacobianModeTest, TestDefaultConstructedIsNotSet) {
+    ASSERT_EQ(CurveJacobianMode_().Switch(), CurveJacobianMode_::Value_::_NOT_SET);
+}
+
 TEST(CurveJacobianModeTest, TestStringRoundTrip) {
     ASSERT_STREQ(CurveJacobianMode_(CurveJacobianMode_::Value_::BUMPED).String(), "BUMPED");
     ASSERT_STREQ(CurveJacobianMode_(CurveJacobianMode_::Value_::ANALYTIC).String(), "ANALYTIC");

--- a/dal-cpp/tests/curve/test_curve_jacobian_mode_flag.cpp
+++ b/dal-cpp/tests/curve/test_curve_jacobian_mode_flag.cpp
@@ -18,16 +18,12 @@
 
 using namespace Dal;
 
-// Flag-behavior tests for the runtime CurveJacobianMode_ switch (PR3 of the analytic-Jacobian
-// redesign). The flag is a best-effort hint: BUMPED (default) is the byte-for-byte pre-analytic
-// path; ANALYTIC engages the AAD dense Jacobian iff EligibleForAnalyticJacobian(), otherwise falls
-// back to bumped with a NOTICE (never throws). These tests pin the migration gate (default options
-// == bumped baseline), the analytic-engage path (ANALYTIC + eligible), the fallback path
-// (ANALYTIC + ineligible -> bumped), the explicit-BUMPED short-circuit, and the NOTICE-once
-// contract (cached eligibility: the predicate runs at most once per CalibrateYieldCurve call).
+// Flag-behavior tests for the runtime CurveJacobianMode_ switch: BUMPED (default) is the
+// byte-for-byte pre-analytic path; ANALYTIC engages the AAD Jacobian iff eligible, else falls
+// back to bumped with a NOTICE (never throws).
 
 namespace {
-    RateLegConvention_ AnnualLegPA() {
+    RateLegConvention_ AnnualLeg() {
         RateLegConvention_ leg;
         leg.paymentLag_ = 0;
         leg.paymentFrequency_ = PeriodLength_("12M");
@@ -39,7 +35,7 @@ namespace {
         return leg;
     }
 
-    RateIndexConvention_ AnnualIndexPA() {
+    RateIndexConvention_ AnnualIndex() {
         RateIndexConvention_ idx;
         idx.forecastTenor_ = PeriodLength_("12M");
         idx.dayBasis_ = DayBasis_("ACT_365F");
@@ -73,9 +69,9 @@ namespace {
             Date_(2024, 1, 1), Date_(2025, 1, 1),
         };
 
-        const auto fixedLeg = AnnualLegPA();
-        const auto floatIdx = AnnualIndexPA();
-        const auto floatLeg = AnnualLegPA();
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
         const auto mkSwap = [&](const Date_& start, const Date_& end, double parPct) {
             return Handle_<YCInstrument_>(new Swap_(spec.today_, start, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
         };
@@ -107,15 +103,8 @@ namespace {
     }
 } // namespace
 
-// ============================================================================
-// Migration gate (acceptance bar): default-constructed options reproduce the
-// pre-feature bumped path byte-for-byte.
-// ============================================================================
-// The single-arg CalibrateYieldCurve(spec) overload delegates to the two-arg form with a
-// default-constructed CurveCalibrationOptions_ (jacobianMode_ == BUMPED). The default-constructed
-// options, an explicit BUMPED options, and the single-arg call must all produce identical curves
-// (the bumped path is deterministic). This is the migration guarantee: a caller who does nothing
-// gets the pre-analytic behavior unchanged.
+// Migration gate: default-constructed options, explicit BUMPED, and the single-arg overload
+// must all produce identical curves -- a caller who does nothing gets the pre-analytic path.
 
 TEST(CurveJacobianModeFlagTest, TestMigrationGateDefaultMatchesBumped) {
     const auto spec = MakeEligibleSpec();
@@ -140,16 +129,9 @@ TEST(CurveJacobianModeFlagTest, TestMigrationGateDefaultMatchesBumped) {
     ASSERT_LT(rSingle.diagnostics_.maxAbsResidual_, 1.0e-7);
 }
 
-// ============================================================================
-// ANALYTIC + eligible: the AAD dense Jacobian engages and drives the solver to
-// the same solution as the bumped path.
-// ============================================================================
-// For an eligible calibration both the bumped and analytic Jacobians are exact, so the solver
-// converges to the same node log-DFs. This test asserts ANALYTIC engages (the run completes and
-// converges) AND that the resulting curve matches the BUMPED result node-by-node within solver
-// tolerance. The "analytic actually engaged" signal is asserted separately via the
-// TestOnly::AnalyticJacobianAt hook in test_analytic_jacobian.cpp (non-empty matrix); here we
-// assert the end-to-end flag behavior on CalibrateYieldCurve.
+// ANALYTIC + eligible: both Jacobians are exact, so the analytic run must converge to the same
+// node log-DFs as BUMPED. ("Analytic actually engaged" is asserted via TestOnly::AnalyticJacobianAt
+// in test_analytic_jacobian.cpp; here we assert the end-to-end flag behavior.)
 
 TEST(CurveJacobianModeFlagTest, TestAnalyticEligibleMatchesBumped) {
     const auto spec = MakeEligibleSpec();
@@ -175,15 +157,8 @@ TEST(CurveJacobianModeFlagTest, TestAnalyticEligibleMatchesBumped) {
         ASSERT_NEAR(logBumped[i], logAnalytic[i], 1.0e-9) << "node " << i;
 }
 
-// ============================================================================
-// ANALYTIC + ineligible: falls back to bumped (never throws), produces a valid
-// curve identical to the explicit BUMPED result.
-// ============================================================================
-// ANALYTIC is a best-effort hint. When the calibration is ineligible (here: non-LOG_DISCOUNT),
-// EligibleForAnalyticJacobian returns false with a NOTICE, Gradient returns nullptr, and the solver
-// dense-bumps. The result must equal the explicit BUMPED result on the same spec (identical
-// numerics), and ANALYTIC must never throw. We assert the curve type, convergence, and node-by-node
-// equality with the bumped baseline.
+// ANALYTIC + ineligible: ANALYTIC never throws; on an ineligible spec Gradient returns nullptr
+// (solver dense-bumps), so the result equals explicit BUMPED. (PLF spec -> compare DFs, not log-DFs.)
 
 TEST(CurveJacobianModeFlagTest, TestAnalyticIneligibleFallsBackToBumped) {
     const auto spec = MakeIneligibleSpec();
@@ -210,13 +185,8 @@ TEST(CurveJacobianModeFlagTest, TestAnalyticIneligibleFallsBackToBumped) {
     }
 }
 
-// ============================================================================
-// BUMPED explicitly: analytic never engages (byte-identical to default).
-// ============================================================================
-// Explicit BUMPED on an eligible calibration short-circuits Gradient to nullptr before any
-// eligibility check or tape work, so the result equals the default-constructed-options result
-// (which is also BUMPED). Combined with the migration gate this closes the loop: default, explicit
-// BUMPED, and the single-arg overload are three spellings of the same bumped path.
+// Explicit BUMPED on an eligible spec short-circuits Gradient to nullptr, so it equals default
+// options (also BUMPED) -- default, explicit BUMPED, and the single-arg overload are one path.
 
 TEST(CurveJacobianModeFlagTest, TestExplicitBumpedMatchesDefaultOnEligibleSpec) {
     const auto spec = MakeEligibleSpec();
@@ -235,20 +205,10 @@ TEST(CurveJacobianModeFlagTest, TestExplicitBumpedMatchesDefaultOnEligibleSpec) 
         ASSERT_DOUBLE_EQ(logDefault[i], logBumped[i]) << "node " << i;
 }
 
-// ============================================================================
-// NOTICE-once contract: the eligibility verdict is cached, so ANALYTIC on an
-// ineligible calibration completes without re-evaluating eligibility per iteration.
-// ============================================================================
-// EligibleForAnalyticJacobian() walks every instrument and emits NOTICEs on fall-through; Gradient
-// is called per solver iteration (up to maxEvaluations_ * maxRestarts_). The verdict is cached on
-// the YieldCurveCalibrationFunc_ (EvaluateEligibilityOnce), so the predicate runs at most once per
-// CalibrateYieldCurve call. The NOTICE stack itself is a scoped push/pop with no public counter, so
-// this contract is verified structurally: an ineligible ANALYTIC calibration with the full solver
-// budget (maxEvaluations_ * maxRestarts_ iterations available) completes and converges to the
-// bumped solution. A per-iteration re-evaluation would re-walk all instruments each call; the cache
-// bounds the predicate to one call. We assert the calibration completes and the result matches
-// bumped, which holds regardless of caching -- the cache is a performance invariant, not a
-// correctness one, and is verified by reading EvaluateEligibilityOnce in the source.
+// NOTICE-once: eligibility is cached (EvaluateEligibilityOnce), so the predicate runs at most once
+// per CalibrateYieldCurve call even though Gradient fires per iteration. The NOTICE stack has no
+// counter, so this is verified structurally -- the run completes and matches bumped; the cache
+// itself is a performance invariant, verified by reading the source.
 
 TEST(CurveJacobianModeFlagTest, TestIneligibleAnalyticCachesEligibilityVerdict) {
     auto spec = MakeIneligibleSpec();

--- a/dal-cpp/tests/curve/test_curve_jacobian_mode_flag.cpp
+++ b/dal-cpp/tests/curve/test_curve_jacobian_mode_flag.cpp
@@ -1,0 +1,274 @@
+//
+// Created by dal-implementer on 2026/6/18.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/curve/calibration.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/discount.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/protocol/rateconvention.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+
+using namespace Dal;
+
+// Flag-behavior tests for the runtime CurveJacobianMode_ switch (PR3 of the analytic-Jacobian
+// redesign). The flag is a best-effort hint: BUMPED (default) is the byte-for-byte pre-analytic
+// path; ANALYTIC engages the AAD dense Jacobian iff EligibleForAnalyticJacobian(), otherwise falls
+// back to bumped with a NOTICE (never throws). These tests pin the migration gate (default options
+// == bumped baseline), the analytic-engage path (ANALYTIC + eligible), the fallback path
+// (ANALYTIC + ineligible -> bumped), the explicit-BUMPED short-circuit, and the NOTICE-once
+// contract (cached eligibility: the predicate runs at most once per CalibrateYieldCurve call).
+
+namespace {
+    RateLegConvention_ AnnualLegPA() {
+        RateLegConvention_ leg;
+        leg.paymentLag_ = 0;
+        leg.paymentFrequency_ = PeriodLength_("12M");
+        leg.dayBasis_ = DayBasis_("ACT_365F");
+        leg.accrualHolidays_ = Holidays::None();
+        leg.paymentHolidays_ = Holidays::None();
+        leg.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        leg.paymentConvention_ = BizDayConvention_("Unadjusted");
+        return leg;
+    }
+
+    RateIndexConvention_ AnnualIndexPA() {
+        RateIndexConvention_ idx;
+        idx.forecastTenor_ = PeriodLength_("12M");
+        idx.dayBasis_ = DayBasis_("ACT_365F");
+        idx.fixingLag_ = 0;
+        idx.spotLag_ = 0;
+        idx.fixingHolidays_ = Holidays::None();
+        idx.accrualHolidays_ = Holidays::None();
+        idx.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        idx.useProjectionCurve_ = false;
+        return idx;
+    }
+
+    // Eligible calibration: LOG_DISCOUNT + DISCOUNT-target + vanilla swaps starting at the anchor +
+    // tradeDate == anchor. This is exactly the shape EligibleForAnalyticJacobian admits.
+    CurveCalibrationSpec_ MakeEligibleSpec() {
+        CurveCalibrationSpec_ spec;
+        spec.today_ = Date_(2022, 1, 1);
+        spec.ccy_ = "USD";
+        spec.curveName_ = "flag_test_eligible";
+        spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+        spec.knotPolicy_ = CurveKnotPolicy_::Value_::INPUT;
+        spec.solveMode_ = CurveSolveMode_::Value_::EXACT;
+        spec.liborBasis_ = DayBasis_("ACT_365F");
+        spec.tolerance_ = 1.0e-10;
+        spec.fitTolerance_ = 1.0e-8;
+        spec.smoothingWeight_ = 1.0;
+        spec.logDfScheme_ = LogDfScheme_::Value_::LOG_LINEAR;
+
+        spec.knotDates_ = {
+            Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1),
+            Date_(2024, 1, 1), Date_(2025, 1, 1),
+        };
+
+        const auto fixedLeg = AnnualLegPA();
+        const auto floatIdx = AnnualIndexPA();
+        const auto floatLeg = AnnualLegPA();
+        const auto mkSwap = [&](const Date_& start, const Date_& end, double parPct) {
+            return Handle_<YCInstrument_>(new Swap_(spec.today_, start, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
+        };
+        spec.instruments_ = {
+            mkSwap(Date_(2022, 1, 1), Date_(2022, 4, 1), 1.00),
+            mkSwap(Date_(2022, 1, 1), Date_(2022, 7, 1), 1.10),
+            mkSwap(Date_(2022, 1, 1), Date_(2023, 1, 1), 1.25),
+            mkSwap(Date_(2022, 1, 1), Date_(2024, 1, 1), 1.55),
+            mkSwap(Date_(2022, 1, 1), Date_(2025, 1, 1), 1.80),
+        };
+        return spec;
+    }
+
+    // Ineligible calibration: non-LOG_DISCOUNT parameterization is rejected by
+    // EligibleForAnalyticJacobian with a NOTICE and falls back to bumped.
+    CurveCalibrationSpec_ MakeIneligibleSpec() {
+        auto spec = MakeEligibleSpec();
+        spec.parameterization_ = CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD;
+        // Knot 0 must be > today for non-LOG_DISCOUNT parameterizations.
+        spec.knotDates_[0] = Date_(2022, 4, 1);
+        return spec;
+    }
+
+    // Pull the calibrated node log-DFs out of a result so two runs can be compared node-by-node.
+    Vector_<> NodeLogDF(const CurveCalibrationResult_& r) {
+        const auto* c = dynamic_cast<const DiscountLogDF_*>(r.curve_.get());
+        REQUIRE(c != nullptr, "expected a DiscountLogDF_ curve");
+        return c->NodeLogDF();
+    }
+} // namespace
+
+// ============================================================================
+// Migration gate (acceptance bar): default-constructed options reproduce the
+// pre-feature bumped path byte-for-byte.
+// ============================================================================
+// The single-arg CalibrateYieldCurve(spec) overload delegates to the two-arg form with a
+// default-constructed CurveCalibrationOptions_ (jacobianMode_ == BUMPED). The default-constructed
+// options, an explicit BUMPED options, and the single-arg call must all produce identical curves
+// (the bumped path is deterministic). This is the migration guarantee: a caller who does nothing
+// gets the pre-analytic behavior unchanged.
+
+TEST(CurveJacobianModeFlagTest, TestMigrationGateDefaultMatchesBumped) {
+    const auto spec = MakeEligibleSpec();
+
+    const auto rSingle = CalibrateYieldCurve(spec);
+    CurveCalibrationOptions_ optDefault;
+    const auto rDefault = CalibrateYieldCurve(spec, optDefault);
+    CurveCalibrationOptions_ optBumped;
+    optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+    const auto rExplicitBumped = CalibrateYieldCurve(spec, optBumped);
+
+    const auto logSingle = NodeLogDF(rSingle);
+    const auto logDefault = NodeLogDF(rDefault);
+    const auto logBumped = NodeLogDF(rExplicitBumped);
+
+    ASSERT_EQ(logSingle.size(), logDefault.size());
+    ASSERT_EQ(logSingle.size(), logBumped.size());
+    for (int i = 0; i < static_cast<int>(logSingle.size()); ++i) {
+        ASSERT_DOUBLE_EQ(logSingle[i], logDefault[i]) << "node " << i;
+        ASSERT_DOUBLE_EQ(logSingle[i], logBumped[i]) << "node " << i;
+    }
+    ASSERT_LT(rSingle.diagnostics_.maxAbsResidual_, 1.0e-7);
+}
+
+// ============================================================================
+// ANALYTIC + eligible: the AAD dense Jacobian engages and drives the solver to
+// the same solution as the bumped path.
+// ============================================================================
+// For an eligible calibration both the bumped and analytic Jacobians are exact, so the solver
+// converges to the same node log-DFs. This test asserts ANALYTIC engages (the run completes and
+// converges) AND that the resulting curve matches the BUMPED result node-by-node within solver
+// tolerance. The "analytic actually engaged" signal is asserted separately via the
+// TestOnly::AnalyticJacobianAt hook in test_analytic_jacobian.cpp (non-empty matrix); here we
+// assert the end-to-end flag behavior on CalibrateYieldCurve.
+
+TEST(CurveJacobianModeFlagTest, TestAnalyticEligibleMatchesBumped) {
+    const auto spec = MakeEligibleSpec();
+
+    CurveCalibrationOptions_ optBumped;
+    optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+    const auto rBumped = CalibrateYieldCurve(spec, optBumped);
+
+    CurveCalibrationOptions_ optAnalytic;
+    optAnalytic.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    const auto rAnalytic = CalibrateYieldCurve(spec, optAnalytic);
+
+    // Both paths must converge.
+    ASSERT_LT(rBumped.diagnostics_.maxAbsResidual_, 1.0e-7);
+    ASSERT_LT(rAnalytic.diagnostics_.maxAbsResidual_, 1.0e-7);
+
+    // The analytic Jacobian is exact, so the solver lands on the same node log-DFs as the bumped
+    // path (both solve the same nonlinear system to the same tolerance).
+    const auto logBumped = NodeLogDF(rBumped);
+    const auto logAnalytic = NodeLogDF(rAnalytic);
+    ASSERT_EQ(logBumped.size(), logAnalytic.size());
+    for (int i = 0; i < static_cast<int>(logBumped.size()); ++i)
+        ASSERT_NEAR(logBumped[i], logAnalytic[i], 1.0e-9) << "node " << i;
+}
+
+// ============================================================================
+// ANALYTIC + ineligible: falls back to bumped (never throws), produces a valid
+// curve identical to the explicit BUMPED result.
+// ============================================================================
+// ANALYTIC is a best-effort hint. When the calibration is ineligible (here: non-LOG_DISCOUNT),
+// EligibleForAnalyticJacobian returns false with a NOTICE, Gradient returns nullptr, and the solver
+// dense-bumps. The result must equal the explicit BUMPED result on the same spec (identical
+// numerics), and ANALYTIC must never throw. We assert the curve type, convergence, and node-by-node
+// equality with the bumped baseline.
+
+TEST(CurveJacobianModeFlagTest, TestAnalyticIneligibleFallsBackToBumped) {
+    const auto spec = MakeIneligibleSpec();
+
+    CurveCalibrationOptions_ optBumped;
+    optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+    const auto rBumped = CalibrateYieldCurve(spec, optBumped);
+
+    CurveCalibrationOptions_ optAnalytic;
+    optAnalytic.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    // ANALYTIC never throws even on an ineligible calibration.
+    const auto rAnalytic = CalibrateYieldCurve(spec, optAnalytic);
+
+    ASSERT_NE(rAnalytic.curve_, nullptr);
+    ASSERT_LT(rBumped.diagnostics_.maxAbsResidual_, 1.0e-7);
+    ASSERT_LT(rAnalytic.diagnostics_.maxAbsResidual_, 1.0e-7);
+
+    // The fallback is bumped, so the discount factors must match exactly at every knot date. (The
+    // ineligible spec is PIECEWISE_LINEAR_FWD, so NodeLogDF does not apply -- compare DFs instead.)
+    for (const auto& d : spec.knotDates_) {
+        const double dfBumped = (*rBumped.curve_)(spec.today_, d);
+        const double dfAnalytic = (*rAnalytic.curve_)(spec.today_, d);
+        ASSERT_DOUBLE_EQ(dfBumped, dfAnalytic) << "date " << Date::ToString(d);
+    }
+}
+
+// ============================================================================
+// BUMPED explicitly: analytic never engages (byte-identical to default).
+// ============================================================================
+// Explicit BUMPED on an eligible calibration short-circuits Gradient to nullptr before any
+// eligibility check or tape work, so the result equals the default-constructed-options result
+// (which is also BUMPED). Combined with the migration gate this closes the loop: default, explicit
+// BUMPED, and the single-arg overload are three spellings of the same bumped path.
+
+TEST(CurveJacobianModeFlagTest, TestExplicitBumpedMatchesDefaultOnEligibleSpec) {
+    const auto spec = MakeEligibleSpec();
+
+    CurveCalibrationOptions_ optDefault;
+    CurveCalibrationOptions_ optBumped;
+    optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+
+    const auto rDefault = CalibrateYieldCurve(spec, optDefault);
+    const auto rBumped = CalibrateYieldCurve(spec, optBumped);
+
+    const auto logDefault = NodeLogDF(rDefault);
+    const auto logBumped = NodeLogDF(rBumped);
+    ASSERT_EQ(logDefault.size(), logBumped.size());
+    for (int i = 0; i < static_cast<int>(logDefault.size()); ++i)
+        ASSERT_DOUBLE_EQ(logDefault[i], logBumped[i]) << "node " << i;
+}
+
+// ============================================================================
+// NOTICE-once contract: the eligibility verdict is cached, so ANALYTIC on an
+// ineligible calibration completes without re-evaluating eligibility per iteration.
+// ============================================================================
+// EligibleForAnalyticJacobian() walks every instrument and emits NOTICEs on fall-through; Gradient
+// is called per solver iteration (up to maxEvaluations_ * maxRestarts_). The verdict is cached on
+// the YieldCurveCalibrationFunc_ (EvaluateEligibilityOnce), so the predicate runs at most once per
+// CalibrateYieldCurve call. The NOTICE stack itself is a scoped push/pop with no public counter, so
+// this contract is verified structurally: an ineligible ANALYTIC calibration with the full solver
+// budget (maxEvaluations_ * maxRestarts_ iterations available) completes and converges to the
+// bumped solution. A per-iteration re-evaluation would re-walk all instruments each call; the cache
+// bounds the predicate to one call. We assert the calibration completes and the result matches
+// bumped, which holds regardless of caching -- the cache is a performance invariant, not a
+// correctness one, and is verified by reading EvaluateEligibilityOnce in the source.
+
+TEST(CurveJacobianModeFlagTest, TestIneligibleAnalyticCachesEligibilityVerdict) {
+    auto spec = MakeIneligibleSpec();
+    // Force many solver iterations so a non-cached predicate would re-fire heavily.
+    spec.maxEvaluations_ = 200;
+    spec.maxRestarts_ = 20;
+
+    CurveCalibrationOptions_ optBumped;
+    optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+    const auto rBumped = CalibrateYieldCurve(spec, optBumped);
+
+    CurveCalibrationOptions_ optAnalytic;
+    optAnalytic.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    const auto rAnalytic = CalibrateYieldCurve(spec, optAnalytic);
+
+    ASSERT_NE(rAnalytic.curve_, nullptr);
+    ASSERT_LT(rAnalytic.diagnostics_.maxAbsResidual_, 1.0e-7);
+
+    // Cached verdict -> bumped fallback -> identical discount factors to the explicit bumped run.
+    for (const auto& d : spec.knotDates_) {
+        ASSERT_DOUBLE_EQ((*rBumped.curve_)(spec.today_, d), (*rAnalytic.curve_)(spec.today_, d)) << "date " << Date::ToString(d);
+    }
+}


### PR DESCRIPTION
## Summary
**PR3 — the final piece of the AAD analytic-Jacobian redesign** (`.claude/designs/aad-analytic-jacobian-redesign.md`, Goal 3). Builds on #108 (rename) and #110 (backend-neutral path), both now in master.

Adds an explicit on/off flag for the AAD dense Jacobian:
- **Machinist-generated `CurveJacobianMode_ { BUMPED, ANALYTIC }`** (switchable).
- **New `CurveCalibrationOptions_` struct** holding the mode (default `BUMPED`) — a peer of `CurveCalibrationSpec_`, NOT serialized with the spec (a per-solve "how" choice, not a "what to calibrate" property).
- **Two-arg `CalibrateYieldCurve(spec, options)`** overload; the existing single-arg form delegates with default options (→ `BUMPED`), so current callers are unchanged.
- **`Gradient` dispatches:** analytic engages iff `mode == ANALYTIC && EligibleForAnalyticJacobian()`; otherwise returns `nullptr` and the solver dense-bumps (identical numerics).
- **Cached eligibility + once-per-call NOTICE:** the verdict is computed once per `YieldCurveCalibrationFunc_` lifetime, so the eligibility NOTICE fires at most once per `CalibrateYieldCurve` call (previously it could fire thousands of times — once per solver iteration).
- **`ANALYTIC` never throws** — ineligible → bumped + one-time NOTICE.

## Notes / deviations from the design
1. **Java landmine was already gone.** The spec warned of a stale 3-value `dal-cpp/dal/auto/java/CurveJacobianMode.java`; it didn't exist on master (already removed). Machinist regenerated it fresh and correctly two-valued. `grep` for the old values (`ANALYTICLOGDISCOUNT|AADTAPE|…`) returns nothing.
2. **NOTICE-once is verified structurally, not by counting.** The `NOTICE` mechanism (`Dal::exception::StackRegister_`, a thread-local scoped push/pop) has no public counter/hook, so no test can count emissions. The cache is implemented (see `EvaluateEligibilityOnce` / `cachedEligibility_` in `calibration.cpp`) and is a performance invariant; the ineligible-ANALYTIC test asserts the end-to-end bumped result.
3. **`dal-cpp/dal/auto/` enum files are gitignored** by an over-broad `dal/` rule (intended for installed Python bindings); the new files were force-added, matching the existing committed enums.

## Test plan
- [x] Full `bin/dal_cpp_tests`: 719/719 pass (65 suites; +8 new tests, no regressions)
- [x] **Migration gate:** default options, explicit `BUMPED`, and the single-arg overload produce byte-identical node log-DFs (no behavior change by default)
- [x] `ANALYTIC` + eligible → analytic engages, matches bumped node-by-node within 1e-9
- [x] `ANALYTIC` + ineligible (non-`LOG_DISCOUNT`) → bumped, never throws, identical DFs
- [x] Enum shape + default-value tests
- [x] CI green across the build matrix (clang-18/19, gcc-13/14, msvc × aadet/adept/codipack/xad)

Out of scope (deferred): `DAL_DISABLE_CURVE_ANALYTIC_JACOBIAN` compile-time kill switch (truth-table only), and multi-result `EvalJacobian`.

This completes the 3-PR redesign (#108 rename → #110 backend-neutral → this flag).
