### PR TITLE
docs: add interpolation/log-DF docs and calibration examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,8 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Yield Curve Construction** — [Yield curve construction](docs/methodology/yield_curve.md)
 - **Underdetermined Search** — [Underdetermined search](docs/methodology/underdetermined_search.md)
 - **Cross-Currency Calibration** — [Cross-currency calibration](docs/methodology/xccy_calibration.md)
+- **Interpolation** — [Interpolation](docs/methodology/interpolation.md)
+- **Log-Discount Curve** — [Log-discount curve](docs/methodology/log_discount_curve.md)
 
 Notable fundamental changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,13 +43,26 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - Multi-instrument term structure calibration
   - Integration with the underdetermined solver
 
+- **[interpolation.md](methodology/interpolation.md)** — Interpolation
+  - Linear, log-linear, cubic-spline, and mixed one-dimensional interpolators
+  - Cubic boundary conditions (`Boundary_` order/value)
+  - Bilinear (2D) interpolation on a rectilinear grid
+  - Selection guidance and where each scheme is used
+
+- **[log_discount_curve.md](methodology/log_discount_curve.md)** — Log-Discount Curve
+  - Node log-discount-factor representation and anchor convention
+  - `LogDfScheme_` interpolation schemes (`LOG_LINEAR`, `LOG_CUBIC_NATURAL`, `MIXED`)
+  - Why `LOG_DISCOUNT` is the parameterization that supports the analytic Jacobian
+
 ### Experimental (`experimental/`)
 
 Notes on capabilities that are working but not yet promoted to normative methodology. These
 may change shape before becoming methodology docs:
 
 - **[aad-analytic-jacobian-curve-calibration.md](experimental/aad-analytic-jacobian-curve-calibration.md)**
-  — Analytic Jacobian mode for yield-curve calibration (the `CurveJacobianMode` flag).
+  — AAD-derived analytic Jacobian for yield-curve calibration, gated by the runtime
+  `CurveJacobianMode_` flag (`BUMPED` default / `ANALYTIC` opt-in) on
+  `CurveCalibrationOptions_`. Backend-neutral across all four AAD backends.
 - **[replicate-ptirds-single-currency-curve.md](experimental/replicate-ptirds-single-currency-curve.md)**
   — Replication study for single-currency-curve PTI ratchet/digital swaps.
 

--- a/docs/experimental/aad-analytic-jacobian-curve-calibration.md
+++ b/docs/experimental/aad-analytic-jacobian-curve-calibration.md
@@ -1,69 +1,116 @@
-# Plan — AAD Analytic Jacobian for Curve Calibration
+# AAD Analytic Jacobian for Curve Calibration
 
-> Status: experimental / proposal. This is an optional enhancement extracted from
+> Status: experimental enhancement, shipped and runtime-opt-in. This note was originally
+> a plan extracted from
 > [`replicate-ptirds-single-currency-curve.md`](replicate-ptirds-single-currency-curve.md)
-> (§3.5 and Phase 6), where it appears as a follow-on phase. This document promotes it
-> to a standalone, self-contained plan.
+> (§3.5 and Phase 6). The implementation went through several revisions; the
+> **Current state** section below is authoritative and the historical plan is preserved
+> further down for context.
 
-## Resolution adopted (Phase A — native-AAD templatization, implemented 2026-06)
+## Current state (2026-06)
+
+The curve-calibration residual function overrides
+`Underdetermined::Function_::Gradient` (`dal-cpp/dal/curve/calibration.cpp`) with an
+AAD-derived analytic Jacobian. It is **off by default** and engaged by a runtime flag.
+
+**Runtime flag.** `CurveJacobianMode_` is a Machinist-generated switchable enumeration
+defined in `dal-cpp/dal/curve/calibration.hpp` with two values:
+
+- `CurveJacobianMode_::Value_::BUMPED` (default) — finite-difference bumping of each free
+  node, byte-for-byte identical to the pre-analytic path. Always available.
+- `CurveJacobianMode_::Value_::ANALYTIC` — the AAD-derived dense Jacobian. Best-effort:
+  engages only when `EligibleForAnalyticJacobian()` is true, otherwise falls back to
+  `BUMPED` with a `NOTICE`. `ANALYTIC` never throws.
+
+The flag lives on `CurveCalibrationOptions_` — a struct deliberately kept **separate**
+from the serialized `CurveCalibrationSpec_`, because the spec describes *what* to
+calibrate and the options describe *how* to solve. The default-constructed options
+reproduce the pre-analytic bumped path byte-for-byte, so existing callers see no change
+unless they opt in:
+
+```cpp
+CurveCalibrationOptions_ opt;
+opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+CalibrateYieldCurve(spec, opt);
+```
+
+**Eligibility.** `EligibleForAnalyticJacobian()` admits a calibration only when **all** of
+the following hold (each failing condition emits a `NOTICE` naming it, then the path falls
+back to `BUMPED`):
+
+- `parameterization_ == CurveParameterization_::Value_::LOG_DISCOUNT` — the independents
+  are the free-node `log(DF)` values, so the Jacobian is taken w.r.t. log-discount nodes;
+- the calibration targets the **discount** curve (`calibrateDiscountCurve_`), not a
+  forecast/projection curve;
+- `forecast == discount` (no separate forecast curve layered in);
+- every instrument is a vanilla `Deposit_`, `FRA_`, `Future_`, or `Swap_` (instruments
+  without a templated rate, e.g. `BasisSwap_`, are rejected);
+- every instrument's **trade date** equals the curve anchor (`knotDates_.front()`).
+
+The trade-date check uses the pure-virtual `YCInstrument_::TradeDate()` accessor, not the
+instrument's effective/spot `start_`. A spot-started instrument has `tradeDate` strictly
+before its `start_` (the typical spot-lag gap); checking `start_` instead would admit
+spot-started instruments and silently misprice their residual rows on the tape.
+
+The eligibility verdict is evaluated once per `CalibrateYieldCurve` call and cached, so
+the `NOTICE`s fire at most once even though `Gradient` is invoked per solver iteration.
+
+**Backend neutrality.** The analytic path runs unchanged under **all four** AAD backends
+(native, XAD, CoDiPack, Adept). It goes through the `Dal::AAD` facade primitives
+(`RegisterIndependent`, `NewRecording`, `ZeroAdjoints`, `Adjoint`,
+`PropagateToStart`) rather than any backend-specific API, and there is no longer a
+compile-time backend `#if` gate around it in `dal-cpp/dal/curve/calibration.cpp`. The
+recording contract that works on every backend is
+`Clear(*Tape())` → `RegisterIndependent` → `NewRecording` → forward → per-row
+`ZeroAdjoints`/seed/`PropagateToStart`.
+
+**Mechanics.** `YieldCurveCalibrationFunc_::AnalyticJacobian` registers the free-node
+`log(DF)` values as independents (the anchor node 0 is pinned at `0` and deliberately
+*not* registered, so the solver's `x` has `nNodes - 1` entries), builds a
+`Tape::DiscountCurve_<Number_>` via `BuildDiscountCurveT<Number_>`, computes
+`Number_`-typed residuals with `PhaseARateAt<Number_>()`, and runs one reverse sweep per
+residual row to harvest `∂residual_i / ∂node_j` into a dense `XCurveJacobian_`. Assembly
+is sparse by row — AAD produces exact structural zeros at nodes an instrument does not
+touch. The multi-result fast path (one sweep for all rows) is a profiling-driven
+follow-up; the single-result loop is what ships today.
+
+**Files.** `dal-cpp/dal/curve/{yclogdf,ycinstrument,ycctx,calibration}.{hpp,cpp}`. The
+`TestOnly::AnalyticJacobianAt(spec, x)` helper in `calibration.cpp` exposes the dense
+Jacobian for unit-test inspection (not part of the stable public API).
+
+**Tests.** `dal-cpp/tests/curve/test_analytic_jacobian.cpp` (suite `AnalyticJacobianTest`)
+runs on every backend: central-difference agreement across all three `LogDfScheme_`
+values (`LOG_LINEAR`, `LOG_CUBIC_NATURAL`, `MIXED`), exact structural zeros, solve
+convergence, per-instrument-type canaries (Deposit/FRA/Future/Swap), tape isolation
+across calls, and the eligibility regressions (non-`LOG_DISCOUNT`, forecast-target,
+`tradeDate != start`). The flag's own behaviour (default == `BUMPED`, eligible
+`ANALYTIC` matches `BUMPED`, ineligible `ANALYTIC` falls back, eligibility is cached) is
+covered by `dal-cpp/tests/curve/test_curve_jacobian_mode{,_flag}.cpp`.
+
+## How this design was reached
 
 After critic and api-designer review, two designs were on the table:
 
