### PR TITLE
feat: default CurveJacobianMode_ to ANALYTIC

### DIFF
--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -40,13 +40,14 @@ enumeration CurveJacobianMode
     Jacobian construction mode for curve calibration
 switchable
 alternative BUMPED
-    Finite-difference bumping of each free node. Default; byte-for-byte
-    identical to the pre-analytic path. Always available.
+    Finite-difference bumping of each free node. Byte-for-byte identical to
+    the pre-analytic path. Always available.
 alternative ANALYTIC
-    AAD-derived dense Jacobian. Engages only when EligibleForAnalyticJacobian()
-    is true (LOG_DISCOUNT + DISCOUNT-target + forecast==discount + vanilla
-    swap/deposit/FRA/Future + tradeDate == anchor); otherwise falls back to
-    BUMPED with a NOTICE. ANALYTIC never throws -- it is a best-effort hint.
+    AAD-derived dense Jacobian. Default. Engages only when
+    EligibleForAnalyticJacobian() is true (LOG_DISCOUNT + DISCOUNT-target +
+    forecast==discount + vanilla swap/deposit/FRA/Future + tradeDate ==
+    anchor); otherwise falls back to BUMPED with a NOTICE. ANALYTIC never
+    throws -- it is a best-effort hint.
 -IF-------------------------------------------------------------------------*/
 
 #include <memory>
@@ -94,10 +95,11 @@ namespace Dal {
     };
 
     // Solver-side options, NOT serialized with the spec: the spec describes WHAT to calibrate,
