### PR TITLE
feat: Add yield-curve Jacobian example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ here as the baseline rather than dated releases:
   `tolerance_` when transforming a sensitivity vector: `r = gᵀ · effJacobianInverse_ / tolerance_`).
   See `docs/methodology/yield_curve_jacobian.md` and the example at
   `dal-cpp/examples/yield_curve_jacobian/`. Non-breaking (new example + diagnostics-only test).
+- `curve`: Exposed the calibration forward Jacobian on the public diagnostics struct as
+  `CurveCalibrationDiagnostics_::jacobian_` (and the `CrossCurrencyCalibrationDiagnostics_` mirror,
+  empty on the xccy path for now) — the unscaled analytic `d(modelRate)/d(logDF_free)` at the solved
+  point, populated iff `jacobianMode_ = ANALYTIC && solveMode_ = EXACT` and eligible. The
+  `yield_curve_jacobian` example now reads the AAD Jacobian from `result.diagnostics_.jacobian_`
+  instead of the `TestOnly::AnalyticJacobianAt` helper, and a new test
+  (`dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp`) gates population and AAD-vs-bump
+  agreement. Non-breaking (additive public field).
 
 <!-- Add new qualifying changes below as dated sections, e.g. -->
 <!-- ## 2026-06 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ here as the baseline rather than dated releases:
   Jacobian mode for yield-curve calibration. See
   `docs/experimental/aad-analytic-jacobian-curve-calibration.md`.
 
+## 2026-06
+
+- `curve`: Added a yield-curve Jacobian example demonstrating AAD-vs-bump agreement and the
+  inverse-Jacobian IR-risk transform; documented the corrected units of
+  `CurveCalibrationDiagnostics_::effJacobianInverse_` as
+  `d(params)·tolerance_ / d(decimal-rate perturbation)` (the underdetermined solver scales
+  residuals by `1/tolerance_` before forming the pseudoinverse, so consumers must divide by
+  `tolerance_` when transforming a sensitivity vector: `r = gᵀ · effJacobianInverse_ / tolerance_`).
+  See `docs/methodology/yield_curve_jacobian.md` and the example at
+  `dal-cpp/examples/yield_curve_jacobian/`. Non-breaking (new example + diagnostics-only test).
+
 <!-- Add new qualifying changes below as dated sections, e.g. -->
 <!-- ## 2026-06 -->
 <!-- - `curve`: Added log-linear interpolation to the interpolation module (non-breaking). -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Cross-Currency Calibration** — [Cross-currency calibration](docs/methodology/xccy_calibration.md)
 - **Interpolation** — [Interpolation](docs/methodology/interpolation.md)
 - **Log-Discount Curve** — [Log-discount curve](docs/methodology/log_discount_curve.md)
+- **Yield-Curve Jacobian and Inverse-Jacobian Risk** — [Yield-curve Jacobian](docs/methodology/yield_curve_jacobian.md)
 
 Notable fundamental changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -802,7 +802,27 @@ namespace Dal {
                                         spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_);
 
         const SolverOutput_ solved = RunCalibrationSolver(spec, func, guess, tol, *weights);
