### PR TITLE
chore: simplify banner/divider comments in Python and Excel bindings

### DIFF
--- a/dal-excel/src/__curve_storable.hpp
+++ b/dal-excel/src/__curve_storable.hpp
@@ -20,91 +20,78 @@
 
 namespace Dal {
 
-    // -- CollateralType_ wrapper
     struct StorableCollateralType_ : public Storable_ {
         CollateralType_ val_;
         explicit StorableCollateralType_(const CollateralType_& v) : Storable_("CollateralType", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- PeriodLength_ wrapper
     struct StorablePeriodLength_ : public Storable_ {
         PeriodLength_ val_;
         explicit StorablePeriodLength_(const PeriodLength_& v) : Storable_("PeriodLength", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- DayBasis_ wrapper
     struct StorableDayBasis_ : public Storable_ {
         DayBasis_ val_;
         explicit StorableDayBasis_(const DayBasis_& v) : Storable_("DayBasis", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- RateLegConvention_ wrapper
     struct StorableRateLegConvention_ : public Storable_ {
         RateLegConvention_ val_;
         explicit StorableRateLegConvention_(const RateLegConvention_& v) : Storable_("RateLegConvention", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- RateIndexConvention_ wrapper
     struct StorableRateIndexConvention_ : public Storable_ {
         RateIndexConvention_ val_;
         explicit StorableRateIndexConvention_(const RateIndexConvention_& v) : Storable_("RateIndexConvention", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- CurrencyPair_ wrapper
     struct StorableCurrencyPair_ : public Storable_ {
         CurrencyPair_ val_;
         explicit StorableCurrencyPair_(const CurrencyPair_& v) : Storable_("CurrencyPair", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- YCInstrument_ wrapper (for single-ccy instruments)
     struct StorableYCInstrument_ : public Storable_ {
         Handle_<YCInstrument_> val_;
         explicit StorableYCInstrument_(const Handle_<YCInstrument_>& v) : Storable_("YCInstrument", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- CrossCurrencySwap_ wrapper
     struct StorableCrossCurrencySwap_ : public Storable_ {
         Handle_<CrossCurrencySwap_> val_;
         explicit StorableCrossCurrencySwap_(const Handle_<CrossCurrencySwap_>& v) : Storable_("CrossCurrencySwap", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- DiscountCurve_ wrapper
     struct StorableDiscountCurve_ : public Storable_ {
         Handle_<DiscountCurve_> val_;
         explicit StorableDiscountCurve_(const Handle_<DiscountCurve_>& v) : Storable_("DiscountCurve", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- CurveBlock_ wrapper
     struct StorableCurveBlock_ : public Storable_ {
         Handle_<CurveBlock_> val_;
         explicit StorableCurveBlock_(const Handle_<CurveBlock_>& v) : Storable_("CurveBlock", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- CurveCalibrationSpec_ wrapper
     struct StorableCurveCalibrationSpec_ : public Storable_ {
         CurveCalibrationSpec_ val_;
         explicit StorableCurveCalibrationSpec_(const CurveCalibrationSpec_& v) : Storable_("CurveCalibrationSpec", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- CalibrationResult_ wrapper (curve + diagnostics), returned by Calibrate_SingleCurve
     struct StorableCurveCalibrationResult_ : public Storable_ {
         CalibrationResult_ val_;
         explicit StorableCurveCalibrationResult_(const CalibrationResult_& v) : Storable_("CurveCalibrationResult", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
-    // -- CrossCurrencyCalibrationSpec_ wrapper
     struct StorableCrossCurrencyCalibrationSpec_ : public Storable_ {
         CrossCurrencyCalibrationSpec_ val_;
         explicit StorableCrossCurrencyCalibrationSpec_(const CrossCurrencyCalibrationSpec_& v) : Storable_("CrossCurrencyCalibrationSpec", String_()), val_(v) {}

--- a/dal-python/src/bindings/calendar.cpp
+++ b/dal-python/src/bindings/calendar.cpp
@@ -16,18 +16,12 @@ namespace Dal {
 using namespace Dal;
 
 void init_bindings_calendar(py::module_& m) {
-    // =======================================================================
-    // BizDayConvention_ enum
-    // =======================================================================
     py::enum_<BizDayConvention_::Value_>(m, "BizDayConvention_")
         .value("UNADJUSTED", BizDayConvention_::Value_::Unadjusted)
         .value("FOLLOWING", BizDayConvention_::Value_::Following)
         .value("MODIFIED_FOLLOWING", BizDayConvention_::Value_::ModifiedFollowing)
         .export_values();
 
-    // =======================================================================
-    // Holidays_ class
-    // =======================================================================
     py::class_<Holidays_>(m, "Holidays_")
         .def(py::init<const String_&>(), py::arg("name"))
         .def(py::init([](const char* name) { return Holidays_(String_(name)); }),
@@ -39,16 +33,10 @@ void init_bindings_calendar(py::module_& m) {
             return std::string("Holidays_(\"") + h.String().c_str() + "\")";
         });
 
-    // =======================================================================
-    // CountBusDays_ class
-    // =======================================================================
     py::class_<CountBusDays_>(m, "CountBusDays_")
         .def(py::init<const Holidays_&>(), py::arg("holidays"))
         .def("__call__", &CountBusDays_::operator(), py::arg("begin"), py::arg("end"));
 
-    // =======================================================================
-    // Holidays namespace functions (module-level)
-    // =======================================================================
     m.def("Is_BizDay", &Holidays::IsBusinessDay,
           py::arg("holidays"), py::arg("date"));
     m.def("NextBizDay", &Holidays::NextBus,

--- a/dal-python/src/bindings/core.cpp
+++ b/dal-python/src/bindings/core.cpp
@@ -25,11 +25,6 @@ PYBIND11_MAKE_OPAQUE(std::vector<Dal::Date_>);
 PYBIND11_MAKE_OPAQUE(std::vector<Dal::Cell_>);
 
 void init_bindings_core(py::module_& m) {
-    // =======================================================================
-    // Core types
-    // =======================================================================
-
-    // -- Date_ --------------------------------------------------------------
     py::class_<Date_>(m, "Date_")
         .def(py::init<int, int, int>(),
              py::arg("yyyy"), py::arg("mm"), py::arg("dd"))
@@ -51,7 +46,6 @@ void init_bindings_core(py::module_& m) {
     m.def("Month", [](const Date_& d) { return Date::Month(d); });
     m.def("Day", [](const Date_& d) { return Date::Day(d); });
 
-    // -- String_ ------------------------------------------------------------
     py::class_<String_>(m, "String_")
         .def(py::init<const char*>(), py::arg("src"))
         .def(py::init<const std::string&>(), py::arg("src"))
@@ -59,7 +53,6 @@ void init_bindings_core(py::module_& m) {
             return s.c_str();
         });
 
-    // -- Cell_ --------------------------------------------------------------
     py::class_<Cell_>(m, "Cell_")
         .def(py::init<bool>(), py::arg("b"))
         .def(py::init<double>(), py::arg("d"))
@@ -67,13 +60,11 @@ void init_bindings_core(py::module_& m) {
         .def(py::init<const String_&>(), py::arg("s"))
         .def(py::init<const char*>(), py::arg("s"));
 
-    // -- STL vector bindings ------------------------------------------------
     py::bind_vector<std::vector<double>>(m, "DoubleVector");
     py::bind_vector<std::vector<std::string>>(m, "StrVector");
     py::bind_vector<std::vector<Date_>>(m, "DateVector");
     py::bind_vector<std::vector<Cell_>>(m, "CellVector");
 
-    // -- DoubleMatrix_ ------------------------------------------------------
     py::class_<Matrix_<>>(m, "DoubleMatrix_")
         .def(py::init<int, int, double>(),
              py::arg("rows"), py::arg("cols"), py::arg("fill") = 0.0)

--- a/dal-python/src/bindings/global.cpp
+++ b/dal-python/src/bindings/global.cpp
@@ -15,23 +15,16 @@
 using namespace Dal;
 
 void init_bindings_global(py::module_& m) {
-    // =======================================================================
-    // Handle_<T> opaque types
-    //
     // Handle_<T> inherits std::shared_ptr<const T>.  These types are bound
     // with std::shared_ptr<T> as their holder (pybind11 requires a mutable
     // shared_ptr to manage the object lifetime — const-correctness is
     // irrelevant for opaque types with no exposed methods).
-    // =======================================================================
     py::class_<ModelData_, std::shared_ptr<ModelData_>>(m, "ModelData_");
     py::class_<ScriptProductData_, std::shared_ptr<ScriptProductData_>>(m, "ScriptProductData_");
     py::class_<PseudoRSG_, std::shared_ptr<PseudoRSG_>>(m, "PseudoRSG_");
     py::class_<SobolRSG_, std::shared_ptr<SobolRSG_>>(m, "SobolRSG_");
     py::class_<Storable_, std::shared_ptr<Storable_>>(m, "Storable_");
 
-    // =======================================================================
-    // Global evaluation date
-    // =======================================================================
     m.def("EvaluationDate_Get", []() {
         return GetEvaluationDate();
     });

--- a/dal-python/src/bindings/models.cpp
+++ b/dal-python/src/bindings/models.cpp
@@ -13,10 +13,6 @@
 using namespace Dal;
 
 void init_bindings_models(py::module_& m) {
-    // =======================================================================
-    // Models
-    // =======================================================================
-
     m.def("BSModelData_New",
         [](double spot, double vol, double rate, double div)
             -> std::shared_ptr<ModelData_> {

--- a/dal-python/src/bindings/module.cpp
+++ b/dal-python/src/bindings/module.cpp
@@ -16,13 +16,10 @@ PYBIND11_MODULE(_dal, m) {
 
     m.doc() = "DAL quantitative finance library -- Python bindings (pybind11)";
 
-    // Calendar types (Holidays_, BizDayConvention_, CountBusDays_)
     init_bindings_calendar(m);
 
-    // Core types (Date_, String_, Cell_, vectors, DoubleMatrix_)
     init_bindings_core(m);
 
-    // Global state (Handle_<T> opaque types, evaluation date)
     init_bindings_global(m);
 
     // Alias Dictionary to Python's built-in dict type so hasattr(dal, "Dictionary")
@@ -30,18 +27,13 @@ PYBIND11_MODULE(_dal, m) {
     // MonteCarlo_Value returns a dict via pybind11's std::map auto-conversion).
     m.attr("Dictionary") = py::module_::import("builtins").attr("dict");
 
-    // Curve calibration (instruments, curves, calibration)
     init_bindings_curve(m);
 
-    // Models (BSModelData_New, DupireModelData_New)
     init_bindings_models(m);
 
-    // Random sequence generators (PseudoRSG, SobolRSG)
     init_bindings_random(m);
 
-    // Script product (Product_New, Product_Debug)
     init_bindings_script(m);
 
-    // Monte Carlo valuation (MonteCarlo_Value)
     init_bindings_value(m);
 }

--- a/dal-python/src/bindings/random.cpp
+++ b/dal-python/src/bindings/random.cpp
@@ -11,10 +11,6 @@
 using namespace Dal;
 
 void init_bindings_random(py::module_& m) {
-    // =======================================================================
-    // Random sequence generators
-    // =======================================================================
-
     m.def("PseudoRSG_New",
         [](int seed, int ndim) -> std::shared_ptr<PseudoRSG_> {
             return std::const_pointer_cast<PseudoRSG_>(

--- a/dal-python/src/bindings/script.cpp
+++ b/dal-python/src/bindings/script.cpp
@@ -15,10 +15,6 @@
 using namespace Dal;
 
 void init_bindings_script(py::module_& m) {
-    // =======================================================================
-    // Script product
-    // =======================================================================
-
     m.def("Product_New",
         [](const py::iterable& dates, const py::iterable& events)
             -> std::shared_ptr<ScriptProductData_> {

--- a/dal-python/src/bindings/value.cpp
+++ b/dal-python/src/bindings/value.cpp
@@ -14,10 +14,6 @@
 using namespace Dal;
 
 void init_bindings_value(py::module_& m) {
-    // =======================================================================
-    // Monte Carlo valuation
-    // =======================================================================
-
     m.def("MonteCarlo_Value",
         [](const std::shared_ptr<ScriptProductData_>& product,
            const std::shared_ptr<ModelData_>& modelData,


### PR DESCRIPTION
## Summary
- Phase 2 of the codebase-wide comment-simplification effort (explanation belongs in docs, not raw code).
- Remove mechanical section banners (`// =====...=====`, `// -- X --`) and per-call-site label comments from the 8 pybind11 binding files (`calendar.cpp`, `core.cpp`, `global.cpp`, `models.cpp`, `module.cpp`, `random.cpp`, `script.cpp`, `value.cpp`) and the 13 `// -- X wrapper` sub-section dividers in `dal-excel/src/__curve_storable.hpp`.
- Preserve genuine why-notes: the `Handle_<T>` / `std::shared_ptr` holder-type rationale in `global.cpp`, the Dictionary-as-dict alias note in `module.cpp`, the iterable-conversion notes in `models.cpp`/`script.cpp`, and the file-purpose and result-wrapper semantic notes in `__curve_storable.hpp`.
- Comment-only: 65 lines deleted, 0 insertions across 9 files. Every removed line is a comment or blank line; no code, Machinist `/*IF*/` blocks, vendored Excel framework files, auto-generated files, or file headers were touched.

## Test plan
- [x] Inspected `git diff`: confirmed every removed line is a `//` comment or blank line (`git diff -U0 | grep '^-[^-]' | grep -v '//'` returns nothing).
- [x] Built the `_dal` pybind11 module (all 8 changed Python `.cpp` files recompiled) via `make -j4 _dal` in the existing `build/` (DAL_BUILD_PYTHON=ON, Python 3.13) — `Built target _dal`, no warnings/errors.
- [x] `dal-excel` is Windows-only and does not build on this Linux box; the `__curve_storable.hpp` edit is purely mechanical comment-line removal (each removed `//` line directly precedes a `struct` declaration), so it cannot affect compilation. Verified by diff inspection.
- [x] No consecutive blank lines or trailing whitespace introduced in any changed file.