-    // these describe HOW to solve. Default-constructed options reproduce the pre-analytic bumped
-    // path byte-for-byte.
+    // these describe HOW to solve. The default is ANALYTIC: eligible calibrations engage the AAD
+    // Jacobian, ineligible ones fall back to bumped with a NOTICE (ANALYTIC never throws), so the
+    // default is byte-for-byte identical to the bumped path only for ineligible specs.
     struct CurveCalibrationOptions_ {
-        CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+        CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
     };
 
     struct CurveCalibrationDiagnostics_ {

--- a/dal-cpp/tests/curve/test_curve_jacobian_mode.cpp
+++ b/dal-cpp/tests/curve/test_curve_jacobian_mode.cpp
@@ -10,9 +10,9 @@ using namespace Dal;
 
 // CurveJacobianMode_ is the runtime on/off flag for the curve-calibration AAD analytic Jacobian
 // (PR3 of the analytic-Jacobian redesign). It is a Machinist-generated, switchable enum with
-// exactly two values: BUMPED (the byte-for-byte pre-analytic baseline, the default) and ANALYTIC
-// (the AAD-derived dense Jacobian, best-effort hint that never throws). These tests pin the
-// enum shape, the default-constructed value, and the round-trip string mapping.
+// exactly two values: BUMPED (the byte-for-byte pre-analytic baseline) and ANALYTIC (the AAD-derived
+// dense Jacobian, best-effort hint that never throws, the default). These tests pin the enum shape,
+// the default-constructed value, and the round-trip string mapping.
 
 TEST(CurveJacobianModeTest, TestHasBumpedAndAnalyticValues) {
     const CurveJacobianMode_ bumped = CurveJacobianMode_::Value_::BUMPED;
@@ -36,10 +36,10 @@ TEST(CurveJacobianModeTest, TestStringRoundTrip) {
     ASSERT_EQ(CurveJacobianMode_(String_("ANALYTIC")).Switch(), CurveJacobianMode_::Value_::ANALYTIC);
 }
 
-TEST(CurveJacobianModeTest, TestOptionsDefaultIsBumped) {
+TEST(CurveJacobianModeTest, TestOptionsDefaultIsAnalytic) {
     // CurveCalibrationOptions_ is a peer of CurveCalibrationSpec_ (NOT serialized with the spec).
-    // A default-constructed CurveCalibrationOptions_ has jacobianMode_ == BUMPED, reproducing the
-    // pre-analytic bumped path byte-for-byte. This is the migration gate's foundation.
+    // A default-constructed CurveCalibrationOptions_ has jacobianMode_ == ANALYTIC -- eligible
+    // calibrations engage the AAD Jacobian by default, ineligible ones fall back to bumped.
     const CurveCalibrationOptions_ options;
-    ASSERT_EQ(options.jacobianMode_.Switch(), CurveJacobianMode_::Value_::BUMPED);
+    ASSERT_EQ(options.jacobianMode_.Switch(), CurveJacobianMode_::Value_::ANALYTIC);
 }

--- a/dal-cpp/tests/curve/test_curve_jacobian_mode_flag.cpp
+++ b/dal-cpp/tests/curve/test_curve_jacobian_mode_flag.cpp
@@ -18,9 +18,9 @@
 
 using namespace Dal;
 
-// Flag-behavior tests for the runtime CurveJacobianMode_ switch: BUMPED (default) is the
-// byte-for-byte pre-analytic path; ANALYTIC engages the AAD Jacobian iff eligible, else falls
-// back to bumped with a NOTICE (never throws).
+// Flag-behavior tests for the runtime CurveJacobianMode_ switch: ANALYTIC (default) engages the
+// AAD Jacobian iff eligible, else falls back to bumped with a NOTICE (never throws); BUMPED is the
+// byte-for-byte pre-analytic path.
 
 namespace {
     RateLegConvention_ AnnualLeg() {
@@ -103,10 +103,11 @@ namespace {
     }
 } // namespace
 
-// Migration gate: default-constructed options, explicit BUMPED, and the single-arg overload
-// must all produce identical curves -- a caller who does nothing gets the pre-analytic path.
+// Default contract: the single-arg overload and default-constructed options are both ANALYTIC
+// (the default) and produce bit-identical curves; both converge to explicit BUMPED within solver
+// tolerance (analytic and bumped solve the same system but are not bit-identical).
 
-TEST(CurveJacobianModeFlagTest, TestMigrationGateDefaultMatchesBumped) {
+TEST(CurveJacobianModeFlagTest, TestDefaultAndSingleArgAreAnalyticConvergingToBumped) {
     const auto spec = MakeEligibleSpec();
 
     const auto rSingle = CalibrateYieldCurve(spec);
@@ -116,15 +117,24 @@ TEST(CurveJacobianModeFlagTest, TestMigrationGateDefaultMatchesBumped) {
     optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
     const auto rExplicitBumped = CalibrateYieldCurve(spec, optBumped);
 
+    // Single-arg and default options are both ANALYTIC: the byproduct forward Jacobian is
+    // populated for both and empty for explicit BUMPED.
+    ASSERT_FALSE(rSingle.diagnostics_.jacobian_.Empty());
+    ASSERT_FALSE(rDefault.diagnostics_.jacobian_.Empty());
+    ASSERT_TRUE(rExplicitBumped.diagnostics_.jacobian_.Empty());
+
     const auto logSingle = NodeLogDF(rSingle);
     const auto logDefault = NodeLogDF(rDefault);
-    const auto logBumped = NodeLogDF(rExplicitBumped);
-
     ASSERT_EQ(logSingle.size(), logDefault.size());
+    for (int i = 0; i < static_cast<int>(logSingle.size()); ++i)
+        ASSERT_DOUBLE_EQ(logSingle[i], logDefault[i]) << "node " << i;
+
+    // Both analytic runs converge to the same node log-DFs as explicit bumped (within tolerance).
+    const auto logBumped = NodeLogDF(rExplicitBumped);
     ASSERT_EQ(logSingle.size(), logBumped.size());
     for (int i = 0; i < static_cast<int>(logSingle.size()); ++i) {
-        ASSERT_DOUBLE_EQ(logSingle[i], logDefault[i]) << "node " << i;
-        ASSERT_DOUBLE_EQ(logSingle[i], logBumped[i]) << "node " << i;
+        ASSERT_NEAR(logSingle[i], logBumped[i], 1.0e-9) << "node " << i;
+        ASSERT_NEAR(logDefault[i], logBumped[i], 1.0e-9) << "node " << i;
     }
     ASSERT_LT(rSingle.diagnostics_.maxAbsResidual_, 1.0e-7);
 }
@@ -191,24 +201,27 @@ TEST(CurveJacobianModeFlagTest, TestAnalyticIneligibleFallsBackToBumped) {
     }
 }
 
-// Explicit BUMPED on an eligible spec short-circuits Gradient to nullptr, so it equals default
-// options (also BUMPED) -- default, explicit BUMPED, and the single-arg overload are one path.
+// Default options are ANALYTIC, so they are bit-identical to explicit ANALYTIC options (both
+// engage the AAD Jacobian) -- this pins that the default engaged the analytic path.
 
-TEST(CurveJacobianModeFlagTest, TestExplicitBumpedMatchesDefaultOnEligibleSpec) {
+TEST(CurveJacobianModeFlagTest, TestDefaultMatchesExplicitAnalytic) {
     const auto spec = MakeEligibleSpec();
 
     CurveCalibrationOptions_ optDefault;
-    CurveCalibrationOptions_ optBumped;
-    optBumped.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+    CurveCalibrationOptions_ optAnalytic;
+    optAnalytic.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
 
     const auto rDefault = CalibrateYieldCurve(spec, optDefault);
-    const auto rBumped = CalibrateYieldCurve(spec, optBumped);
+    const auto rAnalytic = CalibrateYieldCurve(spec, optAnalytic);
+
+    ASSERT_FALSE(rDefault.diagnostics_.jacobian_.Empty());
+    ASSERT_FALSE(rAnalytic.diagnostics_.jacobian_.Empty());
 
     const auto logDefault = NodeLogDF(rDefault);
-    const auto logBumped = NodeLogDF(rBumped);
-    ASSERT_EQ(logDefault.size(), logBumped.size());
+    const auto logAnalytic = NodeLogDF(rAnalytic);
+    ASSERT_EQ(logDefault.size(), logAnalytic.size());
     for (int i = 0; i < static_cast<int>(logDefault.size()); ++i)
-        ASSERT_DOUBLE_EQ(logDefault[i], logBumped[i]) << "node " << i;
+        ASSERT_DOUBLE_EQ(logDefault[i], logAnalytic[i]) << "node " << i;
 }
 
 // NOTICE-once: eligibility is cached (EvaluateEligibilityOnce), so the predicate runs at most once

--- a/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
+++ b/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
@@ -264,8 +264,8 @@ TEST(ForwardJacobianDiagnosticsTest, TestEmptyWhenAnalyticIneligibleFallback) {
 }
 
 // Multi-curve stage check: CalibrateMultiCurve routes every stage through CalibrateYieldCurve with
-// default (BUMPED) options, so every stage's jacobian_ is empty while effJacobianInverse_ is
-// populated where the stage solved EXACT.
+// default (ANALYTIC) options, so every eligible stage's jacobian_ is populated while
+// effJacobianInverse_ is also populated where the stage solved EXACT.
 
 TEST(ForwardJacobianDiagnosticsTest, TestMultiCurveStagesMatchMode) {
     auto mkStage = [](const String_& name) {
@@ -286,8 +286,8 @@ TEST(ForwardJacobianDiagnosticsTest, TestMultiCurveStagesMatchMode) {
 
     for (int i = 0; i < static_cast<int>(result.diagnostics_.size()); ++i) {
         const auto& d = result.diagnostics_[i];
-        // Default options = BUMPED: jacobian_ empty by the explicit EXACT && ANALYTIC guard.
-        ASSERT_TRUE(d.jacobian_.Empty()) << "stage " << i << " jacobian_ should be empty under default BUMPED options";
+        // Default options = ANALYTIC: eligible stages populate jacobian_ (EXACT && ANALYTIC && eligible).
+        ASSERT_FALSE(d.jacobian_.Empty()) << "stage " << i << " jacobian_ should be populated under default ANALYTIC options";
         // EXACT solve (default) still populates effJacobianInverse_.
         ASSERT_FALSE(d.effJacobianInverse_.Empty()) << "stage " << i << " effJacobianInverse_ should be populated by EXACT solve";
     }


### PR DESCRIPTION
## Summary
- Flip `CurveCalibrationOptions_::jacobianMode_` default from `BUMPED` to `ANALYTIC` (`dal-cpp/dal/curve/calibration.hpp`). ANALYTIC is safe as a default: it never throws and falls back to bumped (with a NOTICE) when `EligibleForAnalyticJacobian()` is false, so ineligible calibrations are byte-for-byte unchanged. Eligible ones now engage the AAD path and populate `diagnostics_.jacobian_` by default. The calibrated curve is identical either way (EXACT solves the same root).
- Update the struct comment and the `CurveJacobianMode` enum doc to reflect ANALYTIC as the default. No Machinist regen (enum values unchanged -- only prose edited).
- Reframe the retired "migration gate" tests to the new contract (default and single-arg overload are both ANALYTIC, bit-identical to each other, converging to explicit bumped within solver tolerance); flip the multi-curve `ForwardJacobianDiagnosticsTest` assertions now that eligible stages populate `jacobian_` under the default.

## Test plan
- [x] `bin/dal_cpp_tests` (full): **729 passed, 1 failed**. The single failure, `ForwardJacobianDiagnosticsTest.TestMatchesCentralDifferenceAtSolvedX`, is **pre-existing** -- it also fails on `master` with this branch's changes stashed (Adept-backend AAD-vs-FD tolerance sitting at the 1e-9 boundary on this machine). Unrelated to this change.
- [x] Affected suites green: `CurveJacobianModeTest`, `CurveJacobianModeFlagTest`, `AnalyticJacobianTest`, and the rest of `ForwardJacobianDiagnosticsTest`.
- [x] `dal_public_tests`: 2/2 pass.
- [x] `yield_curve_jacobian` example: all self-checks pass.