-        return AssembleCalibrationResult(spec, instruments, knotDates, solved.result_, solved.effJacobianInverse_);
+        CurveCalibrationResult_ retval = AssembleCalibrationResult(spec, instruments, knotDates, solved.result_, solved.effJacobianInverse_);
+
+        // Forward Jacobian at the solution. effJacobianInverse_ is formed inside the solver at its
+        // final iterate -- a Broyden-perturbed working matrix, solver-weighted and tolerance-scaled
+        // -- which is the wrong object to expose as "the Jacobian". Instead re-evaluate the clean
+        // analytic J at the solved x (where an independent bump oracle also evaluates, so the two
+        // agree to ~machine precision). func.Gradient returns the analytic XCurveJacobian_ iff
+        // ANALYTIC && eligible, else nullptr; combined with the EXACT guard this leaves jacobian_
+        // empty for APPROXIMATE solves, BUMPED mode, and ineligible ANALYTIC specs, mirroring the
+        // effJacobianInverse_ population condition.
+        if (options.jacobianMode_ == CurveJacobianMode_::Value_::ANALYTIC && spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
+            const Vector_<> fAtSolution = func.F(solved.result_);
+            std::unique_ptr<Underdetermined::Jacobian_> j(func.Gradient(solved.result_, fAtSolution));
+            if (j) {
+                const auto* dense = dynamic_cast<const XCurveJacobian_*>(j.get());
+                if (dense) {
+                    retval.diagnostics_.jacobian_ = dense->j_;
+                }
+            }
+        }
+        return retval;
     }
 
     MultiCurveCalibrationResult_ CalibrateMultiCurve(const MultiCurveCalibrationSpec_& spec) {

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -808,10 +808,12 @@ namespace Dal {
         // final iterate -- a Broyden-perturbed working matrix, solver-weighted and tolerance-scaled
         // -- which is the wrong object to expose as "the Jacobian". Instead re-evaluate the clean
         // analytic J at the solved x (where an independent bump oracle also evaluates, so the two
-        // agree to ~machine precision). func.Gradient returns the analytic XCurveJacobian_ iff
-        // ANALYTIC && eligible, else nullptr; combined with the EXACT guard this leaves jacobian_
-        // empty for APPROXIMATE solves, BUMPED mode, and ineligible ANALYTIC specs, mirroring the
-        // effJacobianInverse_ population condition.
+        // agree to ~machine precision). jacobian_ is populated ONLY when all three hold:
+        // jacobianMode_ == ANALYTIC, solveMode_ == EXACT, AND the instrument is analytically
+        // eligible (func.Gradient returns a non-null XCurveJacobian_). It is left empty otherwise.
+        // This is narrower than effJacobianInverse_, which the solver always populates on EXACT
+        // regardless of jacobianMode_ (and never on APPROXIMATE), so the two fields do not share a
+        // single population rule.
         if (options.jacobianMode_ == CurveJacobianMode_::Value_::ANALYTIC && spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
             const Vector_<> fAtSolution = func.F(solved.result_);
             std::unique_ptr<Underdetermined::Jacobian_> j(func.Gradient(solved.result_, fAtSolution));

--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -107,6 +107,22 @@ namespace Dal {
         Vector_<> modelRates_;
         Vector_<> residuals_;
         Matrix_<> effJacobianInverse_;
+        // Unscaled analytic forward Jacobian d(modelRate_i) / d(logDF_free_k), shape
+        // nInstruments x (nKnots - 1), evaluated at the calibrated solution (the solved
+        // free-node logDF vector) by a fresh AAD reverse sweep in CalibrateYieldCurve.
+        // This is the plain Jacobian before the solver's DivideRows(tol_) row-scaling; an
+        // independent finite-difference bump of the solved nodes reproduces it. CONTRAST with
+        // effJacobianInverse_: that matrix is a solver-weighted, tolerance-scaled pseudoinverse
+        // formed at the solver's final iterate, used to map parameter sensitivities to
+        // quote-bucket risk (r = g^T * effJacobianInverse_ / tolerance_). jacobian_ is neither
+        // weighted nor scaled, is evaluated at the solution rather than the iterate, and is NOT
+        // the inverse of effJacobianInverse_. Populated (non-empty) iff jacobianMode_ == ANALYTIC
+        // && solveMode_ == EXACT && the calibration is eligible for the AAD-tape Jacobian;
+        // default-constructed (empty, 0 x 0) otherwise (APPROXIMATE solve, BUMPED mode, or an
+        // ANALYTIC spec that fell back to bumped). Computed by the same AAD path as
+        // TestOnly::AnalyticJacobianAt but carried on the public diagnostics struct so consumers
+        // (e.g. the yield_curve_jacobian example) read it without a TestOnly dependency.
+        Matrix_<> jacobian_;
         double maxAbsResidual_ = 0.0;
         double rmsResidual_ = 0.0;
         bool usedApproximateFit_ = false;

--- a/dal-cpp/dal/curve/xccycalibration.hpp
+++ b/dal-cpp/dal/curve/xccycalibration.hpp
@@ -52,6 +52,9 @@ namespace Dal {
         Vector_<> modelRates_;
         Vector_<> residuals_;
         Matrix_<> effJacobianInverse_;
+        // Forward-Jacobian mirror of CurveCalibrationDiagnostics_::jacobian_. Left empty on the
+        // cross-currency path; populated only by single-curve CalibrateYieldCurve for now.
+        Matrix_<> jacobian_;
         double maxAbsResidual_ = 0.0;
         double rmsResidual_ = 0.0;
         bool usedApproximateFit_ = false;

--- a/dal-cpp/examples/CMakeLists.txt
+++ b/dal-cpp/examples/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(underdetermined)
 add_subdirectory(uoc)
 add_subdirectory(uoc_compiled)
 add_subdirectory(vanilla)
+add_subdirectory(yield_curve_jacobian)
 
 if(DAL_HAS_EXCEL)
     add_subdirectory(excelwriter)

--- a/dal-cpp/examples/yield_curve_jacobian/CMakeLists.txt
+++ b/dal-cpp/examples/yield_curve_jacobian/CMakeLists.txt
@@ -1,0 +1,22 @@
+file(GLOB_RECURSE YIELD_CURVE_JACOBIAN_FILES "*.hpp" "*.cpp")
+add_executable(yield_curve_jacobian ${YIELD_CURVE_JACOBIAN_FILES})
+
+target_link_libraries(yield_curve_jacobian dal_library)
+
+if(DAL_USE_XAD_AAD)
+    target_link_libraries(yield_curve_jacobian XAD::xad)
+elseif(DAL_USE_CODIPACK_AAD)
+    target_link_libraries(yield_curve_jacobian CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(yield_curve_jacobian adept)
+endif()
+
+if(MSVC)
+else()
+    target_link_libraries(yield_curve_jacobian pthread)
+endif()
+
+install(TARGETS yield_curve_jacobian
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )

--- a/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+++ b/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
@@ -12,10 +12,8 @@
 #include <dal/platform/initall.hpp>
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/curveblock.hpp>
-#include <dal/curve/ycctx.hpp>
 #include <dal/curve/yclogdf.hpp>
 #include <dal/curve/ycinstrument.hpp>
-#include <dal/math/aad/aad.hpp>
 #include <dal/math/matrix/matrixarithmetic.hpp>
 #include <dal/math/matrix/matrixs.hpp>
 #include <dal/math/vectors.hpp>
@@ -51,16 +49,15 @@ using namespace Dal;
 //       instrument.
 //
 // AAD is always compiled in this library (dal-cpp/dal/math/aad/aad.hpp:17 defines the native AAET
-// backend on the "no DAL_USE_*_AAD flag set" branch). The AAD block below is therefore unguarded --
-// it runs identically under native AAET, Adept, XAD, and CoDiPack, exactly as
-// dal-cpp/examples/vanilla/vanilla.cpp and dal-cpp/digital/digital.cpp do. The example includes
-// only <dal/math/aad/aad.hpp> and uses only the Dal::AAD facade.
+// backend on the "no DAL_USE_*_AAD flag set" branch) and the analytic Jacobian it produces runs
+// identically under native AAET, Adept, XAD, and CoDiPack. Arc (a) does not record its own tape:
+// it delegates to the library's own analytic Jacobian (Dal::TestOnly::AnalyticJacobianAt, which
+// wraps YieldCurveCalibrationFunc_::AnalyticJacobian in dal-cpp/dal/curve/calibration.cpp:510-565)
+// so the AAD recording contract and backend-portability rules live in exactly one place. The bump
+// oracle below remains an independent finite-difference check; the AAD-vs-bump comparison is what
+// makes arc (a) a real cross-check rather than a tautology.
 
 namespace {
-    using AAD::Adjoint;
-    using AAD::Number_;
-    using AAD::Value;
-
     // Self-check bars (see .claude/specs/yield-curve-jacobian-example.md "AAD-vs-Bump Tolerance
     // Choice"). The 1e-9 AAD-vs-bump bar holds because the Phase A LOG_DISCOUNT residual Jacobian
     // is O(1) and well-conditioned at the chosen 1%-3% par rates; central-difference round-off at
@@ -202,71 +199,19 @@ namespace {
         return j;
     }
 
-    // AAD reverse-sweep Jacobian J_aad(i,k) = d(modelRate_i) / d(logDF_free_k). Mirrors
-    // YieldCurveCalibrationFunc_::AnalyticJacobian in dal-cpp/dal/curve/calibration.cpp:510-565
-    // line-for-line in shape. The forward pass builds a Number_-typed DiscountLogDF_ curve
-    // (Tape::DiscountLogDF_<Number_>, publicly constructible and explicitly instantiated in
-    // yclogdf.cpp), a Tape::YCCtx_<Number_>, and Number_-typed rates via inst->PrecomputeT<Number_>();
-    // then one reverse sweep per row harvests d(modelRate_i)/d(logDF_k+1) from the node adjoints.
+    // AAD reverse-sweep Jacobian J_aad(i,k) = d(modelRate_i) / d(logDF_free_k). Delegate to the
+    // library's own analytic Jacobian rather than re-recording the tape here: the residual Jacobian
+    // d(modelRate - marketRate)/d(logDF) equals d(modelRate)/d(logDF) since marketRate is constant,
+    // which is the unscaled quantity TestOnly::AnalyticJacobianAt returns. The underlying sweep is
+    // YieldCurveCalibrationFunc_::AnalyticJacobian in dal-cpp/dal/curve/calibration.cpp:510-565; the
+    // AAD recording contract and backend-portability rules it encodes are documented in
+    // docs/methodology/aad.md. Reusing it keeps the example's trickiest AAD code in one place.
     Matrix_<> AadJacobian(const CurveCalibrationSpec_& spec, const Vector_<>& x) {
-        auto* tape = Dal::AAD::Tape();
-        Dal::AAD::Clear(*tape);
-
-        const int nNodes = static_cast<int>(spec.knotDates_.size());
-        const int nFree = static_cast<int>(x.size());
-        THROW_REQUIRE(nFree == nNodes - 1, "free-param vector length must equal nNodes - 1");
-
-        // Independents: free-node log(DF) values. Anchor (node 0) pinned at 0 and deliberately NOT
-        // registered -- registering it would add a phantom input column. RegisterIndependent
-        // anchors each free node on every backend before the recording window opens.
-        Vector_<Number_> logDF(nNodes);
-        logDF[0] = 0.0;
-        for (int k = 0; k < nFree; ++k)
-            Dal::AAD::RegisterIndependent(logDF[k + 1], x[k]);
-
-        // Open the recording AFTER registering inputs and BEFORE the forward pass. XAD's canonical
-        // contract drops inputs registered after newRecording; opening here is invisible on native
-        // (NewRecording is a no-op) and correct on CoDiPack/Adept (anchors the sweep bounds).
-        Dal::AAD::NewRecording(*tape);
-
-        std::unique_ptr<Tape::DiscountLogDF_<Number_>> dc(
-            new Tape::DiscountLogDF_<Number_>(spec.curveName_, spec.ccy_, spec.knotDates_, logDF, spec.liborBasis_, spec.logDfScheme_));
-        Tape::YCCtx_<Number_> ctx(*dc);
-
-        // Forward pass: Number_-typed model rates. PrecomputeT<Number_> lives only on the concrete
-        // Phase A instrument types (Deposit_/FRA_/Future_/Swap_), so downcast per instrument --
-        // mirroring PhaseARateAt in calibration.cpp:489-500. Use Dal::AAD::Value / Dal::AAD::Adjoint
-        // to read primals/adjoints; never static_cast<double>(Number_) (FR8: only native and
-        // CoDiPack have operator double(); XAD/Adept do not).
-        const int nInst = static_cast<int>(spec.instruments_.size());
-        Vector_<Number_> modelRates(nInst);
-        for (int i = 0; i < nInst; ++i) {
-            const auto* inst = spec.instruments_[i].get();
-            Handle_<Tape::Rate_<Number_>> rateT;
-            if (const auto* d = dynamic_cast<const Deposit_*>(inst))
-                rateT = d->PrecomputeT<Number_>();
-            else if (const auto* fr = dynamic_cast<const FRA_*>(inst))
-                rateT = fr->PrecomputeT<Number_>();
-            else if (const auto* fu = dynamic_cast<const Future_*>(inst))
-                rateT = fu->PrecomputeT<Number_>();
-            else if (const auto* s = dynamic_cast<const Swap_*>(inst))
-                rateT = s->PrecomputeT<Number_>();
-            else
-                THROW_REQUIRE(false, std::string("instrument ") + std::to_string(i) + " has no Phase A templated rate");
-            modelRates[i] = (*rateT)(ctx);
-        }
-
-        // Single-result reverse sweep, one row at a time. ZeroAdjoints clears propagated adjoints
-        // between rows so each seed lands on a clean slate (Adept's compute_adjoint does not clear
-        // operands between sweeps -- without ZeroAdjoints row 2 inherits row 1's residue).
-        Matrix_<> j(nInst, nFree, 0.0);
-        for (int i = 0; i < nInst; ++i) {
-            Dal::AAD::ZeroAdjoints(*tape);
-            Dal::AAD::Adjoint(modelRates[i]) = 1.0;
-            Dal::AAD::PropagateToStart(*tape);
-            for (int k = 0; k < nFree; ++k)
-                j(i, k) = Dal::AAD::Adjoint(logDF[k + 1]);
-        }
+        Matrix_<> j = Dal::TestOnly::AnalyticJacobianAt(spec, x);
+        // AnalyticJacobianAt returns an empty matrix when the spec is ineligible for the AAD-tape
+        // path (e.g. parameterization_ != LOG_DISCOUNT). The Phase A LOG_DISCOUNT spec built here is
+        // always eligible, so an empty result means the analytic path silently did not engage.
+        THROW_REQUIRE(!j.Empty(), "analytic Jacobian is empty -- spec is ineligible for the AAD-tape path");
         return j;
     }
 

--- a/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+++ b/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
@@ -51,9 +51,10 @@ using namespace Dal;
 // AAD is always compiled in this library (dal-cpp/dal/math/aad/aad.hpp:17 defines the native AAET
 // backend on the "no DAL_USE_*_AAD flag set" branch) and the analytic Jacobian it produces runs
 // identically under native AAET, Adept, XAD, and CoDiPack. Arc (a) does not record its own tape:
-// it delegates to the library's own analytic Jacobian (Dal::TestOnly::AnalyticJacobianAt, which
-// wraps YieldCurveCalibrationFunc_::AnalyticJacobian in dal-cpp/dal/curve/calibration.cpp:510-565)
-// so the AAD recording contract and backend-portability rules live in exactly one place. The bump
+// it reads the forward Jacobian the calibration already computed -- CalibrateYieldCurve populates
+// CurveCalibrationDiagnostics_::jacobian_ via a fresh AAD reverse sweep at the solved x (the same
+// YieldCurveCalibrationFunc_::AnalyticJacobian machinery in dal-cpp/dal/curve/calibration.cpp:510-565)
+// -- so the AAD recording contract and backend-portability rules live in exactly one place. The bump
 // oracle below remains an independent finite-difference check; the AAD-vs-bump comparison is what
 // makes arc (a) a real cross-check rather than a tautology.
 
@@ -196,22 +197,6 @@ namespace {
                 j(i, k) = (modelUp - modelDn) / (2.0 * h);
             }
         }
-        return j;
-    }
-
-    // AAD reverse-sweep Jacobian J_aad(i,k) = d(modelRate_i) / d(logDF_free_k). Delegate to the
-    // library's own analytic Jacobian rather than re-recording the tape here: the residual Jacobian
-    // d(modelRate - marketRate)/d(logDF) equals d(modelRate)/d(logDF) since marketRate is constant,
-    // which is the unscaled quantity TestOnly::AnalyticJacobianAt returns. The underlying sweep is
-    // YieldCurveCalibrationFunc_::AnalyticJacobian in dal-cpp/dal/curve/calibration.cpp:510-565; the
-    // AAD recording contract and backend-portability rules it encodes are documented in
-    // docs/methodology/aad.md. Reusing it keeps the example's trickiest AAD code in one place.
-    Matrix_<> AadJacobian(const CurveCalibrationSpec_& spec, const Vector_<>& x) {
-        Matrix_<> j = Dal::TestOnly::AnalyticJacobianAt(spec, x);
-        // AnalyticJacobianAt returns an empty matrix when the spec is ineligible for the AAD-tape
-        // path (e.g. parameterization_ != LOG_DISCOUNT). The Phase A LOG_DISCOUNT spec built here is
-        // always eligible, so an empty result means the analytic path silently did not engage.
-        THROW_REQUIRE(!j.Empty(), "analytic Jacobian is empty -- spec is ineligible for the AAD-tape path");
         return j;
     }
 
@@ -370,9 +355,9 @@ int main() {
     const auto result = CalibrateYieldCurve(spec, options);
 
     // Eligibility backstop: if the spec silently fell back to BUMPED (ANALYTIC never throws, it
-    // only emits a NOTICE and falls back), the AAD path is a no-op and the whole teaching payload
-    // is hollow. Detect via the analytic-tape Jacobian matching the residual oracle at the solved
-    // point: compute J_aad from first principles and confirm it is non-trivial.
+    // only emits a NOTICE and falls back), the AAD path is a no-op and diagnostics_.jacobian_ is
+    // empty. The non-empty check on jacobian_ in arc (c) catches that before the FD comparison
+    // renders the teaching payload hollow.
     const Vector_<> x = SolvedFreeParams(*result.curve_);
 
     PrintSection("(a) Calibration residuals");
@@ -385,8 +370,13 @@ int main() {
     PrintSection("(b) Bump Jacobian  J_bump = d(modelRate_i) / d(logDF_free_k)");
     PrintMatrix("", jBump, "rows = instruments, cols = free params; central diff h = 1e-6");
 
-    // ---- (c) AAD Jacobian (reverse sweep, from first principles) ----
-    const Matrix_<> jAad = AadJacobian(spec, x);
+    // ---- (c) AAD Jacobian (analytic reverse sweep, read from the calibration diagnostics) ----
+    // jacobian_ is populated by CalibrateYieldCurve on the EXACT + ANALYTIC + eligible path via a
+    // fresh AAD reverse sweep at the solved x -- the same point the bump oracle evaluates -- so the
+    // AAD-vs-bump comparison below cross-checks the library's analytic Jacobian against an
+    // independent finite-difference oracle rather than a re-evaluation of the same code.
+    const Matrix_<>& jAad = result.diagnostics_.jacobian_;
+    THROW_REQUIRE(!jAad.Empty(), "diagnostics_.jacobian_ is empty -- ANALYTIC path did not engage (ineligible spec?)");
     // B2 sentinel: every row must have at least one non-trivial entry. An all-zero row means the
     // tape never learned an input is an independent (the canonical missed-RegisterIndependent /
     // wrong-recording-order failure). Catch it before the FD comparison.

--- a/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+++ b/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
@@ -332,6 +332,105 @@ namespace {
             std::cout << "\n";
         }
     }
+
+    // ---- main() section runners (extracted to keep main's cyclomatic complexity under the
+    //      Codacy limit of 8). Each helper is a verbatim relocation of its inline block in main:
+    //      no logic changes, so the example's stdout is byte-for-byte identical. ----
+
+    // (c) B2 sentinel: every AAD Jacobian row must have at least one non-trivial entry. An all-zero
+    // row means the tape never learned an input is an independent (the canonical missed-
+    // RegisterIndependent / wrong-recording-order failure). Catch it before the FD comparison.
+    void AssertNoAllZeroRows(const Matrix_<>& jAad) {
+        for (int i = 0; i < jAad.Rows(); ++i) {
+            double maxAbs = 0.0;
+            for (int k = 0; k < jAad.Cols(); ++k)
+                maxAbs = std::max(maxAbs, std::abs(jAad(i, k)));
+            if (maxAbs <= 1.0e-6)
+                THROW(std::string("AAD Jacobian row ") + std::to_string(i) + " is all-zero (B2 sentinel: missed RegisterIndependent?)");
+        }
+    }
+
+    // (d) AAD-vs-bump agreement loop (verbatim two-branch form, tol = 1e-9). Returns {maxAbs,
+    // maxRel} for main to print. The two-branch structure (|fd|<tol vs else) and the THROW-on-
+    // fail per cell are preserved exactly.
+    struct AgreementResult_ {
+        double maxAbs;
+        double maxRel;
+    };
+
+    AgreementResult_ RunAgreementCheck(const Matrix_<>& jBump, const Matrix_<>& jAad) {
+        double maxAbs = 0.0;
+        double maxRel = 0.0;
+        THROW_REQUIRE(jBump.Rows() == jAad.Rows() && jBump.Cols() == jAad.Cols(), "Jacobian shape mismatch");
+        for (int i = 0; i < jBump.Rows(); ++i) {
+            for (int k = 0; k < jBump.Cols(); ++k) {
+                const double fd = jBump(i, k);
+                const double an = jAad(i, k);
+                const double absErr = std::abs(an - fd);
+                maxAbs = std::max(maxAbs, absErr);
+                if (std::abs(fd) < AAD_TOL) {
+                    maxRel = std::max(maxRel, absErr);
+                    if (absErr > AAD_TOL)
+                        THROW(std::string("AAD-vs-bump FAIL at (i=") + std::to_string(i) + ",k=" + std::to_string(k) +
+                              "): |an|=" + std::to_string(absErr) + " > " + std::to_string(AAD_TOL) + " (|fd|<1e-9 branch)");
+                } else {
+                    const double rel = absErr / std::max(1.0, std::abs(fd));
+                    maxRel = std::max(maxRel, rel);
+                    if (rel > AAD_TOL)
+                        THROW(std::string("AAD-vs-bump FAIL at (i=") + std::to_string(i) + ",k=" + std::to_string(k) + "): rel=" + std::to_string(rel) +
+                              " > " + std::to_string(AAD_TOL) + " (an=" + std::to_string(an) + ", fd=" + std::to_string(fd) + ")");
+                }
+            }
+        }
+        return {maxAbs, maxRel};
+    }
+
+    // (g) Print the bucketed quote-risk vector r alongside its par-rate DV01 (r[i]*1e-4).
+    void PrintQuoteRisk(const Vector_<>& r) {
+        std::cout << std::fixed << std::setprecision(12);
+        std::cout << "  " << std::left << std::setw(22) << "raw r[i]" << std::right << std::setw(22) << "par-rate DV01 (r[i]*1e-4)"
+                  << "\n";
+        for (int i = 0; i < static_cast<int>(r.size()); ++i)
+            std::cout << "  " << std::left << std::setw(22) << r[i] << std::right << std::setw(22) << r[i] * ONE_BP << "\n";
+    }
+
+    // (h) FR6 inverse-Jacobian nonlinear re-solve sanity. For each calibration instrument, bump its
+    // market quote by +1e-4, re-run CalibrateYieldCurve (ANALYTIC), and compare the true nonlinear
+    // free-param delta against the linear prediction effJacobianInverse_(k,i) * 1e-4 / tolerance_.
+    // The solver-scaled-pseudoinverse / tolerance_ units note from main applies here verbatim.
+    void RunFR6ReSolve(
+        const CurveCalibrationSpec_& spec,
+        const CurveCalibrationOptions_& options,
+        const Matrix_<>& effJacobianInverse,
+        const Vector_<>& baselineFree,
+        int nInst,
+        int nFree) {
+        std::cout << std::fixed << std::setprecision(12);
+        std::cout << "  " << std::left << std::setw(8) << "inst" << std::right << std::setw(22) << "max rel delta" << "\n";
+        bool fr6Passed = true;
+        for (int i = 0; i < nInst; ++i) {
+            const Vector_<> trueDelta = RebumpedParamDelta(spec, options, i, ONE_BP, baselineFree);
+            Vector_<> pred(nFree, 0.0);
+            for (int k = 0; k < nFree; ++k)
+                pred[k] = effJacobianInverse(k, i) * ONE_BP / spec.tolerance_;
+            double maxRel = 0.0;
+            for (int k = 0; k < nFree; ++k) {
+                const double t = trueDelta[k];
+                const double p = pred[k];
+                const double err = std::abs(p - t);
+                const double rel = err / std::max(1.0, std::abs(t));
+                maxRel = std::max(maxRel, rel);
+                if (rel > RE_SOLVE_TOL) {
+                    fr6Passed = false;
+                    THROW(std::string("FR6 re-solve FAIL at inst=") + std::to_string(i) + " k=" + std::to_string(k) + ": rel=" + std::to_string(rel) +
+                          " > " + std::to_string(RE_SOLVE_TOL) + " (pred=" + std::to_string(p) + ", true=" + std::to_string(t) + ")");
+                }
+            }
+            std::cout << "  " << std::left << std::setw(8) << i << std::right << std::setw(22) << maxRel << "\n";
+        }
+        if (fr6Passed)
+            std::cout << "  Verdict : PASS  (all rel <= 1e-6)\n";
+    }
 } // namespace
 
 int main() {
@@ -380,44 +479,16 @@ int main() {
     // B2 sentinel: every row must have at least one non-trivial entry. An all-zero row means the
     // tape never learned an input is an independent (the canonical missed-RegisterIndependent /
     // wrong-recording-order failure). Catch it before the FD comparison.
-    for (int i = 0; i < jAad.Rows(); ++i) {
-        double maxAbs = 0.0;
-        for (int k = 0; k < jAad.Cols(); ++k)
-            maxAbs = std::max(maxAbs, std::abs(jAad(i, k)));
-        if (maxAbs <= 1.0e-6)
-            THROW(std::string("AAD Jacobian row ") + std::to_string(i) + " is all-zero (B2 sentinel: missed RegisterIndependent?)");
-    }
+    AssertNoAllZeroRows(jAad);
     PrintSection("(c) AAD Jacobian  J_aad = d(modelRate_i) / d(logDF_free_k)");
     PrintMatrix("", jAad, "rows = instruments, cols = free params; reverse sweep, 1 per row");
 
     // ---- (d) AAD-vs-bump agreement (verbatim two-branch form, tol = 1e-9) ----
     PrintSection("(d) AAD-vs-bump agreement  (verbatim two-branch form, tol = 1e-9)");
-    double maxAbs = 0.0;
-    double maxRel = 0.0;
-    THROW_REQUIRE(jBump.Rows() == jAad.Rows() && jBump.Cols() == jAad.Cols(), "Jacobian shape mismatch");
-    for (int i = 0; i < jBump.Rows(); ++i) {
-        for (int k = 0; k < jBump.Cols(); ++k) {
-            const double fd = jBump(i, k);
-            const double an = jAad(i, k);
-            const double absErr = std::abs(an - fd);
-            maxAbs = std::max(maxAbs, absErr);
-            if (std::abs(fd) < AAD_TOL) {
-                maxRel = std::max(maxRel, absErr);
-                if (absErr > AAD_TOL)
-                    THROW(std::string("AAD-vs-bump FAIL at (i=") + std::to_string(i) + ",k=" + std::to_string(k) +
-                          "): |an|=" + std::to_string(absErr) + " > " + std::to_string(AAD_TOL) + " (|fd|<1e-9 branch)");
-            } else {
-                const double rel = absErr / std::max(1.0, std::abs(fd));
-                maxRel = std::max(maxRel, rel);
-                if (rel > AAD_TOL)
-                    THROW(std::string("AAD-vs-bump FAIL at (i=") + std::to_string(i) + ",k=" + std::to_string(k) + "): rel=" + std::to_string(rel) +
-                          " > " + std::to_string(AAD_TOL) + " (an=" + std::to_string(an) + ", fd=" + std::to_string(fd) + ")");
-            }
-        }
-    }
+    const AgreementResult_ agree = RunAgreementCheck(jBump, jAad);
     std::cout << std::fixed << std::setprecision(12);
-    std::cout << "  max abs discrepancy : " << maxAbs << "\n";
-    std::cout << "  max rel discrepancy : " << maxRel << "\n";
+    std::cout << "  max abs discrepancy : " << agree.maxAbs << "\n";
+    std::cout << "  max rel discrepancy : " << agree.maxRel << "\n";
     std::cout << "  Verdict              : PASS  (rel <= 1e-9)\n";
 
     // ---- (e) effJacobianInverse_ from the EXACT solve ----
@@ -439,18 +510,12 @@ int main() {
     PrintSection("(g) Bucketed IR risk  r = g^T * effJacobianInverse_");
     std::cout << "  length = nInstruments = " << r.size() << "\n";
     std::cout << "  units: par-rate per absolute decimal quote bump\n";
-    std::cout << std::fixed << std::setprecision(12);
-    std::cout << "  " << std::left << std::setw(22) << "raw r[i]" << std::right << std::setw(22) << "par-rate DV01 (r[i]*1e-4)"
-              << "\n";
-    for (int i = 0; i < static_cast<int>(r.size()); ++i)
-        std::cout << "  " << std::left << std::setw(22) << r[i] << std::right << std::setw(22) << r[i] * ONE_BP << "\n";
+    PrintQuoteRisk(r);
 
     // ---- (h) FR6 inverse-Jacobian nonlinear re-solve sanity ----
     PrintSection("(h) FR6 inverse-Jacobian nonlinear re-solve sanity");
     std::cout << "  bump each marketRate by +1e-4, re-run CalibrateYieldCurve (ANALYTIC),\n";
     std::cout << "  compare true delta vs linear prediction effJacobianInverse_(k,i) * 1e-4 / tolerance_ (tol = 1e-6 rel)\n";
-    std::cout << std::fixed << std::setprecision(12);
-    std::cout << "  " << std::left << std::setw(8) << "inst" << std::right << std::setw(22) << "max rel delta" << "\n";
     // The solver scales each residual row by 1/tolerance_ before forming the pseudoinverse
     // (underdetermined.cpp XScaledFunc_::F divides residuals by tol; J() calls DivideRows(tol)).
     // So effJacobianInverse_(k,i) carries units d(params)/d(scaled residual), i.e.
@@ -458,29 +523,7 @@ int main() {
     // quote bump delta_m on instrument i is therefore effJacobianInverse_(k,i) * delta_m / tolerance_.
     // This was verified empirically against the nonlinear re-solve (it does NOT match a bare
     // effJacobianInverse_ * delta_m, which is off by the tolerance factor).
-    bool fr6Passed = true;
-    for (int i = 0; i < nInst; ++i) {
-        const Vector_<> trueDelta = RebumpedParamDelta(spec, options, i, ONE_BP, x);
-        Vector_<> pred(nFree, 0.0);
-        for (int k = 0; k < nFree; ++k)
-            pred[k] = effJacobianInverse(k, i) * ONE_BP / spec.tolerance_;
-        double maxRel = 0.0;
-        for (int k = 0; k < nFree; ++k) {
-            const double t = trueDelta[k];
-            const double p = pred[k];
-            const double err = std::abs(p - t);
-            const double rel = err / std::max(1.0, std::abs(t));
-            maxRel = std::max(maxRel, rel);
-            if (rel > RE_SOLVE_TOL) {
-                fr6Passed = false;
-                THROW(std::string("FR6 re-solve FAIL at inst=") + std::to_string(i) + " k=" + std::to_string(k) + ": rel=" + std::to_string(rel) +
-                      " > " + std::to_string(RE_SOLVE_TOL) + " (pred=" + std::to_string(p) + ", true=" + std::to_string(t) + ")");
-            }
-        }
-        std::cout << "  " << std::left << std::setw(8) << i << std::right << std::setw(22) << maxRel << "\n";
-    }
-    if (fr6Passed)
-        std::cout << "  Verdict : PASS  (all rel <= 1e-6)\n";
+    RunFR6ReSolve(spec, options, effJacobianInverse, x, nInst, nFree);
 
     PrintBanner("All self-checks passed.");
     return 0;

--- a/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+++ b/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
@@ -1,0 +1,552 @@
+//
+// Created by dal-implementer on 2026/6/19.
+//
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <dal/platform/platform.hpp>
+#include <dal/platform/initall.hpp>
+#include <dal/curve/calibration.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/ycctx.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/math/aad/aad.hpp>
+#include <dal/math/matrix/matrixarithmetic.hpp>
+#include <dal/math/matrix/matrixs.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/string/strings.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+#include <dal/utilities/exceptions.hpp>
+
+using namespace Dal;
+
+// Always-on precondition macro. The library's REQUIRE is conditionally compiled (only active when
+// DAL_USE_REQUIRE is defined), so it cannot carry self-checks that must fire in every build. This
+// local guard uses THROW (always active) so the example's self-checks run under every AAD backend
+// and every CMake configuration.
+#define THROW_REQUIRE(cond, msg)                                                                                                                     \
+    do {                                                                                                                                             \
+        if (!(cond))                                                                                                                                 \
+            THROW(msg);                                                                                                                              \
+    } while (false)
+
+// This example demonstrates two teaching arcs on a single-curve Phase A calibration:
+//
+//   (a) The calibration residual Jacobian J = d(modelRate_i) / d(logDF_free_k) computed two
+//       independent ways -- a central-difference bump oracle and an AAD reverse sweep -- and shown
+//       to agree element-wise to 1e-9 relative.
+//   (b) The inverse-Jacobian IR-risk transform: take the par-rate parameter-sensitivity g of one
+//       off-anchor swap (an independent bump oracle, NOT the AAD tape from arc (a)), left-multiply
+//       by the calibration inverse Jacobian effJacobianInverse_ (the solver-scaled pseudoinverse;
+//       see the units note in TransformToQuoteRisk), and read off bucketed risk per calibration
+//       instrument.
+//
+// AAD is always compiled in this library (dal-cpp/dal/math/aad/aad.hpp:17 defines the native AAET
+// backend on the "no DAL_USE_*_AAD flag set" branch). The AAD block below is therefore unguarded --
+// it runs identically under native AAET, Adept, XAD, and CoDiPack, exactly as
+// dal-cpp/examples/vanilla/vanilla.cpp and dal-cpp/digital/digital.cpp do. The example includes
+// only <dal/math/aad/aad.hpp> and uses only the Dal::AAD facade.
+
+namespace {
+    using AAD::Adjoint;
+    using AAD::Number_;
+    using AAD::Value;
+
+    // Self-check bars (see .claude/specs/yield-curve-jacobian-example.md "AAD-vs-Bump Tolerance
+    // Choice"). The 1e-9 AAD-vs-bump bar holds because the Phase A LOG_DISCOUNT residual Jacobian
+    // is O(1) and well-conditioned at the chosen 1%-3% par rates; central-difference round-off at
+    // h=1e-6 is ~eps/h ~= 2e-10 relative, leaving ~5x margin. The FR6 re-solve is a genuine
+    // nonlinear operation so it is looser by design.
+    constexpr double BUMP_STEP = 1.0e-6;
+    constexpr double AAD_TOL = 1.0e-9;
+    constexpr double RE_SOLVE_TOL = 1.0e-6;
+    constexpr double ONE_BP = 1.0e-4;
+
+    RateLegConvention_ AnnualLeg() {
+        RateLegConvention_ leg;
+        leg.paymentLag_ = 0;
+        leg.paymentFrequency_ = PeriodLength_("12M");
+        leg.dayBasis_ = DayBasis_("ACT_365F");
+        leg.accrualHolidays_ = Holidays::None();
+        leg.paymentHolidays_ = Holidays::None();
+        leg.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        leg.paymentConvention_ = BizDayConvention_("Unadjusted");
+        return leg;
+    }
+
+    RateIndexConvention_ AnnualIndex() {
+        RateIndexConvention_ idx;
+        idx.forecastTenor_ = PeriodLength_("12M");
+        idx.dayBasis_ = DayBasis_("ACT_365F");
+        idx.fixingLag_ = 0;
+        idx.spotLag_ = 0;
+        idx.fixingHolidays_ = Holidays::None();
+        idx.accrualHolidays_ = Holidays::None();
+        idx.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        idx.useProjectionCurve_ = false;
+        return idx;
+    }
+
+    // The exactly-5-instrument vanilla-swap Phase A calibration. Mirrors MakePhaseASpec in
+    // dal-cpp/tests/curve/test_analytic_jacobian.cpp:57-90: LOG_DISCOUNT, EXACT, anchor == today_,
+    // no projection curve, vanilla Swap_ only. This shape is provably eligible for the analytic
+    // (AAD-tape) Jacobian, so requesting CurveJacobianMode_::ANALYTIC engages the tape rather than
+    // silently falling back to bumping.
+    CurveCalibrationSpec_ BuildCalibrationSpec() {
+        CurveCalibrationSpec_ spec;
+        spec.today_ = Date_(2022, 1, 1);
+        spec.ccy_ = "USD";
+        spec.curveName_ = "yield_curve_jacobian";
+        spec.targetCollateral_ = CollateralType_(CollateralType_::Value_::OIS);
+        spec.calibrateDiscountCurve_ = true;
+        spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+        spec.knotPolicy_ = CurveKnotPolicy_::Value_::INPUT;
+        spec.solveMode_ = CurveSolveMode_::Value_::EXACT;
+        spec.liborBasis_ = DayBasis_("ACT_365F");
+        spec.tolerance_ = 1.0e-10;
+        spec.fitTolerance_ = 1.0e-8;
+        spec.smoothingWeight_ = 1.0;
+        spec.logDfScheme_ = LogDfScheme_::Value_::LOG_LINEAR;
+
+        spec.knotDates_ = {
+            Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1), Date_(2024, 1, 1), Date_(2025, 1, 1),
+        };
+
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
+        const auto mkSwap = [&](const Date_& start, const Date_& end, double parPct) {
+            return Handle_<YCInstrument_>(new Swap_(spec.today_, start, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
+        };
+        spec.instruments_ = {
+            mkSwap(Date_(2022, 1, 1), Date_(2022, 4, 1), 1.00), mkSwap(Date_(2022, 1, 1), Date_(2022, 7, 1), 1.10),
+            mkSwap(Date_(2022, 1, 1), Date_(2023, 1, 1), 1.25), mkSwap(Date_(2022, 1, 1), Date_(2024, 1, 1), 1.55),
+            mkSwap(Date_(2022, 1, 1), Date_(2025, 1, 1), 1.80),
+        };
+        return spec;
+    }
+
+    // Index of the off-anchor swap used as the "portfolio" for the FR5 risk transform. Swap 4 (3Y)
+    // has annual coupons landing on the 2023/2024/2025 nodes (free columns 2,3,4); the sub-annual
+    // 2022-04 and 2022-07 nodes (columns 0,1) carry structural zeros in g, which the risk transform
+    // handles correctly.
+    constexpr int PORTFOLIO_INDEX = 4;
+
+    // ---- Curve (re)construction from a free-parameter vector ----
+
+    // Build a CurveBlock_ around a DiscountLogDF_ rebuilt from the supplied free-node log-DF vector
+    // (anchor at index 0 stays 0.0). The instruments price off this block via Precompute() ->
+    // operator()(CurveBlock_). Mirrors EvalResiduals in
+    // dal-cpp/tests/curve/test_analytic_jacobian.cpp:95-113.
+    CurveBlock_ CurveBlockFromFreeParams(const CurveCalibrationSpec_& spec, const Vector_<>& x) {
+        const int nNodes = static_cast<int>(spec.knotDates_.size());
+        Vector_<> full(nNodes, 0.0);
+        for (int i = 1; i < nNodes; ++i)
+            full[i] = x[i - 1];
+        std::unique_ptr<DiscountCurve_> dc(NewDiscountLogDF(spec.curveName_, spec.ccy_, spec.knotDates_, full, spec.liborBasis_, spec.logDfScheme_));
+        std::map<CollateralType_, Handle_<DiscountCurve_>> discounts;
+        discounts[spec.targetCollateral_] = Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), dc.release()));
+        std::map<PeriodLength_, Handle_<DiscountCurve_>> forwards;
+        // The aliasing shared_ptr (empty destructor, raw pointer = dc) takes ownership: dc.release()
+        // hands the bare pointer over without a double-free. Mirrors the test idiom in
+        // test_analytic_jacobian.cpp:103. The CurveBlock_ holds the Handle_ alive through the return.
+        return CurveBlock_(spec.curveName_, spec.ccy_, discounts, forwards, spec.liborBasis_);
+    }
+
+    // Read the solved free-node log-DF vector off a calibrated curve: dynamic_cast to
+    // DiscountLogDF_ and drop the pinned anchor at index 0.
+    Vector_<> SolvedFreeParams(const DiscountCurve_& curve) {
+        const auto* logDf = dynamic_cast<const DiscountLogDF_*>(&curve);
+        THROW_REQUIRE(logDf != nullptr, "calibrated curve is not a DiscountLogDF_ (Phase A shape broken)");
+        const Vector_<> nodes = logDf->NodeLogDF();
+        Vector_<> x(nodes.size() - 1);
+        for (size_t i = 1; i < nodes.size(); ++i)
+            x[i - 1] = nodes[i];
+        return x;
+    }
+
+    // ---- Jacobian oracles ----
+
+    // Two-sided central-difference Jacobian J_bump(i,k) = d(modelRate_i) / d(logDF_free_k).
+    // Mirrors AssertMatchesCentralDifference in test_analytic_jacobian.cpp. Returns a dense
+    // nInstruments x nFreeParams matrix.
+    Matrix_<> BumpJacobian(const CurveCalibrationSpec_& spec, const Vector_<>& x, double h) {
+        const int nInst = static_cast<int>(spec.instruments_.size());
+        const int nFree = static_cast<int>(x.size());
+        Handle_<YieldCurve_> empty;
+        Matrix_<> j(nInst, nFree, 0.0);
+        for (int k = 0; k < nFree; ++k) {
+            Vector_<> xUp = x;
+            Vector_<> xDn = x;
+            xUp[k] += h;
+            xDn[k] -= h;
+            CurveBlock_ ycUp = CurveBlockFromFreeParams(spec, xUp);
+            CurveBlock_ ycDn = CurveBlockFromFreeParams(spec, xDn);
+            for (int i = 0; i < nInst; ++i) {
+                const auto rateUp = spec.instruments_[i]->Precompute(empty);
+                const auto rateDn = spec.instruments_[i]->Precompute(empty);
+                const double modelUp = (*rateUp)(ycUp);
+                const double modelDn = (*rateDn)(ycDn);
+                j(i, k) = (modelUp - modelDn) / (2.0 * h);
+            }
+        }
+        return j;
+    }
+
+    // AAD reverse-sweep Jacobian J_aad(i,k) = d(modelRate_i) / d(logDF_free_k). Mirrors
+    // YieldCurveCalibrationFunc_::AnalyticJacobian in dal-cpp/dal/curve/calibration.cpp:510-565
+    // line-for-line in shape. The forward pass builds a Number_-typed DiscountLogDF_ curve
+    // (Tape::DiscountLogDF_<Number_>, publicly constructible and explicitly instantiated in
+    // yclogdf.cpp), a Tape::YCCtx_<Number_>, and Number_-typed rates via inst->PrecomputeT<Number_>();
+    // then one reverse sweep per row harvests d(modelRate_i)/d(logDF_k+1) from the node adjoints.
+    Matrix_<> AadJacobian(const CurveCalibrationSpec_& spec, const Vector_<>& x) {
+        auto* tape = Dal::AAD::Tape();
+        Dal::AAD::Clear(*tape);
+
+        const int nNodes = static_cast<int>(spec.knotDates_.size());
+        const int nFree = static_cast<int>(x.size());
+        THROW_REQUIRE(nFree == nNodes - 1, "free-param vector length must equal nNodes - 1");
+
+        // Independents: free-node log(DF) values. Anchor (node 0) pinned at 0 and deliberately NOT
+        // registered -- registering it would add a phantom input column. RegisterIndependent
+        // anchors each free node on every backend before the recording window opens.
+        Vector_<Number_> logDF(nNodes);
+        logDF[0] = 0.0;
+        for (int k = 0; k < nFree; ++k)
+            Dal::AAD::RegisterIndependent(logDF[k + 1], x[k]);
+
+        // Open the recording AFTER registering inputs and BEFORE the forward pass. XAD's canonical
+        // contract drops inputs registered after newRecording; opening here is invisible on native
+        // (NewRecording is a no-op) and correct on CoDiPack/Adept (anchors the sweep bounds).
+        Dal::AAD::NewRecording(*tape);
+
+        std::unique_ptr<Tape::DiscountLogDF_<Number_>> dc(
+            new Tape::DiscountLogDF_<Number_>(spec.curveName_, spec.ccy_, spec.knotDates_, logDF, spec.liborBasis_, spec.logDfScheme_));
+        Tape::YCCtx_<Number_> ctx(*dc);
+
+        // Forward pass: Number_-typed model rates. PrecomputeT<Number_> lives only on the concrete
+        // Phase A instrument types (Deposit_/FRA_/Future_/Swap_), so downcast per instrument --
+        // mirroring PhaseARateAt in calibration.cpp:489-500. Use Dal::AAD::Value / Dal::AAD::Adjoint
+        // to read primals/adjoints; never static_cast<double>(Number_) (FR8: only native and
+        // CoDiPack have operator double(); XAD/Adept do not).
+        const int nInst = static_cast<int>(spec.instruments_.size());
+        Vector_<Number_> modelRates(nInst);
+        for (int i = 0; i < nInst; ++i) {
+            const auto* inst = spec.instruments_[i].get();
+            Handle_<Tape::Rate_<Number_>> rateT;
+            if (const auto* d = dynamic_cast<const Deposit_*>(inst))
+                rateT = d->PrecomputeT<Number_>();
+            else if (const auto* fr = dynamic_cast<const FRA_*>(inst))
+                rateT = fr->PrecomputeT<Number_>();
+            else if (const auto* fu = dynamic_cast<const Future_*>(inst))
+                rateT = fu->PrecomputeT<Number_>();
+            else if (const auto* s = dynamic_cast<const Swap_*>(inst))
+                rateT = s->PrecomputeT<Number_>();
+            else
+                THROW_REQUIRE(false, std::string("instrument ") + std::to_string(i) + " has no Phase A templated rate");
+            modelRates[i] = (*rateT)(ctx);
+        }
+
+        // Single-result reverse sweep, one row at a time. ZeroAdjoints clears propagated adjoints
+        // between rows so each seed lands on a clean slate (Adept's compute_adjoint does not clear
+        // operands between sweeps -- without ZeroAdjoints row 2 inherits row 1's residue).
+        Matrix_<> j(nInst, nFree, 0.0);
+        for (int i = 0; i < nInst; ++i) {
+            Dal::AAD::ZeroAdjoints(*tape);
+            Dal::AAD::Adjoint(modelRates[i]) = 1.0;
+            Dal::AAD::PropagateToStart(*tape);
+            for (int k = 0; k < nFree; ++k)
+                j(i, k) = Dal::AAD::Adjoint(logDF[k + 1]);
+        }
+        return j;
+    }
+
+    // ---- FR5 portfolio parameter sensitivity g ----
+
+    // g[k] = d(modelParRate_portfolio) / d(logDF_free_k) for the off-anchor portfolio swap, via an
+    // INDEPENDENT central-difference bump on the calibrated curve. This is deliberately a separate
+    // oracle from the FR3 AAD tape: that tape records the residual sensitivities d(modelRate -
+    // marketRate)/d(logDF) for every calibration row, which is a different quantity (residual, not
+    // a single portfolio's par rate). Reusing it would conflate the two.
+    //
+    // Units note: the YCInstrument_ interface exposes only the par-rate model rate S = floatPv /
+    // annuity, not PV. So g is a par-rate sensitivity (rate per logDF), and r = g^T *
+    // effJacobianInverse_ / tolerance_ (see TransformToQuoteRisk) is "par-rate risk per absolute
+    // decimal quote bump" -- how much the portfolio's par rate moves per +1 in calibration quote i,
+    // and r * 1e-4 is the par-rate DV01 per +1bp. The annuity scaling that would convert this to a
+    // true price DV01 is not exposed by the public API.
+    Vector_<> PortfolioParamSensitivity(const CurveCalibrationSpec_& spec, const Vector_<>& x, double h) {
+        const int nFree = static_cast<int>(x.size());
+        Handle_<YieldCurve_> empty;
+        Vector_<> g(nFree, 0.0);
+        const Handle_<YCInstrument_>& portfolio = spec.instruments_[PORTFOLIO_INDEX];
+        for (int k = 0; k < nFree; ++k) {
+            Vector_<> xUp = x;
+            Vector_<> xDn = x;
+            xUp[k] += h;
+            xDn[k] -= h;
+            CurveBlock_ ycUp = CurveBlockFromFreeParams(spec, xUp);
+            CurveBlock_ ycDn = CurveBlockFromFreeParams(spec, xDn);
+            const auto rateUp = portfolio->Precompute(empty);
+            const auto rateDn = portfolio->Precompute(empty);
+            g[k] = ((*rateUp)(ycUp) - (*rateDn)(ycDn)) / (2.0 * h);
+        }
+        return g;
+    }
+
+    // r = g^T * effJacobianInverse_ / tolerance_ via the Vector_,Matrix_ overload of Matrix::Multiply
+    // (matrixarithmetic.hpp:11 computes left^T * right). effJacobianInverse_ is nFreeParams x
+    // nInstruments with units d(params) * tolerance_ / d(decimal-rate perturbation) (the solver
+    // scales residuals by 1/tolerance_ before forming the pseudoinverse -- see the FR6 note in
+    // main). Dividing by tolerance_ puts r in honest d(portfolio par rate)/d(decimal quote bump)
+    // units; r[i] is how much the portfolio par rate moves per +1 in calibration quote i, and
+    // r[i] * 1e-4 is the par-rate DV01 per +1bp.
+    Vector_<> TransformToQuoteRisk(const Vector_<>& g, const Matrix_<>& effJacobianInverse, double tolerance) {
+        Vector_<> r;
+        Dal::Matrix::Multiply(g, effJacobianInverse, &r);
+        const double scale = 1.0 / tolerance;
+        for (auto& v : r)
+            v *= scale;
+        return r;
+    }
+
+    // ---- FR6 nonlinear re-solve sanity ----
+
+    // For instrument bumpedIdx: bump its market quote by +1e-4 absolute decimal, re-run
+    // CalibrateYieldCurve with CurveJacobianMode_::ANALYTIC, diff the new NodeLogDF() against the
+    // baseline free params to get the true nonlinear rebumped delta, and compare to the linear
+    // prediction effJacobianInverse_ * e_bumpedIdx * 1e-4. The re-calibrate path is the genuine
+    // nonlinear sanity test (the linear "analytic forward map" alternative is tautological and
+    // explicitly disallowed by FR6).
+    Vector_<> RebumpedParamDelta(
+        const CurveCalibrationSpec_& spec, const CurveCalibrationOptions_& options, int bumpedIdx, double bump, const Vector_<>& baselineFree) {
+        CurveCalibrationSpec_ bumped = spec;
+        // Re-quote instrument bumpedIdx at marketRate + bump (absolute decimal). Swap_'s marketRate
+        // is the par rate in decimal units; +1e-4 == +1bp.
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
+        const auto& orig = spec.instruments_[bumpedIdx];
+        const auto* swapOrig = dynamic_cast<const Swap_*>(orig.get());
+        THROW_REQUIRE(swapOrig != nullptr, "FR6 re-quote expects a vanilla Swap_");
+        const auto span = swapOrig->TimeSpan();
+        const double newRate = swapOrig->MarketRate() + bump;
+        bumped.instruments_[bumpedIdx] =
+            Handle_<YCInstrument_>(new Swap_(spec.today_, span.first, span.second, newRate, fixedLeg, floatIdx, floatLeg));
+
+        const auto res = CalibrateYieldCurve(bumped, options);
+        const Vector_<> rebumpedFree = SolvedFreeParams(*res.curve_);
+        THROW_REQUIRE(rebumpedFree.size() == baselineFree.size(), "rebumped free-param length mismatch");
+        Vector_<> delta(rebumpedFree.size());
+        for (size_t k = 0; k < rebumpedFree.size(); ++k)
+            delta[k] = rebumpedFree[k] - baselineFree[k];
+        return delta;
+    }
+
+    // ---- output helpers ----
+
+    void PrintBanner(const String_& title) {
+        const std::string bar(70, '=');
+        std::cout << "\n" << bar << "\n";
+        const int pad = static_cast<int>(bar.size() - static_cast<int>(title.size())) / 2;
+        std::cout << std::string(pad > 0 ? pad : 1, ' ') << title << "\n";
+        std::cout << bar << "\n";
+    }
+
+    void PrintSection(const String_& title) {
+        const std::string bar(70, '-');
+        std::cout << "\n" << bar << "\n  " << title << "\n" << bar << "\n";
+    }
+
+    void PrintResiduals(const CurveCalibrationDiagnostics_& diag) {
+        std::cout << std::fixed << std::setprecision(6);
+        std::cout << std::left << std::setw(26) << "Instrument" << std::right << std::setw(14) << "Market(%)" << std::setw(14) << "Model(%)"
+                  << std::setw(12) << "Error(bp)" << "\n";
+        std::cout << std::string(62, '-') << "\n";
+        for (int i = 0; i < static_cast<int>(diag.instrumentNames_.size()); ++i) {
+            std::cout << std::left << std::setw(26) << diag.instrumentNames_[i].c_str() << std::right << std::setw(14) << diag.marketRates_[i] * 100.0
+                      << std::setw(14) << diag.modelRates_[i] * 100.0 << std::setw(12) << diag.residuals_[i] * 10000.0 << "\n";
+        }
+    }
+
+    void PrintVector(const String_& label, const Vector_<>& v) {
+        std::cout << std::fixed << std::setprecision(12);
+        if (!label.empty())
+            std::cout << label << "\n";
+        for (int i = 0; i < static_cast<int>(v.size()); ++i)
+            std::cout << "  [" << i << "] " << std::setw(20) << v[i] << "\n";
+    }
+
+    void PrintMatrix(const String_& label, const Matrix_<>& m, const String_& orientation) {
+        std::cout << std::fixed << std::setprecision(12);
+        if (!label.empty())
+            std::cout << label << "\n";
+        std::cout << "  " << orientation << "  (rows=" << m.Rows() << ", cols=" << m.Cols() << ")\n";
+        std::cout << "          ";
+        for (int j = 0; j < m.Cols(); ++j)
+            std::cout << std::setw(18) << ("[" + std::to_string(j) + "]");
+        std::cout << "\n";
+        for (int i = 0; i < m.Rows(); ++i) {
+            std::cout << "  [" << i << "]  ";
+            for (int j = 0; j < m.Cols(); ++j)
+                std::cout << std::setw(18) << m(i, j);
+            std::cout << "\n";
+        }
+    }
+} // namespace
+
+int main() {
+    RegisterAll_::Init();
+
+    PrintBanner("Yield-Curve Jacobian Example");
+
+    const auto spec = BuildCalibrationSpec();
+    const int nInst = static_cast<int>(spec.instruments_.size());
+    const int nFree = static_cast<int>(spec.knotDates_.size()) - 1;
+    THROW_REQUIRE(nInst == nFree, "Phase A calibration must be square: nInstruments == nKnotDates - 1");
+
+    std::cout << "\nCalibration: " << nInst << " instruments on " << spec.knotDates_.size() << " LOG_DISCOUNT knots (" << nFree
+              << " free params + anchor)\n";
+    std::cout << "Parameterization: LOG_DISCOUNT   Solve mode: EXACT   Jacobian mode: ANALYTIC\n";
+    std::cout << "Bump step h: " << std::scientific << std::setprecision(6) << BUMP_STEP << std::fixed << "\n";
+
+    // ---- (a) Calibrate with the analytic Jacobian engaged ----
+    CurveCalibrationOptions_ options;
+    options.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    const auto result = CalibrateYieldCurve(spec, options);
+
+    // Eligibility backstop: if the spec silently fell back to BUMPED (ANALYTIC never throws, it
+    // only emits a NOTICE and falls back), the AAD path is a no-op and the whole teaching payload
+    // is hollow. Detect via the analytic-tape Jacobian matching the residual oracle at the solved
+    // point: compute J_aad from first principles and confirm it is non-trivial.
+    const Vector_<> x = SolvedFreeParams(*result.curve_);
+
+    PrintSection("(a) Calibration residuals");
+    PrintResiduals(result.diagnostics_);
+    std::cout << "\nSolved free-node log-DF params x (anchor pinned at 0):\n";
+    PrintVector("", x);
+
+    // ---- (b) Bump Jacobian (oracle) ----
+    const Matrix_<> jBump = BumpJacobian(spec, x, BUMP_STEP);
+    PrintSection("(b) Bump Jacobian  J_bump = d(modelRate_i) / d(logDF_free_k)");
+    PrintMatrix("", jBump, "rows = instruments, cols = free params; central diff h = 1e-6");
+
+    // ---- (c) AAD Jacobian (reverse sweep, from first principles) ----
+    const Matrix_<> jAad = AadJacobian(spec, x);
+    // B2 sentinel: every row must have at least one non-trivial entry. An all-zero row means the
+    // tape never learned an input is an independent (the canonical missed-RegisterIndependent /
+    // wrong-recording-order failure). Catch it before the FD comparison.
+    for (int i = 0; i < jAad.Rows(); ++i) {
+        double maxAbs = 0.0;
+        for (int k = 0; k < jAad.Cols(); ++k)
+            maxAbs = std::max(maxAbs, std::abs(jAad(i, k)));
+        if (maxAbs <= 1.0e-6)
+            THROW(std::string("AAD Jacobian row ") + std::to_string(i) + " is all-zero (B2 sentinel: missed RegisterIndependent?)");
+    }
+    PrintSection("(c) AAD Jacobian  J_aad = d(modelRate_i) / d(logDF_free_k)");
+    PrintMatrix("", jAad, "rows = instruments, cols = free params; reverse sweep, 1 per row");
+
+    // ---- (d) AAD-vs-bump agreement (verbatim two-branch form, tol = 1e-9) ----
+    PrintSection("(d) AAD-vs-bump agreement  (verbatim two-branch form, tol = 1e-9)");
+    double maxAbs = 0.0;
+    double maxRel = 0.0;
+    THROW_REQUIRE(jBump.Rows() == jAad.Rows() && jBump.Cols() == jAad.Cols(), "Jacobian shape mismatch");
+    for (int i = 0; i < jBump.Rows(); ++i) {
+        for (int k = 0; k < jBump.Cols(); ++k) {
+            const double fd = jBump(i, k);
+            const double an = jAad(i, k);
+            const double absErr = std::abs(an - fd);
+            maxAbs = std::max(maxAbs, absErr);
+            if (std::abs(fd) < AAD_TOL) {
+                maxRel = std::max(maxRel, absErr);
+                if (absErr > AAD_TOL)
+                    THROW(std::string("AAD-vs-bump FAIL at (i=") + std::to_string(i) + ",k=" + std::to_string(k) +
+                          "): |an|=" + std::to_string(absErr) + " > " + std::to_string(AAD_TOL) + " (|fd|<1e-9 branch)");
+            } else {
+                const double rel = absErr / std::max(1.0, std::abs(fd));
+                maxRel = std::max(maxRel, rel);
+                if (rel > AAD_TOL)
+                    THROW(std::string("AAD-vs-bump FAIL at (i=") + std::to_string(i) + ",k=" + std::to_string(k) + "): rel=" + std::to_string(rel) +
+                          " > " + std::to_string(AAD_TOL) + " (an=" + std::to_string(an) + ", fd=" + std::to_string(fd) + ")");
+            }
+        }
+    }
+    std::cout << std::fixed << std::setprecision(12);
+    std::cout << "  max abs discrepancy : " << maxAbs << "\n";
+    std::cout << "  max rel discrepancy : " << maxRel << "\n";
+    std::cout << "  Verdict              : PASS  (rel <= 1e-9)\n";
+
+    // ---- (e) effJacobianInverse_ from the EXACT solve ----
+    const Matrix_<>& effJacobianInverse = result.diagnostics_.effJacobianInverse_;
+    THROW_REQUIRE(effJacobianInverse.Rows() == nFree && effJacobianInverse.Cols() == nInst,
+                  "effJacobianInverse_ shape must be nFreeParams x nInstruments (populated only by EXACT solve)");
+    PrintSection("(e) effJacobianInverse_  d(params) * tolerance_ / d(decimal-rate perturbation)");
+    PrintMatrix("", effJacobianInverse, "rows = free params, cols = instruments; solver-scaled pseudoinverse (residuals scaled by 1/tolerance_)");
+
+    // ---- (f) Portfolio parameter sensitivity g ----
+    const Vector_<> g = PortfolioParamSensitivity(spec, x, BUMP_STEP);
+    PrintSection("(f) Portfolio parameter-sensitivity  g = d(modelParRate_portfolio) / d(logDF_free_k)");
+    std::cout << "  portfolio = swap " << PORTFOLIO_INDEX << " (off-anchor); length = nFree = " << g.size() << "\n";
+    std::cout << "  units: par-rate per unit log-DF bump (annuity-scaled PV not exposed by YCInstrument_)\n";
+    PrintVector("", g);
+
+    // ---- (g) Bucketed IR risk r = g^T * effJacobianInverse_ ----
+    const Vector_<> r = TransformToQuoteRisk(g, effJacobianInverse, spec.tolerance_);
+    PrintSection("(g) Bucketed IR risk  r = g^T * effJacobianInverse_");
+    std::cout << "  length = nInstruments = " << r.size() << "\n";
+    std::cout << "  units: par-rate per absolute decimal quote bump\n";
+    std::cout << std::fixed << std::setprecision(12);
+    std::cout << "  " << std::left << std::setw(22) << "raw r[i]" << std::right << std::setw(22) << "par-rate DV01 (r[i]*1e-4)"
+              << "\n";
+    for (int i = 0; i < static_cast<int>(r.size()); ++i)
+        std::cout << "  " << std::left << std::setw(22) << r[i] << std::right << std::setw(22) << r[i] * ONE_BP << "\n";
+
+    // ---- (h) FR6 inverse-Jacobian nonlinear re-solve sanity ----
+    PrintSection("(h) FR6 inverse-Jacobian nonlinear re-solve sanity");
+    std::cout << "  bump each marketRate by +1e-4, re-run CalibrateYieldCurve (ANALYTIC),\n";
+    std::cout << "  compare true delta vs linear prediction effJacobianInverse_(k,i) * 1e-4 / tolerance_ (tol = 1e-6 rel)\n";
+    std::cout << std::fixed << std::setprecision(12);
+    std::cout << "  " << std::left << std::setw(8) << "inst" << std::right << std::setw(22) << "max rel delta" << "\n";
+    // The solver scales each residual row by 1/tolerance_ before forming the pseudoinverse
+    // (underdetermined.cpp XScaledFunc_::F divides residuals by tol; J() calls DivideRows(tol)).
+    // So effJacobianInverse_(k,i) carries units d(params)/d(scaled residual), i.e.
+    // d(params) * tolerance_ / d(decimal-rate perturbation). The linear prediction for a decimal
+    // quote bump delta_m on instrument i is therefore effJacobianInverse_(k,i) * delta_m / tolerance_.
+    // This was verified empirically against the nonlinear re-solve (it does NOT match a bare
+    // effJacobianInverse_ * delta_m, which is off by the tolerance factor).
+    bool fr6Passed = true;
+    for (int i = 0; i < nInst; ++i) {
+        const Vector_<> trueDelta = RebumpedParamDelta(spec, options, i, ONE_BP, x);
+        Vector_<> pred(nFree, 0.0);
+        for (int k = 0; k < nFree; ++k)
+            pred[k] = effJacobianInverse(k, i) * ONE_BP / spec.tolerance_;
+        double maxRel = 0.0;
+        for (int k = 0; k < nFree; ++k) {
+            const double t = trueDelta[k];
+            const double p = pred[k];
+            const double err = std::abs(p - t);
+            const double rel = err / std::max(1.0, std::abs(t));
+            maxRel = std::max(maxRel, rel);
+            if (rel > RE_SOLVE_TOL) {
+                fr6Passed = false;
+                THROW(std::string("FR6 re-solve FAIL at inst=") + std::to_string(i) + " k=" + std::to_string(k) + ": rel=" + std::to_string(rel) +
+                      " > " + std::to_string(RE_SOLVE_TOL) + " (pred=" + std::to_string(p) + ", true=" + std::to_string(t) + ")");
+            }
+        }
+        std::cout << "  " << std::left << std::setw(8) << i << std::right << std::setw(22) << maxRel << "\n";
+    }
+    if (fr6Passed)
+        std::cout << "  Verdict : PASS  (all rel <= 1e-6)\n";
+
+    PrintBanner("All self-checks passed.");
+    return 0;
+}

--- a/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+++ b/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
@@ -27,14 +27,14 @@
 
 using namespace Dal;
 
-// Always-on precondition macro. The library's REQUIRE is conditionally compiled (only active when
-// DAL_USE_REQUIRE is defined), so it cannot carry self-checks that must fire in every build. This
-// local guard uses THROW (always active) so the example's self-checks run under every AAD backend
-// and every CMake configuration.
+// Always-on precondition macro. The library's REQUIRE (dal-cpp/dal/utilities/exceptions.hpp) routes
+// to THROW, so it would also fire in every build -- but it is a generic precondition helper that
+// does not name a self-check. Defining THROW_REQUIRE here gives the example an explicit, self-naming
+// guard that runs under every AAD backend and every CMake configuration.
 #define THROW_REQUIRE(cond, msg)                                                                                                                     \
-    do {                                                                                                                                             \
-        if (!(cond))                                                                                                                                 \
-            THROW(msg);                                                                                                                              \
+    do {                                                                                                                                            \
+        if (!(cond))                                                                                                                                \
+            THROW(msg);                                                                                                                             \
     } while (false)
 
 // This example demonstrates two teaching arcs on a single-curve Phase A calibration:
@@ -152,11 +152,11 @@ namespace {
             full[i] = x[i - 1];
         std::unique_ptr<DiscountCurve_> dc(NewDiscountLogDF(spec.curveName_, spec.ccy_, spec.knotDates_, full, spec.liborBasis_, spec.logDfScheme_));
         std::map<CollateralType_, Handle_<DiscountCurve_>> discounts;
-        discounts[spec.targetCollateral_] = Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), dc.release()));
+        discounts[spec.targetCollateral_] = Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(dc.release()));
         std::map<PeriodLength_, Handle_<DiscountCurve_>> forwards;
-        // The aliasing shared_ptr (empty destructor, raw pointer = dc) takes ownership: dc.release()
-        // hands the bare pointer over without a double-free. Mirrors the test idiom in
-        // test_analytic_jacobian.cpp:103. The CurveBlock_ holds the Handle_ alive through the return.
+        // Take ownership of the curve: the owning shared_ptr deletes it when the returned CurveBlock_
+        // dies. The previous aliasing-ctor form (empty owner shared_ptr) did not own the pointer, so
+        // dc.release() orphans it and the curve leaks every call (per-node-per-bump).
         return CurveBlock_(spec.curveName_, spec.ccy_, discounts, forwards, spec.liborBasis_);
     }
 

--- a/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
+++ b/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
@@ -3,7 +3,10 @@
 //
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <cmath>
+#include <map>
+#include <memory>
 #include <dal/platform/platform.hpp>
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/curveblock.hpp>

--- a/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
+++ b/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
@@ -1,0 +1,291 @@
+//
+// Created by dal-implementer on 2026/6/19.
+//
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <dal/platform/platform.hpp>
+#include <dal/curve/calibration.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/discount.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/protocol/rateconvention.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+
+using namespace Dal;
+
+// Tests for the public forward-Jacobian diagnostics field CurveCalibrationDiagnostics_::jacobian_.
+// The field is the unscaled analytic forward Jacobian d(modelRate_i) / d(logDF_free_k) evaluated at
+// the calibrated solution by a fresh AAD reverse sweep in CalibrateYieldCurve (a re-evaluation at
+// the solved x, deliberately NOT the solver's Broyden-perturbed iterate matrix, which is what
+// effJacobianInverse_ is formed from). It is therefore distinct from effJacobianInverse_ -- a
+// solver-weighted, tolerance-scaled pseudoinverse at the iterate -- and the two are NOT inverses in
+// their exposed form. Populated iff solveMode_ == EXACT && jacobianMode_ == ANALYTIC && eligible;
+// default-constructed (empty, 0 x 0) otherwise.
+
+namespace {
+    RateLegConvention_ AnnualLeg() {
+        RateLegConvention_ leg;
+        leg.paymentLag_ = 0;
+        leg.paymentFrequency_ = PeriodLength_("12M");
+        leg.dayBasis_ = DayBasis_("ACT_365F");
+        leg.accrualHolidays_ = Holidays::None();
+        leg.paymentHolidays_ = Holidays::None();
+        leg.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        leg.paymentConvention_ = BizDayConvention_("Unadjusted");
+        return leg;
+    }
+
+    RateIndexConvention_ AnnualIndex() {
+        RateIndexConvention_ idx;
+        idx.forecastTenor_ = PeriodLength_("12M");
+        idx.dayBasis_ = DayBasis_("ACT_365F");
+        idx.fixingLag_ = 0;
+        idx.spotLag_ = 0;
+        idx.fixingHolidays_ = Holidays::None();
+        idx.accrualHolidays_ = Holidays::None();
+        idx.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        idx.useProjectionCurve_ = false;
+        return idx;
+    }
+
+    // Eligible Phase A spec: LOG_DISCOUNT + vanilla swaps starting at the anchor. Anchor pinned,
+    // so nFreeParams = nKnots - 1 = 5, and nInstruments = 5 (square).
+    CurveCalibrationSpec_ MakeEligibleSpec() {
+        CurveCalibrationSpec_ spec;
+        spec.today_ = Date_(2022, 1, 1);
+        spec.ccy_ = "USD";
+        spec.curveName_ = "forward_jacobian_eligible";
+        spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+        spec.knotPolicy_ = CurveKnotPolicy_::Value_::INPUT;
+        spec.solveMode_ = CurveSolveMode_::Value_::EXACT;
+        spec.liborBasis_ = DayBasis_("ACT_365F");
+        spec.tolerance_ = 1.0e-10;
+        spec.fitTolerance_ = 1.0e-8;
+        spec.smoothingWeight_ = 1.0;
+        spec.logDfScheme_ = LogDfScheme_::Value_::LOG_LINEAR;
+
+        spec.knotDates_ = {
+            Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1),
+            Date_(2024, 1, 1), Date_(2025, 1, 1),
+        };
+
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
+        const auto mkSwap = [&](const Date_& start, const Date_& end, double parPct) {
+            return Handle_<YCInstrument_>(new Swap_(spec.today_, start, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
+        };
+        spec.instruments_ = {
+            mkSwap(Date_(2022, 1, 1), Date_(2022, 4, 1), 1.00),
+            mkSwap(Date_(2022, 1, 1), Date_(2022, 7, 1), 1.10),
+            mkSwap(Date_(2022, 1, 1), Date_(2023, 1, 1), 1.25),
+            mkSwap(Date_(2022, 1, 1), Date_(2024, 1, 1), 1.55),
+            mkSwap(Date_(2022, 1, 1), Date_(2025, 1, 1), 1.80),
+        };
+        return spec;
+    }
+
+    // Ineligible spec: non-LOG_DISCOUNT parameterization falls back to bumped via NOTICE.
+    CurveCalibrationSpec_ MakeIneligibleSpec() {
+        auto spec = MakeEligibleSpec();
+        spec.parameterization_ = CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD;
+        spec.knotDates_[0] = Date_(2022, 4, 1); // knot 0 must be > today for non-LOG_DISCOUNT.
+        return spec;
+    }
+
+    Vector_<> SolvedFreeParams(const DiscountCurve_& curve) {
+        const auto* logDf = dynamic_cast<const DiscountLogDF_*>(&curve);
+        REQUIRE(logDf != nullptr, "calibrated curve is not a DiscountLogDF_");
+        Vector_<> nodes = logDf->NodeLogDF();
+        nodes.erase(nodes.begin()); // drop the anchor (pinned at 0)
+        return nodes;
+    }
+
+    // Independent two-sided central-difference Jacobian of the residual w.r.t. logDF_free at x.
+    // d(residual)/d(logDF) == d(modelRate)/d(logDF) since marketRate is constant, so this oracle is
+    // directly comparable to diagnostics_.jacobian_.
+    Vector_<> EvalResiduals(const CurveCalibrationSpec_& spec, const Vector_<>& x) {
+        Vector_<> full(spec.knotDates_.size(), 0.0);
+        for (int i = 1; i < static_cast<int>(spec.knotDates_.size()); ++i)
+            full[i] = x[i - 1];
+        std::unique_ptr<DiscountCurve_> dc(
+            NewDiscountLogDF(spec.curveName_, spec.ccy_, spec.knotDates_, full, spec.liborBasis_, spec.logDfScheme_));
+        std::map<CollateralType_, Handle_<DiscountCurve_>> discounts;
+        discounts[spec.targetCollateral_] =
+            Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), dc.get()));
+        std::map<PeriodLength_, Handle_<DiscountCurve_>> forwards;
+        CurveBlock_ yc(spec.curveName_, spec.ccy_, discounts, forwards, spec.liborBasis_);
+        Vector_<> f(spec.instruments_.size());
+        Handle_<YieldCurve_> empty;
+        for (int i = 0; i < static_cast<int>(spec.instruments_.size()); ++i) {
+            auto rate = spec.instruments_[i]->Precompute(empty);
+            f[i] = (*rate)(yc) - spec.instruments_[i]->MarketRate();
+        }
+        return f;
+    }
+} // namespace
+
+// Shape test: ANALYTIC + EXACT populates jacobian_ with shape nInstruments x (nKnots - 1).
+
+TEST(ForwardJacobianDiagnosticsTest, TestShapeWhenAnalyticExactEligible) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-7);
+
+    const Matrix_<>& j = result.diagnostics_.jacobian_;
+    ASSERT_FALSE(j.Empty());
+    ASSERT_EQ(j.Rows(), static_cast<int>(spec.instruments_.size()));
+    ASSERT_EQ(j.Cols(), static_cast<int>(spec.knotDates_.size()) - 1);
+}
+
+// Agreement test: jacobian_ matches a two-sided central difference of the residual w.r.t. logDF_free
+// at the solved x within 1e-9. Both the stored jacobian_ and the FD oracle evaluate at the solution,
+// so this is a clean AAD-vs-FD agreement (no iterate-vs-solution gap -- jacobian_ is re-evaluated at
+// the solved x, not read off the solver's iterate matrix).
+
+TEST(ForwardJacobianDiagnosticsTest, TestMatchesCentralDifferenceAtSolvedX) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-7);
+
+    const Matrix_<>& j = result.diagnostics_.jacobian_;
+    ASSERT_EQ(j.Rows(), static_cast<int>(spec.instruments_.size()));
+    ASSERT_EQ(j.Cols(), static_cast<int>(spec.knotDates_.size()) - 1);
+
+    const Vector_<> x = SolvedFreeParams(*result.curve_);
+    const double h = 1.0e-6;
+    const double relTol = 1.0e-9;
+    for (int c = 0; c < j.Cols(); ++c) {
+        Vector_<> xUp = x;
+        Vector_<> xDn = x;
+        xUp[c] += h;
+        xDn[c] -= h;
+        const Vector_<> fUp = EvalResiduals(spec, xUp);
+        const Vector_<> fDn = EvalResiduals(spec, xDn);
+        for (int r = 0; r < j.Rows(); ++r) {
+            const double fd = (fUp[r] - fDn[r]) / (2.0 * h);
+            const double an = j(r, c);
+            if (std::abs(fd) < relTol) {
+                ASSERT_NEAR(an, 0.0, relTol) << "row=" << r << " col=" << c << " FD=" << fd;
+            } else {
+                ASSERT_NEAR(an, fd, relTol * std::max(1.0, std::abs(fd))) << "row=" << r << " col=" << c;
+            }
+        }
+    }
+}
+
+// jacobian_ and effJacobianInverse_ have complementary shapes (nInst x nFree and nFree x nInst) and
+// are co-populated on the EXACT + ANALYTIC path. They are NOT the same matrix and jacobian_ is NOT
+// the inverse of effJacobianInverse_ in the exposed (unscaled vs tolerance-scaled) form; this test
+// pins only their co-population and complementary shape.
+
+TEST(ForwardJacobianDiagnosticsTest, TestCoherentWithEffJacobianInversePopulation) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-7);
+
+    ASSERT_FALSE(result.diagnostics_.jacobian_.Empty());
+    ASSERT_FALSE(result.diagnostics_.effJacobianInverse_.Empty());
+    ASSERT_EQ(result.diagnostics_.jacobian_.Rows(), result.diagnostics_.effJacobianInverse_.Cols());
+    ASSERT_EQ(result.diagnostics_.jacobian_.Cols(), result.diagnostics_.effJacobianInverse_.Rows());
+}
+
+// Empty-field regression: APPROXIMATE solve leaves jacobian_ empty.
+
+TEST(ForwardJacobianDiagnosticsTest, TestEmptyWhenApproximateSolve) {
+    auto spec = MakeEligibleSpec();
+    spec.solveMode_ = CurveSolveMode_::Value_::APPROXIMATE;
+    spec.fitTolerance_ = 1e-4;
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_TRUE(result.diagnostics_.usedApproximateFit_);
+    ASSERT_TRUE(result.diagnostics_.jacobian_.Empty());
+}
+
+// Empty-field regression: EXACT solve + BUMPED leaves jacobian_ empty.
+
+TEST(ForwardJacobianDiagnosticsTest, TestEmptyWhenBumpedDefault) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_TRUE(result.diagnostics_.jacobian_.Empty());
+}
+
+// B2 regression: EXACT && BUMPED. effJacobianInverse_ IS populated, but jacobian_ must be EMPTY --
+// the two fields have different population conditions by design (only the analytic path produces a
+// well-defined forward J).
+
+TEST(ForwardJacobianDiagnosticsTest, TestEmptyWhenExactBumpedButEffJacobianInversePopulated) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_FALSE(result.diagnostics_.usedApproximateFit_);
+    // effJacobianInverse_ is populated on EXACT regardless of jacobianMode_.
+    ASSERT_FALSE(result.diagnostics_.effJacobianInverse_.Empty());
+    // jacobian_ is NOT well-defined for the bumped J source -- must be empty by the explicit guard.
+    ASSERT_TRUE(result.diagnostics_.jacobian_.Empty());
+}
+
+// Empty-field regression: ANALYTIC on an ineligible spec falls back to bumped, so jacobian_ is
+// empty (no analytic J was ever produced).
+
+TEST(ForwardJacobianDiagnosticsTest, TestEmptyWhenAnalyticIneligibleFallback) {
+    const auto spec = MakeIneligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_NE(result.curve_, nullptr);
+    ASSERT_TRUE(result.diagnostics_.jacobian_.Empty());
+}
+
+// Multi-curve stage check: CalibrateMultiCurve routes every stage through CalibrateYieldCurve with
+// default (BUMPED) options, so every stage's jacobian_ is empty while effJacobianInverse_ is
+// populated where the stage solved EXACT.
+
+TEST(ForwardJacobianDiagnosticsTest, TestMultiCurveStagesMatchMode) {
+    auto mkStage = [](const String_& name) {
+        CurveCalibrationSpec_ stage = MakeEligibleSpec();
+        stage.curveName_ = name;
+        stage.calibrateDiscountCurve_ = true;
+        stage.targetCollateral_ = CollateralType_(CollateralType_::Value_::OIS);
+        return stage;
+    };
+
+    MultiCurveCalibrationSpec_ multi;
+    multi.name_ = "fwd_diag_multi";
+    multi.ccy_ = "USD";
+    multi.stages_ = {mkStage("stage_a"), mkStage("stage_b")};
+
+    const MultiCurveCalibrationResult_ result = CalibrateMultiCurve(multi);
+    ASSERT_EQ(result.diagnostics_.size(), multi.stages_.size());
+
+    for (int i = 0; i < static_cast<int>(result.diagnostics_.size()); ++i) {
+        const auto& d = result.diagnostics_[i];
+        // Default options = BUMPED: jacobian_ empty by the explicit EXACT && ANALYTIC guard.
+        ASSERT_TRUE(d.jacobian_.Empty()) << "stage " << i << " jacobian_ should be empty under default BUMPED options";
+        // EXACT solve (default) still populates effJacobianInverse_.
+        ASSERT_FALSE(d.effJacobianInverse_.Empty()) << "stage " << i << " effJacobianInverse_ should be populated by EXACT solve";
+    }
+}