-- **Phase A** — templatize the curve rebuild + repricing on `Dal::AAD::Number_` so the
-  native AAD tape produces exact adjoints, and override `Function_::Gradient` to harvest
-  them. Originally scoped as the heaviest of three phases.
-- **Counter-Proposal CP1** — an analytic chain-rule Jacobian computed in plain `double`
-  (`InterpBasisWeights`, `DRateDDiscount`, a `CurveJacobianMode_` enum), with NO
-  templatization and NO `Number_` tape. Proposed as a lighter fallback if Phase A turned
-  out infeasible.
+- **Templatize the curve rebuild + repricing on `Dal::AAD::Number_`** so the AAD tape
+  produces exact adjoints, and override `Function_::Gradient` to harvest them. This is
+  the path that shipped.
+- **A plain-`double` chain-rule Jacobian** (`InterpBasisWeights`, `DRateDDiscount`) with
+  no templatization and no `Number_` tape, proposed as a lighter fallback.
 
-**Phase A was adopted.** The templatization turned out to be tractable: the pricing path
-was generalized on the scalar type via a parallel `Dal::Tape` namespace
-(`Tape::DiscountCurve_<T_>`, `Tape::Rate_<T_>`, and `PrecomputeT<T_>()` factories on
-`Deposit_`/`FRA_`/`Future_`/`Swap_`), so a single `Number_`-typed recording yields the
-exact residual sensitivities in one reverse sweep per row — no bump noise, exact curve
-risk. CP1 was **explored then dropped** (commit `2b2de93`): with Phase A delivering exact
-adjoints straight from the tape, the plain-`double` chain-rule machinery
-(`InterpBasisWeights`, `DRateDDiscount`, and the `CurveJacobianMode_` opt-in enum) was
-redundant and was removed. No CP1 symbols remain under `dal-cpp/dal/curve/` (verified
-by grep).
+The templatization was tractable: the pricing path was generalized on the scalar type via
+a parallel `Dal::Tape` namespace (`Tape::DiscountCurve_<T_>`, `Tape::Rate_<T_>`, and
+`PrecomputeT<T_>()` / `PhaseARateAt<T_>()` factories on `Deposit_`/`FRA_`/`Future_`/`Swap_`),
+so a single `Number_`-typed recording yields the exact residual sensitivities. The
+plain-`double` chain-rule machinery was explored then dropped as redundant
+(commit `2b2de93`).
 
