### PR TITLE
docs: expand project guidance, enforce docs conventions, fix naming violations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,3 +121,14 @@ Tests (Google Test, `.claude/rules/unit-test-style.md`):
   API docs at http://127.0.0.1:8001/docs.
 - Web UI e2e: run `./dal-web/scripts/setup-playwright.sh` once, then
   `cd dal-web/frontend && npm run test:e2e`.
+
+## Project docs and guidance
+
+- Quant-method write-ups live under `docs/methodology/` (AAD, yield-curve construction,
+  interpolation, log-discount curve, underdetermined search, xccy calibration, yield-curve
+  Jacobian). Reconcile them against current headers when changing the relevant code.
+- Record notable fundamental changes in `CHANGELOG.md`.
+- Full rule sets live in `.claude/rules/`: `code-style.md`, `unit-test-style.md`,
+  `dal-web-design.md` (web UI standards), and `git-commit-pr.md` (commit/PR workflow).
+- Specialist agents for the spec → design → critique → implement → review → document
+  pipeline are defined under `.claude/agents/` (see its `README.md`).


### PR DESCRIPTION
## Summary
- Add a **Project docs and guidance** section to `.github/copilot-instructions.md` pointing to methodology docs, changelog conventions, `.claude/rules/`, and specialist agents.
- Add `## Documentation` section to `.claude/rules/code-style.md` codifying three rules: docs describe current state only (no historical narrative), no source line numbers in docs, fundamental changes belong in `CHANGELOG.md`.
- Extend `dal-doc-writer` agent with the same rules in its Single-Version Rule and What Not to Do sections.
- Strip all historical content from `docs/experimental/aad-analytic-jacobian-curve-calibration.md` (219 -> 83 lines).
- Replace stale source line numbers with struct/function names in `docs/methodology/yield_curve.md` and `docs/methodology/xccy_calibration.md`.
- Fix C++ naming violations: add namespace closing comments in `underdetermined.hpp`, rename struct members `maxAbs`/`maxRel` -> `maxAbs_`/`maxRel_` in the yield-curve Jacobian example, rename snake_case locals and parameters to camelCase in `underdetermined.hpp`/`.cpp`.

## Test plan
- [x] Full `dal_cpp_tests` — 733/733 passed
- [x] Verified all referenced paths in `.github/copilot-instructions.md` resolve
- [x] Verified `docs/README.md` index and `CLAUDE.md` methodology list consistent
- [x] No broken cross-reference links in changed docs