--- a/dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp
+++ b/dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp
@@ -2,6 +2,8 @@
 // Created by dal-tester on 2026/6/19.
 //
 
+#include <gtest/gtest.h>
+
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/discount.hpp>
@@ -16,7 +18,6 @@
 #include <dal/time/holidays.hpp>
 #include <dal/time/periodlength.hpp>
 #include <dal/utilities/exceptions.hpp>
-#include <gtest/gtest.h>
 
 using namespace Dal;
 

--- a/dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp
+++ b/dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp
@@ -1,0 +1,234 @@
+//
+// Created by dal-tester on 2026/6/19.
+//
+
+#include <dal/curve/calibration.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/discount.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/math/matrix/matrixarithmetic.hpp>
+#include <dal/math/matrix/matrixs.hpp>
+#include <dal/platform/platform.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+#include <dal/utilities/exceptions.hpp>
+#include <gtest/gtest.h>
+
+using namespace Dal;
+
+// These tests gate the inverse-Jacobian IR-risk machinery that dal-cpp/examples/yield_curve_jacobian
+// demonstrates but does NOT register in CTest (examples are plain executables with no add_test call,
+// so the example's THROW-based self-checks never fire under `ctest`). The novel, subtle piece under
+// test is the unit correction on diagnostics_.effJacobianInverse_: the underdetermined solver scales
+// every residual row by 1/tolerance_ before forming the pseudoinverse
+// (dal-cpp/dal/math/optimization/underdetermined.cpp -- XScaledFunc_::F divides residuals by tol,
+// J() calls DivideRows(tol)), so effJacobianInverse_ carries units
+// d(params) * tolerance_ / d(decimal-rate perturbation). Both the linear re-solve prediction and the
+// bucketed-risk transform r = g^T * effJacobianInverse_ must therefore divide by tolerance_. If a
+// future change drops that division, these tests fail. The example self-check is good documentation
+// but is not a regression gate; this file is the gate.
+
+namespace {
+    RateLegConvention_ AnnualLeg() {
+        RateLegConvention_ leg;
+        leg.paymentLag_ = 0;
+        leg.paymentFrequency_ = PeriodLength_("12M");
+        leg.dayBasis_ = DayBasis_("ACT_365F");
+        leg.accrualHolidays_ = Holidays::None();
+        leg.paymentHolidays_ = Holidays::None();
+        leg.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        leg.paymentConvention_ = BizDayConvention_("Unadjusted");
+        return leg;
+    }
+
+    RateIndexConvention_ AnnualIndex() {
+        RateIndexConvention_ idx;
+        idx.forecastTenor_ = PeriodLength_("12M");
+        idx.dayBasis_ = DayBasis_("ACT_365F");
+        idx.fixingLag_ = 0;
+        idx.spotLag_ = 0;
+        idx.fixingHolidays_ = Holidays::None();
+        idx.accrualHolidays_ = Holidays::None();
+        idx.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        idx.useProjectionCurve_ = false;
+        return idx;
+    }
+
+    // Square 5-instrument Phase A ladder (5 knots -> 5 free params + anchor). Mirrors the shape in
+    // test_analytic_jacobian.cpp MakePhaseASpec so the analytic Jacobian is eligible and the EXACT
+    // solve populates effJacobianInverse_.
+    CurveCalibrationSpec_ MakeSquarePhaseASpec() {
+        CurveCalibrationSpec_ spec;
+        spec.today_ = Date_(2022, 1, 1);
+        spec.ccy_ = "USD";
+        spec.curveName_ = "inverse_jacobian_risk_test";
+        spec.targetCollateral_ = CollateralType_(CollateralType_::Value_::OIS);
+        spec.calibrateDiscountCurve_ = true;
+        spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+        spec.knotPolicy_ = CurveKnotPolicy_::Value_::INPUT;
+        spec.solveMode_ = CurveSolveMode_::Value_::EXACT;
+        spec.liborBasis_ = DayBasis_("ACT_365F");
+        spec.tolerance_ = 1.0e-10;
+        spec.fitTolerance_ = 1.0e-8;
+        spec.smoothingWeight_ = 1.0;
+        spec.logDfScheme_ = LogDfScheme_::Value_::LOG_LINEAR;
+
+        spec.knotDates_ = {
+            Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1), Date_(2024, 1, 1), Date_(2025, 1, 1),
+        };
+
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
+        const auto mkSwap = [&](const Date_& start, const Date_& end, double parPct) {
+            return Handle_<YCInstrument_>(new Swap_(spec.today_, start, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
+        };
+        spec.instruments_ = {
+            mkSwap(Date_(2022, 1, 1), Date_(2022, 4, 1), 1.00), mkSwap(Date_(2022, 1, 1), Date_(2022, 7, 1), 1.10),
+            mkSwap(Date_(2022, 1, 1), Date_(2023, 1, 1), 1.25), mkSwap(Date_(2022, 1, 1), Date_(2024, 1, 1), 1.55),
+            mkSwap(Date_(2022, 1, 1), Date_(2025, 1, 1), 1.80),
+        };
+        return spec;
+    }
+
+    CurveCalibrationOptions_ AnalyticOptions() {
+        CurveCalibrationOptions_ opts;
+        opts.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+        return opts;
+    }
+
+    // Helper (not a test body, so no ASSERT_* macros): cast the solved curve to DiscountLogDF_ and
+    // drop the pinned anchor. THROW on type mismatch -- always active, mirroring the example.
+    Vector_<> SolvedFreeParams(const DiscountCurve_& curve, int nFree) {
+        const auto* logDf = dynamic_cast<const DiscountLogDF_*>(&curve);
+        if (logDf == nullptr)
+            THROW("calibrated curve is not a DiscountLogDF_");
+        const Vector_<> nodes = logDf->NodeLogDF();
+        Vector_<> x(nFree);
+        for (int i = 0; i < nFree; ++i)
+            x[i] = nodes[i + 1];
+        return x;
+    }
+} // namespace
+
+// FR6 nonlinear re-solve: bump instrument i's market quote by +1bp, re-run CalibrateYieldCurve, and
+// assert the linear prediction effJacobianInverse_(:,i) * 1e-4 / tolerance_ matches the true
+// rebumped parameter delta to 1e-6 relative. The /tolerance_ factor is the unit correction on
+// effJacobianInverse_ (the solver-scaled pseudoinverse); dropping it makes the prediction off by
+// ~1e10. The 1e-6 bar reflects the genuine curvature of the nonlinear re-solve (per spec
+// yield-curve-jacobian-example.md FR6). Runs on every AAD backend because the analytic Jacobian and
+// the EXACT-solve pseudoinverse are backend-neutral.
+TEST(InverseJacobianRiskTest, TestReSolveMatchesLinearPrediction) {
+    const auto spec = MakeSquarePhaseASpec();
+    const int nInst = static_cast<int>(spec.instruments_.size());
+    const int nFree = static_cast<int>(spec.knotDates_.size()) - 1;
+    ASSERT_EQ(nInst, nFree);
+
+    const auto base = CalibrateYieldCurve(spec, AnalyticOptions());
+    ASSERT_LT(base.diagnostics_.maxAbsResidual_, 1.0e-7);
+    const Matrix_<>& effJacobianInverse = base.diagnostics_.effJacobianInverse_;
+    ASSERT_EQ(effJacobianInverse.Rows(), nFree);
+    ASSERT_EQ(effJacobianInverse.Cols(), nInst);
+
+    const Vector_<> xBase = SolvedFreeParams(*base.curve_, nFree);
+    const double bump = 1.0e-4;
+
+    for (int i = 0; i < nInst; ++i) {
+        CurveCalibrationSpec_ bumped = spec;
+        const auto fixedLeg = AnnualLeg();
+        const auto floatIdx = AnnualIndex();
+        const auto floatLeg = AnnualLeg();
+        const auto* swapOrig = dynamic_cast<const Swap_*>(spec.instruments_[i].get());
+        ASSERT_NE(swapOrig, nullptr);
+        const auto span = swapOrig->TimeSpan();
+        bumped.instruments_[i] =
+            Handle_<YCInstrument_>(new Swap_(spec.today_, span.first, span.second, swapOrig->MarketRate() + bump, fixedLeg, floatIdx, floatLeg));
+
+        const auto res = CalibrateYieldCurve(bumped, AnalyticOptions());
+        ASSERT_LT(res.diagnostics_.maxAbsResidual_, 1.0e-7);
+        const Vector_<> xBumped = SolvedFreeParams(*res.curve_, nFree);
+
+        for (int k = 0; k < nFree; ++k) {
+            const double trueDelta = xBumped[k] - xBase[k];
+            const double pred = effJacobianInverse(k, i) * bump / spec.tolerance_;
+            const double rel = std::abs(pred - trueDelta) / std::max(1.0, std::abs(trueDelta));
+            ASSERT_LE(rel, 1.0e-6) << "inst=" << i << " k=" << k << " pred=" << pred << " true=" << trueDelta;
+        }
+    }
+}
+
+// FR5 bucketed-risk transform: r = g^T * effJacobianInverse_ / tolerance_ is the linear risk number
+// (par-rate per absolute decimal quote bump) for the off-anchor portfolio swap. The /tolerance_
+// factor is the unit correction on effJacobianInverse_ (solver-scaled pseudoinverse; see the file
+// header). The regression this catches: if the /tolerance_ division is dropped, every entry of r
+// collapses to ~1e-10 and the diagonal-dominance + order-unity assertions below fail. We do NOT
+// assert r[portfolioIdx] == 1 exactly: r is the LINEAR approximation of a nonlinear map, so a +1
+// bump on the portfolio's own pillar produces r ~ 0.999 (curvature ~1e-3 at the +1 scale), not 1.
+// The diagonal-dominance and order-unity bounds are tight enough to catch the missing-divide
+// regression without asserting a false exact identity.
+TEST(InverseJacobianRiskTest, TestBucketedRiskTransformAppliesToleranceCorrection) {
+    const auto spec = MakeSquarePhaseASpec();
+    const int nInst = static_cast<int>(spec.instruments_.size());
+    const int nFree = static_cast<int>(spec.knotDates_.size()) - 1;
+
+    const auto result = CalibrateYieldCurve(spec, AnalyticOptions());
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-7);
+    const Matrix_<>& effJacobianInverse = result.diagnostics_.effJacobianInverse_;
+    const Vector_<> x = SolvedFreeParams(*result.curve_, nFree);
+
+    // Portfolio == instrument nInst-1 (the 3Y off-anchor swap; its annual coupons land on the
+    // 2023/2024/2025 nodes so g has non-trivial entries at columns 2,3,4).
+    const int portfolioIdx = nInst - 1;
+    const double h = 1.0e-6;
+    Vector_<> g(nFree, 0.0);
+    Handle_<YieldCurve_> empty;
+    for (int k = 0; k < nFree; ++k) {
+        Vector_<> full(spec.knotDates_.size(), 0.0);
+        for (int j = 1; j < static_cast<int>(spec.knotDates_.size()); ++j)
+            full[j] = x[j - 1];
+        Vector_<> fullUp = full;
+        Vector_<> fullDn = full;
+        fullUp[k + 1] += h;
+        fullDn[k + 1] -= h;
+        std::unique_ptr<DiscountCurve_> dcUp(
+            NewDiscountLogDF(spec.curveName_, spec.ccy_, spec.knotDates_, fullUp, spec.liborBasis_, spec.logDfScheme_));
+        std::unique_ptr<DiscountCurve_> dcDn(
+            NewDiscountLogDF(spec.curveName_, spec.ccy_, spec.knotDates_, fullDn, spec.liborBasis_, spec.logDfScheme_));
+        std::map<CollateralType_, Handle_<DiscountCurve_>> up;
+        std::map<CollateralType_, Handle_<DiscountCurve_>> dn;
+        up[spec.targetCollateral_] = Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), dcUp.get()));
+        dn[spec.targetCollateral_] = Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), dcDn.get()));
+        std::map<PeriodLength_, Handle_<DiscountCurve_>> fwd;
+        CurveBlock_ ycUp(spec.curveName_, spec.ccy_, up, fwd, spec.liborBasis_);
+        CurveBlock_ ycDn(spec.curveName_, spec.ccy_, dn, fwd, spec.liborBasis_);
+        const auto rateUp = spec.instruments_[portfolioIdx]->Precompute(empty);
+        const auto rateDn = spec.instruments_[portfolioIdx]->Precompute(empty);
+        g[k] = ((*rateUp)(ycUp) - (*rateDn)(ycDn)) / (2.0 * h);
+        dcUp.release();
+        dcDn.release();
+    }
+
+    Vector_<> rRaw;
+    Dal::Matrix::Multiply(g, effJacobianInverse, &rRaw);
+    for (auto& v : rRaw)
+        v /= spec.tolerance_;
+
+    // Order-unity diagonal: r[portfolioIdx] is the portfolio's par-rate risk to its own pillar. It
+    // is ~1 (linear approximation of a +1 bump moving the par rate by ~+1); the 1e-2 band absorbs
+    // the ~1e-3 linear-vs-nonlinear curvature. Dropping the /tolerance_ divide collapses this to
+    // ~1e-10 and fails the lower bound immediately.
+    ASSERT_GT(rRaw[portfolioIdx], 0.99) << "diagonal risk r[portfolioIdx]=" << rRaw[portfolioIdx] << " not order-unity";
+    ASSERT_LT(rRaw[portfolioIdx], 1.01) << "diagonal risk r[portfolioIdx]=" << rRaw[portfolioIdx] << " not order-unity";
+
+    // Diagonal dominance: the portfolio's own pillar carries the bulk of the risk; off-diagonals
+    // (bucketed risk to other pillars) are at least an order of magnitude smaller.
+    for (int j = 0; j < nInst; ++j) {
+        if (j == portfolioIdx)
+            continue;
+        ASSERT_LT(std::abs(rRaw[j]), 1.0e-2) << "off-diagonal r[" << j << "]=" << rRaw[j] << " unexpectedly large";
+    }
+}

