### PR TITLE
chore: remove stale TODO/stub comments from core lib

### DIFF
--- a/dal-cpp/dal/indice/index/ir.cpp
+++ b/dal-cpp/dal/indice/index/ir.cpp
@@ -27,7 +27,6 @@ namespace Dal {
         }
 
         String_ MatPostfix(const Cell_& start) {
-            // TODO: incomplete implementation
             if (Cell::IsString(start))
                 return Cell::ToString(start);
             else if (Cell::IsDate(start))

--- a/dal-cpp/dal/indice/indexparse.cpp
+++ b/dal-cpp/dal/indice/indexparse.cpp
@@ -13,7 +13,6 @@
 
 namespace Dal {
     namespace {
-        // stubbed out, sorry
         Index_* ParseSuperShot(const String_&) { return nullptr; }
 
         std::map<String_, Index::parser_t>& TheIndexParsers() { RETURN_STATIC(std::map<String_, Index::parser_t>); }
@@ -28,7 +27,6 @@ namespace Dal {
             return (*pp->second)(name);
         }
 
-        // stubbed out, sorry
         Index::Composite_* ParseComposite(const String_&) { return nullptr; }
     } // namespace
 

--- a/dal-cpp/dal/indice/indexpath.cpp
+++ b/dal-cpp/dal/indice/indexpath.cpp
@@ -14,7 +14,6 @@ namespace Dal {
                                 const Dal::DateTime_ &to,
                                 double monitoring_interval,
                                 const std::pair<double, double> &collar) const {
-        // TODO: fix this implementation
         auto prob = AllInRangeProb(from, to, collar, monitoring_interval, 0.0);
         if (prob > 0.0 && maximum)
             return collar.second;

--- a/dal-cpp/dal/math/matrix/banded.cpp
+++ b/dal-cpp/dal/math/matrix/banded.cpp
@@ -245,7 +245,6 @@ namespace Dal {
                         (*correlated)[jj] += val_(jj, ii) * (*iidBegin);
                 }
 
-                // TODO: why return the end?
                 return iidBegin;
             }
 

--- a/dal-cpp/dal/model/blackscholes.cpp
+++ b/dal-cpp/dal/model/blackscholes.cpp
@@ -17,7 +17,6 @@ namespace Dal {
     BSModelData_* BSModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
         std::unique_ptr<BSModelData_> temp(new BSModelData_(*newName, spot_, vol_, rate_, div_));
         if (slide) {
-            // TODO: finish the implementation
         }
         return temp.release();
     }

--- a/dal-cpp/dal/model/dupire.cpp
+++ b/dal-cpp/dal/model/dupire.cpp
@@ -17,7 +17,6 @@ namespace Dal {
     DupireModelData_* DupireModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
         std::unique_ptr<DupireModelData_> temp(new DupireModelData_(*newName, spot_, rate_, repo_, spots_, times_, vols_));
         if (slide) {
-            // TODO: finish the implementation
         }
         return temp.release();
     }

--- a/dal-cpp/dal/storage/json.cpp
+++ b/dal-cpp/dal/storage/json.cpp
@@ -32,7 +32,6 @@ namespace Dal {
         rapidjson::GenericStringRef<char> LendToJSON(const String_& s) {
             return {s.c_str(), static_cast<rapidjson::SizeType>(s.size())};
         }
-        // POSTPONED -- add checking strategy for funny characters inside strings
         struct XDocStore_ : Archive::Store_ {
             std::ostream& dst_;
             std::map<const Storable_*, String_>& sharedTags_;


### PR DESCRIPTION
## Summary

Phase 4 of the codebase-wide comment-simplification effort (guiding principle: *explanation belongs in docs, not raw code*). Removes 8 stale `TODO` / stub / `POSTPONED` comments across 7 core library `.cpp` files. **Comment-only** — no code logic, whitespace-around-code, file headers, license headers, `dal-cpp/dal/auto/`, `dal-cpp/externals/`, or Machinist blocks touched.

### Per-TODO decision table

| # | File | Comment | Decision | Notes |
|---|------|---------|----------|-------|
| 1 | `dal-cpp/dal/model/blackscholes.cpp` | `// TODO: finish the implementation` (empty `if (slide)` branch in `MutantModel`) | **Real missing feature** → deleted, flagged | Slide/mutant-model support genuinely unimplemented. The `if (slide) {}` branch is now empty/dead; left in place per task scope (comment-only). Worth a follow-up issue. |
| 2 | `dal-cpp/dal/model/dupire.cpp` | `// TODO: finish the implementation` (same pattern) | **Real missing feature** → deleted, flagged | Same as #1; dead `if (slide) {}` left in place. |
| 3 | `dal-cpp/dal/indice/index/ir.cpp` | `// TODO: incomplete implementation` (`MatPostfix`) | **Stale** → deleted | Function fully handles string / date / empty / else with proper throws; the TODO no longer reflects reality. |
| 4a | `dal-cpp/dal/indice/indexparse.cpp` | `// stubbed out, sorry` (`ParseSuperShot`) | **Real missing feature** → deleted, flagged | Returns `nullptr`; supershot parsing non-functional. |
| 4b | `dal-cpp/dal/indice/indexparse.cpp` | `// stubbed out, sorry` (`ParseComposite`) | **Real missing feature** → deleted, flagged | Returns `nullptr`; composite-index parsing non-functional (caller falls back to `ParseSingle`). |
| 5 | `dal-cpp/dal/indice/indexpath.cpp` | `// TODO: fix this implementation` (`IndexPath_::Extremum`) | **Real weakness** → deleted, flagged | Implementation is functional but simplified (returns collar bounds when in-range prob > 0). |
| 6 | `dal-cpp/dal/math/matrix/banded.cpp` | `// TODO: why return the end?` (`Correlate`) | **Stale** → deleted | Returns the advanced `iidBegin` past-the-end iterator — standard iterator semantics; the question is moot. |
| 7 | `dal-cpp/dal/storage/json.cpp` | `// POSTPONED -- add checking strategy for funny characters inside strings` (`XDocStore_`) | **Real deferred work** → deleted, flagged | No validation/escaping strategy for special characters in serialized strings. Worth a follow-up issue. |

(Note: `json.cpp` contains a second, unrelated `// POSTPONED -- use "r" on non-Windows platforms` at the `fopen` call. It is outside this task's enumerated edit list and was deliberately left untouched.)

## Test plan

- [x] Diff inspection confirms every removed line is a comment (8 deletions, 0 additions, 0 code changes)
- [x] Configured a fresh Release build in an isolated git worktree off `master`, ran Machinist codegen
- [x] Built the `dal_cpp` target — compiles all 7 modified `.cpp` files successfully
- [x] Built the `dal_cpp_tests` target
- [x] Ran `build/dal-cpp/dal_cpp_tests` (from `build/`, not `bin/`) — **750/750 tests pass** (68 suites)
- [x] `dal-cpp/dal/auto/` regenerated files unchanged vs `master` (no enum markup changed)