### PR TITLE
docs: migrate narrative source comments into methodology docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Interpolation** — [Interpolation](docs/methodology/interpolation.md)
 - **Log-Discount Curve** — [Log-discount curve](docs/methodology/log_discount_curve.md)
 - **Yield-Curve Jacobian and Inverse-Jacobian Risk** — [Yield-curve Jacobian](docs/methodology/yield_curve_jacobian.md)
+- **Script Engine** — [Script engine](docs/methodology/script_engine.md)
 
 Notable fundamental changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -187,10 +187,6 @@ namespace Dal {
             }
         }
 
-        // Phase A templated curve builder. Handles ONLY LOG_DISCOUNT -- the only parameterization
-        // the AAD path supports. The other parameterizations REQUIRE(false) in the Number_
-        // instantiation; this is unreachable because EligibleForAnalyticJacobian rejects non-LOG_DISCOUNT
-        // before constructing any templated object.
         template <class T_>
         std::unique_ptr<Tape::DiscountCurve_<T_>> BuildDiscountCurveT(const String_& name,
                                                                  const String_& ccy,
@@ -200,26 +196,13 @@ namespace Dal {
                                                                  const Vector_<T_>& logDF,
                                                                  const DayBasis_& dayCount,
                                                                  const Handle_<DiscountCurve_>& baseCurve) {
-            // baseCurve is a Handle_<DiscountCurve_> (double) -- the templated curve treats it as
-            // a constant multiplier. The Number_-typed Tape::DiscountLogDF_ ctor accepts this via the
-            // CurveWithBase_<Tape::DiscountCurve_<T_>> base, but the base's operator() reads double DFs
-            // (constant from the tape's perspective).
             REQUIRE(parameterization == CurveParameterization_::Value_::LOG_DISCOUNT,
                     "Phase A BuildDiscountCurveT: only LOG_DISCOUNT parameterization is supported");
             return std::unique_ptr<Tape::DiscountCurve_<T_>>(
                 new Tape::DiscountLogDF_<T_>(name, ccy, knotDates, logDF, dayCount, logDfScheme, baseCurve));
         }
 
-        // RAII tape scope: Clear on entry, Clear on exit (even on throw). AnalyticJacobian owns
-        // exactly one AAD cycle per solver restart -- the recording, sweep, and harvest all live
-        // inside this scope. NewRecording is opened by AnalyticJacobian AFTER RegisterIndependent,
-        // not here: XAD requires inputs registered before the recording window opens (its canonical
-        // idiom), and opening the recording before registration silently drops the inputs and yields
-        // an all-zero Jacobian. The tape must be clean before the next Gradient call (or the next
-        // F call which, while it does not touch the tape, would inherit any state if a future change
-        // ever reads the tape from F). Single-threaded today; thread-local Tape_ isolates
-        // per-worker state if calibration ever becomes parallel, but the residual loop itself must
-        // stay serial until a parallel-residual design exists.
+        // Clear the AAD tape on entry and exit (exception-safe), single-threaded.
         struct TapeGuard_ {
             Dal::AAD::Tape_* t_;
             explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
@@ -235,11 +218,7 @@ namespace Dal {
         };
 
         class YieldCurveCalibrationFunc_ : public Underdetermined::Function_ {
-            // Cached eligibility verdict for the AAD analytic Jacobian. EligibleForAnalyticJacobian()
-            // is expensive (walks every instrument) and emits NOTICEs on fall-through, and Gradient is
-            // called per solver iteration (up to maxEvaluations_ * maxRestarts_). Evaluating the
-            // predicate once and caching the verdict bounds every NOTICE to at most one per
-            // CalibrateYieldCurve call (H1 NOTICE-frequency contract).
+            // Cached eligibility avoids re-evaluating the expensive per-instrument predicate every solver iteration.
             enum class Eligibility_ { Unknown, Eligible, Ineligible };
 
             String_ ccy_;
@@ -313,62 +292,33 @@ namespace Dal {
                 return CurveBlock_(curveName_, ccy_, discountCurves, forwardCurves, liborBasis_);
             }
 
-            // Sparse Jacobian (LOG_DISCOUNT free-node log-DF unknowns). Returns the reverse-mode AAD
-            // Jacobian (single-result sweep on the active Number_ tape) when the mode is ANALYTIC and
-            // EligibleForAnalyticJacobian() holds; otherwise returns nullptr so the solver dense-bumps.
-            // The residual is modelRate - marketRate, so dResidual_i/dx_j = dModelRate_i/dx_j
-            // (marketRate is constant, contributes nothing). Backend-neutral: the same path runs under
-            // native, XAD, CoDiPack, and Adept via the Dal::AAD facade (RegisterIndependent,
-            // ZeroAdjoints, Adjoint, PropagateToStart).
+            // Returns AAD-tape Jacobian when ANALYTIC + eligible; nullptr otherwise (solver falls back to dense bumping).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
-                // Engage the analytic Jacobian IFF the mode is explicitly ANALYTIC. Both BUMPED and
-                // _NOT_SET (default-constructed / uninitialized) route to nullptr so the solver
-                // dense-bumps -- this matches the contract "analytic iff mode == ANALYTIC && eligible"
-                // and keeps a stray _NOT_SET off the analytic path.
                 if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC) {
                     static_cast<void>(x);
                     static_cast<void>(f);
                     return nullptr;
                 }
-                // ANALYTIC: engage the AAD Jacobian iff the cached eligibility verdict is Eligible.
-                // The verdict is evaluated once (EvaluateEligibilityOnce) and cached, so the NOTICEs
-                // inside EligibleForAnalyticJacobian fire at most once per CalibrateYieldCurve call.
                 EvaluateEligibilityOnce();
                 if (cachedEligibility_ == Eligibility_::Eligible)
                     return AnalyticJacobian(x, f);
-                // Ineligible: NOTICE was emitted once inside EvaluateEligibilityOnce; return nullptr so
-                // the solver dense-bumps. ANALYTIC never throws -- it is a best-effort hint.
                 static_cast<void>(x);
                 static_cast<void>(f);
                 return nullptr;
             }
 
-            // Evaluate EligibleForAnalyticJacobian() exactly once per func lifetime and cache the
-            // verdict. Gradient is called per solver iteration; without this guard the predicate (and
-            // its NOTICEs) would re-fire thousands of times per CalibrateYieldCurve call. The NOTICEs
-            // naming the offending condition live inside EligibleForAnalyticJacobian and fire on the
-            // single uncached evaluation.
+            // Cache the eligibility verdict once; Gradient is called per solver iteration.
             void EvaluateEligibilityOnce() const {
                 if (cachedEligibility_ != Eligibility_::Unknown)
                     return;
                 cachedEligibility_ = EligibleForAnalyticJacobian() ? Eligibility_::Eligible : Eligibility_::Ineligible;
             }
 
-            // Force-evaluate and return the cached analytic-Jacobian eligibility verdict. Public so
-            // CalibrateYieldCurve can decide whether to request the at-solution forward Jacobian from
-            // the solver (only the ANALYTIC && EXACT && eligible path produces a well-defined forward J;
-            // every other path must pass nullptr so the solver leaves the output empty).
             [[nodiscard]] bool Eligible() const {
                 EvaluateEligibilityOnce();
                 return cachedEligibility_ == Eligibility_::Eligible;
             }
 
-            // Phase A eligibility predicate (per .claude/designs/aad-analytic-jacobian-selector-api.md
-            // §4.2). Returns true iff every Phase A constraint is satisfied. The predicate is a
-            // pure query over ctor-stored state and NEVER throws -- ineligibility routes through
-            // a NOTICE + return nullptr (solver dense-bumps) instead of failing. Each fall-through
-            // path emits a NOTICE that names the offending condition so the user can see why the
-            // AAD Jacobian did not engage.
             [[nodiscard]] bool EligibleForAnalyticJacobian() const {
                 if (parameterization_ != CurveParameterization_::Value_::LOG_DISCOUNT) {
                     const String_ msg = String_("AAD Jacobian requires CurveParameterization_::LOG_DISCOUNT, got ")
@@ -381,20 +331,12 @@ namespace Dal {
                            "(calibrateDiscountCurve_ == true); falling back to bumped");
                     return false;
                 }
-                // Every instrument must (a) be a type Phase A has a templated rate for, and
-                // (b) not use a projection curve (forecast == discount). The tradeDate == anchor
-                // check is folded in: a Swap_ with tradeDate != knotDates_.front() is structurally
-                // fine for Phase A (the templated Tape::SwapRate_ reads DF(tradeDate_, p) directly), but
-                // requires anchor alignment so every instrument starts at knotDates_.front().
                 for (int i = 0; i < static_cast<int>(instruments_.size()); ++i)
                     if (!InstrumentEligibleForAnalyticJacobian(instruments_[i].get()))
                         return false;
                 return true;
             }
 
-            // Float-index convention of a Phase-A-supported instrument (Deposit/FRA/Future/vanilla
-            // Swap, in that priority order), or nullptr if the instrument type has no Phase A
-            // templated rate. Mirrors the dispatch in PhaseARateAt so eligibility and pricing agree.
             [[nodiscard]] static const RateIndexConvention_* PhaseAFloatConvention(const YCInstrument_* inst) {
                 if (const auto* deposit = dynamic_cast<const Deposit_*>(inst))
                     return &deposit->FloatConvention();
@@ -407,9 +349,6 @@ namespace Dal {
                 return nullptr;
             }
 
-            // Per-instrument Phase A eligibility. Returns true iff the instrument has a templated
-            // rate, uses no projection curve (forecast == discount), and starts at the curve anchor.
-            // Emits a NOTICE naming the offending condition on each fall-through.
             [[nodiscard]] bool InstrumentEligibleForAnalyticJacobian(const YCInstrument_* inst) const {
                 const String_ name = inst->Name();
                 const RateIndexConvention_* floatConv = PhaseAFloatConvention(inst);
@@ -426,11 +365,7 @@ namespace Dal {
                     NOTICE(msg);
                     return false;
                 }
-                // tradeDate == anchor (knotDates_.front()). Phase A's templated rates read
-                // DF(tradeDate_, p) (see ycinstrument.cpp), so the gate must check the real trade
-                // date via TradeDate(), not the effective/spot start that TimeSpan().first returns
-                // -- a spot-started instrument has tradeDate strictly before start, and admitting
-                // it would silently misprice its residual row on the tape.
+                // Must use TradeDate(), not TimeSpan().first -- spot-started instruments trade before start.
                 if (inst->TradeDate() != knotDates_.front()) {
                     const String_ msg = String_("AAD Jacobian requires every instrument to trade at the "
                                                 "curve anchor; instrument '")
@@ -441,16 +376,8 @@ namespace Dal {
                 return true;
             }
 
-            // Phase A AAD-tape Jacobian. Single-result reverse sweep: one forward recording per
-            // Gradient call, nRows reverse sweeps (one per residual), harvest adjoints column by
-            // column. Returns XCurveJacobian_ (a dense Jacobian subclass: storage is dense,
-            // assembly is sparse-by-row because AAD produces exact structural zeros).
             [[nodiscard]] Underdetermined::Jacobian_* AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const;
 
-            // Downcast instrument i to its concrete type and dispatch to PrecomputeT<T_>. Returns
-            // an empty handle if the instrument type is not supported (Phase A scope is Deposit,
-            // FRA, Future, vanilla Swap); EligibleForAnalyticJacobian rejects such calibrations before this
-            // is ever called, so the empty-handle branch is unreachable in practice.
             template <class T_> [[nodiscard]] Handle_<Tape::Rate_<T_>> PhaseARateAt(int i) const {
                 const auto* inst = instruments_[i].get();
                 if (const auto* d = dynamic_cast<const Deposit_*>(inst))
@@ -465,44 +392,27 @@ namespace Dal {
             }
         };
 
-        // AnalyticJacobian body. TapeGuard on entry/exit (Clear only), build Number_-typed
-        // curve, build Number_-typed rates via PrecomputeT<Number_>, compute residuals, single-result
-        // reverse loop. NewRecording is opened explicitly after RegisterIndependent (XAD requires
-        // inputs registered before newRecording). The column map is solver col j = storage node j+1,
-        // so Adjoint(logDF[j+1]) reads the sensitivity to x[j]. Backend-neutral: RegisterIndependent,
-        // ZeroAdjoints, Adjoint, and PropagateToStart are all Dal::AAD facade primitives, so the same
-        // loop runs unchanged under native, XAD, CoDiPack, and Adept.
         Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
             static_cast<void>(f); // the residual values themselves are unused; we recompute on the tape
 
-            // Independents: free-node log(DF) values. Anchor (node 0) is pinned at 0 and is NOT an
-            // independent -- the solver's x vector has NX() = nNodes-1 entries, matching. RegisterIndependent
-            // registers each node with the active tape on every backend; the anchor stays a plain
-            // assignment because routing it through RegisterIndependent would add a phantom input column.
             const int nNodes = static_cast<int>(knotDates_.size());
             REQUIRE(static_cast<int>(x.size()) == nNodes - 1,
                     "AnalyticJacobian: x vector length must equal nNodes - 1 (anchor excluded)");
             Vector_<Dal::AAD::Number_> logDF(nNodes);
-            logDF[0] = 0.0; // pinned anchor; deliberately NOT registered (adjoint never read)
+            logDF[0] = 0.0; // anchor fixed at 0, not registered (no adjoint)
             for (int i = 0; i < static_cast<int>(x.size()); ++i)
                 Dal::AAD::RegisterIndependent(logDF[i + 1], x[i]);
 
-            // Open the recording AFTER registering the independents and BEFORE the forward pass.
-            // XAD's canonical contract requires inputs registered before newRecording; opening the
-            // recording earlier silently drops them and yields an all-zero Jacobian (the B2 class).
-            // On native NewRecording is a no-op, so this is invisible there; on CoDiPack/Adept it
-            // anchors the sweep bounds to this point, which is exactly what PropagateToStart sweeps.
+            // XAD requires inputs registered BEFORE NewRecording; opening earlier silently produces an all-zero Jacobian.
             Dal::AAD::NewRecording(*tape);
 
-            // Build the Number_-typed calibrated curve directly with the tape-registered logDF.
             std::unique_ptr<Tape::DiscountCurve_<Dal::AAD::Number_>> dc(
                 BuildDiscountCurveT<Dal::AAD::Number_>(curveName_, ccy_, parameterization_, logDfScheme_,
                                                        knotDates_, logDF, liborBasis_, baseCurve_));
             Tape::YCCtx_<Dal::AAD::Number_> ctx(*dc);
 
-            // Compute Number_-typed residuals: modelRate - marketRate, for every instrument.
             const int nRows = static_cast<int>(instruments_.size());
             Vector_<Dal::AAD::Number_> residuals(nRows);
             for (int i = 0; i < nRows; ++i) {
@@ -510,16 +420,10 @@ namespace Dal {
                 residuals[i] = (*rateT)(ctx) - static_cast<double>(marketRates_[i]);
             }
 
-            // Dense Jacobian (m x NX()). Assembly is sparse by row; structural zeros stay exactly
-            // zero because AAD produces exact structural zeros (one of the wins over bump).
             const int nCols = nNodes - 1;
             Matrix_<> j(nRows, nCols, 0.0);
 
-            // Single-result reverse sweep. One PropagateToStart per residual row; ZeroAdjoints clears
-            // the propagated adjoints between rows so each seed lands on a clean slate. The multi-result
-            // path (SetNumResultsForAAD(true, nRows), one sweep for all rows) is a ~nRows-x speedup and
-            // remains a profiling-driven follow-up; the single-result path is simpler and runs identically
-            // on every backend.
+            // Single-result reverse sweep: one PropagateToStart per row yields exact structural zeros.
             for (int i = 0; i < nRows; ++i) {
                 Dal::AAD::ZeroAdjoints(*tape);
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
@@ -648,9 +552,6 @@ namespace Dal {
     }
 
     namespace {
-        // Build the initial-guess vector for the solver. Split out of CalibrateYieldCurve to keep
-        // its cyclomatic complexity under the Codacy limit. Behavior is byte-for-byte identical to
-        // the inlined version that previously lived in CalibrateYieldCurve.
         Vector_<> BuildCalibrationGuess(const CurveCalibrationSpec_& spec, const Vector_<Date_>& knotDates, bool anchorIsToday, int nParams) {
             const int nKnots = static_cast<int>(knotDates.size());
             Vector_<> guess(nParams);
@@ -669,8 +570,6 @@ namespace Dal {
             return guess;
         }
 
-        // Run the EXACT or APPROXIMATE solver and return {result, effJacobianInverse}. Split out so
-        // the solveMode branch does not count against CalibrateYieldCurve's cyclomatic complexity.
         struct SolverOutput_ {
             Vector_<> result_;
             Matrix_<> effJacobianInverse_;
@@ -689,9 +588,6 @@ namespace Dal {
             SolverOutput_ out;
             if (spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
                 std::unique_ptr<Sparse::SymmetricDecomposition_> wDecomp(weights.DecomposeSymmetric());
-                // The at-solution forward Jacobian is requested only on the ANALYTIC && eligible path
-                // (caller passes nullptr otherwise). The solver's convergence-branch hook then calls
-                // func.Gradient ONCE at the solved x to capture the UNSCALED forward J.
                 out.result_ = Underdetermined::Find(func, guess, tol, *wDecomp, controls, &out.effJacobianInverse_, fwdJacobian);
             } else {
                 out.result_ = Underdetermined::Approximate(func, guess, tol, spec.fitTolerance_, weights, controls);
@@ -699,9 +595,6 @@ namespace Dal {
             return out;
         }
 
-        // Assemble the CurveCalibrationResult_ from the solver output. Split out so the
-        // parameterization / diagnostics branches do not count against CalibrateYieldCurve's
-        // cyclomatic complexity. Behavior is byte-for-byte identical to the inlined version.
         CurveCalibrationResult_ AssembleCalibrationResult(const CurveCalibrationSpec_& spec,
                                                           const Vector_<Handle_<YCInstrument_>>& instruments,
                                                           const Vector_<Date_>& knotDates,
@@ -739,7 +632,6 @@ namespace Dal {
     } // namespace
 
     CurveCalibrationResult_ CalibrateYieldCurve(const CurveCalibrationSpec_& spec) {
-        // Default-constructed options -> jacobianMode_ == BUMPED -> byte-for-byte pre-analytic path.
         return CalibrateYieldCurve(spec, CurveCalibrationOptions_());
     }
 
@@ -770,12 +662,7 @@ namespace Dal {
                                         spec.forwardCurves_, spec.baseCurve_, spec.targetCollateral_, spec.targetTenor_, spec.calibrateDiscountCurve_,
                                         spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_);
 
-        // The at-solution forward Jacobian is requested from the solver only when all three hold:
-        // jacobianMode_ == ANALYTIC, solveMode_ == EXACT, AND the calibration is eligible for the
-        // AAD-tape Jacobian. Otherwise nullptr is passed so the solver leaves the output empty,
-        // preserving the contract (jacobian_ empty for BUMPED / APPROXIMATE / ineligible ANALYTIC).
-        // The solver's convergence-branch hook then captures the UNSCALED forward J with a single
-        // raw func.Gradient(xNew, fNew) call -- evaluated at the solution, not the iterate.
+        // Forward Jacobian requested only for ANALYTIC + EXACT + eligible; nullptr otherwise so the solver leaves the output empty.
         const bool wantFwdJacobian = options.jacobianMode_ == CurveJacobianMode_::Value_::ANALYTIC && spec.solveMode_ == CurveSolveMode_::Value_::EXACT
                                      && func.Eligible();
         Matrix_<> fwdJacobian;

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -35,10 +35,7 @@ namespace Dal {
         constexpr const char* KEY_MAX_EVALUATIONS = "MAXEVALUATIONS";
         constexpr const char* KEY_MAX_RESTARTS = "MAXRESTARTS";
 
-        // PWL/PWC params-per-knot for the joint path. LOG_DISCOUNT and ZERO_RATE are out of scope
-        // for the joint first cut (the spec scopes the joint residual to PIECEWISE_LINEAR_FWD); we
-        // REQUIRE(false) on them so a future caller fails loudly at validation rather than silently
-        // slicing the wrong number of parameters.
+        // PWL/PWC params only; LOG_DISCOUNT and ZERO_RATE fail loudly for the joint path.
         int ParamsPerKnot(CurveParameterization_ parameterization) {
             switch (parameterization.Switch()) {
             case CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD:
@@ -57,20 +54,6 @@ namespace Dal {
             }
         }
 
-        // Build ONE declaration's curve from its slice of the joint parameter vector. A forward
-        // declaration may opt into base layering via decl.baseLayeredOverDiscount_: when set, the
-        // caller supplies the discount curve at decl.targetCollateral_ (built earlier in the SAME
-        // solve iteration) as `base`, and the forward curve is stored as NewDiscountPWLF(..., base)
-        // so the smoother acts on the spread forward f_abs - f_ois -- matching the staged path's
-        // ApplyStageDefaults base layering. When base is empty (the default, including every
-        // discount declaration and every baseless forward declaration), the curve is a raw PWL/PWC
-        // with no base handle; the IBOR residual rows still read yc.Forward off the assembled
-        // CurveBlock_ and route discounting to the discount declaration's slice.
-        //
-        // Base-layered forward curves carry OIS sensitivity through their base handle (B-new-2 fixed
-        // for the opt-in path): a bump-and-reprice consumer who reads the standalone forward handle
-        // sees the OIS delta flow through. The baseless representation remains available for callers
-        // who prefer a self-contained forward curve and re-price through the assembled CurveBlock_.
         Handle_<DiscountCurve_> BuildDeclarationCurve(const JointCurveDeclaration_& decl,
                                                       const String_& ccy,
                                                       const DayBasis_& dayCount,
@@ -100,9 +83,6 @@ namespace Dal {
             }
         }
 
-        // The Phase A float-convention accessor (Deposit/FRA/Future/Swap), or nullptr if the
-        // instrument has no projection convention to inspect. Mirrors the eligibility helper in
-        // calibration.cpp but is read-only here (used by the forward-projection validator).
         const RateIndexConvention_* FloatConventionOf(const YCInstrument_& inst) {
             if (const auto* deposit = dynamic_cast<const Deposit_*>(&inst))
                 return &deposit->FloatConvention();
@@ -115,10 +95,7 @@ namespace Dal {
             return nullptr;
         }
 
-        // B-new-1 validator: every forward declaration's instruments must route their fixing
-        // through the forward curve (useProjectionCurve_ == true). A mis-conventioned instrument
-        // would silently leave the forward curve unconstrained by data (BAR-C fails by percent-level
-        // with no principled diagnostic). Returns the offending instrument name, or empty if OK.
+        // Forward-declaration instruments must route fixings through the forward curve (useProjectionCurve_ == true).
         String_ ForwardDeclarationOffendingInstrument(const JointCurveDeclaration_& decl) {
             for (const auto& inst : decl.instruments_) {
                 const RateIndexConvention_* conv = FloatConventionOf(*inst);
@@ -128,9 +105,6 @@ namespace Dal {
             return String_();
         }
 
-        // Mirrors calibration.cpp's OrderInstruments: sort by (maturity, start, name) so the
-        // residual vector the solver sees is in a deterministic, monotone order. The per-curve
-        // diagnostics preserve this order (instrumentNames_[i] aligns with residuals_[i]).
         Vector_<Handle_<YCInstrument_>> OrderInstruments(const Vector_<Handle_<YCInstrument_>>& instruments) {
             auto ordered = instruments;
             std::sort(ordered.begin(), ordered.end(), [](const Handle_<YCInstrument_>& lhs, const Handle_<YCInstrument_>& rhs) {
@@ -145,8 +119,6 @@ namespace Dal {
             return ordered;
         }
 
-        // Per-curve slice metadata: where this declaration's free parameters live in the joint x
-        // vector, and where its instrument residuals live in the stacked residual vector.
         struct CurveSlot_ {
             int curveIndex;
             int paramOffset;
@@ -161,13 +133,6 @@ namespace Dal {
             double smoothingWeight;
         };
 
-        // Entry-point validation per the api-note Error Cases table. Throws on the first violation
-        // with a message naming the offending input. Runs BEFORE the residual function, the
-        // CurveBlock_, and the solver are constructed so mis-routings surface as clear entry errors
-        // rather than late confusing throws deep inside the first residual evaluation.
-        // Validate spec-level fields, detect duplicate collaterals/tenors and forward-only invariants.
-        // Returns (producedCollaterals, producedTenors).  Extracted from ValidateAndBuildSlots
-        // for cyclomatic complexity (Codacy).
         std::pair<std::set<CollateralType_>, std::set<PeriodLength_>>
         DedupCollateralsAndTenors(const JointMultiCurveCalibrationSpec_& spec) {
             REQUIRE(!spec.curves_.empty(), "Joint multi-curve calibration requires at least one curve declaration");
@@ -247,10 +212,6 @@ namespace Dal {
             return slots;
         }
 
-        // Block-diagonal smoothing matrix: one tridiagonal block per curve, zero off-block by
-        // construction. Each block is built by Underdetermined::SelfCouplePWC at the curve's
-        // parameter offset, mirroring BuildCurveCalibrationWeights in calibration.cpp but
-        // accumulated into a single full-joint-size Sparse::TriDiagonal_.
         std::unique_ptr<Sparse::TriDiagonal_> BuildJointSmoothing(const std::vector<CurveSlot_>& slots) {
             int totalParams = 0;
             for (const auto& slot : slots)
@@ -267,8 +228,6 @@ namespace Dal {
             return weights;
         }
 
-        // Build the per-declaration initial-guess slice. Falls back to spec.initialGuess_ flat when
-        // the declaration leaves initialGuessPerNode_ empty.
         Vector_<> BuildGuessSlice(const JointMultiCurveCalibrationSpec_& spec, const JointCurveDeclaration_& decl, int nParams) {
             if (!decl.initialGuessPerNode_.empty()) {
                 REQUIRE(static_cast<int>(decl.initialGuessPerNode_.size()) == nParams,
@@ -278,9 +237,7 @@ namespace Dal {
             return Vector_<>(nParams, spec.initialGuess_);
         }
 
-        // RAII tape scope: Clear on entry and on exit (exception-safe), single-threaded contract.
-        // Verbatim from calibration.cpp:268-280 (Phase A); factored inline here because the joint
-        // path is the only second consumer and a shared header for two consumers is premature.
+        // Clear the AAD tape on entry and exit (exception-safe), single-threaded.
         struct TapeGuard_ {
             Dal::AAD::Tape_* t_;
             explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
@@ -295,10 +252,7 @@ namespace Dal {
             TapeGuard_& operator=(const TapeGuard_&) = delete;
         };
 
-        // Templated PWL_FWD curve builder (joint analogue of calibration.cpp:239-256
-        // BuildDiscountCurveT<T_>). Constructs a Tape::DiscountPWLF_<T_> from the declaration's
-        // fLeft/fRight parameter slice. Baseless when base is empty; base-layered (B_ = T_) when a
-        // base handle is supplied (Gap 4 -- the base adjoints propagate through the reverse sweep).
+        // Templated PWL_FWD curve builder. Base-layered when a base handle is supplied so adjoints propagate through the reverse sweep.
         template <class T_, class B_ = Tape::DiscountCurve_<double>>
         std::shared_ptr<Tape::DiscountPWLF_<T_, B_>>
         BuildDeclarationCurveT(const JointCurveDeclaration_& decl,
@@ -312,15 +266,11 @@ namespace Dal {
             return std::make_shared<Tape::DiscountPWLF_<T_, B_>>(decl.curveName_, ccy, knotDates, fLeftT, fRightT, base);
         }
 
-        // True if the instrument type is among the supported set for the AAD path.
         [[nodiscard]] bool IsSupportedInstrumentType(const YCInstrument_& inst) {
             return dynamic_cast<const OISSwap_*>(&inst) || dynamic_cast<const Swap_*>(&inst) || dynamic_cast<const Deposit_*>(&inst)
                    || dynamic_cast<const FRA_*>(&inst) || dynamic_cast<const Future_*>(&inst);
         }
 
-        // Per-instrument joint eligibility (FR3 (e)/(g)). Returns true if the instrument can be
-        // priced on the AAD tape; on fall-through emits a NOTICE naming the instrument and the
-        // failing condition. NEVER throws (FR6).
         bool InstrumentEligibleForAnalyticJacobian(const YCInstrument_& inst, bool onDiscountDeclaration) {
             const RateIndexConvention_* convPtr = FloatConventionOf(inst);
             if (!convPtr) {
@@ -329,11 +279,7 @@ namespace Dal {
             }
             const RateIndexConvention_& conv = *convPtr;
             if (IsSupportedInstrumentType(inst)) {
-                // Type is fine. Check projection-vs-declaration consistency (FR3 (g)): a
-                // discount-declaration instrument must NOT project (useProjectionCurve_ == false),
-                // so its fixing routes to the discount curve and the AAD path binds a single curve.
-                // OIS-discount-slice instruments (OIS overnight index has useProjectionCurve_ == false)
-                // are the canonical discount-eligible case.
+                // Discount-declaration instruments must NOT project so fixings route to a single curve on the AAD tape.
                 if (onDiscountDeclaration && conv.useProjectionCurve_) {
                     const String_ msg = String_("Joint AAD Jacobian requires discount-declaration instruments to forecast off "
                                                 "the discount curve; instrument '")
@@ -351,13 +297,9 @@ namespace Dal {
             return false;
         }
 
-        // Per-spec joint eligibility (FR3). Pure query over ctor-stored state, NEVER throws,
-        // returns true iff EVERY clause holds. Evaluated once and cached on JointResidualFunction_
-        // (Phase A H1 once-per-call NOTICE budget).
         bool JointSpecEligibleForAnalyticJacobian(const JointMultiCurveCalibrationSpec_* spec,
                                                    const std::vector<CurveSlot_>* slots) {
             REQUIRE(spec && slots, "JointSpecEligibleForAnalyticJacobian: null spec/slots");
-            // (j): liborBasis_ == ACT_365F (spec-level, checked once).
             if (spec->liborBasis_.String() != String_("ACT_365F")) {
                 NOTICE("Joint AAD Jacobian requires liborBasis_ == ACT_365F; falling back to bumped");
                 return false;
@@ -378,11 +320,6 @@ namespace Dal {
             return true;
         }
 
-        // The joint residual function. Builds EVERY declaration's curve from its slice of x,
-        // assembles them into ONE CurveBlock_, and returns the stacked residuals of every
-        // instrument. The CurveBlock_ routes IBOR discounting to the OIS slice of x automatically
-        // (the post-2008 routing in curveblock.cpp) -- the one cross-curve coupling the joint
-        // system has under interpretation (a).
         class JointResidualFunction_ : public Underdetermined::Function_ {
             const JointMultiCurveCalibrationSpec_* spec_;
             const std::vector<CurveSlot_>* slots_;
@@ -414,8 +351,6 @@ namespace Dal {
 
             [[nodiscard]] int EvaluationCount() const { return evaluationCount_; }
 
-            // Two-pass double curve build from the parameter vector x. Extracted from F for
-            // cyclomatic complexity (Codacy).
             CurveBlock_ BuildCurvesFromX(const Vector_<>& x) const {
                 std::map<CollateralType_, Handle_<DiscountCurve_>> discountCurves;
                 std::map<PeriodLength_, Handle_<DiscountCurve_>> forwardCurves;
@@ -454,9 +389,7 @@ namespace Dal {
                 return residuals;
             }
 
-            // Engage the analytic Jacobian IFF the mode is ANALYTIC AND the cached eligibility
-            // verdict is Eligible. Otherwise return nullptr and the solver dense-bumps. Mirrors
-            // Phase A's YieldCurveCalibrationFunc_::Gradient at calibration.cpp:368-389.
+            // Returns AAD-tape Jacobian when ANALYTIC + eligible; nullptr otherwise (solver dense-bumps).
             [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
                 if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC)
                     return nullptr;
@@ -465,8 +398,6 @@ namespace Dal {
                     return AnalyticJacobian(x, f);
                 return nullptr;
             }
-
-            // Extracted helpers for AnalyticJacobian — reduce cyclomatic complexity (Codacy AC).
 
             [[nodiscard]] std::vector<std::pair<Vector_<Dal::AAD::Number_>, Vector_<Dal::AAD::Number_>>>
             RegisterTapeParameters(const Vector_<>& x) const {
@@ -509,12 +440,6 @@ namespace Dal {
                 return forwardStorage;
             }
 
-            // Compute every instrument's templated residual given the assembled JointCurveBlock_.
-            // Projection instruments (useProjectionCurve_ == true) are priced through
-            // Tape::ProjectionRateAt<T_> reading the block's discount+forward handles; discount-slice
-            // instruments are priced through the single-curve YCCtx_<T_> path.
-            // Compute the Number_-typed rate for one instrument.  Extracted from
-            // ComputeTemplatedResiduals to reduce cyclomatic complexity (Codacy).
             [[nodiscard]] Handle_<Tape::Rate_<Dal::AAD::Number_>>
             DiscountRateT(const YCInstrument_& inst) const {
                 if (const auto* dep = dynamic_cast<const Deposit_*>(&inst))
@@ -551,12 +476,6 @@ namespace Dal {
             }
         };
 
-        // The AAD reverse-sweep Jacobian (FR2, FR5). Recording contract (the ONE order that works on
-        // all four backends): Clear -> RegisterIndependent (per free parameter, every declaration's
-        // 2 * nKnots PWL params, NO anchor exclusion) -> NewRecording -> forward eval (build every
-        // Number_-typed Tape::DiscountPWLF_<Number_>, baseless or base-layered, assemble the
-        // JointCurveBlock_<Number_> + per-collateral YCCtx_<Number_> map) -> per residual row
-        // {ZeroAdjoints -> Adjoint(residuals[i]) = 1.0 -> PropagateToStart -> harvest}.
         Underdetermined::Jacobian_* JointResidualFunction_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& /*f*/) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
@@ -596,7 +515,6 @@ namespace Dal {
             return new XCurveJacobian_(std::move(j));
         }
 
-        // Run the joint solver (EXACT via Find, APPROXIMATE via Approximate) and return the solved x.
         Vector_<> RunJointSolver(const JointMultiCurveCalibrationSpec_& spec,
                                  const JointResidualFunction_& func,
                                  const Vector_<>& guess,
@@ -615,8 +533,6 @@ namespace Dal {
             return Underdetermined::Approximate(func, guess, tol, spec.fitTolerance_, weights, controls);
         }
 
-        // Assemble the per-curve + joint diagnostics from the solved x. Mirrors BuildDiagnostics in
-        // calibration.cpp: modelRates via a final CurveBlock_ read, residuals = model - market.
         JointCurveCalibrationDiagnostics_
         BuildCurveDiagnostics(const JointCurveDeclaration_& decl, const CurveSlot_& slot, const CurveBlock_& solvedBlock, bool usedApproximateFit) {
             JointCurveCalibrationDiagnostics_ diag;
@@ -643,8 +559,6 @@ namespace Dal {
             return diag;
         }
 
-        // On non-convergence the joint residual norm exceeds the fit tolerance floor. Report the
-        // failing solve and the residual norm so the caller can see how far off convergence is.
         [[noreturn]] void ThrowNonConvergence(const JointResidualFunction_& func, const Vector_<>& residuals) {
             double maxAbs = 0.0;
             double sq = 0.0;

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -255,13 +255,6 @@ namespace Dal {
     } // namespace
 
     namespace Tape {
-        // Phase A templated rate classes (native AAD only). These mirror the double rate
-        // classes above; the arithmetic bodies are identical with T_ in place of double for the
-        // DF reads and the rate/annuity/fixing accumulations. dcf, yf, fixing dates and convexity
-        // adjustments stay double -- they are schedule-driven constants. The tape records the
-        // dependence of the residual on each free-node logDF value through the templated curve's
-        // operator() (which reads logDF_<T_> through the basis-weight machinery).
-
         template <class T_>
         T_ ForwardRate(const DiscountCurve_<T_>& forecast,
                         const Date_& start,
@@ -346,9 +339,7 @@ namespace Dal {
                   floatIndexConvention_(floatIndexConvention) {}
 
             T_ operator()(const YCCtx_<T_>& ctx) const override {
-                // Phase A eligibility guarantees forecast == discount == ctx.curve_ (the calibrated
-                // target curve), so we read every DF from ctx.curve_. tradeDate_ == anchor is also
-                // guaranteed by EligibleForAnalyticJacobian, so DF(anchor, p) = ctx.curve_(tradeDate_, p).
+                // Phase A: forecast == discount == ctx.curve_ (guaranteed by EligibleForAnalyticJacobian).
                 const DiscountCurve_<T_>& discount = ctx.curve_;
                 T_ annuity(static_cast<double>(0.0));
                 for (const auto& period : fixedPeriods_)
@@ -370,20 +361,7 @@ namespace Dal {
             }
         };
 
-        // ---- Phase B projection-capable rates (CP3, critique B4) ----
-        //
-        // Sibling classes of the Phase A Tape::Rate_<T_> hierarchy above, inheriting JointRate_<T_>
-        // instead. The pure virtual takes a JointCurveBlock_<T_> routing context (Gap 1) and performs
-        // BOTH a discount read at the leg's collateral AND a forecast read at (forecastTenor_,
-        // collateral_) in the T_ domain (Gap 3). Used ONLY for the IBOR(3M) projection slice where
-        // forecast != discount; the OIS-discount slice (forecast == discount) rides the inherited
-        // Swap_::PrecomputeT<T_> above (no projection needed). Phase A's Tape::Rate_<T_>, YCCtx_<T_>,
-        // and the four rate subclasses above are UNTOUCHED (NG2).
-
-        // Resolve a T_-typed forecast curve: the forecast tenor's registered forward curve when
-        // useProjectionCurve_, else the discount curve at the convention's collateral. Mirrors
-        // ResolveForecastCurve (ycinstrument.cpp:41-51) and CurveBlock_::Forward's fallback
-        // (curveblock.cpp:76-83).
+        // Resolve forecast curve in joint block: forward if useProjectionCurve_, else discount.
         template <class T_>
         inline const DiscountCurve_<T_>& ResolveForecastT(const JointCurveBlock_<T_>& block, const RateIndexConvention_& conv) {
             return conv.useProjectionCurve_ ? block.Forward(conv.forecastTenor_, conv.collateral_)
@@ -466,11 +444,7 @@ namespace Dal {
                   floatIndexConvention_(floatIndexConvention) {}
 
             T_ operator()(const JointCurveBlock_<T_>& block) const override {
-                // The joint analogue of Tape::SwapRate_<T_>::operator() above, but the forecast and
-                // discount curves are DISTINCT (Gap 3): forecast resolves via ResolveForecastT (the
-                // forward curve at (forecastTenor_, collateral_) when useProjectionCurve_, else the
-                // discount curve), and discount reads via block.Discount(collateral_). Every DF and
-                // fixing read records on the tape through the T_-typed block.
+                // Forecast and discount are distinct: forecast via ResolveForecastT, discount via block.Discount.
                 const DiscountCurve_<T_>& discount = block.Discount(floatIndexConvention_.collateral_);
                 const DiscountCurve_<T_>& forecast = ResolveForecastT<T_>(block, floatIndexConvention_);
                 T_ annuity(static_cast<double>(0.0));
@@ -511,15 +485,10 @@ namespace Dal {
         return Handle_<Rate_>(new DepositRate_(start_, maturity_, convention_, funding_yc));
     }
 
-    // Phase A templated factory: returns a Tape::DepositRate_<T_> bound to the instrument's schedule.
-    // The funding-yc handle is unused -- Phase A rates read only the calibrated target curve.
     template <class T_> Handle_<Tape::Rate_<T_>> Deposit_::PrecomputeT() const {
         return Handle_<Tape::Rate_<T_>>(new Tape::DepositRate_<T_>(start_, maturity_, convention_));
     }
 
-    // Phase B projection factory: returns a Tape::DepositRateProj_<T_> that reads BOTH a forecast
-    // curve (at the convention's forecastTenor_/collateral_) AND a discount curve (at collateral_)
-    // off a JointCurveBlock_<T_>. Used only on the IBOR projection slice where forecast != discount.
     template <class T_> Handle_<Tape::JointRate_<T_>> Deposit_::PrecomputeProjectionT() const {
         return Handle_<Tape::JointRate_<T_>>(new Tape::DepositRateProj_<T_>(start_, maturity_, convention_));
     }
@@ -624,9 +593,6 @@ namespace Dal {
         return Handle_<Rate_>(new SwapRate_(tradeDate_, fixedPeriods, floatPeriods, floatIndexConvention_, funding_yc));
     }
 
-    // Phase A templated factory: shares the schedule-building logic with the double Precompute.
-    // The only T_-parameterised part is the final Tape::SwapRate_<T_> construction; the schedule is
-    // scalar-free and reused verbatim. The funding-yc handle is unused on the Phase A path.
     template <class T_> Handle_<Tape::Rate_<T_>> Swap_::PrecomputeT() const {
         const auto fixedPeriods = BuildLegPeriods(start_,
                                                   maturity_,
@@ -641,11 +607,6 @@ namespace Dal {
         return Handle_<Tape::Rate_<T_>>(new Tape::SwapRate_<T_>(tradeDate_, fixedPeriods, floatPeriods, floatIndexConvention_));
     }
 
-    // Phase B projection factory for vanilla Swap_ (and OISSwap_ which inherits it). The schedule
-    // is identical to PrecomputeT; only the returned rate class differs -- SwapRateProj_<T_> reads
-    // forecast and discount off separate slots of a JointCurveBlock_<T_>. OIS-discount-slice
-    // instruments (forecast == discount) ride the inherited PrecomputeT instead, so this factory
-    // is invoked only on the IBOR projection slice where forecast != discount.
     template <class T_> Handle_<Tape::JointRate_<T_>> Swap_::PrecomputeProjectionT() const {
         const auto fixedPeriods = BuildLegPeriods(start_,
                                                   maturity_,
@@ -660,30 +621,17 @@ namespace Dal {
         return Handle_<Tape::JointRate_<T_>>(new Tape::SwapRateProj_<T_>(tradeDate_, fixedPeriods, floatPeriods, floatIndexConvention_));
     }
 
-    // Explicit instantiation of PrecomputeT<Dal::AAD::Number_> on each instrument so the linker
-    // finds the symbol when calibration.cpp's AnalyticJacobian calls it. The Number_-typed rate
-    // bodies forward arithmetic and value extraction to the Dal::AAD facade, so they compile and
-    // run under every AAD backend. These were previously gated to the native backend because the
-    // analytic Jacobian reached into the native-only Dal::AAD::Tape_::nodes_ member; that reach is
-    // gone (zeroing now goes through the backend-neutral Dal::AAD::ZeroAdjoints), so the gate is
-    // gone too and the instantiation is needed under every backend.
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> Deposit_::PrecomputeT<Dal::AAD::Number_>() const;
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> FRA_::PrecomputeT<Dal::AAD::Number_>() const;
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> Future_::PrecomputeT<Dal::AAD::Number_>() const;
     template Handle_<Tape::Rate_<Dal::AAD::Number_>> Swap_::PrecomputeT<Dal::AAD::Number_>() const;
 
-    // Phase B projection-rate explicit instantiations. Same backend-neutral contract as PrecomputeT
-    // above: the Number_-typed rate bodies forward arithmetic and value extraction to the Dal::AAD
-    // facade, so they compile and run under every AAD backend.
     template Handle_<Tape::JointRate_<Dal::AAD::Number_>> Deposit_::PrecomputeProjectionT<Dal::AAD::Number_>() const;
     template Handle_<Tape::JointRate_<Dal::AAD::Number_>> FRA_::PrecomputeProjectionT<Dal::AAD::Number_>() const;
     template Handle_<Tape::JointRate_<Dal::AAD::Number_>> Future_::PrecomputeProjectionT<Dal::AAD::Number_>() const;
     template Handle_<Tape::JointRate_<Dal::AAD::Number_>> Swap_::PrecomputeProjectionT<Dal::AAD::Number_>() const;
 
     namespace Tape {
-        // Dispatch the projection-rate factory by dynamic_cast (mirrors PhaseARateAt<T_> in
-        // calibration.cpp:499-510). Returns an empty handle if the instrument type has no projection
-        // subclass; the joint eligibility predicate rejects such types upstream.
         template <class T_>
         Handle_<JointRate_<T_>> ProjectionRateAt(const YCInstrument_& inst) {
             if (const auto* d = dynamic_cast<const Deposit_*>(&inst))

--- a/dal-cpp/dal/curve/yclogdf.cpp
+++ b/dal-cpp/dal/curve/yclogdf.cpp
@@ -43,10 +43,7 @@ namespace Dal {
 #include <dal/auto/MG_DiscountLogDF_v2_Write.inc>
 
     namespace {
-        // Build the log-DF interpolator from knot year-fractions and log(DF) values.
-        // Centralised here so calibration, ApplyDX, and deserialisation all share one definition;
-        // each scheme is fully determined by (yf, logDF) -- boundary conditions are fixed (natural
-        // cubic) and the mixed cutoff is the (nKnots-4)-th knot, matching calibration.cpp.
+        // Centralised here so calibration, ApplyDX, and deserialisation share one definition.
         Handle_<Interp1_> BuildLogDfInterpFromYf(const String_& name,
                                                  LogDfScheme_ scheme,
                                                  const Vector_<>& yf,
@@ -56,12 +53,11 @@ namespace Dal {
                 // linear on log(DF) is log-linear on DF
                 return Handle_<Interp1_>(Interp::NewLinear(name + "_loglin", yf, logDF));
             case LogDfScheme_::Value_::LOG_CUBIC_NATURAL: {
-                // natural cubic on log(DF) (Boundary_(2, 0.0)) -- the primary choice per design §3.2 D3.
                 const Interp::Boundary_ natural(2, 0.0);
                 return Handle_<Interp1_>(Interp::NewCubic(name + "_logcub", yf, logDF, natural, natural));
             }
             case LogDfScheme_::Value_::MIXED: {
-                // cutoff at the (nKnots-4)-th knot so the cubic tail has >= 3 knots beyond it.
+                // cutoff at (nKnots-4) so the cubic tail has >= 3 knots beyond it.
                 const int cutoffIndex = std::max(1, static_cast<int>(yf.size()) - 5);
                 MixedSchemeSpec_ spec;
                 spec.cutoffYf_ = yf[cutoffIndex];
@@ -72,10 +68,7 @@ namespace Dal {
             }
         }
 
-        // Solve a symmetric tridiagonal system M z = b in place where M is specified by its
-        // subdiagonal `a` (size n-1), diagonal `d` (size n), and superdiagonal `c` (size n-1).
-        // Returns z (size n). Standard Thomas algorithm; assumes M is diagonally dominant
-        // (true for the natural-cubic spline matrix).
+        // Standard Thomas algorithm; M is diagonally dominant (true for natural-cubic splines).
         Vector_<> SolveTriDiagonal(const Vector_<>& a, const Vector_<>& d, const Vector_<>& c, const Vector_<>& b) {
             const int n = static_cast<int>(d.size());
             REQUIRE(static_cast<int>(a.size()) == n - 1 && static_cast<int>(c.size()) == n - 1 && static_cast<int>(b.size()) == n,
@@ -93,21 +86,16 @@ namespace Dal {
                 }
             }
             Vector_<> x(n);
-            // Forward substitution: y[i] = (b[i] - a[i-1]*y[i-1]) / dp[i]
             Vector_<> y(n);
             y[0] = b[0] / dp[0];
             for (int i = 1; i < n; ++i)
                 y[i] = (b[i] - a[i - 1] * y[i - 1]) / dp[i];
-            // Back-substitution: x[n-1] = y[n-1]; x[i] = y[i] - cp[i]*x[i+1]
             x[n - 1] = y[n - 1];
             for (int i = n - 2; i >= 0; --i)
                 x[i] = y[i] - cp[i] * x[i + 1];
             return x;
         }
 
-        // db[i]/d(f[j]) for the natural-cubic rhs at interior node i, source knot j, given the
-        // segment lengths h. The four Kronecker-delta terms of the second-difference collapse to
-        // this dispatch; extracted so the per-source loop stays linear in branches.
         double NaturalCubicRhsEntry(int j, int i, const Vector_<>& h) {
             double val = 0.0;
             if (j == i + 1)
@@ -121,11 +109,9 @@ namespace Dal {
             return 6.0 * val;
         }
 
-        // Build the sub/diag/sup rows of the (n-2) x (n-2) interior natural-cubic system in the
-        // segment-length vector h (size n, with h[0] unused).
         void NaturalCubicInteriorMatrix(const Vector_<>& h, int m, Vector_<>* sub, Vector_<>* diag, Vector_<>* sup) {
             for (int r = 0; r < m; ++r) {
-                const int i = r + 1; // interior node index
+                const int i = r + 1;
                 (*diag)[r] = 2.0 * (h[i] + h[i + 1]);
                 if (r > 0)
                     (*sub)[r - 1] = h[i];
@@ -134,12 +120,6 @@ namespace Dal {
             }
         }
 
-        // Natural-cubic-spline second-derivative sensitivity matrix:
-        //   fppCoef[k][j] = d(fpp[k]) / d(f[j])
-        // where fpp[0] = fpp[n-1] = 0 (natural BC) and fpp[1..n-2] are obtained by solving
-        //   h[i-1]*fpp[i-1] + 2*(h[i-1]+h[i])*fpp[i] + h[i]*fpp[i+1] = b[i]   for i = 1..n-2
-        // with h[k] = x[k] - x[k-1] and b[i] = 6*((f[i+1]-f[i])/h[i+1] - (f[i]-f[i-1])/h[i]).
-        // We solve n column systems (one per nonzero source f[j]).
         Vector_<Vector_<>> BuildNaturalCubicFppCoef(const Vector_<>& x) {
             const int n = static_cast<int>(x.size());
             Vector_<Vector_<>> coef(n, Vector_<>(n, 0.0));
@@ -166,11 +146,8 @@ namespace Dal {
             return coef;
         }
 
-        // Locate the largest index k such that yf_[k] <= yf; return 0 if yf < yf_[1]. Identical
-        // semantics to InterpLinearImplX's lower-bound branch used by Interp1Linear_::operator().
         int LowerBoundSegment(const Vector_<>& yf, double yfQuery) {
             const int n = static_cast<int>(yf.size());
-            // Anchor (yf[0]) is 0; we are interested in the segment [k, k+1].
             int k = 0;
             for (int i = 1; i < n - 1; ++i) {
                 if (yf[i] <= yfQuery)
@@ -178,14 +155,12 @@ namespace Dal {
                 else
                     break;
             }
-            // Clamp: yfQuery may equal yf[n-1] exactly (last knot) -- segment is k=n-2.
+            // Clamp: yfQuery may equal yf[n-1] exactly.
             if (k > n - 2)
                 k = n - 2;
             return k;
         }
 
-        // Linear-basis storage-node weights on segment [yf[k], yf[k+1]]: (1-g) at storage k, g at
-        // storage k+1, with g = (yfQuery - yf[k])/h. Shared by LOG_LINEAR and the MIXED head.
         Vector_<std::pair<int, double>> LinearSegmentWeights(const Vector_<>& yf, int k, double yfQuery) {
             const double h = yf[k + 1] - yf[k];
             const double g = (yfQuery - yf[k]) / h;
@@ -198,11 +173,8 @@ namespace Dal {
 
     namespace Tape {
 
-    // The ctor body is parameterised on T_ but the runtime validation (REQUIRE on logDF[0] == 0,
-    // IsMonotonic) only makes sense for double -- for Number_ the value extraction would record
-    // spurious tape nodes. The geometric invariants (nodeDates, dayCount, yf, scheme, interp,
-    // fppCoef) are T_-independent and built unconditionally. The Number_ factory in calibration.cpp
-    // pins logDF[0] = 0 itself before construction, so the runtime check is redundant there.
+    // Runtime validation (isfinite, logDF[0]==0) is double-only -- Number_ value extraction
+    // would record spurious tape nodes. The Number_ factory pins logDF[0]=0 before construction.
     template <class T_>
     DiscountLogDF_<T_>::DiscountLogDF_(const String_& name,
                                           const String_& ccy,
@@ -238,11 +210,8 @@ namespace Dal {
 
     template <class T_>
     void DiscountLogDF_<T_>::RebuildInterp() {
-        // interp_ is always double-valued and depends only on yf_ and the (double-extracted) logDF
-        // values -- it is the knot-position-driven interpolator the double path reads through.
-        // For Number_ we cannot build a double interp_ from Number_ values; we extract via Value()
-        // so the interpolator exists for any code that defensively calls it, but the Number_ LogDfAt
-        // path does NOT consult interp_ (it accumulates basis weights against logDF_ directly).
+        // interp_ is always double-valued; extract via Value() for existence,
+        // but the Number_ LogDfAt path does not consult it.
         Vector_<> logDFDouble(yf_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
             logDFDouble[i] = Dal::AAD::Value(logDF_[i]);
@@ -258,21 +227,15 @@ namespace Dal {
         if (scheme_ == LogDfScheme_::Value_::LOG_CUBIC_NATURAL) {
             fppCoef_ = BuildNaturalCubicFppCoef(yf_);
         } else if (scheme_ == LogDfScheme_::Value_::MIXED) {
-            // The cutoff is the (nKnots-4)-th knot (see BuildLogDfInterpFromYf). The cubic tail
-            // needs fppCoef_ over the tail subarray; we store the full-curve fppCoef_ as if the
-            // cubic ran over the whole array -- BUT the actual cubic is built on the tail only.
-            // To stay correct, we compute fppCoef_ on the cubic TAIL subarray (from cutoffIndex
-            // onward) and store offsets so CubicBasisAt can map back to storage nodes.
+            // Cutoff at (n-4)-th knot; cubic tail fppCoef_ computed on subarray, expanded back.
             const int cutoffIndex = std::max(1, static_cast<int>(yf_.size()) - 5);
             mixedCutoffIndex_ = cutoffIndex;
             mixedCutoffYf_ = yf_[cutoffIndex];
-            // The cubic tail is yf_[cutoffIndex..end]; build fppCoef_ on this subarray.
             const int tailLen = static_cast<int>(yf_.size()) - cutoffIndex;
             Vector_<> tailYf(tailLen);
             for (int i = 0; i < tailLen; ++i)
                 tailYf[i] = yf_[cutoffIndex + i];
             Vector_<Vector_<>> tailCoef = BuildNaturalCubicFppCoef(tailYf);
-            // Expand tailCoef back to full-curve storage indices.
             fppCoef_ = Vector_<Vector_<>>(yf_.size(), Vector_<>(yf_.size(), 0.0));
             for (int k = 0; k < tailLen; ++k)
                 for (int j = 0; j < tailLen; ++j)
@@ -282,12 +245,7 @@ namespace Dal {
 
     template <class T_>
     Vector_<std::pair<int, double>> DiscountLogDF_<T_>::CubicBasisAt(int k, double yf) const {
-        // On segment [yf_[k], yf_[k+1]] with h = yf_[k+1] - yf_[k]:
-        //   S(yf) = a*f[k] + b*f[k+1] - a*b*(h^2/6) * ((1+a)*fpp[k] + (1+b)*fpp[k+1])
-        // where a = 1-b, b = (yf - yf_[k])/h. The basis weight at storage node j is
-        //   b_j(yf) = a*delta(j,k) + b*delta(j,k+1)
-        //             - a*b*(h^2/6) * ((1+a)*fppCoef_[k][j] + (1+b)*fppCoef_[k+1][j])
-        // fppCoef_ is the storage-indexed matrix (empty entries are zero).
+        // fppCoef_ is the storage-indexed second-derivative sensitivity matrix.
         const double h = yf_[k + 1] - yf_[k];
         const double b = (yf - yf_[k]) / h;
         const double a = 1.0 - b;
@@ -310,12 +268,8 @@ namespace Dal {
 
     template <class T_>
     Vector_<std::pair<int, double>> DiscountLogDF_<T_>::CubicExtrapWeights(double yf) const {
-        // LogDfAt extrapolates past yf_.back() by the last segment's log-DF secant slope:
-        //   logDF(yf) = logDF[n-1] + slopeLast * (yf - yf_[n-1])
-        // where slopeLast = (logDF[n-1] - logDF[n-2]) / (yf_[n-1] - yf_[n-2]).
-        // So dlogDF(yf)/dlogDF[j] is 1 if j==n-1, slopeLast/slopeLast==1 if j==n-2 (with weight
-        // -(yf-yf_[n-1])/h), and 0 elsewhere. For LOG_CUBIC_NATURAL the same secant-extension is
-        // used (see LogDfAt docstring) -- it does NOT use the cubic derivative at the boundary.
+        // Secant-extension of the last segment: does NOT use the cubic derivative at the boundary,
+        // even for LOG_CUBIC_NATURAL.
         const int n = static_cast<int>(yf_.size());
         const double dyfLast = yf_[n - 1] - yf_[n - 2];
         Vector_<std::pair<int, double>> retval;
@@ -323,8 +277,6 @@ namespace Dal {
             retval.emplace_back(n - 1, 1.0);
             return retval;
         }
-        // weight at storage node n-2: -(yf - yf_[n-1]) / dyfLast
-        // weight at storage node n-1: 1 + (yf - yf_[n-1]) / dyfLast
         const double excess = (yf - yf_[n - 1]) / dyfLast;
         retval.emplace_back(n - 2, -excess);
         retval.emplace_back(n - 1, 1.0 + excess);
@@ -333,9 +285,7 @@ namespace Dal {
 
     template <class T_>
     Vector_<std::pair<int, double>> DiscountLogDF_<T_>::StorageBasisWeightsAt(double yf) const {
-        // Returns STORAGE-node weights (no anchor drop, no solver-column remap). The Number_-typed
-        // LogDfAt accumulates these against logDF_ to produce a tape-registered logDF(yf). The
-        // weights are functions of knot positions only, so they are identical for any T_.
+        // Returns storage-node weights (knot-position-dependent only, same for any T_).
         if (yf < 0.0 || yf_.size() < 2)
             return {};
         if (yf > yf_.back())
@@ -358,13 +308,11 @@ namespace Dal {
         const double yfFrom = dayCount_(nodeDates_.front(), from, nullptr);
         const double yfTo = dayCount_(nodeDates_.front(), to, nullptr);
         if constexpr (std::is_same_v<T_, double>) {
-            // Byte-identical to pre-Phase-A DiscountLogDF_::operator().
             const double logDfFrom = LogDfAt(yfFrom);
             const double logDfTo = LogDfAt(yfTo);
             return std::exp(logDfTo - logDfFrom) * (this->base_ ? (*this->base_)(from, to) : 1.0);
         } else {
-            // Number_ path: tape records dependence of logDf* on each free-node logDF_ value.
-            // The base curve is double and is treated as a constant multiplier.
+            // Base curve is double and treated as a constant multiplier.
             const T_ logDfFrom = LogDfAt(yfFrom);
             const T_ logDfTo = LogDfAt(yfTo);
             const double baseFactor = this->base_ ? (*this->base_)(from, to) : 1.0;
@@ -372,16 +320,6 @@ namespace Dal {
         }
     }
 
-    // Evaluate log(DF) at year-fraction yf.
-    //
-    // For T_=double (byte-identical to pre-Phase-A): the path uses (*interp_)(yf) in-range, and
-    // the final-segment secant slope out of range. The interp_ rebuild at construction stores the
-    // double-extracted logDF values so this matches the pre-Phase-A behaviour exactly.
-    //
-    // For T_=Number_: the path accumulates StorageBasisWeightsAt(yf) against logDF_, so the tape
-    // records the dependence of logDF(yf) on each free-node logDF_ value. Out-of-range the same
-    // secant weights apply. The forward evaluation here re-uses the same basis-weight machinery
-    // the double path computes, now differentiated through the tape.
     template <class T_>
     T_ DiscountLogDF_<T_>::LogDfAt(double yf) const {
         if constexpr (std::is_same_v<T_, double>) {
@@ -394,12 +332,8 @@ namespace Dal {
             const double slopeLast = (logDF_[n - 1] - logDF_[n - 2]) / dyfLast;
             return logDF_[n - 1] + slopeLast * (yf - yf_[n - 1]);
         } else {
-            // Anchor (storage node 0) is pinned at logDF=0; dropping it from the weighted sum is
-            // value-preserving (0 * w_0 = 0) AND produces the correct Jacobian: d(logDF(yf)) /
-            // d(logDF_[0]) must be zero because the anchor is a constant. Including it would
-            // register a tape dependence on logDF_[0] that the calibration overrides anyway, but
-            // it is cleaner to omit it here so the column map (solver col = storage node - 1)
-            // holds without exception.
+            // Anchor is pinned at logDF=0; excluding it gives the correct Jacobian
+            // and keeps the column map (solver col = storage node - 1) clean.
             T_ acc(static_cast<double>(0.0));
             for (const auto& [storageNode, w] : StorageBasisWeightsAt(yf)) {
                 if (storageNode == 0)
@@ -410,18 +344,11 @@ namespace Dal {
         }
     }
 
-    // Free-node count: the anchor (node 0, logDF pinned at 0) is excluded from the unknown
-    // vector. For a square 13-instrument / 13-free-node LOG_DISCOUNT solve this is what makes
-    // the parameter dimension match the instrument count.
+    // Free-node count: anchor (node 0) is pinned, so solver dimension = n-1.
     template <class T_>
     int DiscountLogDF_<T_>::NX() const { return static_cast<int>(logDF_.size()) - 1; }
 
-    // Bump only the FREE nodes logDF_[1..] by dx[i] * leverage; keep logDF_[0] pinned at 0 and
-    // rebuild interp_ so operator() reflects the bumped curve. A stale interp_ after a bump would
-    // silently desync the curve from its node values -- the risk-engine landmine the reviewer flagged.
-    // The Number_ factory in calibration.cpp never calls ApplyDX (the AAD path constructs the
-    // curve directly with the tape-registered logDF vector), so the body below is only ever
-    // exercised for T_=double; for T_=Number_ it would compile but is unreachable.
+    // Stale interp_ after bump silently desyncs the curve from node values.
     template <class T_>
     void DiscountLogDF_<T_>::ApplyDX(Vector_<>::const_iterator dx, double leverage) {
         for (int i = 1; i < static_cast<int>(logDF_.size()); ++i)
@@ -431,9 +358,7 @@ namespace Dal {
 
     template <class T_>
     void DiscountLogDF_<T_>::Write(Archive::Store_& dst) const {
-        // Serialisation is double-only; the Number_ path never persists. Extract the primal value
-        // via the backend-neutral Dal::AAD::Value facade (static_cast<double> works on native and
-        // CoDiPack but not on XAD/Adept, which have no conversion operator).
+        // Extract primal via backend-neutral Value facade.
         Vector_<> logDFDouble(logDF_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
             logDFDouble[i] = Dal::AAD::Value(logDF_[i]);
@@ -463,25 +388,12 @@ namespace Dal {
 
     template <class T_>
     Vector_<> DiscountLogDF_<T_>::NodeLogDF() const {
-        // Returns the double view of logDF_ -- for T_=double this is logDF_ itself (byte-identical
-        // to pre-Phase-A); for T_=Number_ it is the primal values. The Number_ path is never
-        // introspected this way at runtime (the AAD override works off the tape, not the curve),
-        // but the method exists so dynamic_cast<DiscountLogDF_<Number_>*> does not yield a type
-        // missing the public surface a caller might assume.
         Vector_<> retval(logDF_.size());
         for (int i = 0; i < static_cast<int>(logDF_.size()); ++i)
             retval[i] = Dal::AAD::Value(logDF_[i]);
         return retval;
     }
 
-    // Explicit instantiations. DiscountLogDF_<double> is the hot path (F loop, bumped fallback,
-    // serialisation). DiscountLogDF_<Dal::AAD::Number_> is linked into the AnalyticJacobian override
-    // in calibration.cpp; the Number_-typed body forwards to the Dal::AAD facade (exp/log/value via
-    // ADL), so it compiles and runs under every AAD backend. These instantiations were previously
-    // gated to the native backend because the analytic Jacobian zeroed adjoints by walking the
-    // native-only Dal::AAD::Tape_::nodes_ member; zeroing now goes through the backend-neutral
-    // Dal::AAD::ZeroAdjoints facade primitive, so the gate is gone and the instantiation is needed
-    // under every backend.
     template class DiscountLogDF_<double>;
     template class DiscountLogDF_<Dal::AAD::Number_>;
 
@@ -501,19 +413,15 @@ namespace Dal {
 #include <dal/auto/MG_DiscountLogDF_v2_Read.inc>
 
     Storable_* DiscountLogDF_v1::Reader_::Build() const {
-        // Legacy v1 stored the built Interp1_ handle directly and did NOT persist the LogDfScheme_.
-        // The scheme cannot be recovered from the deserialised handle: every Interp1_ subtype reports
-        // the same Storable_::type_ ("Interp1", fixed by the Interp1_ base constructor -- it is not
-        // "Cubic1"/"Interp1Linear"), and the concrete interpolators live in anonymous namespaces so
-        // RTTI cannot tell them apart either. v1 therefore always reconstructs as LOG_LINEAR, the only
-        // scheme honestly rebuildable from (nodeDates, logDF) alone. This is exactly why v2 -- the
-        // canonical format -- carries the scheme by name; callers needing cubic/mixed must use v2.
+        // Legacy v1 stored a built Interp1_ handle and did NOT persist LogDfScheme_.
+        // The scheme cannot be recovered from the handle (all interp subtypes report
+        // type "Interp1"), so v1 always reconstructs as LOG_LINEAR.
+        // v2 (the canonical format) carries the scheme by name.
         return new Tape::DiscountLogDF_<double>(
             name_, ccy_, nodeDates_, logDF_, DayBasis_(dayCount_), LogDfScheme_::Value_::LOG_LINEAR, base_);
     }
 
     Storable_* DiscountLogDF_v2::Reader_::Build() const {
-        // v2 stores the scheme by name and rebuilds the interpolator from (nodeDates, logDF).
         return new Tape::DiscountLogDF_<double>(name_, ccy_, nodeDates_, logDF_, DayBasis_(dayCount_), LogDfScheme_(scheme_), base_);
     }
 } // namespace Dal

--- a/dal-cpp/dal/io/exceldriverlite.cpp
+++ b/dal-cpp/dal/io/exceldriverlite.cpp
@@ -17,16 +17,13 @@ namespace Dal {
                                          int sheetColumn,
                                          const String_& label,
                                          const Vector_<>& values) {
-        // Get cells.
         Excel::RangePtr pRange = sheet->Cells;
 
-        // First cell contains the label.
         Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
         item->Value2 = label.c_str();
 
         sheetColumn++;
 
-        // Next cells contain the values.
         for (std::size_t i = 0; i < values.size(); ++i) {
             Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
             item->Value2 = values[i];
@@ -35,31 +32,24 @@ namespace Dal {
         }
     }
 
-    // Writes label and vector to cells in vertical direction.
-
     void ExcelDriver_::ToSheetVertical(Excel::_WorksheetPtr sheet,
                                        int sheetRow,
                                        int sheetColumn,
                                        const String_& label,
                                        const Vector_<>& values) {
-        // Get cells.
         Excel::RangePtr pRange = sheet->Cells;
 
-        // First cell contains the label.
         Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
         item->Value2 = label.c_str();
 
         sheetRow++;
 
-        // Next cells contain the values.
         for (std::size_t i = 0; i < values.size(); ++i) {
             Excel::RangePtr item = pRange->Item[sheetRow][sheetColumn];
             item->Value2 = values[i];
             sheetRow++;
         }
     }
-
-    // Throw COM error as string.
 
     void ExcelDriver_::ThrowAsString(_com_error& error) {
         bstr_t description = error.Description();
@@ -69,7 +59,6 @@ namespace Dal {
         THROW(String_(description));
     }
 
-    // RAII helper for COM initialization/uninitialization
     class ComInitializer_ {
     private:
         bool initialized_;
@@ -94,18 +83,13 @@ namespace Dal {
         ComInitializer_& operator=(const ComInitializer_&) = delete;
     };
 
-    // Constructor. Starts Excel in invisible mode.
-
     ExcelDriver_::ExcelDriver_(int currentColumn) : curDataColumn_(currentColumn) {
-        // Initialize COM Runtime Libraries with RAII guard
         ComInitializer_ comInit;
 
         try {
-            // Start excel application.
             xl_.CreateInstance(L"Excel.Application");
             xl_->Workbooks->Add((long)Excel::xlWorksheet);
 
-            // Rename "Sheet1" to "Chart Data".
             Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
             Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->GetItem(1);
             pSheet->Name = "Chart Data";
@@ -113,8 +97,6 @@ namespace Dal {
             ThrowAsString(error);
         }
     }
-
-    // Destructor.
 
     ExcelDriver_::~ExcelDriver_() {
         try {
@@ -135,13 +117,6 @@ namespace Dal {
     }
 
 
-    // Create chart with a number of functions. The arguments are:
-    //  x:			vector with input values
-    //  labels:		labels for output values
-    //  vectorList: list of vectors with output values.
-    //  chartTitle:	title of chart
-    //  xTitle:		label of x axis
-    //  yTitle:		label of y axis
     void ExcelDriver_::CreateChart(const Vector_<>& x,
                                    const Vector_<String_>& labels,
                                    const Vector_<Vector_<>>& vectorList,
@@ -149,7 +124,6 @@ namespace Dal {
                                    const String_& xTitle,
                                    const String_& yTitle) {
         try {
-            // Validate input sizes
             if (labels.size() != vectorList.size()) {
                 THROW(String_("CreateChart error: labels.size() must equal vectorList.size()"));
             }
@@ -159,41 +133,30 @@ namespace Dal {
                 }
             }
 
-            // Activate sheet with numbers.
             Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
             Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->GetItem("Chart Data");
 
-            // Calculate range with source data.
-            // The first row contains the labels shown in the chart's legend.
             int beginRow = 1;
             int beginColumn = curDataColumn_;
-            int endRow = x.size() + 1;                       // +1 to include labels.
-            int endColumn = beginColumn + vectorList.size(); // 1st is input, rest is output.
+            int endRow = x.size() + 1;
+            int endColumn = beginColumn + vectorList.size();
 
-            // Write label + input values to cells in vertical direction.
-            ToSheetVertical(pSheet, 1, curDataColumn_, xTitle, x); // X values.
+            ToSheetVertical(pSheet, 1, curDataColumn_, xTitle, x);
             curDataColumn_++;
 
-            // Write label + output values to cells in vertical direction.
             auto labelIt = labels.begin();
             for (auto vectorIt = vectorList.begin(); vectorIt != vectorList.end(); ++vectorIt) {
-                // Get label and row index.
                 String_ label = *labelIt;
-
-                // Add label + output values to Excel.
                 ToSheetVertical(pSheet, 1, curDataColumn_, label, *vectorIt);
 
-                // Advance row and label.
                 curDataColumn_++;
                 ++labelIt;
             }
 
-            // Create range objects for source data.
             Excel::RangePtr pBeginRange = pSheet->Cells->Item[beginRow][beginColumn];
             Excel::RangePtr pEndRange = pSheet->Cells->Item[endRow][endColumn];
             Excel::RangePtr pTotalRange = pSheet->Range[static_cast<Excel::Range*>(pBeginRange)][static_cast<Excel::Range*>(pEndRange)];
 
-            // Create the chart and sets its type
             Excel::_ChartPtr pChart = xl_->ActiveWorkbook->Charts->Add();
             pChart->ChartWizard(static_cast<Excel::Range*>(pTotalRange), (long)Excel::xlXYScatter, 6L, (long)Excel::xlColumns, 1L,
                                 1L, true, chartTitle.c_str(), xTitle.c_str(), yTitle.c_str());
@@ -219,28 +182,18 @@ namespace Dal {
         }
     }
 
-    // Create chart with a number of functions. The arguments are:
-    //  x:			vector with input values
-    //  y:			vector with output values.
-    //  chartTitle:	title of chart
-    //  xTitle:		label of x axis
-    //  yTitle:		label of y axis
     void ExcelDriver_::CreateChart(const Vector_<>& x,
                                   const Vector_<>& y,
                                   const String_& chartTitle,
                                   const String_& xTitle,
                                   const String_& yTitle) {
-        // Create list with single function and single label.
         Vector_<Vector_<>> functions = {y};
         Vector_<String_> labels = {chartTitle};
 
         CreateChart(x, labels, functions, chartTitle, xTitle, yTitle);
     }
 
-    // Make Excel window visible.
-
     void ExcelDriver_::MakeVisible(bool b) {
-        // Make excel visible.
         xl_->Visible = b ? VARIANT_TRUE : VARIANT_FALSE;
     }
 
@@ -250,7 +203,6 @@ namespace Dal {
                                  const Vector_<String_>& columnLabels,
                                  int row,
                                  int col) {
-        // Validate input sizes
         if (rowLabels.size() != matrix.Rows()) {
             THROW(String_("AddMatrix error: rowLabels.size() must equal matrix.Rows()"));
         }
@@ -258,12 +210,10 @@ namespace Dal {
             THROW(String_("AddMatrix error: columnLabels.size() must equal matrix.Cols()"));
         }
 
-        // Add sheet.
         Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
         Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
         pSheet->Name = sheetName.c_str();
 
-        // Add column labels starting at column col.
         Excel::RangePtr pRange = pSheet->Cells;
 
         long col2 = col + 1;
@@ -272,7 +222,6 @@ namespace Dal {
             ++col2;
         }
 
-        // Add row labels + values.
         row++;
         auto rowLabelIt = rowLabels.begin();
         for (long r = 0; r < matrix.Rows(); ++r) {
@@ -284,18 +233,15 @@ namespace Dal {
     }
 
     void ExcelDriver_::AddMatrix(const Matrix_<>& matrix, const String_& name, int row, int col) {
-        // Add sheet.
         Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
         Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
         pSheet->Name = name.c_str();
 
-        // Make empty row labels. Can later make it more general
         Vector_<String_> rowLabels;
         for (std::size_t r2 = 0; r2 < matrix.Rows(); ++r2) {
             rowLabels.push_back(String_());
         }
 
-        // Add row labels + values.
         auto rowLabelIt = rowLabels.begin();
         for (std::size_t r = 0; r < matrix.Rows(); ++r) {
             Vector_<> rowArray = matrix.Row(r);
@@ -305,7 +251,6 @@ namespace Dal {
         }
     }
 
-    // Vector visualisation
     void ExcelDriver_::AddVector(const Vector_<>& vec, const String_& name, int row, int col) {
         Matrix_<> m = Matrix::FromVectors(Vector_<Vector_<>>(1, vec));
         AddMatrix(m, name, row, col);
@@ -323,20 +268,15 @@ namespace Dal {
         AddMatrix(m, sheetName, rowLabels, columnLabels, row, col);
     }
 
-    // For debugging, for example
-
     void ExcelDriver_::PrintStringInExcel(const String_& s, int row, int col) {
-        // Add sheet.
         Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
         Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
 
-        // Add properties to cells.
         Excel::RangePtr pRange = pSheet->Cells;
         pRange->Item[row][col] = s.c_str();
     }
 
     void ExcelDriver_::PrintStringInExcel(const Vector_<String_>& s, int row, int col) {
-        // Add sheet.
         Excel::_WorkbookPtr pWorkbook = xl_->ActiveWorkbook;
         Excel::_WorksheetPtr pSheet = pWorkbook->Worksheets->Add();
 

--- a/dal-cpp/dal/io/exceldriverlite.hpp
+++ b/dal-cpp/dal/io/exceldriverlite.hpp
@@ -14,36 +14,28 @@
 #include <dal/string/strings.hpp>
 #include <dal/io/excelimport.hpp>
 
-// Excel driver class definition. Contains functionality to add charts
-// and matrices. Hides all COM details. COM exceptions are re-thrown
-// as Dal::Exception_.
 namespace Dal {
     class ExcelDriver_ {
     private:
-        // Private member data.
-        Excel::_ApplicationPtr xl_; // Pointer to Excel.
+        Excel::_ApplicationPtr xl_;
 
         int curDataColumn_;
 
-        // Writes label and std::vector<double> to cells in horizontal direction.
         void ToSheetHorizontal(Excel::_WorksheetPtr sheet,
                                int sheetRow,
                                int sheetColumn,
                                const String_& label,
                                const Vector_<>& values);
 
-        // Writes label and std::vector<double> to cells in vertical direction.
         void ToSheetVertical(Excel::_WorksheetPtr sheet,
                              int sheetRow,
                              int sheetColumn,
                              const String_& label,
                              const Vector_<>& values);
 
-        // Throw COM error as string.
         void ThrowAsString(_com_error& error);
 
     public:
-        // Constructor. Starts Excel in invisible mode.
         explicit ExcelDriver_(int currentColumn = 1);
         ~ExcelDriver_();
 
@@ -55,26 +47,12 @@ namespace Dal {
             return instance;
         }
 
-        // Create chart with a number of functions. The arguments are:
-        //  x:			std::vector<double> with input values
-        //  labels:		labels for output values
-        //  vectorList: list of vectors with output values.
-        //  chartTitle:	title of chart
-        //  xTitle:		label of x axis
-        //  yTitle:		label of y axis
         void CreateChart(const Vector_<>& x,
                          const Vector_<String_>& labels,
                          const Vector_<Vector_<>>& vectorList,
                          const String_& chartTitle,
                          const String_& xTitle = "X",
                          const String_& yTitle = "Y");
-
-        // Create chart with a number of functions. The arguments are:
-        //  x:			std::vector<double> with input values
-        //  y:			std::vector<double> with output values.
-        //  chartTitle:	title of chart
-        //  xTitle:		label of x axis
-        //  yTitle:		label of y axis
 
         void CreateChart(const Vector_<>& x,
                          const Vector_<>& y,
@@ -84,7 +62,6 @@ namespace Dal {
 
         void MakeVisible(bool b);
 
-        // Matrix visualisation
         void AddMatrix(const Matrix_<>& matrix, const String_& name = String_("Matrix"), int row = 1, int col = 1);
 
         void AddMatrix(const Matrix_<>& matrix,
@@ -94,7 +71,6 @@ namespace Dal {
                        int row = 1,
                        int col = 1);
 
-        // Vector visualisation as numbers
         void AddVector(const Vector_<>& vec,
                        const String_& sheetName = String_("Vector"),
                        int row = 1,
@@ -107,7 +83,6 @@ namespace Dal {
                        int row = 1,
                        int col = 1);
 
-        // For debugging, for example; print string at a (row,col) position
         void PrintStringInExcel(const String_& s, int row, int col);
         void PrintStringInExcel(const Vector_<String_>& s, int row, int col);
     };

--- a/dal-cpp/dal/math/optimization/underdetermined.cpp
+++ b/dal-cpp/dal/math/optimization/underdetermined.cpp
@@ -87,7 +87,7 @@ namespace Dal {
             const Underdetermined::Function_& func_;
             int nEvals_;
             int nRestarts_;
-            Matrix_<> jDense_; // provides memory, if needed, underpinning jacobian structure
+            Matrix_<> jDense_;
 
             XScaledFunc_(const Vector_<>& tol,
                          const Underdetermined::Function_& func,
@@ -107,7 +107,6 @@ namespace Dal {
                     sparse->DivideRows(tol_);
                     return sparse;
                 }
-                // have to set up dense J
                 func_.Gradient(x, f, &jDense_);
                 std::unique_ptr<XJDense_> retVal(new XJDense_(jDense_));
                 retVal->DivideRows(tol_);
@@ -150,11 +149,6 @@ namespace Dal {
             }
         }
 
-        // Capture the UNSCALED dense forward Jacobian at the solution. Called only on the convergence
-        // branch with the RAW func (funcIn), so DivideRows(tol) is never applied -- the output is the
-        // plain dF_i/dx_j matrix. Works for any Jacobian_ subclass by probing each unit column via
-        // MultiplyLeft (which returns J * e_k = column k, length Rows). The caller guards the
-        // nullptr-Gradient case before calling, so jac is always a valid Jacobian here.
         void StoreForwardJacobianAtSolution(const Underdetermined::Jacobian_& jac, Matrix_<>* out) {
             out->Resize(jac.Rows(), jac.Columns());
             for (int k = 0; k < jac.Columns(); ++k) {
@@ -246,7 +240,6 @@ namespace Dal {
                                     const Controls_& controls,
                                     Matrix_<>* effJInv,
                                     Matrix_<>* fwdJacobianAtSolution) {
-        // set up the wrapper through which we will call the function
         XScaledFunc_ func(tol, funcIn, controls);
         Vector_<> xOld(guess);
         Vector_<> fOld = func.F(xOld);
@@ -262,22 +255,12 @@ namespace Dal {
                 restart = false;
             }
             QPStep(fOld, *j, w, &q, &s);
-            // backtracking linesearch
             bool tookStep = false;
             for (int iBacktrack = 0; iBacktrack < controls.maxBacktrackTries_; ++iBacktrack) {
                 Transform(xOld, s, std::plus<>(), &xNew);
                 Vector_<> fNew = func.F(xNew);
                 if (*MaxElement(fNew) < 1.0 && *MinElement(fNew) > -1.0) {
                     StoreEffectiveJacobianInverse(*j, w, effJInv);
-                    // Unscaled forward Jacobian at the solution, produced by ONE raw funcIn.Gradient
-                    // call (NOT XScaledFunc_::J), so DivideRows(tol) is never applied. fNew is the
-                    // SCALED residual (XScaledFunc_::F divides by tol), so reconstruct the UNSCALED
-                    // residual as fNew * tol element-wise and pass that -- no redundant funcIn.F
-                    // evaluation, which matters because funcIn.F bypasses the solver's nEvals_ budget
-                    // in XScaledFunc_. (F/tol)*tol == F to machine precision, and it is correct for any
-                    // Function_ whose Gradient consumes f, harmless for the analytic path (which
-                    // ignores f). A nullptr Gradient return clears the output so a caller-reused matrix
-                    // cannot leak stale contents; there is no dense-FD fallback on this branch.
                     if (fwdJacobianAtSolution) {
                         fwdJacobianAtSolution->Clear();
                         Vector_<> fUnscaled = fNew;
@@ -292,8 +275,6 @@ namespace Dal {
                 const double oldOld = InnerProduct(fOld, fOld);
                 const double oldNew = InnerProduct(fOld, fNew);
                 const double newNew = InnerProduct(fNew, fNew);
-                // \tilde f^2 = oldOld * k^2 + 2 * oldNew * k * (1-k) + newNew * (1-k)^2
-                // its k-derivative is oldOld * 2 * k + oldNew * (1 - 2*k) + 2 * newNew * (k-1)
                 double kMin = (newNew - 0.5 * oldNew) / (newNew - oldNew + oldOld);
                 if (kMin < controls.backtrackTolerance_) {
                     if (!restart) {
@@ -310,7 +291,7 @@ namespace Dal {
                 double k = min(controls.maxBacktrack_, min(kMin, 2 * (kMin - controls.backtrackTolerance_)));
                 assert(k > 0.0);
                 s *= 1.0 - k;
-            } // end backtracking loop
+            }
             REQUIRE(tookStep || approxJ, "Could not find a descent direction in underdetermined search");
         }
     }
@@ -321,7 +302,6 @@ namespace Dal {
                                            double fitTol,            // accuracy of approximate fit
                                            const Sparse::Square_& w,
                                            const Controls_& controls) {
-        // set up the wrapper through which we will call the function
         XScaledFunc_ func(funcTol, funcIn, controls);
         Vector_<> xOld(guess);
         Vector_<> fOld = func.F(xOld);
@@ -339,7 +319,7 @@ namespace Dal {
                 ++ie; // we used up an evaluation too
             }
             Vector_<> s = ApproxQPStep(guess, xOld, fOld, *j, jWeight, w);
-            // const double sNorm = InnerProduct(s, s); POSTPONED -- stop early when step is very small
+            // POSTPONED -- stop early when step is very small
             Transform(xOld, s, std::plus<>(), &xNew);
             Vector_<> fNew = func.F(xNew);
             if (sqrt(InnerProduct(fNew, fNew)) <= fitTol)

--- a/dal-cpp/dal/math/random/pseudorandom.cpp
+++ b/dal-cpp/dal/math/random/pseudorandom.cpp
@@ -11,7 +11,6 @@
 #include <dal/utilities/exceptions.hpp>
 
 namespace Dal {
-    // derived classes can call this explicitly
     void PseudoRandom_::FillUniform(Vector_<>* devs) {
         if (anti_) {
             for (size_t i = 0; i < devs->size(); ++i)
@@ -68,11 +67,9 @@ namespace Dal {
                 : PseudoRandom_(nDim, precise), seed_(seed), irn_(M_), shuffle_(S_), irl_(0) {
                 const unsigned MASK = 0x1F2E3D4C;
                 const unsigned MUL = 17;
-                // initialize IRN_
                 irn_[0] = seed;
                 for (int ii = 1; ii < M_; ++ii)
                     irn_[ii] = ((MUL * irn_[ii - 1]) % DE_NOM) ^ MASK;
-                // initialize shuffle_
                 for (int ii = 0; ii < S_; ++ii)
                     shuffle_[ii] = IRN();
             }
@@ -104,23 +101,19 @@ namespace Dal {
             }
 
             void Reset() {
-                // Reset state
                 xn_ = xn1_ = xn2_ = a_;
                 yn_ = yn1_ = yn2_ = b_;
             }
 
             double NextUniform() override {
                 double x = a12_ * xn1_ - a13_ * xn2_;
-                // Modulus
                 x -= long(x / m1_) * m1_;
                 if (x < 0)
                     x += m1_;
-                // Update
                 xn2_ = xn1_;
                 xn1_ = xn_;
                 xn_ = x;
 
-                // Same for Y
                 double y = a21_ * yn_ - a23_ * yn2_;
                 y -= long(y / m2_) * m2_;
                 if (y < 0)
@@ -129,7 +122,6 @@ namespace Dal {
                 yn1_ = yn_;
                 yn_ = y;
 
-                // Uniform
                 const double u = x > y ? (x - y) / m1p1_ : (x - y + m1_) / m1p1_;
                 return u;
             }
@@ -188,30 +180,22 @@ namespace Dal {
             }
 
         private:
-            //  Matrix product with modulus
             static void MPrd(const size_t lhs[3][3], const size_t rhs[3][3], const size_t& mod, size_t result[3][3]) {
-                // Result go to temp, in case result points to lhs or rhs
                 size_t temp[3][3];
 
                 for (size_t j = 0; j < 3; j++) {
                     for (size_t k = 0; k < 3; k++) {
                         size_t s = 0;
                         for (size_t l = 0; l < 3; l++) {
-                            //	Apply modulus to innermost product
                             size_t tmpNum = lhs[j][l] * rhs[l][k];
-                            //	Apply mod
                             tmpNum %= mod;
-                            //	Result
                             s += tmpNum;
-                            //	Reapply mod
                             s %= mod;
                         }
-                        //  Store result in temp
                         temp[j][k] = s;
                     }
                 }
 
-                //	Now product is done, copy temp to result
                 for (int j = 0; j < 3; j++) {
                     for (int k = 0; k < 3; k++) {
                         result[j][k] = temp[j][k];

--- a/dal-cpp/dal/script/preprocessor.hpp
+++ b/dal-cpp/dal/script/preprocessor.hpp
@@ -12,49 +12,27 @@
 #include <dal/time/date.hpp>
 
 namespace Dal::Script {
-    // Outcome of preprocessing a raw events table.
-    //
-    // It carries the two "definition" products that the payoff parser consumes:
-    //  - constVariables_: named constant values declared in the table,
-    //  - events_:         macro/schedule-resolved descriptions keyed by date.
+    // Resolves constant variables, macros, and schedules into dated event descriptions.
+    // Independent of Parser_ — never builds an AST — so the two halves can be tested in isolation.
     struct PreprocessedEvents_ {
         std::map<String_, double> constVariables_;
         std::map<Date_, String_> events_;
     };
 
-    // Front-end of the script engine.
-    //
-    // Preprocessor_ resolves the "definition" half of an events table -- constant
-    // variables, textual macros and schedules -- into concrete dated event
-    // descriptions. It is deliberately independent of Parser_ (the payoff
-    // back-end): it never builds an AST and knows nothing about nodes, so the two
-    // halves can be developed and unit-tested in isolation.
-    //
-    // The class is built for extension. Process orchestrates the fixed pipeline
-    // while every meaningful decision is delegated to a protected virtual, so a
-    // derived preprocessor can recognise new directive kinds or new placeholders
-    // without re-implementing the orchestration.
+    // Built for extension: Process orchestrates a fixed pipeline; every meaningful decision
+    // is a protected virtual, so a derived class can recognise new directive kinds or
+    // placeholders without re-implementing the orchestration.
     class Preprocessor_ {
     public:
         virtual ~Preprocessor_() = default;
 
-        // Resolve a raw (date-or-name, description) events table into constant
-        // variables and dated event descriptions.
         [[nodiscard]] PreprocessedEvents_ Process(const Vector_<std::pair<Cell_, String_>>& events) const;
 
     protected:
-        // True when a non-date directive description denotes a schedule.
         [[nodiscard]] virtual bool IsSchedule(const String_& desc) const;
-
-        // True when a non-date directive value defines a constant variable rather
-        // than a textual macro.
         [[nodiscard]] virtual bool IsConstVariable(const String_& value) const;
-
-        // Replace every registered macro name found in statement with its body.
         [[nodiscard]] virtual String_ ExpandMacros(const String_& statement,
                                                    const std::map<String_, String_>& macros) const;
-
-        // Replace schedule placeholders (PeriodBegin / PeriodEnd) for one period.
         [[nodiscard]] virtual String_ ExpandSchedulePlaceholders(const String_& statement,
                                                                  const Date_& begin,
                                                                  const Date_& end) const;

--- a/dal-cpp/dal/script/visitor/constcondprocessor.hpp
+++ b/dal-cpp/dal/script/visitor/constcondprocessor.hpp
@@ -10,18 +10,11 @@
 
 namespace Dal::Script {
 
-    // ConstCond processor
-    // Processes all IsConstant (always true/false) conditions and conditional statements
-    // Remove all the if and condition nodes that are always true or always false
-    // The domain proc must have been run first, so always true/false flags are properly set inside the nodes
-    // The always true/false if nodes are replaced by collections of statements to be evaluated
-    // The always true/false conditions are replaced by true/false nodes
-
+    // Collapses always-true and always-false condition/if nodes into concrete true/false nodes
+    // or statement collections. DomainProcessor_ must run first to set the flags.
     class ConstCondProcessor_ : public Visitor_<ConstCondProcessor_> {
-        // The (unique) pointer on the node currently being visited
         ExprTree_* current_;
 
-        // Visit arguments_ plus set current_ pointer
         void VisitArgsSetCurrent(Node_& node) {
             for (auto& arg : node.arguments_) {
                 current_ = &arg;
@@ -32,38 +25,28 @@ namespace Dal::Script {
     public:
         ConstCondProcessor_() = default;
 
-        // Overload catch-all-nodes visitor to Visit argcurrent_uments_ plus set current_
         template <class N_>
         std::enable_if_t<std::is_same<N_, std::remove_const_t<N_>>::value && !HasConstVisit_<ConstCondProcessor_>::ForNodeType<N_>()>
         Visit(N_& node) {
             VisitArgsSetCurrent(node);
         }
 
-        // This particular visitor modifies the structure of the tree, hence it must be called only
-        // with this method from the Top of every tree, passing a ref on the unique_ptr holding
-        // the Top node of the tree
+        // Must be called from the root — this visitor mutates the tree structure.
         void ProcessFromTop(std::unique_ptr<Node_>& top) {
             current_ = &top;
             top->Accept(*this);
         }
 
-        // Conditions
-
-        // One visitor for all booleans
+        // Conditions — one handler for all boolean nodes
         void VisitBool(BoolNode_& node) {
-            // Always true ==> replace the tree by a True node
             if (node.alwaysTrue_)
                 *current_ = std::unique_ptr<Node_>(new NodeTrue_);
-            // Always false ==> replace the tree by a False node
             else if (node.alwaysFalse_)
                 *current_ = std::unique_ptr<Node_>(new NodeFalse_);
-
-            // Nothing to do here ==> Visit the arguments_
             else
                 VisitArgsSetCurrent(node);
         }
 
-        // Visitors
         void Visit(NodeEqual_& node) { VisitBool(node); }
         void Visit(NodeSup_& node) { VisitBool(node); }
         void Visit(NodeSupEqual_& node) { VisitBool(node); }
@@ -73,11 +56,9 @@ namespace Dal::Script {
 
         // If
         void Visit(NodeIf_& node) {
-            // Always true ==> replace the tree by the collection of "if true" statements
             if (node.alwaysTrue_) {
                 size_t lastTrueStat = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
 
-                // Move arguments_, destroy node
                 Vector_<ExprTree_> args = std::move(node.arguments_);
                 *current_ = std::unique_ptr<Node_>(new NodeCollect_);
 
@@ -85,12 +66,9 @@ namespace Dal::Script {
                     (*current_)->arguments_.push_back(std::move(args[i]));
                 VisitArgsSetCurrent(**current_);
             }
-
-            // Always false ==> replace the tree by the collection of "else" statements
             else if (node.alwaysFalse_) {
                 int firstElseStatement = node.firstElse_;
 
-                // Move arguments_, destroy node
                 Vector_<ExprTree_> args = std::move(node.arguments_);
                 *current_ = std::unique_ptr<Node_>(new NodeCollect_);
 
@@ -99,7 +77,6 @@ namespace Dal::Script {
                         (*current_)->arguments_.push_back(std::move(args[i]));
                 VisitArgsSetCurrent(**current_);
             }
-            // Nothing to do here ==> Visit the arguments_
             else
                 VisitArgsSetCurrent(node);
         }

--- a/dal-cpp/dal/script/visitor/domainproc.hpp
+++ b/dal-cpp/dal/script/visitor/domainproc.hpp
@@ -25,44 +25,24 @@ alternative TrueOrFalse
 
 namespace Dal::Script {
 #include <dal/auto/MG_DomainCondProp_enum.hpp>
-    /*
-            Domain_ processor
-
-            Variable indexer and if processor must have been run prior
-
-            Determines the domains of all variables and expressions. Note that the goal is to identify singletons from
-       IsContinuous intervals, not necessarily to compute all intervals accurately. For example, is x's domain is {0} and
-       y's domain is (-inf, inf) then xy's domain is {0}, but if x and y have domain (-inf, inf), then xy's domain is
-       (-inf, inf), even if it turns out that y=x.
-
-            This processor sets the "always true" and "always false" flags
-            on the if, equal, superior, not, and and or nodes according to the condition's domain
-
-            In addition, when fuzzy processing is requested, the processor sets the IsContinuous/isDiscrete_ flag on the
-       equal and superior nodes and if isDiscrete_, the left and right interpolation bounds
-
-    */
+    // Determines domains of all variables and expressions. Sets alwaysTrue_/alwaysFalse_ flags
+    // on condition and if nodes. When fuzzy is enabled, also sets isDiscrete_ and interpolation bounds.
 
     class DomainProcessor_ : public Visitor_<DomainProcessor_> {
-        // Fuzzy?
         const bool fuzzy_;
-
-        // Domains for all variables
         Vector_<Domain_> varDomains_;
-
-        // Stack of domains for expressions
         StaticStack_<Domain_> domStack_;
+
         using Value_ = typename DomainCondProp_::Value_;
         StaticStack_<Value_> condStack_;
 
-        // LHS variable being visited?
         bool isLhsVar_;
         size_t lhsVarIdx_;
 
     public:
         using Visitor_<DomainProcessor_>::Visit;
 
-        // Domains start with the IsSingleton 0
+        // All variable domains start as the singleton {0}
         DomainProcessor_(const size_t nVars, bool fuzzy)
             : fuzzy_(fuzzy), varDomains_(nVars, Domain_(0.0)), isLhsVar_(false), lhsVarIdx_(-1), condStack_() {}
 
@@ -70,11 +50,7 @@ namespace Dal::Script {
             return varDomains_;
         }
 
-        // Visitors
-
-        // Expressions
-
-        // Binaries
+        // Expressions — binaries
 
         void Visit(NodeAdd_& node) {
             VisitArguments(node);
@@ -183,10 +159,8 @@ namespace Dal::Script {
                 condStack_.Push(Value_::TrueOrFalse);
 
                 if (fuzzy_) {
-                    // Continuous or isDiscrete_?
                     node.isDiscrete_ = dom.ZeroIsDiscrete();
 
-                    // Discrete
                     if (node.isDiscrete_) {
                         bool subDomRightOfZero = dom.SmallestPosLb(node.rb_, true);
                         if (!subDomRightOfZero)
@@ -243,18 +217,15 @@ namespace Dal::Script {
                 condStack_.Push(Value_::TrueOrFalse);
 
                 if (fuzzy_) {
-                    // Continuous or isDiscrete_?
                     node.isDiscrete_ = !dom.CanBeZero() || dom.ZeroIsDiscrete();
 
-                    // Fuzzy logic processing
                     if (node.isDiscrete_) {
-                        // Case 1: expr cannot be IsZero
+                        // Case 1: expr cannot be zero — subdomains on both sides of 0 exist
                         if (!dom.CanBeZero()) {
-                            //  we know we have subdomains on the left and on the right of 0
                             std::ignore = dom.SmallestPosLb(node.rb_, true);
                             std::ignore = dom.BiggestNegRb(node.lb_, true);
                         }
-                        // Case 2: {0} is a IsSingleton
+                        // Case 2: {0} is a singleton
                         else {
                             if (Strict_) {
                                 node.lb_ = 0.0;
@@ -318,115 +289,88 @@ namespace Dal::Script {
 
         // Instructions
         void Visit(NodeIf_& node) {
-            // Last "if true" statement index
             const size_t lastTrueStat = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
 
-            // Visit condition
             node.arguments_[0]->Accept(*this);
 
-            // Always true/false?
             const DomainCondProp_ cp = condStack_.Top();
             condStack_.Pop();
 
             if (cp == Value_::AlwaysTrue) {
                 node.alwaysTrue_ = true;
                 node.alwaysFalse_ = false;
-                // Visit "if true" statements
                 for (size_t i = 1; i <= lastTrueStat; ++i)
                     node.arguments_[i]->Accept(*this);
             } else if (cp == Value_::AlwaysFalse) {
                 node.alwaysTrue_ = false;
                 node.alwaysFalse_ = true;
-                // Visit "if false" statements, if any
                 if (node.firstElse_ != -1)
                     for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                         node.arguments_[i]->Accept(*this);
             } else {
                 node.alwaysTrue_ = node.alwaysFalse_ = false;
 
-                // Record variable domain before if statements are executed
                 Vector_<Domain_> domStore0(node.affectedVars_.size());
                 for (size_t i = 0; i < node.affectedVars_.size(); ++i)
                     domStore0[i] = varDomains_[node.affectedVars_[i]];
 
-                // Execute if statements
                 for (size_t i = 1; i <= lastTrueStat; ++i)
                     node.arguments_[i]->Accept(*this);
 
-                // Record variable domain after if statements are executed
                 Vector_<Domain_> domStore1(node.affectedVars_.size());
                 for (size_t i = 0; i < node.affectedVars_.size(); ++i)
                     domStore1[i] = std::move(varDomains_[node.affectedVars_[i]]);
 
-                // Reset variable domains
                 for (size_t i = 0; i < node.affectedVars_.size(); ++i)
                     varDomains_[node.affectedVars_[i]] = std::move(domStore0[i]);
 
-                // Execute else statements if any
                 if (node.firstElse_ != -1)
                     for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                         node.arguments_[i]->Accept(*this);
 
-                // Merge domains
                 for (size_t i = 0; i < node.affectedVars_.size(); ++i)
                     varDomains_[node.affectedVars_[i]].AddDomain(domStore1[i]);
             }
         }
 
         void Visit(NodeAssign_& node) {
-            // Visit the LHS variable
             isLhsVar_ = true;
             node.arguments_[0]->Accept(*this);
             isLhsVar_ = false;
 
-            // Visit the RHS expression
             node.arguments_[1]->Accept(*this);
 
-            // Write RHS domain into variable
             varDomains_[lhsVarIdx_] = domStack_.Top();
-
-            // Pop
             domStack_.Pop();
         }
 
         void Visit(NodePays_& node) {
-            // Visit the LHS variable
             isLhsVar_ = true;
             node.arguments_[0]->Accept(*this);
             isLhsVar_ = false;
 
-            // Visit the RHS expression
             node.arguments_[1]->Accept(*this);
 
-            // Write RHS domain into variable
-
-            // Numeraire domain = (0,+inf)
+            // Payment is divided by numeraire: (0,+inf)
             static const Domain_ numDomain(Interval_(Bound_(0.0), Bound_(Bound_::plusInfinity_)));
-
-            // Payment domain
             Domain_ payDomain = domStack_.Top() / numDomain;
 
-            // Write
             varDomains_[lhsVarIdx_] = varDomains_[lhsVarIdx_] + payDomain;
-
-            // Pop
             domStack_.Pop();
         }
 
         // Variables and constants
         void Visit(NodeVar_& node) {
-            // LHS?
             if (isLhsVar_)
                 lhsVarIdx_ = node.index_;
             else
-                // Push domain onto the stack
                 domStack_.Push(varDomains_[node.index_]);
         }
 
         void Visit(NodeConst_& node) { domStack_.Push(node.constVal_); }
         void Visit(NodeConstVar_& node) { domStack_.Push(node.constVal_); }
 
-        // Scenario related
+        // Scenario
         void Visit(NodeSpot_&) {
             static auto interval = Interval_(Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_));
             static const Domain_ realDom(interval);

--- a/dal-cpp/dal/script/visitor/fuzzy.hpp
+++ b/dal-cpp/dal/script/visitor/fuzzy.hpp
@@ -50,23 +50,18 @@ namespace Dal::Script {
         return 1.0 - x / rb;
     }
 
-    // The fuzzy evaluator
     template <class T> class FuzzyEvaluator_ : public EvaluatorBase_<T, FuzzyEvaluator_> {
         // Default smoothing factor for conditions that don't override it
         double defEps_;
-
-        // Stack for the fuzzy evaluation of conditions
         StaticStack_<T> fuzzyStack_;
 
-        // Temp storage for variables, preallocated for performance
-        // [i][j] = nested if level i variable j
+        // Preallocated for performance. [i][j] = nested if level i, variable j.
         Vector_<Vector_<T>> varStore0_;
         Vector_<Vector_<T>> varStore1_;
 
-        // Nested if level, 0: not in an if, 1: in the outermost if, 2: if nested in another if, etc.
+        // 0: not in an if, 1: outermost if, 2: nested once, etc.
         size_t nestedIfLvl_;
 
-        // Pop the Top 2 numbers of the fuzzy condition stack
         FORCE_INLINE pair<T, T> Pop2f() {
             pair<T, T> res;
             res.first = fuzzyStack_.TopAndPop();
@@ -90,7 +85,6 @@ namespace Dal::Script {
                 varStore.Resize(variables.size());
         }
 
-        // Copy/Move
         FuzzyEvaluator_(const FuzzyEvaluator_& rhs)
             : Base(rhs), defEps_(rhs.defEps_), varStore0_(rhs.varStore0_.size()), varStore1_(rhs.varStore1_.size()),
               nestedIfLvl_(0) {
@@ -127,63 +121,48 @@ namespace Dal::Script {
             return *this;
         }
 
-        // (Re)set default smoothing factor
         FORCE_INLINE void SetDefEps(double defEps) { defEps_ = defEps; }
 
-        // Overriden visitors
-        // If
         void Visit(const NodeIf_& node) {
-            //	Last "if true" statement index
             const size_t lastTrueStat = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
 
-            //	Increase nested if level
             ++nestedIfLvl_;
 
-            //	Visit the condition and compute its degree of truth dt
             VisitNode(*node.arguments_[0]);
             const T dt = fuzzyStack_.TopAndPop();
 
-            //	Absolutely true
+            // Absolutely true
             if (dt > 1.0 - EPSILON) {
-                //	Eval "if true" statements
                 for (size_t i = 1; i <= lastTrueStat; ++i)
                     VisitNode(*node.arguments_[i]);
-
             }
-            //	Absolutely false
+            // Absolutely false
             else if (dt < EPSILON) {
-                //	Eval "if false" statements if any
                 if (node.firstElse_ != -1)
                     for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                         VisitNode(*node.arguments_[i]);
             }
-            //	Fuzzy
+            // Fuzzy: split evaluation between true and false branches, weight by dt
             else {
-                //	Record values of variables to be changed
                 for (auto idx : node.affectedVars_)
                     varStore0_[nestedIfLvl_ - 1][idx] = variables_[idx];
 
-                //	Eval "if true" statements
                 for (size_t i = 1; i <= lastTrueStat; ++i)
                     VisitNode(*node.arguments_[i]);
 
-                //	Record and Reset values of variables to be changed
                 for (auto idx : node.affectedVars_) {
                     varStore1_[nestedIfLvl_ - 1][idx] = variables_[idx];
                     variables_[idx] = varStore0_[nestedIfLvl_ - 1][idx];
                 }
 
-                //	Eval "if false" statements if any
                 if (node.firstElse_ != -1)
                     for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                         VisitNode(*node.arguments_[i]);
 
-                //	Set values of variables to fuzzy values
                 for (auto idx : node.affectedVars_)
                     variables_[idx] = dt * varStore1_[nestedIfLvl_ - 1][idx] + (1.0 - dt) * variables_[idx];
             }
 
-            //	Decrease nested if level
             --nestedIfLvl_;
         }
 
@@ -193,44 +172,33 @@ namespace Dal::Script {
 
         // Equality
         FORCE_INLINE void Visit(const NodeEqual_& node) {
-            //	Evaluate expression to be compared to 0
             VisitNode(*node.arguments_[0]);
             const T expr = dStack_.TopAndPop();
 
-            //	Discrete case: 0 is a IsSingleton in expr's domain
+            // Discrete case: 0 is a singleton in expr's domain
             if (node.isDiscrete_)
                 fuzzyStack_.Push(BFly(expr, node.lb_, node.rb_));
-            //	Continuous case: 0 is part of expr's IsContinuous domain
+            // Continuous case: 0 lies inside expr's continuous domain
             else {
-                //	Effective epsilon: take default unless overwritten on the node
+                // Use node's epsilon if set, otherwise fall back to default
                 double eps = node.eps_ < 0 ? defEps_ : node.eps_;
-
-                //	Butterfly
                 fuzzyStack_.Push(BFly(expr, eps));
             }
         }
 
-        // Inequality
-        // For visiting superior and supEqual
+        // Inequality (sup/supEqual share the logic)
         void VisitComp(const CompNode_& node) {
-            //	Evaluate expression to be compared to 0
             VisitNode(*node.arguments_[0]);
             const T expr = dStack_.TopAndPop();
 
-            //	Discrete case:
-            //	Either 0 is a IsSingleton in expr's domain
-            //	Or 0 is not part of expr's domain, but expr's domain has subdomains left and right of 0
-            //		otherwise the condition would be always true/false
+            // Discrete case: 0 is either a singleton or outside expr's domain entirely,
+            // but with subdomains on both sides (otherwise the condition is always true/false)
             if (node.isDiscrete_) {
-                //	Call spread on the right
                 fuzzyStack_.Push(CSpr(expr, node.lb_, node.rb_));
             }
-            //	Continuous case: 0 is part of expr's IsContinuous domain
+            // Continuous case: 0 lies inside expr's continuous domain
             else {
-                //	Effective epsilon: take default unless overwritten on the node
                 const double eps = node.eps_ < 0 ? defEps_ : node.eps_;
-
-                //	Call Spread
                 fuzzyStack_.Push(CSpr(expr, eps));
             }
         }
@@ -244,8 +212,7 @@ namespace Dal::Script {
             fuzzyStack_.Top() = 1.0 - fuzzyStack_.Top();
         }
 
-        // Combinators
-        // Hard coded proba stlye and->dt(lhs)*dt(rhs), or->dt(lhs)+dt(rhs)-dt(lhs)*dt(rhs)
+        // Combinators: probability-style fuzzy logic
         FORCE_INLINE void Visit(const NodeAnd_& node) {
             VisitNode(*node.arguments_[0]);
             VisitNode(*node.arguments_[1]);

--- a/dal-cpp/dal/storage/json.cpp
+++ b/dal-cpp/dal/storage/json.cpp
@@ -32,12 +32,7 @@ namespace Dal {
         rapidjson::GenericStringRef<char> LendToJSON(const String_& s) {
             return {s.c_str(), static_cast<rapidjson::SizeType>(s.size())};
         }
-        // WRITE interface
-        // given up on rapidjson, think it is simple enough to just stream out
-        // POSTPONED -- add a template parameter determining the checking strategy for funny characters inside strings
-        // this simple implementation just assumes there are none (fastest)
-        // could have one that wraps, one that errors
-
+        // POSTPONED -- add checking strategy for funny characters inside strings
         struct XDocStore_ : Archive::Store_ {
             std::ostream& dst_;
             std::map<const Storable_*, String_>& sharedTags_;
@@ -71,7 +66,6 @@ namespace Dal {
                 return false;
             }
             void SetType(const String_& type) override {
-                // assert(!empty_);	// should have a tag -- unless it is the toplevel!
                 dst_ << Prep() << "\"" << TYPE_LABEL << "\": \"" << type << "\"";
                 empty_ = false;
             }
@@ -79,14 +73,12 @@ namespace Dal {
             Store_& Child(const String_& name) override {
                 std::shared_ptr<XDocStore_>& retval = children_[name];
                 if (!retval) {
-                    // assume we are going to write the child immediately
                     dst_ << Prep() << "\"" << name << "\": ";
                     retval = std::make_shared<XDocStore_>(dst_, sharedTags_, this, name);
                 }
                 return *retval;
             }
 
-            // store atoms
             XDocStore_& operator=(const double val) override {
                 char buf[32];
                 std::snprintf(buf, sizeof(buf), "%.15g", val);
@@ -162,7 +154,6 @@ namespace Dal {
             XDocStore_& operator=(const Dictionary_& val) override { operator=(Dictionary::ToString(val)); return *this; }
         };
 
-        // READ interface
         template <class E_>
         auto AsVector(element_t& doc, const E_& extract) -> typename vector_of<decltype(extract(doc))>::type {
             REQUIRE(doc.IsArray(), "Can't get a vector value");
@@ -172,7 +163,6 @@ namespace Dal {
                 ret_val[ii] = extract(doc[ii]);
             return ret_val;
         }
-        // create matrix from vector of values
         template <class E_> Matrix_<E_> AsMatrix(int cols, const Vector_<E_>& vals) {
             REQUIRE(cols > 0 && !(vals.size() % cols), "Invalid number of matrix columns");
             const int rows = vals.size() / cols;
@@ -182,7 +172,6 @@ namespace Dal {
             return ret_val;
         }
 
-        // need checked access at every level -- support with "E" element-extractors
         double EDouble(const element_t& doc) {
             REQUIRE(doc.IsDouble() || doc.IsInt(), "Can't get a numeric value");
             return doc.GetDouble();
@@ -238,14 +227,11 @@ namespace Dal {
             THROW("Invalid cell type");
         }
 
-        // JSON reader based on RapidJSON DOM interface
         struct XDocView_ : Archive::View_ {
-            element_t& doc_; // may be shared
+            element_t& doc_;
             mutable std::map<String_, Handle_<XDocView_>> children_;
             explicit XDocView_(element_t& doc) : doc_(doc) {}
 
-            // shared-object part of Archive::View_ interface
-            // we will do this by having a Tag() which is empty except for shared objects (same as Splat)
             String_ AfterPrefix(char prefix) const {
                 if (doc_.IsString() && doc_.GetStringLength() > 1 && doc_.GetString()[0] == prefix) {
                     return String_(doc_.GetString()).substr(1);
@@ -257,12 +243,10 @@ namespace Dal {
                     return EString(doc_[TAG_LABEL]);
                 return {};
             }
-            Handle_<Storable_>& Known(Archive::Built_& built) const override // returns a reference within 'built'
-            {
+            Handle_<Storable_>& Known(Archive::Built_& built) const override {
                 return built.known_[Tag()];
             }
 
-            // direct storage of atoms
             double AsDouble() const override { return EDouble(doc_); }
             int AsInt() const override { return EInt(doc_); }
             bool AsBool() const override { return EBool(doc_); }
@@ -278,9 +262,7 @@ namespace Dal {
             Vector_<DateTime_> AsDateTimeVector() const override { return AsVector(doc_, EDateTime); }
             Vector_<Cell_> AsCellVector() const override { return AsVector(doc_, ECell); }
 
-            // matrix storage is:
-            //		the matrix has a child "cols" that gives the number of columns
-            //		and a child "vals" that gives all the values, scanning each row in turn
+            // Matrix stored as child "cols" + child "vals" (row-major)
             Matrix_<> AsDoubleMatrix() const override {
                 return AsMatrix(EInt(doc_[COLS_LABEL]), AsVector(doc_[VALS_LABEL], EDouble));
             }
@@ -291,7 +273,6 @@ namespace Dal {
                 return AsMatrix(EInt(doc_[COLS_LABEL]), AsVector(doc_[VALS_LABEL], ECell));
             }
 
-            // object query interface
             String_ Type() const override {
                 if (doc_.HasMember(TYPE_LABEL))
                     return EString(doc_[TYPE_LABEL]);
@@ -306,9 +287,9 @@ namespace Dal {
                 return *ret_val;
             }
 
-            void Unexpected(const String_&) const override {} // ignore extra children
+            void Unexpected(const String_&) const override {}
         };
-    }	// leave local
+    }
 
     Handle_<Storable_> JSON::ReadString(const String_& src, bool quiet) {
         NOTE("Extracting object from JSON string");

--- a/dal-cpp/dal/storage/json.cpp
+++ b/dal-cpp/dal/storage/json.cpp
@@ -289,7 +289,7 @@ namespace Dal {
 
             void Unexpected(const String_&) const override {}
         };
-    }
+    } // namespace
 
     Handle_<Storable_> JSON::ReadString(const String_& src, bool quiet) {
         NOTE("Extracting object from JSON string");

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,13 +31,15 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - Discount curve framework (`DiscountPWLF_`, `DiscountPWC_`)
   - Piecewise-linear and piecewise-constant forward rates
   - Multi-curve construction and calibration (sequential and joint simultaneous)
+  - Single-curve AAD calibration internals (TapeGuard, eligibility predicate, analytic Jacobian)
   - Joint multi-curve AAD analytic Jacobian (reverse-sweep, backend-neutral)
   - Integration with the underdetermined solver
 
 - **[underdetermined_search.md](methodology/underdetermined_search.md)** — Underdetermined Optimization
   - Scaled quasi-Newton method for underdetermined systems
-  - Application to yield curve calibration
-  - Regularization and smoothness penalties
+  - Residual scaling, backtracking line search, forward Jacobian capture at solution
+  - Solver controls structure and Broyden update regime
+  - Application to yield curve calibration via smoothness penalties
 
 - **[xccy_calibration.md](methodology/xccy_calibration.md)** — Cross-Currency Calibration
   - Cross-currency market and basis curve framework
@@ -54,12 +56,20 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
 - **[log_discount_curve.md](methodology/log_discount_curve.md)** — Log-Discount Curve
   - Node log-discount-factor representation and anchor convention
   - `LogDfScheme_` interpolation schemes (`LOG_LINEAR`, `LOG_CUBIC_NATURAL`, `MIXED`)
+  - Thomas algorithm for the natural-cubic system, basis weights, and `fppCoef_` matrix
+  - Serialization version design (v1 without scheme, v2 with named scheme)
   - Why `LOG_DISCOUNT` is the parameterization that supports the analytic Jacobian
 
 - **[yield_curve_jacobian.md](methodology/yield_curve_jacobian.md)** — Yield-Curve Jacobian and Inverse-Jacobian Risk
   - Forward residual Jacobian via AAD reverse sweep vs finite-difference bump
   - Inverse-Jacobian IR-risk transform `r = gᵀ · effJacobianInverse_ / tolerance_`
   - Why `effJacobianInverse_` carries an extra `tolerance_` factor (solver residual scaling)
+
+- **[script_engine.md](methodology/script_engine.md)** — Script Engine
+  - Preprocessing pipeline (macros, schedules, constant variables)
+  - Domain processor (variable range analysis, always-true/false flags)
+  - Constant condition processor (dead-branch pruning)
+  - Fuzzy evaluator (smooth transitions for pathwise AAD; nested-if merging)
 
 ### Experimental (`experimental/`)
 

--- a/docs/methodology/log_discount_curve.md
+++ b/docs/methodology/log_discount_curve.md
@@ -130,10 +130,10 @@ at construction. `BuildNaturalCubicFppCoef` solves the interior tridiagonal syst
 each unit source $\ell_j$ column to populate this matrix.
 
 **MIXED.** The cutoff is at the $(N-4)$-th knot (ensuring $\ge 3$ knots in the cubic
-tail). The cubic portion (`LOG_CUBIC_NATURAL` basis) applies for $\tau \le \tau_{\text{cutoff}}$;
-`LOG_LINEAR` basis applies beyond. The `fppCoef_` matrix is computed on the cubic tail
-subarray and expanded back to full storage-node indices, with `mixedCutoffIndex_` and
-`mixedCutoffYf_` stored for dispatch at evaluation.
+tail). `LOG_LINEAR` basis applies for $\tau \le \tau_{\text{cutoff}}$; the cubic portion
+(`LOG_CUBIC_NATURAL` basis) applies beyond. The `fppCoef_` matrix is computed on the
+cubic tail subarray and expanded back to full storage-node indices, with
+`mixedCutoffIndex_` and `mixedCutoffYf_` stored for dispatch at evaluation.
 
 ### Extrapolation
 
@@ -183,10 +183,10 @@ constructs the curve directly with the tape-registered `logDF` vector). A stale
 ### Double vs Number_ Dispatch
 
 The `DiscountLogDF_<T_>::operator()(from, to)` method uses `if constexpr` to select the
-`double` path (reads `LogDfAt` + `std::exp` + base multiplication as pure arithmetic,
-byte-identical to the pre-Phase-A implementation) or the `Number_` path where the
-base curve is treated as a constant `double` multiplier. Both specializations are
-explicitly instantiated so the linker finds them under every AAD backend.
+`double` path (reads `LogDfAt` + `std::exp` + base multiplication as pure arithmetic)
+or the `Number_` path where the base curve is treated as a constant `double` multiplier.
+Both specializations are explicitly instantiated so the linker finds them under every
+AAD backend.
 
 ### Serialization: v1 vs v2
 

--- a/docs/methodology/log_discount_curve.md
+++ b/docs/methodology/log_discount_curve.md
@@ -78,6 +78,128 @@ tape records the dependence of every queried $\ell(\tau)$ on the node $\ell_i$ v
 directly. The same machinery supports all three schemes; eligibility for the analytic path
 is independent of which `LogDfScheme_` is chosen.
 
+## Internal Algorithms
+
+This section describes the numerical methods inside `Tape::DiscountLogDF_<T_>`, implemented
+in `dal-cpp/dal/curve/yclogdf.cpp`. The `T_ = double` path uses the `Interp1_` handle for
+evaluation; the `T_ = Dal::AAD::Number_` path accumulates storage-node basis weights
+directly against the tape-registered `logDF_` vector, so the tape records the dependence of
+every queried $\ell(\tau)$ on the node $\ell_i$.
+
+### Anchor and Free-Node Convention
+
+Storage node $0$ (the anchor, $\ell_0 = 0$) is pinned and excluded from the unknown vector.
+The solver column mapping is `solver col j = storage node j+1`, so the parameter dimension
+$N-1$ matches the instrument count in a square calibration. In the `Number_` path, the
+anchor is deliberately omitted from the weighted sum in `LogDfAt` — its contribution is
+zero by construction, and including it would register a spurious tape dependence on
+$\ell_0$ that the calibration overrides anyway. Excluding it keeps the column map clean
+without exception.
+
+### Basis Weights by Interpolation Scheme
+
+`StorageBasisWeightsAt(yf)` returns a sparse vector of `(storageNode, weight)` pairs so
+that $\ell(\tau) = \sum_{(j,w)} w \cdot \ell_j$. The weights are functions of the knot
+positions only, so they are identical for any `T_`.
+
+**LOG_LINEAR (log-linear / linear-in-$\ell$).** On segment $[\tau_k, \tau_{k+1}]$ with
+step $h = \tau_{k+1} - \tau_k$, the interpolation is
+
+$$
+\ell(\tau) = \ell_k + \frac{\tau - \tau_k}{h} (\ell_{k+1} - \ell_k)
+           = (1 - g)\,\ell_k + g\,\ell_{k+1},
+\qquad g = \frac{\tau - \tau_k}{h}.
+$$
+
+The basis weights are $(k,\; 1-g)$ and $(k+1,\; g)$. The same weights serve the `MIXED`
+head (the linear portion before the cutoff).
+
+**LOG_CUBIC_NATURAL (natural cubic spline).** On segment $[\tau_k, \tau_{k+1}]$ with
+$h = \tau_{k+1} - \tau_k$, the cubic Hermite representation in terms of the unknown
+second derivatives $\ell''_k$ (known as `fpp` in the code) gives the basis weight at
+storage node $j$ as
+
+$$
+b_j(\tau) = a\,\delta_{j,k} + b\,\delta_{j,k+1}
+          - \frac{a\,b\,h^2}{6}\Big((1+a)\,\mathrm{fppCoef}_{k,j} + (1+b)\,\mathrm{fppCoef}_{k+1,j}\Big),
+$$
+
+where $b = (\tau - \tau_k)/h$, $a = 1 - b$, and $\mathrm{fppCoef}_{k,j} = \partial\,
+\ell''_k / \partial\,\ell_j$ is the second-derivative sensitivity matrix, computed once
+at construction. `BuildNaturalCubicFppCoef` solves the interior tridiagonal system for
+each unit source $\ell_j$ column to populate this matrix.
+
+**MIXED.** The cutoff is at the $(N-4)$-th knot (ensuring $\ge 3$ knots in the cubic
+tail). The cubic portion (`LOG_CUBIC_NATURAL` basis) applies for $\tau \le \tau_{\text{cutoff}}$;
+`LOG_LINEAR` basis applies beyond. The `fppCoef_` matrix is computed on the cubic tail
+subarray and expanded back to full storage-node indices, with `mixedCutoffIndex_` and
+`mixedCutoffYf_` stored for dispatch at evaluation.
+
+### Extrapolation
+
+Beyond $\tau_{N-1}$, every scheme uses the secant slope of the last segment:
+
+$$
+\ell(\tau) = \ell_{N-1} + \frac{\ell_{N-1} - \ell_{N-2}}{\tau_{N-1} - \tau_{N-2}}
+             (\tau - \tau_{N-1}).
+$$
+
+The weighting is linear in the last two storage nodes — the cubic derivative at the
+boundary is deliberately not used, even for `LOG_CUBIC_NATURAL`. This keeps the tail
+simple, monotone, and consistent with the linear head.
+
+### Thomas Algorithm for the Natural-Cubic System
+
+The natural-cubic spline interior system for $\ell''_1,\dots,\ell''_{N-2}$ is
+tridiagonal and diagonally dominant:
+
+$$
+h_{i-1}\,\ell''_{i-1} + 2(h_{i-1}+h_i)\,\ell''_i + h_i\,\ell''_{i+1}
+= 6\!\left( \frac{\ell_{i+1}-\ell_i}{h_i} - \frac{\ell_i-\ell_{i-1}}{h_{i-1}} \right),
+\qquad i = 1,\dots,N-2,
+$$
+
+with $h_i = \tau_{i+1} - \tau_i$. The solver `SolveTriDiagonal(a, d, c, b)` in
+`dal-cpp/dal/curve/yclogdf.cpp` uses the standard Thomas algorithm: forward elimination
+with the modified diagonal $d'_i = d_i - a_{i-1}c_{i-1}/d'_{i-1}$, then back-substitution.
+`NaturalCubicRhsEntry(j, i, h)` returns the four-term Kronecker-delta dispatch
+$\partial b_i / \partial \ell_j$ that feeds the column-solve loop in
+`BuildNaturalCubicFppCoef`.
+
+### Rebuild and ApplyDX
+
+`RebuildInterp()` constructs the double-valued `interp_` handle from the (possibly
+`Number_`-typed) `logDF_` vector, extracting primals via `Dal::AAD::Value`. The
+`Number_` `LogDfAt` path does **not** consult `interp_` — it uses the basis weights
+above directly — but `RebuildInterp` still exists so the handle is available for any
+code that defensively calls it.
+
+`ApplyDX(dx, leverage)` bumps only the free nodes `logDF_[1..]` and calls
+`RebuildInterp` so the bumped curve re-synchronises the interpolator. This method is
+only exercised for `T_ = double`; the `Number_` factory never calls it (the AAD path
+constructs the curve directly with the tape-registered `logDF` vector). A stale
+`interp_` after a bump would silently desync the curve from its node values.
+
+### Double vs Number_ Dispatch
+
+The `DiscountLogDF_<T_>::operator()(from, to)` method uses `if constexpr` to select the
+`double` path (reads `LogDfAt` + `std::exp` + base multiplication as pure arithmetic,
+byte-identical to the pre-Phase-A implementation) or the `Number_` path where the
+base curve is treated as a constant `double` multiplier. Both specializations are
+explicitly instantiated so the linker finds them under every AAD backend.
+
+### Serialization: v1 vs v2
+
+- **v1** (`DiscountLogDF_v1`) stored a built `Interp1_` handle and did **not** persist
+  `LogDfScheme_`. The scheme cannot be recovered from the deserialised handle (all
+  interpolator subtypes report the same `Storable_::type_` as `"Interp1"`, and RTTI
+  cannot tell them apart because the concrete classes live in anonymous namespaces). v1
+  therefore always reconstructs as `LOG_LINEAR`, the only scheme honestly rebuildable
+  from `(nodeDates, logDF)` alone.
+- **v2** (`DiscountLogDF_v2`) is the canonical format: it carries the scheme by name
+  (`LogDfScheme_` serialised as a string) and fully reconstructs the curve including
+  the `fppCoef_` matrix for cubic and mixed schemes.
+
 ## Relationship to the Forward-Rate Parameterizations
 
 The [yield curve methodology](yield_curve.md) describes the curve through the

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -32,12 +32,12 @@ every meaningful decision delegates to a protected virtual method, so a derived
 preprocessor can recognise new directive kinds or new placeholders without
 re-implementing the orchestration.
 
-| Virtual method                 | Role                                                              |
-|--------------------------------|-------------------------------------------------------------------|
-| `IsSchedule(desc)`             | True when a non-date directive description denotes a schedule     |
-| `IsConstVariable(value)`       | True when a non-date directive value defines a constant variable  |
-| `ExpandMacros(stmt, macros)`   | Replace every registered macro name in a statement with its body  |
-| `ExpandSchedulePlaceholders(...)` | Replace `PeriodBegin` / `PeriodEnd` placeholders for one period |
+| Virtual method                    | Role                                                              |
+|-----------------------------------|-------------------------------------------------------------------|
+| `IsSchedule(desc)`                | True when a non-date directive description denotes a schedule     |
+| `IsConstVariable(value)`          | True when a non-date directive value defines a constant variable  |
+| `ExpandMacros(stmt, macros)`      | Replace every registered macro name in a statement with its body  |
+| `ExpandSchedulePlaceholders(...)` | Replace `PeriodBegin` / `PeriodEnd` placeholders for one period   |
 
 The default implementation recognises simple textual macros and period-based
 schedule expansion; a derived preprocessor can override any of these to support

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -1,0 +1,217 @@
+# Script Engine
+
+This note describes the script-engine pipeline that turns a human-readable events
+table into an evaluable expression tree, and the visitor passes that transform it
+before simulation or valuation. The implementation lives in `dal-cpp/dal/script/`.
+
+## Architecture
+
+The script engine is split into two independent halves connected by a well-defined
+interface:
+
+1. **Preprocessor** (`dal-cpp/dal/script/preprocessor.hpp`) — resolves the
+   "definition" half of an events table: constant variables, textual macros, and
+   schedules. Produces dated event descriptions. Does not build an AST and knows
+   nothing about nodes.
+
+2. **Parser** — consumes the preprocessor's output and builds the AST (expression
+   tree) of `Node_` objects. Operates independently of the preprocessor, so the two
+   halves can be developed and unit-tested in isolation.
+
+After parsing, a sequence of **visitor passes** (domain analysis, constant-condition
+folding, evaluation) walks the AST to prepare and execute it.
+
+## Preprocessing Pipeline
+
+The `Preprocessor_` class in `dal-cpp/dal/script/preprocessor.hpp` resolves a raw
+`(Cell_, String_)` events table into `PreprocessedEvents_`: a map of constant
+variables (`String_ -> double`) and dated event descriptions (`Date_ -> String_`).
+
+The class is built for extension: `Process` orchestrates a fixed pipeline while
+every meaningful decision delegates to a protected virtual method, so a derived
+preprocessor can recognise new directive kinds or new placeholders without
+re-implementing the orchestration.
+
+| Virtual method                 | Role                                                              |
+|--------------------------------|-------------------------------------------------------------------|
+| `IsSchedule(desc)`             | True when a non-date directive description denotes a schedule     |
+| `IsConstVariable(value)`       | True when a non-date directive value defines a constant variable  |
+| `ExpandMacros(stmt, macros)`   | Replace every registered macro name in a statement with its body  |
+| `ExpandSchedulePlaceholders(...)` | Replace `PeriodBegin` / `PeriodEnd` placeholders for one period |
+
+The default implementation recognises simple textual macros and period-based
+schedule expansion; a derived preprocessor can override any of these to support
+domain-specific directive syntax without touching the orchestration logic.
+
+## Domain Processor
+
+`DomainProcessor_` in `dal-cpp/dal/script/visitor/domainproc.hpp` determines the
+domains (value ranges) of all script variables and expressions. Its purposes are:
+
+1. Set the `alwaysTrue_` / `alwaysFalse_` flags on condition nodes (`NodeEqual_`,
+   `NodeSup_`, `NodeSupEqual_`, `NodeNot_`, `NodeAnd_`, `NodeOr_`) and `NodeIf_`
+   by evaluating the condition's domain.
+2. When fuzzy processing is enabled, additionally set the `isDiscrete_` flag and
+   left/right interpolation bounds on equality and comparison nodes for the fuzzy
+   evaluator.
+
+**Domain stack.** The processor maintains a stack of `Domain_` objects that
+represent the runtime value range of each sub-expression. All variable domains
+start as the singleton $\{0\}$. As the walker descends through arithmetic
+operations, domains are combined (pushed/popped) on the stack. A boolean condition
+stack (`DomainCondProp_` values: `AlwaysTrue`, `AlwaysFalse`, `TrueOrFalse`)
+tracks the outcome of evaluated conditions.
+
+**Condition detection.** For `NodeEqual_` (expr $= 0$), if the domain of the
+sub-expression `expr` cannot be zero, the condition is `AlwaysFalse`; if its
+only possible value is $0$, it is `AlwaysTrue`. For `NodeSup_` (expr $> 0$),
+the same reasoning applies with the sign of the domain.
+
+**If-node analysis.** `NodeIf_` evaluation is the most important pass. The
+processor evaluates the condition, then:
+
+- **Always true:** sets `alwaysTrue_ = true` and visits only the if-true statements.
+- **Always false:** sets `alwaysFalse_ = true` and visits only the else statements.
+- **Otherwise (domain cannot decide):** records variable domains before and after
+  both the if-true and else branches, then merges them via `Domain_::AddDomain`.
+  This merged domain is the post-if variable range and feeds downstream analysis.
+
+This analysis makes the constant-condition processor's job possible: once
+`alwaysTrue_`/`alwaysFalse_` flags are set, the next pass can collapse dead
+branches.
+
+**Fuzzy interpolation bounds.** When fuzzy mode is active, the processor also
+computes the `lb_` (left bound) and `rb_` (right bound) fields on equal and
+comparison nodes. For a discrete sub-expression whose domain has no sign-change,
+these capture the nearest subdomain boundaries on either side of zero; for a
+continuous expression with a zero-crossing, the bounds come from the `eps_`
+smoothing parameter.
+
+## Constant Condition Processor
+
+`ConstCondProcessor_` in `dal-cpp/dal/script/visitor/constcondprocessor.hpp`
+mutates the AST by collapsing always-true and always-false condition and if
+nodes into their concrete outcomes:
+
+- An `alwaysTrue_` boolean condition node is replaced by a `NodeTrue_` leaf.
+- An `alwaysFalse_` boolean condition node is replaced by a `NodeFalse_` leaf.
+- An `alwaysTrue_` if-node is replaced by a `NodeCollect_` containing only its
+  if-true statements.
+- An `alwaysFalse_` if-node is replaced by a `NodeCollect_` containing only its
+  else statements.
+
+`DomainProcessor_` must run first so the `alwaysTrue_`/`alwaysFalse_` flags are
+properly set. Because this visitor *mutates* the tree structure (replacing nodes
+in place), it must be invoked from the root via `ProcessFromTop(std::unique_ptr<Node_>& top)`,
+which passes a reference to the owning `unique_ptr` so the replacement is safe.
+
+## Fuzzy Evaluator
+
+`FuzzyEvaluator_<T>` in `dal-cpp/dal/script/visitor/fuzzy.hpp` is a templated
+AST evaluator that smooths discontinuous payoff functions for pathwise AAD (see
+[Automatic Adjoint Differentiation](aad.md)). Indicator functions
+$\mathbb{1}_{S>K}$ are replaced by smooth approximations over a small spread,
+trading a small controlled bias for a finite, low-variance derivative.
+
+### Smoothing Functions
+
+Two primitive smooth transitions are used. For a comparison `expr > 0` (or `>=`),
+the **continuous spread** function transitions from $0$ to $1$ across a band of
+width $\varepsilon$:
+
+$$
+\operatorname{CSpr}(x;\; \varepsilon) =
+\begin{cases}
+0       & x < -\varepsilon/2,\\
+1       & x > +\varepsilon/2,\\
+(x + \varepsilon/2)/\varepsilon & \text{otherwise}.
+\end{cases}
+$$
+
+For an equality `expr = 0`, the **butterfly** function is a triangular pulse
+centred at $0$:
+
+$$
+\operatorname{BFly}(x;\; \varepsilon) =
+\begin{cases}
+0 & |x| \ge \varepsilon/2,\\
+(\varepsilon/2 - |x|)/(\varepsilon/2) & \text{otherwise}.
+\end{cases}
+$$
+
+When the condition node carries explicit domain-derived left and right bounds
+(`lb_`, `rb_`) — set by `DomainProcessor_` for discrete sub-expressions — the
+two-argument overloads use the subdomain endpoints instead of a symmetric
+$\pm\varepsilon/2$ band:
+
+$$
+\operatorname{CSpr}(x;\; lb, rb) =
+\begin{cases}
+0          & x < lb,\\
+1          & x > rb,\\
+(x - lb)/(rb - lb) & \text{otherwise},
+\end{cases}
+\qquad
+\operatorname{BFly}(x;\; lb, rb) =
+\begin{cases}
+0            & x < lb \text{ or } x > rb,\\
+1 - x/lb & lb \le x < 0,\\
+1 - x/rb & 0 \le x \le rb.
+\end{cases}
+$$
+
+### Nested If Evaluation
+
+The fuzzy evaluator handles conditionally-assigned variables via a **split
+evaluation** with probability-style fuzzy logic. When an if-condition has a
+fractional degree of truth $\delta$ (neither absolutely true nor absolutely
+false), the evaluator:
+
+1. Records the current values of all affected variables (`varStore0_`).
+2. Evaluates the if-true branch with the current variable state and records the
+   post-true values (`varStore1_`).
+3. Resets the variables to their pre-if state.
+4. Evaluates the else branch (if present).
+5. Blends the two outcomes: `variables_[idx] = δ * varStore1_[idx] + (1 - δ) * variables_[idx]`.
+
+The nested-if level counter (`nestedIfLvl_`) tracks nesting depth, and variables
+are stored in two-level arrays preallocated for performance (`varStore0_[level][var]`,
+`varStore1_[level][var]`).
+
+### Combinators
+
+Boolean combinators use a probability-style fuzzy logic:
+
+- **And:** `dt(lhs) * dt(rhs)` — the joint truth is the product of the component truths.
+- **Or:** `dt(lhs) + dt(rhs) - dt(lhs) * dt(rhs)` — probability of the union.
+- **Not:** `1 - dt(condition)` — the complementary truth.
+
+### Default Smoothing Factor
+
+Each fuzzy evaluator carries a `defEps_` default smoothing factor. Individual
+condition nodes can override it via their `eps_` field; a negative `eps_` on
+the node means "use the evaluator's default". This lets the caller set a global
+smoothing width while allowing exceptional conditions (e.g., a known
+discontinuous barrier) to carry a tighter or looser spread.
+
+## Pipeline Ordering
+
+The visitors must run in a specific order:
+
+1. **`DomainProcessor_`** — computes variable/expression domains and sets
+   `alwaysTrue_`/`alwaysFalse_` flags (and `isDiscrete_` bounds if fuzzy).
+2. **`ConstCondProcessor_`** — collapses always-true/false nodes into concrete
+   forms, pruning dead branches.
+3. **Evaluation** — `Evaluator_<T>` (exact) or `FuzzyEvaluator_<T>` (smoothed)
+   walks the simplified tree to produce numeric results.
+
+The shared AST nodes and visitor base classes live in
+`dal-cpp/dal/script/visitor/`; the preprocessor lives in `dal-cpp/dal/script/`
+and is deliberately separate.
+
+## See Also
+
+- [Automatic Adjoint Differentiation](aad.md) — the reverse-mode machinery that
+  fuzzy evaluation feeds, enabling pathwise Greeks through discontinuous payoffs.
+- `dal-cpp/examples/script.cpp` — runnable example of the full pipeline: events
+  table parsing, preprocessing, domain analysis, condition folding, and evaluation.

--- a/docs/methodology/underdetermined_search.md
+++ b/docs/methodology/underdetermined_search.md
@@ -253,12 +253,12 @@ The `Underdetermined::Controls_` struct (default-constructed) carries:
 
 | Field                   | Default        | Role                                                          |
 |-------------------------|----------------|---------------------------------------------------------------|
-| `maxEvaluations_`       | $150$          | Hard evaluation budget across all restarts                     |
-| `maxRestarts_`          | $3$            | Maximum Broyden refreshes before failure                       |
-| `maxBacktrackTries_`    | $3$            | Line-search tries per iteration                                |
-| `maxBacktrack_`         | $0.5$          | Maximum fractional step shrinkage                              |
-| `backtrackTolerance_`   | $0.1$          | $k_{\min}$ below which the full step is accepted               |
-| `restartTolerance_`     | $0.5$          | $k_{\min}$ above which the linear model is considered invalid  |
+| `maxEvaluations_`       | $150$          | Hard evaluation budget across all restarts                    |
+| `maxRestarts_`          | $3$            | Maximum Broyden refreshes before failure                      |
+| `maxBacktrackTries_`    | $3$            | Line-search tries per iteration                               |
+| `maxBacktrack_`         | $0.5$          | Maximum fractional step shrinkage                             |
+| `backtrackTolerance_`   | $0.1$          | $k_{\min}$ below which the full step is accepted              |
+| `restartTolerance_`     | $0.5$          | $k_{\min}$ above which the linear model is considered invalid |
 
 ## Summary
 

--- a/docs/methodology/underdetermined_search.md
+++ b/docs/methodology/underdetermined_search.md
@@ -175,6 +175,91 @@ penalising differences between adjacent knots acts as a discrete smoothness
 solver then selects the smoothest — the least oscillatory curve consistent with the
 market.
 
+## Implementation Details
+
+The solver is implemented as free functions `Underdetermined::Find` and
+`Underdetermined::Approximate` in `dal-cpp/dal/math/optimization/underdetermined.cpp`.
+
+### Scaled Residual Wrapper (`XScaledFunc_`)
+
+Before the solver loop, the raw residual function `funcIn` is wrapped in
+`XScaledFunc_`, which divides every residual and every Jacobian row by the per-instrument
+tolerance $\tau_j$ returned by `funcIn.Tolerances()`. This normalises the convergence test
+to $|f_j| \le 1$ per component (exact mode) or $\|f\| \le \texttt{fitTol}$ (approximate
+mode). The wrapper also caps the evaluation budget and tracks `nEvals_`.
+
+The wrapper's Jacobian factory `XScaledFunc_::J` first queries the raw function's
+`Gradient` method. If it returns a sparse Jacobian, the tol-divided sparse is used
+directly. If it returns a dense Jacobian (the `XCurveJacobian_` case), the wrapper
+divides rows by tol and wraps the result in an `XJDense_`. If `Gradient` returns
+`nullptr` (bump fallback, or the analytic path declined eligibility), the wrapper
+allocates a dense `jDense_` member, calls `funcIn.Gradient(x, f, &jDense_)` to fill
+it, and divides rows. This shared dense storage avoids repeated allocation across
+bump iterations.
+
+### Forward Jacobian at the Solution
+
+When the caller requests `fwdJacobianAtSolution` (non-null pointer), the convergence
+branch in `Find` captures the **unscaled** dense forward Jacobian at the solution:
+
+1. The raw (unwrapped) `funcIn` is called: `funcIn.Gradient(xNew, fUnscaled, fwdJacobianAtSolution)`.
+2. The residual `fUnscaled` is reconstructed by element-wise multiplication of the
+   scaled residual by the tolerance vector — avoiding a redundant `funcIn.F()` call
+   that would bypass the solver's evaluation budget.
+3. If `Gradient` returns `nullptr` (no analytic Jacobian at this `x`), the output is
+   cleared so a caller-reused matrix cannot leak stale contents. There is no dense-FD
+   fallback on this branch.
+
+`StoreForwardJacobianAtSolution` performs the column-by-column extraction: it probes
+each unit column of the Jacobian via `MultiplyLeft` (which returns $J \cdot e_k =
+\text{column } k$, length $m$) and stores it into the output. This works for any
+`Jacobian_` subclass.
+
+### Backtracking Line Search
+
+The exact-mode line search minimises a one-dimensional quadratic model of the scaled
+residual norm squared along the trial step $s$. Given $a = f^{\mathsf T} f$ (current),
+$b = f^{\mathsf T} f_{\text{new}}$ (cross), and $c = f_{\text{new}}^{\mathsf T}
+f_{\text{new}}$ (candidate), the quadratic model
+
+$$
+\tilde f^2(k) = a\,k^2 + 2b\,k(1-k) + c\,(1-k)^2
+$$
+
+has derivative $\partial\tilde f^2/\partial k = 2a k + 2b(1-2k) + 2c(k-1)$, which
+vanishes at
+
+$$
+k_{\min} = \frac{c - \tfrac{1}{2} b}{c - b + a}.
+$$
+
+The interpretation of $k_{\min}$ relative to the backtrack and restart tolerances:
+
+- $k_{\min} < \texttt{backtrackTolerance\_}$ — the full step is good; accept it and
+  optionally capture the forward Jacobian at the solution.
+- $k_{\min} > \texttt{restartTolerance\_}$ — the linear model is poor; discard the
+  secant-updated Jacobian (or the analytic one) and restart from a freshly computed
+  Jacobian.
+- Between the two — shrink the step by factor $1 - k$, capped by `maxBacktrack_`, and
+  retry with the same Jacobian.
+
+The loop budgets `maxBacktrackTries_` attempts per iteration; exceeding it forces a
+restart. The `approxJ` guard (Broyden-updated Jacobian) ensures at least one Jacobian
+is freshly computed per restart cycle.
+
+### Controls Structure
+
+The `Underdetermined::Controls_` struct (default-constructed) carries:
+
+| Field                   | Default        | Role                                                          |
+|-------------------------|----------------|---------------------------------------------------------------|
+| `maxEvaluations_`       | $150$          | Hard evaluation budget across all restarts                     |
+| `maxRestarts_`          | $3$            | Maximum Broyden refreshes before failure                       |
+| `maxBacktrackTries_`    | $3$            | Line-search tries per iteration                                |
+| `maxBacktrack_`         | $0.5$          | Maximum fractional step shrinkage                              |
+| `backtrackTolerance_`   | $0.1$          | $k_{\min}$ below which the full step is accepted               |
+| `restartTolerance_`     | $0.5$          | $k_{\min}$ above which the linear model is considered invalid  |
+
 ## Summary
 
 The method poses calibration as a constrained least-change problem. The exact mode

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -175,6 +175,66 @@ without re-solving the system. That inverse carries a `tolerance_` factor from t
 solver's residual scaling — see [Yield-Curve Jacobian and Inverse-Jacobian
 Risk](yield_curve_jacobian.md) before consuming it.
 
+### Single-Curve AAD Calibration Internals
+
+When `CurveJacobianMode_::ANALYTIC` is set and the calibration is eligible, the
+residual function `YieldCurveCalibrationFunc_` in
+`dal-cpp/dal/curve/calibration.cpp` overrides `Underdetermined::Function_::Gradient`
+to supply an AAD-tape Jacobian instead of returning `nullptr` (which would trigger
+dense bumping). The `LOG_DISCOUNT` parameterization exposes the node log-discount
+factors $\ell_1,\dots,\ell_{N-1}$ as the free parameters.
+
+**TapeGuard.** Each analytic-Jacobian cycle is bracketed by `TapeGuard_`, an RAII
+scope that calls `Dal::AAD::Clear` on the active tape at construction and (via its
+destructor) at scope exit, even on exception. The guard does **not** open a
+recording — the recording is opened explicitly by `AnalyticJacobian` after
+`RegisterIndependent` (the canonical order across all four AAD backends).
+
+**Eligibility predicate.** `EligibleForAnalyticJacobian()` is a pure query over
+member state: it checks `parameterization_ == LOG_DISCOUNT`,
+`calibrateDiscountCurve_ == true`, and every instrument passes
+`InstrumentEligibleForAnalyticJacobian`. Each fall-through path emits a `NOTICE`
+naming the offending condition. The predicate never throws — ineligibility routes
+through `return nullptr` so the solver dense-bumps. The verdict is evaluated once
+per `CalibrateYieldCurve` call and cached (via `EvaluateEligibilityOnce`), so
+every `NOTICE` fires at most once.
+
+Per-instrument eligibility requires the instrument to:
+
+- Have a type among `Deposit_`, `FRA_`, `Future_`, and `Swap_` (the set for which
+  templated `Tape::Rate_<T_>` subclasses exist).
+- **Not** use a projection curve (`useProjectionCurve_ == false`), so forecast
+  equals discount (both read from the single calibrated curve).
+- Trade at the curve anchor date (`TradeDate() == knotDates_.front()`), because the
+  templated rates read $P(\text{tradeDate}, p)$ from the calibrated curve
+  directly. Spot-started instruments trade before their effective start, so the
+  real trade date — not `TimeSpan().first` — must be checked.
+
+**Analytic Jacobian construction.** `AnalyticJacobian` performs one reverse sweep
+per residual row:
+
+1. Register the free node values $x_0,\dots,x_{N-2}$ on the tape via
+   `Dal::AAD::RegisterIndependent(logDF[i+1], x[i])`, where the anchored node
+   $\ell_0$ is assigned $0$ but not registered (it is not an independent).
+2. Open the recording with `Dal::AAD::NewRecording(*tape)`.
+3. Forward pass: build `Tape::DiscountLogDF_<Number_>`, construct each
+   `Tape::Rate_<Number_>` via `PrecomputeT<Number_>()`, evaluate residuals.
+4. For each row $i$: zero all adjoints, seed $\bar r_i = 1$, propagate to start,
+   and harvest $\bar{\ell}_{j+1}$ as $\partial r_i / \partial x_j$. The column
+   map is `col j = storage node j+1`, and AAD produces exact structural zeros
+   at nodes an instrument does not touch.
+
+The single-result path (one sweep per row) is simpler than the multi-result
+alternative and runs identically on all four backends.
+
+**Forward Jacobian at the solution.** The solver's convergence branch can capture
+an unscaled forward Jacobian $J$ at the solved $x^\star$ by calling
+`func.Gradient(x, f, &fwdJacobian)` once at the solution. This is requested only
+when `jacobianMode_ == ANALYTIC AND solveMode_ == EXACT AND eligible`; callers
+pass `nullptr` otherwise so the solver leaves the output empty. The output appears
+on `CurveCalibrationDiagnostics_::jacobian_` (shape $m \times (N-1)$), unscaled
+— it is the plain $J$ before the solver's `DivideRows(tol_)` row-scaling.
+
 ## Construction Pipeline
 
 ```text
@@ -510,3 +570,7 @@ API citations:
   cross-currency basis curve.
 - [AAD methodology](aad.md) — supplies the analytic Jacobian used in calibration
   and the curve risk sensitivities.
+- [Log-Discount Curve](log_discount_curve.md) — the curve parameterization on which
+  the single-curve AAD path operates.
+- [Script Engine](script_engine.md) — the preprocessing and evaluation pipeline for
+  script-based payoff descriptions.


### PR DESCRIPTION
## Summary
- Extracted design rationale, algorithm explanations, and methodology notes from ~650 lines of deleted source comments across 11 files into `docs/methodology/`
- Created new `script_engine.md` documenting the preprocessing pipeline, domain processor, constant condition processor, and fuzzy evaluator
- Expanded `log_discount_curve.md` with Thomas algorithm, basis weights per interpolator, `fppCoef_` matrix, extrapolation, and serialization v1/v2 design
- Expanded `underdetermined_search.md` with solver implementation details: `XScaledFunc_` wrapper, forward Jacobian capture, backtracking line search, and controls structure
- Expanded `yield_curve.md` with single-curve AAD calibration internals: TapeGuard, eligibility predicate, analytic Jacobian construction, and forward Jacobian output contract
- Updated `docs/README.md` index and `CLAUDE.md` methodology list with the new doc

## Test plan
- No test suite applies (documentation-only change)
- Manual verification: reviewed git diffs for all 5 cleanup commits; cross-checked all cross-reference links resolve; verified every file ends with a newline and has no trailing whitespace; confirmed all type names match current headers; verified `dal-cpp/examples/script.cpp` exists