--- a/dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp
+++ b/dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp
@@ -4,6 +4,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <memory>
+
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/discount.hpp>
@@ -209,8 +214,6 @@ TEST(InverseJacobianRiskTest, TestBucketedRiskTransformAppliesToleranceCorrectio
         const auto rateUp = spec.instruments_[portfolioIdx]->Precompute(empty);
         const auto rateDn = spec.instruments_[portfolioIdx]->Precompute(empty);
         g[k] = ((*rateUp)(ycUp) - (*rateDn)(ycDn)) / (2.0 * h);
-        dcUp.release();
-        dcDn.release();
     }
 
     Vector_<> rRaw;

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,11 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - `LogDfScheme_` interpolation schemes (`LOG_LINEAR`, `LOG_CUBIC_NATURAL`, `MIXED`)
   - Why `LOG_DISCOUNT` is the parameterization that supports the analytic Jacobian
 
+- **[yield_curve_jacobian.md](methodology/yield_curve_jacobian.md)** — Yield-Curve Jacobian and Inverse-Jacobian Risk
+  - Forward residual Jacobian via AAD reverse sweep vs finite-difference bump
+  - Inverse-Jacobian IR-risk transform `r = gᵀ · effJacobianInverse_ / tolerance_`
+  - Why `effJacobianInverse_` carries an extra `tolerance_` factor (solver residual scaling)
+
 ### Experimental (`experimental/`)
 
 Notes on capabilities that are working but not yet promoted to normative methodology. These

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -171,7 +171,9 @@ extend it. Knots can be supplied by the caller, taken from the instrument
 maturities, or formed from the union of both. After the solve, repricing residuals
 (RMS and maximum absolute error) quantify the fit quality, and the effective
 (weighted) Jacobian inverse is retained so that risk sensitivities can be obtained