-**Scope and gating.** The Phase A Jacobian ships for
-`CurveParameterization_::LOG_DISCOUNT` only; other parameterizations, FORECAST-target
-calibrations, projection-curve instruments, instruments without a templated rate
-(`BasisSwap_`), and — critically — any instrument whose **trade date** differs from the
-curve anchor, make `EligibleForPhaseA` return false, `Gradient` returns `nullptr`, and the
-solver dense-bumps. A `NOTICE` is emitted per fall-through. The whole path is compiled
-only under the native AAD backend, gated by:
+A runtime on/off selector was subsequently re-introduced as the `CurveJacobianMode_`
+flag (PR #111) so callers can A/B the analytic path against the bumped path and so the
+default build is unchanged. The earlier `Phase A` symbol naming was renamed to
+`AnalyticJacobian` / `EligibleForAnalyticJacobian` (PR #108) — `Phase A` survives only as
+legacy source comments.
 
-```cpp
-#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
-```
-
-(`dal-cpp/dal/curve/calibration.cpp`). The native backend is the default;
-`CMakePresets.json` disables XAD/CodiPack/Adept, so the Phase A path compiles in the
-standard build. Under a third-party backend the override is absent and `Gradient` falls
-back to the base class's bumped path.
-
-**Eligibility checks the trade date, not the start.** Phase A's templated rates read
-`DF(tradeDate_, p)` (see `dal-cpp/dal/curve/ycinstrument.cpp`), so the gate compares
-`inst->TradeDate()` against `knotDates_.front()`. A spot-started instrument has
-`tradeDate` strictly before its effective/spot `start_` (the typical `spotLag` gap); the
-original gate mistakenly checked `TimeSpan().first` (== `start_`), which admitted
-spot-started instruments and silently mispriced their residual rows on the tape. The
-`YCInstrument_::TradeDate()` pure-virtual accessor (overridden on every concrete
-instrument) fixes this.
-
-**Implementation.** `dal-cpp/dal/curve/{yclogdf,ycinstrument,calibration}.{hpp,cpp}`;
-the `TestOnly::AnalyticJacobianAt` helper in `calibration.cpp` exposes the dense
-`XCurveJacobian_` for unit tests. Verified by
-`dal-cpp/tests/curve/test_phase_a_jacobian.cpp` (suite `PhaseAAADJacobianTest`, 12 tests):
-central-difference agreement across all three `LogDfScheme_` values, exact structural
-zeros, solve convergence, per-instrument-type canaries (Deposit/FRA/Future/Swap), tape
-isolation across calls, and the eligibility regressions (non-LOG_DISCOUNT,
-FORECAST-target, `tradeDate != start`).
-
-The original Phase A/B/C plan is preserved below as the adopted design.
+The original Phase A/B/C plan is preserved below as historical context.
 
 
 ## 1. Motivation
@@ -121,19 +168,21 @@ exactly in one reverse sweep — fewer iterations, no bump noise, exact curve ri
 - `YieldCurveCalibrationFunc_::Gradient` overrides the base bumped path
   (`dal-cpp/dal/math/optimization/underdetermined.cpp`). It records the residual vector
   as functions of the node `log(DF)` independents on the tape, runs one reverse sweep
-  per row (`PhaseAJacobian_NativeAAD`), and writes the resulting
+  per row (`AnalyticJacobian`), and writes the resulting
   `∂residual_i / ∂node_j` into a dense `XCurveJacobian_` (storage dense, assembly
   sparse-by-row because AAD produces exact structural zeros).
 - Sparsity is automatic: AAD yields exact zeros at nodes an instrument does not touch.
 
-### Phase C — Selection (shipped as compile-time + eligibility gating, not a runtime enum)
-- The analytic path is gated at compile time by the native-backend macro
-  (`#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)`)
-  and at runtime by `EligibleForPhaseA` (LOG_DISCOUNT only, discount-target, no projection
-  curve, supported instrument type, and `TradeDate() == knotDates_.front()`). Anything
-  ineligible returns `nullptr` from `Gradient`, and the solver dense-bumps unchanged.
-- The originally-proposed runtime `CurveJacobianMode_` opt-in enum was part of CP1 and
-  was dropped with it (commit `2b2de93`); there is no runtime selector.
+### Phase C — Selection (shipped as a runtime flag + eligibility gating)
+- The analytic path is gated at runtime by the `CurveJacobianMode_` flag
+  (`CurveCalibrationOptions_::jacobianMode_`, default `BUMPED`) and, when `ANALYTIC` is
+  selected, by `EligibleForAnalyticJacobian()` (LOG_DISCOUNT only, discount-target, no
+  projection curve, supported instrument type, and `TradeDate() == knotDates_.front()`).
+  An ineligible calibration emits a `NOTICE` and the solver dense-bumps unchanged. See
+  the **Current state** section above for the full contract.
+- The flag is backend-neutral: there is no compile-time backend `#if` gate around the
+  analytic path in `dal-cpp/dal/curve/calibration.cpp`; it runs on native, XAD, CoDiPack,
+  and Adept via the `Dal::AAD` facade.
 
 ## 5. Tests
 

--- a/docs/methodology/interpolation.md
+++ b/docs/methodology/interpolation.md
@@ -1,0 +1,140 @@
+# Interpolation
+
+This note describes the one- and two-dimensional interpolators exposed by the
+`Dal::Interp` namespace (`dal-cpp/dal/math/interp/`). The focus is the mathematical
+definition of each scheme, the boundary conditions it accepts, and where in the library
+each is used. All one-dimensional interpolators inherit from `Interp1_` and are constructed
+through factory functions rather than directly.
+
+## Common Interface
+
+Every one-dimensional interpolator is a `Storable_` subclass of `Interp1_`
+(`dal-cpp/dal/math/interp/interp.hpp`) with
+
+$$
+\texttt{double operator()(double x) const}, \qquad \texttt{bool IsInBounds(double x) const}.
+$$
+
+The abscissae $x_1 < x_2 < \dots < x_N$ must be strictly increasing (`IsMonotonic` is
+checked at construction). Evaluation is by `LowerBound` on the knot vector followed by a
+scheme-specific local formula; values exactly at a knot return the knot's $f$ value
+without rounding error. The shared linear kernel used internally is
+
+$$
+f(x) = f_i + \frac{x - x_i}{x_{i+1} - x_i}\,(f_{i+1} - f_i), \qquad x \in [x_i, x_{i+1}],
+$$
+
+implemented by `InterpLinearImplX` in `dal-cpp/dal/math/interp/interp.hpp`.
+
+| Scheme                         | Factory                          | Header                                                  |
+|--------------------------------|----------------------------------|---------------------------------------------------------|
+| Linear                         | `Interp::NewLinear`              | `dal-cpp/dal/math/interp/interplinear.hpp`              |
+| Log-linear                     | `Interp::NewLogLinear`           | `dal-cpp/dal/math/interp/interploglinear.hpp`           |
+| Cubic spline                   | `Interp::NewCubic`               | `dal-cpp/dal/math/interp/interpcubic.hpp`               |
+| Mixed log-DF (cubic + linear)  | `NewMixedLogDF`                  | `dal-cpp/dal/math/interp/interpmixed.hpp`               |
+| Bilinear (2D)                  | `Interp::NewLinear2`             | `dal-cpp/dal/math/interp/interp2d.hpp`                  |
+
+## Linear
+
+Piecewise-linear interpolation between knots — the kernel above. It is exact at knots,
+continuous, and first-order accurate between them. `IsInBounds` returns true on
+$[x_1, x_N]$; outside that range the kernel clamps to the nearest endpoint value (flat
+extrapolation via the `LowerBound` edge cases).
+
+Factory: `Interp::NewLinear(name, x, f)` (`dal-cpp/dal/math/interp/interplinear.hpp`).
+Requires $N \ge 2$.
+
+## Log-Linear
+
+Interpolates linearly in $\ln f$ rather than in $f$:
+
+$$
+f(x) = \exp\!\left( \ln f_i + \frac{x - x_i}{x_{i+1} - x_i}\,(\ln f_{i+1} - \ln f_i) \right).
+$$
+
+This is the natural choice for strictly positive quantities that scale geometrically with
+the abscissa — discount factors, forward rates, volatilities — because it preserves
+positivity exactly: a convex combination of logs can never produce a negative value.
+
+Factory: `Interp::NewLogLinear(name, x, f)` (`dal-cpp/dal/math/interp/interploglinear.hpp`).
+Requires $N \ge 2$ and **every $f_i > 0$** (checked at construction). This scheme is the
+default for the `LOG_DISCOUNT` curve parameterization — see
+[Log-discount curve](log_discount_curve.md).
+
+## Cubic Spline
+
+A natural cubic spline through the knots: a piecewise-cubic polynomial on each
+$[x_i, x_{i+1}]$ that is $C^2$ continuous, with second derivatives $f''_i$ at the knots
+solved once at construction by the standard tri-diagonal elimination (the routine is based
+on the *Numerical Recipes* `spline`/`splint` pair). Evaluation between knots uses the local
+Hermite form
+
+$$
+f(x) = a\,f_i + b\,f_{i+1} - \tfrac{h^2}{6}\Big((1+a)a\,f''_i + (1+b)b\,f''_{i+1}\Big),
+$$
+
+with $h = x_{i+1}-x_i$, $b = (x-x_i)/h$, $a = 1-b$.
+
+The two end conditions are supplied as a `Boundary_(order, value)` pair, where `order`
+selects which derivative is pinned at the boundary:
+
+| `order_` | Boundary condition                              |
+|----------|-------------------------------------------------|
+| 1        | first derivative $f'(x_1) = $ `value_`          |
+| 2        | second derivative $f''(x_1) = $ `value_`        |
+| 3        | third derivative fixed (not-a-knot family)      |
+
+`Boundary_(2, 0.0)` on both ends gives the classic natural spline (zero end curvature).
+
+Factory: `Interp::NewCubic(name, x, f, lhs, rhs)` (`dal-cpp/dal/math/interp/interpcubic.hpp`).
+Requires $N > 2$ and strictly increasing $x$. `IsInBounds` forbids extrapolation.
+
+## Mixed Log-DF
+
+A composite scheme used by the log-discount curve to combine a smooth cubic core with a
+linear tail. The abscissa is the year fraction and the ordinate is $\ln P$. The curve is
+cubic (with configurable `Boundary_` conditions on each side) out to a cutoff year
+fraction `cutoffYf_` and linear in $\ln P$ beyond it. This gives the smoothness of a spline
+where the term structure is data-rich and the robustness of log-linear extrapolation at the
+long end, where knots are sparse and a spline would oscillate.
+
+Factory: `NewMixedLogDF(name, yf, logDF, spec)` where `spec` is a `MixedSchemeSpec_`
+carrying `cutoffYf_` and the two cubic `Boundary_` conditions
+(`dal-cpp/dal/math/interp/interpmixed.hpp`). This scheme backs the `MIXED` value of
+`LogDfScheme_` — see [Log-discount curve](log_discount_curve.md).
+
+## Bilinear (2D)
+
+Tensor-product linear interpolation on a rectilinear grid: linear in $x$ along each row,
+then linear in $y$ across the two bracketing rows,
+
+$$
+f(x, y) = (1-t)\,f(x, y_{\text{lo}}) + t\,f(x, y_{\text{hi}}), \qquad
+t = \frac{y - y_{\text{lo}}}{y_{\text{hi}} - y_{\text{lo}}},
+$$
+
+with the per-row $f(x, y_{\text{lo}})$ and $f(x, y_{\text{hi}})$ obtained by the same
+linear kernel as the 1D case. It is implemented by `Interp2Linear_` and constructed through
+`Interp::NewLinear2(name, x, y, f)` where `f` is a row-major `Matrix_<>` of shape
+$(N_x, N_y)$ (`dal-cpp/dal/math/interp/interp2d.hpp`).
+
+## Selection Guidance
+
+- Use **linear** for noisy or sparse data where higher-order smoothness would amplify
+  noise, and for piecewise-linear forwards in calibration (see
+  [Yield curve construction](yield_curve.md)).
+- Use **log-linear** for any strictly positive, geometrically-scaling quantity — discount
+  factors and forward rates are the canonical cases.
+- Use **cubic** when $C^2$ smoothness matters (e.g. second-derivative-dependent risk) and
+  the data is dense enough to support it; pick end conditions deliberately.
+- Use **mixed log-DF** for the long end of a discount curve, where a pure spline would
+  oscillate.
+- Use **bilinear** for surfaces quoted on a regular grid (e.g. option volatility by
+  expiry and strike).
+
+## See Also
+
+- [Log-discount curve](log_discount_curve.md) — uses log-linear, cubic, and mixed
+  interpolation on $\ln P$ as its `LogDfScheme_` parameterization.
+- [Yield curve construction](yield_curve.md) — the piecewise-linear and
+  piecewise-constant forward parameterizations are built on the linear kernel.

--- a/docs/methodology/log_discount_curve.md
+++ b/docs/methodology/log_discount_curve.md
@@ -1,0 +1,105 @@
+# Log-Discount Curve
+
+This note describes the `LOG_DISCOUNT` curve parameterization: how a discount curve is
+represented as a set of node log-discount-factors, how it is interpolated, and why it is
+the parameterization on which the analytic Jacobian for calibration is built. It ties
+together [Yield curve construction](yield_curve.md) and
+[Interpolation](interpolation.md).
+
+## Representation
+
+A `LOG_DISCOUNT` curve stores the discount curve at a fixed set of **node dates**
+$t_0 < t_1 < \dots < t_{N-1}$ as the **log discount factors** relative to the anchor
+$t_0$,
+
+$$
+\ell_i \equiv \ln P(t_0, t_i), \qquad \ell_0 = \ln P(t_0,t_0) = 0.
+$$
+
+The anchor node is pinned at $\ell_0 = 0$ (today's discount factor is 1), so the curve
+has $N-1$ free parameters — the quantities the calibration solver drives. Between nodes
+the log discount factor is obtained by interpolation in the year-fraction abscissa
+$\tau = \mathrm{YearFrac}(t_0, t;\,\text{dayCount})$, and the discount factor itself is
+
+$$
+P(t_0, t) = \exp\!\big( \ell(\tau) \big).
+$$
+
+Because the parameter is $\ell = \ln P$ rather than $P$ or the forward rate, every
+interpolated discount factor is strictly positive by construction — the exponential can
+never cross zero — which makes the curve numerically robust to bump during calibration.
+The implementation is `Tape::DiscountLogDF_<T_>` (alias `DiscountLogDF_` for `T_ = double`),
+declared in `dal-cpp/dal/curve/yclogdf.hpp` and constructed via the
+`NewDiscountLogDF(...)` factory.
+
+## Interpolation Schemes: `LogDfScheme_`
+
+The shape of $\ell(\tau)$ between nodes is selected by the `LogDfScheme_` enumeration
+(`dal-cpp/dal/curve/logdfscheme.hpp`), carried on the calibration spec as
+`CurveCalibrationSpec_::logDfScheme_` (default `LOG_LINEAR`). Each scheme is a concrete
+interpolator from [Interpolation](interpolation.md) applied to the $(\tau_i, \ell_i)$
+knots:
+
+| `LogDfScheme_`        | Interpolator on $\ell(\tau)$                         | Properties                                                       |
+|-----------------------|------------------------------------------------------|------------------------------------------------------------------|
+| `LOG_LINEAR`          | linear in $\ell$ (i.e. log-linear in $P$)            | $C^0$, positivity-preserving, cheapest; default                  |
+| `LOG_CUBIC_NATURAL`   | natural cubic spline in $\ell$ (`Boundary_(2, 0.0)`) | $C^2$ smooth, curved between knots                               |
+| `MIXED`               | cubic to a cutoff year fraction, linear beyond       | spline smoothness at the short end, log-linear tail at long end  |
+
+The mapping lives in `BuildLogDfInterpFromYf` in `dal-cpp/dal/curve/yclogdf.cpp`.
+
+- **`LOG_LINEAR`** is the cheapest and most robust scheme; linear interpolation of $\ell$
+  is exactly log-linear interpolation of $P$ and is the default.
+- **`LOG_CUBIC_NATURAL`** fits a natural cubic spline (zero end curvature,
+  `Boundary_(2, 0.0)` on both sides) through the knot $\ell$ values, giving a $C^2$ curve.
+  Smoothness is valuable when second-derivative-dependent risk is computed off the curve.
+- **`MIXED`** uses a cubic spline out to a cutoff year fraction and log-linear beyond it,
+  combining spline smoothness where the term structure is data-rich with the robustness
+  of log-linear extrapolation at the long end (where knots are sparse and a spline would
+  oscillate). The cutoff is placed at the $(N-4)$-th knot so that the cubic tail retains
+  at least three knots; the two cubic `Boundary_` conditions default to natural
+  (`MixedSchemeSpec_`, `dal-cpp/dal/math/interp/interpmixed.hpp`).
+
+## Why Log-Discount is the Analytic-Jacobian Parameterization
+
+The analytic Jacobian shipped for curve calibration (see
+[AAD analytic Jacobian](../experimental/aad-analytic-jacobian-curve-calibration.md))
+is scoped to `LOG_DISCOUNT`. The reason is mechanical. The calibration residuals are
+smooth functions of the node $\ell_i$ through the pricing machinery, so when the node
+$\ell_i$ are placed on the AAD tape as independents the per-residual adjoints produced by
+one reverse sweep per row are exactly the Jacobian entries
+$\partial r_j / \partial \ell_i$ — no bump noise, exact structural zeros at nodes an
+instrument does not touch. Because the anchor $\ell_0$ is pinned at zero, the solver's $x$
+has exactly $N-1$ entries and matches the free-node count.
+
+The `Tape::DiscountLogDF_<Number_>` specialization routes its log-DF evaluation through
+basis weights (one per interpolation scheme) rather than the `Interp1_` handle, so the
+tape records the dependence of every queried $\ell(\tau)$ on the node $\ell_i$ values
+directly. The same machinery supports all three schemes; eligibility for the analytic path
+is independent of which `LogDfScheme_` is chosen.
+
+## Relationship to the Forward-Rate Parameterizations
+
+The [yield curve methodology](yield_curve.md) describes the curve through the
+instantaneous forward rate $f(t)$, parameterized as piecewise-constant or piecewise-linear
+across knots. `LOG_DISCOUNT` is an alternative parameterization of the *same* underlying
+discount curve: the node $\ell_i$ are the cumulative integrals of the forward rate up to
+each node,
+
+$$
+\ell_i = -\tfrac{1}{365}\int_{t_0}^{t_i} f(t)\,dt,
+$$
+
+and interpolation in $\ell$ induces a particular between-node shape of $f$. The three views
+(forward rate, node $\ell$, node $P$) are equivalent descriptions of one curve object;
+`LOG_DISCOUNT` is preferred when analytic risk is wanted because its parameter is the
+natural input to the AAD tape.
+
+## See Also
+
+- [Interpolation](interpolation.md) — the linear, log-linear, cubic, and mixed
+  interpolators that `LogDfScheme_` selects between.
+- [Yield curve construction](yield_curve.md) — the forward-rate parameterizations and the
+  calibration pipeline this curve plugs into.
+- [AAD analytic Jacobian](../experimental/aad-analytic-jacobian-curve-calibration.md) —
+  the calibration enhancement scoped to this parameterization.

--- a/docs/methodology/xccy_calibration.md
+++ b/docs/methodology/xccy_calibration.md
@@ -118,6 +118,170 @@ diagnostics (per-instrument residuals, RMS and maximum absolute error) quantify 
 fit, and the retained effective Jacobian inverse maps quote bumps to basis-rate
 changes for sensitivity analysis without re-solving.
 
+## Examples
+
+The snippets below are condensed from
+`dal-cpp/examples/xccy_curve_calibration/xccy_curve_calibration.cpp` and adapt
+its real call sequence. They show the public surface declared in
+`dal-cpp/dal/curve/xccycalibration.hpp` and `dal-cpp/dal/curve/xccyinstrument.hpp`.
+Class and enum names, factory functions, struct fields, and include paths match
+the current source; see the citations in each example.
+
+### Two-currency market, collateral assumption, and basis calibration
+
+The example builds two single-currency curve blocks (domestic USD, foreign EUR),
+quotes cross-currency swaps from a synthetic basis-bearing market to obtain
+realistic par spreads, then re-calibrates a basis curve from those spreads.
+Collateral/discounting is OIS in both currencies; the
+`fxForwardCollateral_` field on the spec pins which collateral curve drives the
+FX-forward computation.
+
+```cpp
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/xccycalibration.hpp>
+#include <dal/curve/ycimp.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/protocol/rateconvention.hpp>
+
+using namespace Dal;
+
+const Date_ today(2024, 1, 15);
+
+// Flat domestic (USD) and foreign (EUR) curve blocks. In production these are the
+// pre-calibrated OIS + tenor-forecast blocks from the single-currency side.
+auto usdBlock = Handle_<CurveBlock_>(
+    new CurveBlock_(Handle_<DiscountCurve_>(
+        NewDiscountPWLF("usd_ois", "USD", MakeFlat("USD", today, 0.02))));
+auto eurBlock = Handle_<CurveBlock_>(
+    new CurveBlock_(Handle_<DiscountCurve_>(
+        NewDiscountPWLF("eur_ois", "EUR", MakeFlat("EUR", today, 0.01))));
+
+// Index and leg conventions: 12M tenor, ACT/365F, OIS-collateralised in both legs.
+auto index = [] {
+    RateIndexConvention_ r;
+    r.useProjectionCurve_ = true;
+    r.forecastTenor_      = PeriodLength_("12M");
+    r.dayBasis_           = DayBasis_("ACT_365F");
+    r.collateral_         = CollateralType_(CollateralType_::Value_::OIS);
+    return r;
+}();
+auto leg = [] {
+    RateLegConvention_ r;
+    r.paymentFrequency_ = PeriodLength_("12M");
+    r.dayBasis_         = DayBasis_("ACT_365F");
+    return r;
+}();
+
+// Cross-currency swap conventions: full notional exchange, par spread on the
+// foreign (EUR) leg.
+CrossCurrencyConvention_ convention;
+convention.initialNotionalExchange_ = true;
+convention.finalNotionalExchange_   = true;
+convention.spreadOnForeignLeg_      = true;
+convention.domesticIndex_           = index;
+convention.domesticLeg_             = leg;
+convention.foreignIndex_            = index;
+convention.foreignLeg_              = leg;
+
+// One swap per maturity, each carrying its market par basis spread.
+auto makeSwap = [&](double marketSpread, int maturityMonths) {
+    return Handle_<CrossCurrencySwap_>(new CrossCurrencySwap_(today,
+                                                              today,
+                                                              Date::AddMonths(today, maturityMonths),
+                                                              marketSpread,
+                                                              CurrencyPair_(Ccy_("USD"), Ccy_("EUR")),
+                                                              110.0,   // domestic notional
+                                                              100.0,   // foreign notional
+                                                              convention));
+};
+
+CrossCurrencyCalibrationSpec_ spec;
+spec.today_              = today;
+spec.basisPair_          = CurrencyPair_(Ccy_("USD"), Ccy_("EUR"));
+spec.domesticCurveBlock_ = usdBlock;
+spec.foreignCurveBlock_  = eurBlock;
+spec.fxSpot_             = 1.10;            // USD per EUR
+// fxForwardCollateral_ defaults to CollateralType_::Value_::OIS (xccycalibration.hpp:72).
+spec.knotDates_          = {Date::AddMonths(today, 6),  Date::AddMonths(today, 12),
+                            Date::AddMonths(today, 24), Date::AddMonths(today, 60),
+                            Date::AddMonths(today, 120)};
+spec.solveMode_          = CurveSolveMode_::Value_::EXACT;
+for (const int m : {6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 72, 84, 96, 108, 120})
+    spec.instruments_.push_back(makeSwap(/*marketSpread=*/0.0, m));   // spreads filled in below
+
+const CrossCurrencyCalibrationResult_ result = CalibrateCrossCurrencyMarket(spec);
+```
+
+### Extracting the implied FX forward and basis discount factor
+
+The result carries a calibrated `CrossCurrencyMarket_` plus a
+`CrossCurrencyFxForwardCurve_` snapshot at the knot dates. Use the market
+accessors for arbitrary-date queries; use the snapshot for the calibrated
+pillar grid.
+
+```cpp
+// Implied FX forward (USD per EUR) for delivery at each knot date.
+for (const Date_& d : spec.knotDates_)
+    const double fwd = result.market_.FxForward(d);
+
+// Same forward via the calibrated overloads that take explicit from/to/collateral.
+const double fwdTodayTo1y = result.market_.FxForward(today,
+                                                     Date::AddMonths(today, 12),
+                                                     CollateralType_(CollateralType_::Value_::OIS));
+
+// The basis discount factor P_b(today, T) — equals 1 when the basis is zero.
+const double pb12m = result.market_.BasisDiscountFactor(today, Date::AddMonths(today, 12));
+
+// The calibrated pillar grid (basis-consistent FX forwards at the knots).
+// result.fxForwardCurve_.dates_    == spec.knotDates_
+// result.fxForwardCurve_.forwards_ == FxForward(d) at each knot
+```
+
+### Quoting market spreads from a synthetic basis-bearing market
+
+`xccy_curve_calibration.cpp` derives its market spreads by repricing prototype
+zero-spread swaps against a market that already carries a basis, then feeding
+those spreads back into a fresh calibration. This pattern is useful for
+self-consistent tests:
+
+```cpp
+// Build a quote market with a known flat basis to derive market-implied spreads.
+CrossCurrencyMarket_ quoteMarket(usdBlock, eurBlock, 1.10);
+quoteMarket.SetBasisCurve(Handle_<DiscountCurve_>(
+    NewDiscountPWLF("usd_eur_basis", "USD", MakeFlat("USD", today, 0.0020))));
+
+// Prototype swaps at zero spread; their model par spread is the market quote.
+Vector_<> marketSpreads;
+for (const int m : {6, 12, 18, 24, /*...*/ 120}) {
+    const auto proto = makeSwap(0.0, m);
+    marketSpreads.push_back((*proto->Precompute())(quoteMarket));
+}
+// ...then push makeSwap(marketSpreads[i], m) into spec.instruments_ as above.
+```
+
+API citations:
+
+- `CrossCurrencyCalibrationSpec_` fields (incl. `fxForwardCollateral_`, `solveMode_`) and
+  `CalibrateCrossCurrencyMarket` — `dal-cpp/dal/curve/xccycalibration.hpp:66-82,97`.
+- `CrossCurrencyMarket_` constructor, `SetBasisCurve`, `FxForward`, `BasisDiscountFactor` —
+  `dal-cpp/dal/curve/xccycalibration.hpp:28-46`.
+- `CrossCurrencySwap_` constructor and `Precompute` — `dal-cpp/dal/curve/xccyinstrument.hpp:46-57`.
+- `CrossCurrencyConvention_`, `RateIndexConvention_`, `RateLegConvention_` —
+  `dal-cpp/dal/protocol/rateconvention.hpp:14-48`.
+- `CurrencyPair_(domestic, foreign)` — `dal-cpp/dal/curve/xccyinstrument.hpp:17-26`.
+- `CalibrateCrossCurrencyMarket` result fields `market_`, `basisCurves_`, `fxForwardCurve_`,
+  `diagnostics_` — `dal-cpp/dal/curve/xccycalibration.hpp:84-95`.
+
+### Diagnostic and revaluation surface
+
+`result.diagnostics_` (`CrossCurrencyCalibrationDiagnostics_`,
+`dal-cpp/dal/curve/xccycalibration.hpp:49-58`) exposes per-instrument
+`marketRates_`, `modelRates_`, `residuals_`, plus `rmsResidual_`,
+`maxAbsResidual_`, and `usedApproximateFit_`. The `effJacobianInverse_` maps
+basis-spread bumps to basis-rate changes for sensitivity work without re-solving,
+exactly as on the single-currency side.
+
 ## See Also
 
 - [Yield curve construction](yield_curve.md) — the single-currency framework the

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -191,6 +191,213 @@ discount factors  P(t₁,t₂) = exp(−∫f dt / 365) × P_base
 multi-curve routing: OIS discounting + tenor forecasting
 ```
 
+## Examples
+
+The snippets below are condensed from the standalone example programs under
+`dal-cpp/examples/` and adapt their real call sequences. They show the public
+calibration surface declared in `dal-cpp/dal/curve/calibration.hpp`,
+`dal-cpp/dal/curve/curveblock.hpp`, and `dal-cpp/dal/curve/ycinstrument.hpp`.
+Class and enum names, factory functions, and include paths match the current
+source; see the citations in each example.
+
+### Single-curve bootstrap from deposits, futures, and swaps
+
+This mirrors `dal-cpp/examples/euribor3m_curve/euribor3m_curve.cpp`: a classic
+single-curve Euribor 3M bootstrap that discounts and forecasts off one curve
+(no OIS data). The instrument set is deposit + STIR futures + vanilla swaps,
+assembled into a `CurveCalibrationSpec_` and solved by `CalibrateYieldCurve`.
+
+```cpp
+#include <dal/curve/calibration.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/protocol/rateconvention.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+
+using namespace Dal;
+
+// Trade date and spot, on the TARGET calendar (Euribor T+2).
+const Date_ today(2026, 4, 30);
+const Holidays_ target("TARGET");
+
+// Single-curve conventions: forecast routes to the discount curve.
+RateIndexConvention_ euribor3m = Ccy::Conventions::LiborIndex()(Ccy_("EUR"));
+euribor3m.useProjectionCurve_ = false;            // single curve: 3M forecast == discount
+euribor3m.forecastTenor_       = PeriodLength_("3M");
+euribor3m.dayBasis_            = DayBasis_("ACT_360");
+euribor3m.fixingHolidays_      = target;
+euribor3m.accrualHolidays_     = target;
+
+RateLegConvention_ fixedLeg = Ccy::Conventions::SwapFixedLeg()(Ccy_("EUR"));
+fixedLeg.paymentFrequency_ = PeriodLength_("12M");
+fixedLeg.dayBasis_         = DayBasis_("30_360");
+fixedLeg.accrualHolidays_  = target;
+fixedLeg.paymentHolidays_  = target;
+
+RateLegConvention_ floatLeg = Ccy::Conventions::SwapFloatLeg()(Ccy_("EUR"));
+floatLeg.paymentFrequency_ = PeriodLength_("3M");
+floatLeg.dayBasis_         = DayBasis_("ACT_360");
+
+// Instruments: a 3M cash deposit, a serial 3M future, and a vanilla IRS.
+const Handle_<YCInstrument_> deposit(new Deposit_(today,
+                                                  spot,
+                                                  Date::AddMonths(spot, 3),
+                                                  0.021990,            // 3M cash rate
+                                                  euribor3m));
+const Handle_<YCInstrument_> future(new Future_(today,
+                                                Date_(2026, 6, 17),  // IMM settle (3rd Wed)
+                                                Date_(2026, 9, 16),  // underlying 3M end
+                                                0.0224992,           // convexity-adjusted rate
+                                                euribor3m,
+                                                0.0));
+const Handle_<YCInstrument_> swap(new Swap_(today,
+                                            spot,
+                                            Date::AddMonths(spot, 60), // 5Y
+                                            0.0279255,                  // mid swap rate
+                                            fixedLeg,
+                                            euribor3m,
+                                            floatLeg));
+
+// Assemble the spec: one pillar per instrument maturity, piecewise-linear forwards,
+// EXACT solve. (For an overdetermined system — more quotes than free knots — switch
+// solveMode_ to CurveSolveMode_::Value_::APPROXIMATE; see the multi-curve example.)
+CurveCalibrationSpec_ spec;
+spec.today_                 = today;
+spec.ccy_                   = "EUR";
+spec.curveName_             = "euribor3m";
+spec.targetCollateral_      = CollateralType_(CollateralType_::Value_::OIS);
+spec.calibrateDiscountCurve_ = true;
+spec.parameterization_      = CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD;
+spec.knotPolicy_            = CurveKnotPolicy_::Value_::INPUT;
+spec.liborBasis_            = DayBasis_("ACT_365F");
+spec.instruments_           = {deposit, future, swap};
+spec.knotDates_             = {deposit->TimeSpan().second,
+                               future->TimeSpan().second,
+                               swap->TimeSpan().second};
+
+const CurveCalibrationResult_ result = CalibrateYieldCurve(spec);
+
+// Read discount factors and continuously-compounded zero rates off the calibrated curve.
+for (const int months : {6, 12, 24, 60, 120}) {
+    const Date_ d   = Date::AddMonths(today, months);
+    const double df = (*result.curve_)(today, d);
+    const double yf = static_cast<double>(d - today) / 365.0;
+    const double z  = -std::log(df) / yf;       // continuously-compounded zero
+    // ...
+}
+```
+
+The `CurveCalibrationDiagnostics_` returned in `result.diagnostics_` carries
+per-instrument market/model rates and residuals, plus `rmsResidual_` and
+`maxAbsResidual_`; the `effJacobianInverse_` matrix maps quote bumps to
+forward-rate parameters without re-solving.
+
+API citations:
+
+- `CurveCalibrationSpec_` fields and `CalibrateYieldCurve` overload — `dal-cpp/dal/curve/calibration.hpp:70-95,142`.
+- `Deposit_`, `Future_`, `Swap_` constructors — `dal-cpp/dal/curve/ycinstrument.hpp:65-153`.
+- `DiscountCurve_::operator()(Date_, Date_)` returns the discount factor — `dal-cpp/dal/curve/discount.hpp:28`.
+
+### Sequential multi-curve calibration (OIS discounting + tenor forecasting)
+
+This mirrors `dal-cpp/examples/curve_calibration/curve_calibration.cpp`. Two
+stages share a knot grid: stage 1 calibrates the OIS discount curve from OIS
+deposits and OIS swaps; stage 2 calibrates the 3M forecasting curve from FRAs
+and IRS, holding the discount curve fixed. Each stage quotes 20 instruments
+onto 9 knots, an overdetermined system, so both stages use the least-squares
+`APPROXIMATE` solver.
+
+```cpp
+#include <dal/curve/calibration.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/ycimp.hpp>
+#include <dal/protocol/collateraltype.hpp>
+
+// Stage 1 — OIS discount curve.
+CurveCalibrationSpec_ oisStage;
+oisStage.today_                = today;
+oisStage.ccy_                  = "USD";
+oisStage.curveName_            = "ois";
+oisStage.targetCollateral_     = CollateralType_(CollateralType_::Value_::OIS);
+oisStage.solveMode_            = CurveSolveMode_::Value_::APPROXIMATE;
+oisStage.fitTolerance_         = 1e-8;
+oisStage.knotDates_            = {Date::AddMonths(today, 1),  Date::AddMonths(today, 3),
+                                  Date::AddMonths(today, 6),  Date::AddMonths(today, 12),
+                                  Date::AddMonths(today, 24), Date::AddMonths(today, 36),
+                                  Date::AddMonths(today, 60), Date::AddMonths(today, 84),
+                                  Date::AddMonths(today, 120)};
+oisStage.instruments_          = /* OIS deposits + OISSwap_ handles */;
+
+// Stage 2 — 3M forecasting curve, discount curve held fixed.
+CurveCalibrationSpec_ liborStage;
+liborStage.today_                 = today;
+liborStage.ccy_                   = "USD";
+liborStage.curveName_             = "libor3m";
+liborStage.calibrateDiscountCurve_ = false;          // forecast-only stage
+liborStage.targetCollateral_      = CollateralType_(CollateralType_::Value_::OIS);
+liborStage.targetTenor_           = libor3m.forecastTenor_;  // PeriodLength_("3M")
+liborStage.knotDates_             = oisStage.knotDates_;
+liborStage.solveMode_             = CurveSolveMode_::Value_::APPROXIMATE;
+liborStage.fitTolerance_          = 1e-8;
+liborStage.instruments_           = /* FRA_ + Swap_ handles */;
+
+MultiCurveCalibrationSpec_ multi;
+multi.name_       = "usd_example";
+multi.ccy_        = "USD";
+multi.liborBasis_ = libor3m.dayBasis_;
+multi.stages_     = {oisStage, liborStage};
+
+const MultiCurveCalibrationResult_ result = CalibrateMultiCurve(multi);
+
+// Reprice a 3x6 FRA off the calibrated multi-curve block.
+const CurveBlock_ bundle("usd_example",
+                         "USD",
+                         result.discountCurves_,
+                         result.forwardCurves_,
+                         libor3m.dayBasis_);
+const auto fraRate = fra3x6->Precompute(Handle_<YieldCurve_>());
+const double modelFra = (*fraRate)(bundle);
+```
+
+API citations:
+
+- `OISSwap_` and `FRA_` constructors — `dal-cpp/dal/curve/ycinstrument.hpp:81-101,155-166`.
+- `MultiCurveCalibrationSpec_` and `CalibrateMultiCurve` — `dal-cpp/dal/curve/calibration.hpp:120-144`.
+- `CurveBlock_` multi-curve constructor — `dal-cpp/dal/curve/curveblock.hpp:28-32`.
+
+### Flat starting curve for synthetic examples
+
+When no market quotes are available (e.g. building a market to derive implied
+quotes), a flat forward curve is built directly with `NewDiscountPWLF`. This is
+the helper used in both `curve_calibration.cpp` and
+`xccy_curve_calibration.cpp`:
+
+```cpp
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/ycimp.hpp>
+
+const Vector_<Date_> knots = {Date::AddMonths(today, 1),  Date::AddMonths(today, 3),
+                              Date::AddMonths(today, 6),  Date::AddMonths(today, 12),
+                              Date::AddMonths(today, 24), Date::AddMonths(today, 36),
+                              Date::AddMonths(today, 60), Date::AddMonths(today, 84),
+                              Date::AddMonths(today, 120)};
+const Vector_<> values(knots.size(), 0.02);   // flat 2% forward rate
+
+// Layer an optional base curve by passing it as the last argument (multi-curve
+// spread construction — see the multi-curve framework above).
+Handle_<DiscountCurve_> flat(
+    NewDiscountPWLF("flat", "USD", PiecewiseLinear_(knots, values, values)));
+```
+
+API citations:
+
+- `PiecewiseLinear_(knots, fLeft, fRight)` — `dal-cpp/dal/curve/piecewiselinear.hpp:23`.
+- `NewDiscountPWLF(name, ccy, fwds, base)` — `dal-cpp/dal/curve/ycimp.hpp:12-15`.
+
 ## See Also
 
 - [Underdetermined search](underdetermined_search.md) — the optimisation method


### PR DESCRIPTION
## Summary
- Add methodology docs for **interpolation** (linear, log-linear, cubic with `Boundary_` end conditions, mixed log-DF, bilinear 2D) and the **`LOG_DISCOUNT`** curve parameterization (`LogDfScheme_` schemes and why it underpins the analytic Jacobian)
- Correct the analytic-Jacobian experimental note: it described `CurveJacobianMode_` as dropped and the path as native-only, but the flag was re-added in #111 and made backend-neutral in #110
- Add worked **Examples** sections to the yield-curve and cross-currency calibration docs, traced from the existing compiling example programs (`euribor3m_curve`, `curve_calibration`, `xccy_curve_calibration`) and `test_xccymarket.cpp`
- Index the new docs from `docs/README.md` and `CLAUDE.md`

## Test plan
- [x] Verified every API symbol, factory, enum value, and include path in the new docs against current source
- [x] Confirmed markdown table alignment, trailing newlines, and no tabs in all changed docs
- [x] Docs-only PR — no C++ changed, so `dal_cpp_tests` / `dal_public_tests` are unaffected