-without re-solving the system.
+without re-solving the system. That inverse carries a `tolerance_` factor from the
+solver's residual scaling — see [Yield-Curve Jacobian and Inverse-Jacobian
+Risk](yield_curve_jacobian.md) before consuming it.
 
 ## Construction Pipeline
 
@@ -293,7 +295,11 @@ for (const int months : {6, 12, 24, 60, 120}) {
 The `CurveCalibrationDiagnostics_` returned in `result.diagnostics_` carries
 per-instrument market/model rates and residuals, plus `rmsResidual_` and
 `maxAbsResidual_`; the `effJacobianInverse_` matrix maps quote bumps to
-forward-rate parameters without re-solving.
+forward-rate parameters without re-solving. Note that its units include an extra
+`tolerance_` factor (the solver scales residuals by `1/tolerance_` before forming
+the pseudoinverse), so a sensitivity transform must read
+`r = gᵀ · effJacobianInverse_ / tolerance_` — see [Yield-Curve Jacobian and
+Inverse-Jacobian Risk](yield_curve_jacobian.md).
 
 API citations:
 

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -1,0 +1,121 @@
+# Yield-Curve Jacobian and Inverse-Jacobian Risk
+
+This note explains two operations that sit on top of a calibrated yield curve
+(see [Yield Curve Construction](yield_curve.md) and
+[Underdetermined search](underdetermined_search.md) for the calibration itself):
+
+1. the **residual Jacobian** $J = \partial\,\text{modelRate}_i / \partial\,x_k$,
+   computed two independent ways — AAD reverse sweep and finite-difference bump —
+   and shown to agree; and
+2. the **inverse-Jacobian IR-risk transform**, which turns a parameter
+   sensitivity vector $g$ into bucketed risk per market quote via the calibration
+   inverse Jacobian `effJacobianInverse_`.
+
+The runnable demonstration of both is the example program
+`dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp`.
+
+## The Forward Jacobian, Two Ways
+
+At a solved point $x^\star$ the calibration residuals vanish by construction, but
+the Jacobian of the residual map is still the useful linearisation of the curve.
+For each instrument $i$ and each free curve parameter $x_k$ (a log-discount-factor
+node value; the anchor node is pinned at $0$ and is not free),
+
+$$
+J_{ik} = \frac{\partial\, \text{modelRate}_i}{\partial\, x_k}(x^\star).
+$$
+
+**AAD reverse sweep.** Recording the free node values as independents on the AAD
+tape, building a `Number_`-typed curve, and running one reverse sweep per
+instrument output harvests a full row of $J$ at the cost of one forward pass plus
+$n$ sweeps — the canonical AAD cost asymmetry. The example records the tape from
+first principles (it does not call `TestOnly::AnalyticJacobianAt`) so the
+mechanics are visible; the same tape sits behind the library's
+`CurveJacobianMode_::ANALYTIC` flag (see
+[Analytic Jacobian for curve calibration](../experimental/aad-analytic-jacobian-curve-calibration.md)).
+
+**Bump oracle.** A two-sided central difference — perturb $x_k$ by $\pm h$,
+rebuild the curve via `NewDiscountLogDF(...)`, reprice every instrument — gives
+the same $J$ with a truncation error of $O(h^2)$ and a round-off floor of
+roughly $\varepsilon/h$. At $h = 10^{-6}$ both are around $10^{-10}$ for the
+well-conditioned Phase A residual map, so the two methods agree to $10^{-9}$
+relative. The example asserts that bar element-wise and prints the worst
+discrepancy.
+
+The agreement is not a tautology: the AAD path is analytic in the tape, the bump
+path rebuilds a fresh curve per perturbation, and a missed `RegisterIndependent`
+or a wrong recording order would make the AAD row silently zero. That is exactly
+the failure the two-way comparison is built to catch.
+
+## The Inverse Jacobian and Bucketed IR Risk
+
+Once the curve is calibrated with `solveMode_ = EXACT`, the diagnostics carry
+`CurveCalibrationDiagnostics_::effJacobianInverse_` — the solver's effective
+(weighted) inverse Jacobian, shape `nFreeParams × nInstruments`. It is the linear
+map from a perturbation of the market quotes to the resulting perturbation of the
+free parameters, modulo the solver's internal scaling (see below).
+
+Given a portfolio parameter-sensitivity vector
+
+$$
+g_k = \frac{\partial\, \text{PV}}{\partial\, x_k}
+$$
+
+(length `nFreeParams`), the bucketed risk per calibration instrument is
+
+$$
+r = g^{\mathsf T} \cdot \texttt{effJacobianInverse\_} \;/\; \texttt{tolerance\_},
+\qquad r_i = \frac{\partial\, \text{PV}}{\partial\, (\text{decimal quote}_i)} .
+$$
+
+A true DV01 (price change per $+1\text{bp} = +10^{-4}$ decimal) is $r_i \times 10^{-4}$.
+
+### Why divide by `tolerance_`
+
+The underdetermined solver does not operate on the raw residuals. It scales every
+residual row by $1/\tau_j$ before forming the pseudoinverse (see
+[Residual Scaling](underdetermined_search.md#residual-scaling)); equivalently,
+`effJacobianInverse_` carries units
+
+$$
+\texttt{effJacobianInverse\_[}k,i\texttt{]} \sim
+\frac{\partial\, x_k \cdot \texttt{tolerance\_}}{\partial\, (\text{decimal-rate perturbation}_i)} .
+$$
+
+A consumer that reads a sensitivity vector in honest price-per-decimal-rate units
+must therefore divide by `tolerance_` when applying the transform. Omitting that
+division leaves the result off by exactly the tolerance factor — silently, since
+the magnitude looks plausible. The example applies the correction in
+`TransformToQuoteRisk`; the regression test
+`dal-cpp/tests/curve/test_inverse_jacobian_risk.cpp` gates it against a genuine
+nonlinear re-solve (bump one market quote, re-run `CalibrateYieldCurve`, diff the
+new `NodeLogDF()` against the linear prediction). That re-solve path is the
+honest sanity check: the alternative "analytic forward map" prediction is
+tautological and is deliberately not used.
+
+### Parameter sensitivity $g$
+
+The transform needs $g$ as a *portfolio* sensitivity, computed independently of
+the AAD tape that produced the residual Jacobian. That tape records
+$\partial(\text{modelRate} - \text{marketRate})/\partial x$ — a rate residual, not
+a price. Reusing it for $g$ would conflate a residual sensitivity with a PV
+sensitivity (different units, different sign). The example computes $g$ by its
+own central-difference bump on the calibrated curve. In the public API the
+`YCInstrument_` surface exposes only the par-rate model rate (float-PV over
+annuity), not the leg PVs, so $g$ there is a par-rate sensitivity and $r$ is a
+par-rate risk per decimal quote bump; the annuity scaling that would convert it
+to a true price DV01 is not exposed.
+
+## See Also
+
+- [Yield Curve Construction](yield_curve.md) — the calibration that produces
+  `effJacobianInverse_`.
+- [Underdetermined search](underdetermined_search.md) — the solver whose residual
+  scaling motivates the `/tolerance_` correction.
+- [AAD methodology](aad.md) — the reverse-mode machinery behind the analytic
+  Jacobian.
+- [Analytic Jacobian for curve calibration](../experimental/aad-analytic-jacobian-curve-calibration.md)
+  — the `CurveJacobianMode_::{BUMPED,ANALYTIC}` flag that selects the AAD path
+  inside `CalibrateYieldCurve`.
+- `dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp` — the
+  runnable program demonstrating both arcs end to end.

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -28,11 +28,23 @@ $$
 **AAD reverse sweep.** Recording the free node values as independents on the AAD
 tape, building a `Number_`-typed curve, and running one reverse sweep per
 instrument output harvests a full row of $J$ at the cost of one forward pass plus
-$n$ sweeps — the canonical AAD cost asymmetry. The example records the tape from
-first principles (it does not call `TestOnly::AnalyticJacobianAt`) so the
-mechanics are visible; the same tape sits behind the library's
-`CurveJacobianMode_::ANALYTIC` flag (see
-[Analytic Jacobian for curve calibration](../experimental/aad-analytic-jacobian-curve-calibration.md)).
+$n$ sweeps — the canonical AAD cost asymmetry. This is the sweep behind the
+library's `CurveJacobianMode_::ANALYTIC` flag (see
+[Analytic Jacobian for curve calibration](../experimental/aad-analytic-jacobian-curve-calibration.md)),
+and `CalibrateYieldCurve` exposes its result on the public diagnostics struct:
+`CurveCalibrationDiagnostics_::jacobian_` (shape `nInstruments × nFreeParams`) is a
+fresh analytic reverse sweep evaluated at the solved $x^\star$. It is the plain
+Jacobian before the solver's `DivideRows(tol_)` row-scaling, and it is populated
+iff `jacobianMode_ = ANALYTIC && solveMode_ = EXACT` and the calibration is
+eligible for the AAD-tape Jacobian (default-constructed empty otherwise). The
+example reads $J$ straight from `result.diagnostics_.jacobian_`, so the AAD
+recording contract and backend-portability rules live in the library rather than
+in example code.
+
+`jacobian_` is a different object from `effJacobianInverse_` below: it is unscaled
+and evaluated at the solution, whereas `effJacobianInverse_` is a solver-weighted,
+tolerance-scaled pseudoinverse formed at the solver's final iterate. They are not
+inverses in their exposed form.
 
 **Bump oracle.** A two-sided central difference — perturb $x_k$ by $\pm h$,
 rebuild the curve via `NewDiscountLogDF(...)`, reprice every instrument — gives


### PR DESCRIPTION
## Summary
- New standalone example `dal-cpp/examples/yield_curve_jacobian/` demonstrating yield-curve Jacobian computation two ways (AAD analytic vs central-difference bump) and the bucketed IR-risk transform via the inverse calibration Jacobian.
- AAD-vs-bump Jacobian agreement hard-asserted at 1e-9 rel (verbatim two-branch form from `test_analytic_jacobian.cpp`); the inverse-Jacobian risk transform `r = g^T · effJacobianInverse_ / tolerance_` is hard-asserted via a nonlinear re-solve sanity check at 1e-6 rel.
- Adds a 2-test gtest (`test_inverse_jacobian_risk.cpp`) gating the novel `/tolerance_` correction in CI.
- Documents the corrected units of `CurveCalibrationDiagnostics_::effJacobianInverse_` (the underdetermined solver scales residuals by `1/tolerance_`, so the field carries `d(params)·tolerance_ / d(decimal-rate perturbation)` — consumers must divide by `tolerance_`). New methodology note `docs/methodology/yield_curve_jacobian.md`, indexed from `docs/README.md` and `CLAUDE.md`; CHANGELOG entry added.

## Test plan
- [x] `bin/yield_curve_jacobian` exits 0 under native AAET and XAD (AAD-vs-bump max rel 6.3e-11; FR6 re-solve max rel 7.2e-7)
- [x] `bin/dal_cpp_tests` 722/722 pass under native AAET and XAD (no regressions)
- [x] Adept and CoDiPack backends build-verified
