### PR TITLE
docs: methodology homes for comment-simplification Phase 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ here as the baseline rather than dated releases:
   nonlinear calibration. See `docs/methodology/underdetermined_search.md`.
 - **Cross-Currency Calibration** — XCCY basis-curve fitting across two currencies. See
   `docs/methodology/xccy_calibration.md`.
+- **Interpolation** — linear, log-linear, cubic-spline, and mixed 1D interpolators plus
+  bilinear 2D interpolation. See `docs/methodology/interpolation.md`.
+- **Log-Discount Curve** — node log-discount-factor parameterisation with `LogDfScheme_`
+  interpolation schemes (the parameterisation that supports the analytic Jacobian). See
+  `docs/methodology/log_discount_curve.md`.
+- **Yield-Curve Jacobian and Inverse-Jacobian Risk** — AAD forward Jacobian and the
+  inverse-Jacobian IR-risk transform, including the `effJacobianInverse_` unit convention.
+  See `docs/methodology/yield_curve_jacobian.md`.
+- **Script Engine** — events-table to AST pipeline, visitor passes (domain analysis,
+  constant-condition folding), and the fuzzy evaluator for pathwise AAD through
+  discontinuous payoffs. See `docs/methodology/script_engine.md`.
 - **Analytic Jacobian for curve calibration (CurveJacobianMode flag)** — optional analytic
   Jacobian mode for yield-curve calibration. See
   `docs/experimental/aad-analytic-jacobian-curve-calibration.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,4 +109,4 @@ When adding new documentation:
 2. **Update this index** — add a brief description and link to new documents
 3. **Cross-reference** — link related documents using relative paths
 
-Keep documentation focused and technical. Avoid duplicating information that belongs in code comments or the main README.
+Keep documentation focused and technical. Docs own the **WHY** (methodology, math, invariants); source comments own the **WHAT** (local intent, invariants that must live next to the code they constrain). When a comment grows into methodology prose, move the prose here and reduce the comment to a short pointer rather than duplicating it in both places.

--- a/docs/methodology/aad.md
+++ b/docs/methodology/aad.md
@@ -293,6 +293,86 @@ per declaration. The harvested adjoints form a dense
 `XCurveJacobian_` (`dal-cpp/dal/curve/curvejacobian.hpp`) with exact structural
 zeros where an instrument has no parametric dependence on a given knot.
 
+## Backends
+
+The library compiles with one of four AAD backends selected at build time:
+
+- **native** — the in-tree reference tape (`dal-cpp/dal/math/aad/tape.hpp`,
+  `dal-cpp/dal/math/aad/node.hpp`), always available.
+- **Adept** (`DAL_USE_ADEPT_AAD`) — `adept::Stack`-based tape.
+- **XAD** (`DAL_USE_XAD_AAD`) — `xad::adj<double>` tape.
+- **CoDiPack** (`DAL_USE_CODIPACK_AAD`) — `codi::RealReverseUnchecked` tape.
+
+All four expose the same `Number_` / `Tape_` surface through facade functions in
+`dal-cpp/dal/math/aad/aad.hpp`, so caller code is backend-neutral. The
+differences that matter at the call site are the recording contract and the
+gradient-zeroing semantics between single-result reverse sweeps.
+
+### Load-Bearing Recording Contract
+
+A correct Jacobian on all four backends requires this exact ordering:
+
+$$
+\text{Clear}(\textit{tape}) \;\rightarrow\;
+\text{RegisterIndependent}(x_k)\;\forall k \;\rightarrow\;
+\text{NewRecording}(\textit{tape}) \;\rightarrow\;
+\text{forward pass} \;\rightarrow\;
+\text{per output row } \bigl\{\,\text{ZeroAdjoints},\;\bar{y}_i = 1,\;\text{PropagateToStart},\;\text{harvest}\,\bigr\}.
+$$
+
+Each step has a backend-specific reason to be in this position:
+
+- **Clear** resets the recorded graph and the position markers so nothing from
+  a previous run contaminates the new one.
+- **RegisterIndependent** stamps each input as a tape leaf that subsequent
+  operations differentiate. It must run *before* `NewRecording` opens the
+  recording window on XAD (see below); running it after silently drops the input
+  and yields an all-zero Jacobian column.
+- **NewRecording** marks the start of the live recording so the reverse sweep
+  terminates at the right point.
+- **ZeroAdjoints** between rows is **not** a no-op on every backend (Adept in
+  particular), and is the single most common source of corrupted multi-row
+  Jacobians.
+
+### Per-Backend Zeroing Semantics
+
+- **Native.** `ZeroAdjoints` walks the node list and writes `0.0` to every
+  node's adjoint, leaving the recorded graph intact. Behaviour is the obvious
+  one and is safe to call between rows.
+
+- **Adept.** Adept's `compute_adjoint` zeroes only the LHS adjoint of each
+  consumed statement and then accumulates into the operands; operands whose
+  gradients are never cleared keep residual values across sweeps. In a
+  single-result reverse-sweep loop, row 2's seed would land on row 1's operand
+  residue and corrupt the Jacobian. The `ZeroGradientArray` helper
+  (`tape.hpp`) clears the live gradient array while keeping
+  `gradients_initialized_` true, which satisfies the `compute_adjoint` `THROW`
+  guard ("Adept gradients are not initialized"). `Dal::AAD::ZeroAdjoints`
+  routes to `ZeroGradientArray` on this backend, so callers that use the facade
+  are safe; callers that bypass it must replicate the semantics.
+
+- **XAD.** `registerInput` must run *before* `NewRecording` opens the recording
+  window: registering an input after `NewRecording` silently drops it and
+  yields an all-zero Jacobian column. The `RegisterIndependent` facade asserts
+  the tape is active (`clearAll` does not deactivate a tape constructed with
+  `activate=true`), so a passive tape fails loudly at registration time rather
+  than producing a silent zero column. `ZeroAdjoints` maps to
+  `xad::Tape::clearDerivatives`.
+
+- **CoDiPack.** `RegisterIndependent` calls `tape.registerInput` on the active
+  tape; `ZeroAdjoints` calls the no-argument `clearAdjoints`, which zeroes up
+  to the largest created index and leaves the statement graph intact. Both are
+  safe between sweeps.
+
+### Passive vs Active Tape
+
+XAD and CoDiPack distinguish an *active* tape (records statements) from a
+*passive* tape (does not). The native backend has no notion of a passive tape —
+recording is unconditional — and Adept's activity is governed by its
+`Stack` base. Code that needs a value-only pass (e.g. a baseline pricing run
+without differentiation) should use a plain `double` evaluation rather than
+relying on tape passivity, which is backend-dependent.
+
 ## Summary
 
 Reverse-mode AAD records the computational graph on a forward pass and applies

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -21,6 +21,94 @@ interface:
 After parsing, a sequence of **visitor passes** (domain analysis, constant-condition
 folding, evaluation) walks the AST to prepare and execute it.
 
+## Parser and AST
+
+`Parser_` (`dal-cpp/dal/script/parser.cpp`) consumes a token stream produced by
+the lexer (`dal-cpp/dal/script/lexer.cpp`) and builds an expression tree of
+`Node_` objects (`dal-cpp/dal/script/node.hpp`). Every node holds a vector of
+child expressions in `arguments_`, so arithmetic, conditions, assignments, and
+control flow all share one polymorphic hierarchy.
+
+### Precedence Levels
+
+The parser implements expressions as a cascade of precedence levels, each
+delegating to the next tighter level:
+
+| Level | Operator class          | Produces                                                                                                   |
+|-------|-------------------------|------------------------------------------------------------------------------------------------------------|
+| L1    | `+`, `-` (binary)       | `NodeAdd_`, `NodeSub_`                                                                                     |
+| L2    | `*`, `/`                | `NodeMulti_`, `NodeDiv_`                                                                                   |
+| L3    | `^` (right-assoc)       | `NodePow_`                                                                                                 |
+| L4    | unary `+`, `-`          | `NodeUPlus_`, `NodeUMinus_`                                                                                |
+| Atom  | literal, variable, func | `NodeConst_`, `NodeVar_`/`NodeConstVar_`, `NodeSpot_`, `NodeLog_`, `NodeExp_`, `NodeSqrt_`, `NodeMin_`, `NodeMax_` |
+
+Parenthesised sub-expressions re-enter at the top level through a shared
+`ParseParentheses` helper. Conditions form a parallel cascade — `OR` (loosest)
+binds over `AND`, which binds over comparison elements — producing `NodeOr_`,
+`NodeAnd_`, and the comparison/equality nodes.
+
+### Reserved Keywords and Variables
+
+A fixed reserved-word set (`IF`, `THEN`, `ELSE`, `END`, `PAYS`, `AND`, `OR`,
+`SPOT`, `MAX`, `MIN`, `LOG`, `SQRT`, `EXP`, `DCF`) cannot be used as variable
+names. Any other alphabetic token becomes either a `NodeVar_` (looked up in the
+preprocessor's constant-variable map and promoted to `NodeConstVar_` if it
+resolves there). Statements are either assignments (`=`, `NodeAssign_`), pays
+clauses (`PAYS`, `NodePays_`), or `IF/THEN/ELSE/END` blocks (`NodeIf_`, with
+`firstElse_` indexing the else-branch within `arguments_`).
+
+### Comparators and Smoothing Hints
+
+`ParseCondElem` lowers every comparison to a subtraction wrapped in the
+appropriate condition node (`NodeEqual_`, `NodeSup_`, `NodeSupEqual_`), with
+`!=`, `<`, `<=` rewritten in terms of `=`, `>`, `>=`. An optional `;eps` or
+`:eps` suffix on a comparison sets the node's `eps_` field, which the fuzzy
+evaluator consumes as the smoothing width for that condition (see
+[Fuzzy Evaluator](#fuzzy-evaluator)).
+
+### Day-Count Functions
+
+`DCF(basis, start, end)` is folded to a literal at parse time: the parser
+extracts the basis code and the two date strings, constructs a `DayBasis_`, and
+emits a `NodeConst_` carrying the computed year fraction. This means a
+`DCF(...)` call cannot contain a nested expression — its arguments must be
+literal tokens.
+
+## Events and Schedules
+
+A script product is a sequence of dated events. `ScriptProduct_`
+(`dal-cpp/dal/script/event.hpp`) splits the preprocessed events into **past**
+events (dates before the evaluation date, evaluated once with the known fixings)
+and **future** events (dates on or after the evaluation date, evaluated per
+simulated path). Both halves share the same AST representation
+(`Event_ = Vector_<Statement_>`).
+
+### From Events to a Timeline
+
+`PreProcess` builds the simulation timeline from the future event dates: each
+event date is converted to a year fraction from the evaluation date and paired
+with an `AAD::SampleDef_` that requests the numeraire, a forward maturity at the
+event time, and a discount factor at the event time. The model consumes this
+`defLine_` to allocate the per-event scenario structure that evaluators read
+when they walk the AST.
+
+### Schedule Expansion
+
+Schedule expansion itself lives in the preprocessor
+([Preprocessing Pipeline](#preprocessing-pipeline)): the `ExpandSchedulePlaceholders`
+virtual replaces `PeriodBegin` / `PeriodEnd` placeholders for each period of a
+recurring schedule, producing one dated event description per period. The parser
+and event layer see only the expanded, dated descriptions — they know nothing
+about schedules.
+
+### Variable Indexing and the Payoff Slot
+
+After parsing, `IndexVariables` runs a `VarIndexer_` pass to assign every named
+variable a stable integer slot in the evaluator's variable vector. The product
+also records the slot of the variable named in its `payoff_` field
+(`payoffIdx_`, defaulting to the last variable); simulation harvests that slot
+as the path value.
+
 ## Preprocessing Pipeline
 
 The `Preprocessor_` class in `dal-cpp/dal/script/preprocessor.hpp` resolves a raw
@@ -208,6 +296,95 @@ The visitors must run in a specific order:
 The shared AST nodes and visitor base classes live in
 `dal-cpp/dal/script/visitor/`; the preprocessor lives in `dal-cpp/dal/script/`
 and is deliberately separate.
+
+## Simulation and Evaluation
+
+`MCSimulation<T_>` (`dal-cpp/dal/script/simulation.hpp`) drives Monte Carlo
+valuation of a `ScriptProduct_`. It has two instantiations: `T_ = double`
+(value-only) and `T_ = AAD::Number_` (pathwise-adjoint, see
+[Automatic Adjoint Differentiation](aad.md)).
+
+### RNG and Brownian Bridge
+
+`CreateRNG` selects the underlying generator from a method string — `sobol`
+(Sobol low-discrepancy), `mrg32` (MRG32k3a pseudo-random), or `irn` (industrial
+pseudo-random) — sized to the model's simulation dimension. When the Brownian
+bridge flag is set, the generator is wrapped in a `BrownianBridge_` so the draw
+order reconstructs the path from coarse to fine maturities rather than in
+chronological order; this often reduces variance for path-dependent payoffs.
+
+### Batching and Thread Pool
+
+Paths are divided into batches (`BATCH_SIZE = 8192`, clamped to keep at least
+one path per thread) and submitted to `ThreadPool_::GetInstance()`. Each thread
+owns its own RNG, Gaussian vector, scenario (`Scenario_<T_>`), and evaluator
+state, so the per-path work is lock-free; thread-local results are summed at
+the end. This is the parallel structure described in [Pathwise Adjoints in Monte
+Carlo](aad.md#pathwise-adjoints-in-monte-carlo).
+
+### Value-Only vs AAD Evaluation
+
+The `double` instantiation walks the AST with an `Evaluator_<double>` (or, in
+compiled mode, an `EvalState_<double>` over pre-compiled node/const/data
+streams) and accumulates the payoff slot across paths. The `AAD::Number_`
+instantiation additionally:
+
+1. Activates the tape and registers model parameters and constant variables on
+   it (`InitModel4ParallelAAD`), then marks.
+2. Per path: rewinds to the mark, generates the path, evaluates the AST with a
+   `FuzzyEvaluator_<AAD::Number_>` (or compiled `EvalState_<AAD::Number_>`),
+   seeds the payoff adjoint to $1$, and propagates back to the mark.
+3. After the batch: propagates from mark to start, harvests per-parameter
+   adjoints, and divides by `nPaths`.
+
+The result is a `SimResults_` carrying the aggregated payoff and a risk vector
+labelled by model parameter and constant variable.
+
+### Compiled vs Interpreted
+
+`Compile()` flattens each event's AST into a `nodeStreams_` / `constStreams_` /
+`dataStreams_` triple via a `Compiler_` visitor. `EvaluateCompiled` interprets
+that flat representation against a scenario without re-walking the polymorphic
+node tree, trading the per-node virtual dispatch for a tight switch over a
+stream of opcodes. The interpreted path (`Evaluate`) is simpler and is used
+where the AST is small or where the compile step is not worth its cost.
+
+## Visitor Machinery
+
+Every AST pass — indexing, IF-flattening, domain analysis, constant-condition
+folding, evaluation, fuzzy evaluation, compilation, debugging — is a visitor.
+The machinery in `dal-cpp/dal/script/visitor.hpp` and
+`dal-cpp/dal/script/visitorlist.hpp` makes adding a new pass or a new node type
+cheap.
+
+### Visitor Base
+
+`Visitor_<V_>` and `ConstVisitor_<V_>` provide two helpers each: `VisitNode`
+dispatches a node to the concrete visitor `V_` via `node.Accept(...)`, and
+`VisitArguments` walks the node's `arguments_` children. They also provide a
+default `Visit(Node_&)`/`Visit(const N_&)` that simply visits the children — so
+a concrete visitor only declares `Visit(...)` overloads for the node types it
+actually cares about, and the rest fall through to traversal.
+
+### The Visitable Sugar
+
+`VisitableBase_<V1, V2, ...>` declares, for the abstract `Node_`, one pure
+virtual `Accept(Vi&)` per visitor on the list. `Visitable_<Node_, NodeTag, V1, V2, ...>`
+generates, for a concrete node, the matching overrides that each call
+`v.Visit(*this)`. The generated code is exactly what one would write by hand
+(`virtual void Accept(Vi& v) override { v.Visit(*this); }` for each visitor),
+so the meta-programming is purely sugar — the run-time behaviour is a plain
+double-dispatch table. Adding a node type means inheriting `Visitable_<...>`
+with the full visitor list; adding a visitor means adding it to the list once.
+
+### Const-Correctness
+
+`ConstVisitor_<V_>` is used by passes that only read the tree (evaluation,
+debugging); `Visitor_<V_>` is used by passes that mutate it
+(`ConstCondProcessor_`, `DomainProcessor_`). The const visitor enforces its
+contract at compile time: a non-const `Visit` overload on a const visitor does
+not override the const base, so attempts to mutate through a const visitor fail
+to build rather than corrupt the tree.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Phase 0 prerequisite for the comment-simplification effort: the methodology docs
must exist **before** the source comments are trimmed, so each trimmed comment can
be reduced to a one-line pointer rather than deleted. Doc-only — no source files
modified, no build or test suite applies.

- **`docs/methodology/aad.md` — new `## Backends` section.** Covers the
  load-bearing recording contract that produces a correct Jacobian on all four
  backends (`Clear → RegisterIndependent → NewRecording → forward → per-row
  {ZeroAdjoints, seed, PropagateToStart, harvest}`), and the per-backend
  semantics that motivate each step:
  - **Adept** — `compute_adjoint` zeroes only each consumed statement's LHS and
    accumulates into operands whose gradients are never cleared, so row-2's seed
    lands on row-1's residue; `ZeroGradientArray` clears the live gradient array
    while keeping `gradients_initialized_` true to satisfy the `THROW` guard.
  - **XAD** — `registerInput` must run **before** `NewRecording`; registering
    after silently drops the input and yields an all-zero Jacobian column. The
    facade asserts the tape is active.
  - **CoDiPack** — `registerInput` on the active tape; no-arg `clearAdjoints`
    zeroes up to the largest created index, graph intact.
  - **Native** — unconditional recording; `ZeroAdjoints` walks and zeroes every
    node adjoint.
  - Passive-vs-active tape behaviour (XAD/CoDiPack distinguish active from
    passive; native does not).
  This homes the ~115 comment-lines in `dal-cpp/dal/math/aad/aad.hpp` and
  `dal-cpp/dal/math/aad/tape.hpp`. (The `static_cast<double>(Number_)`
  portability caveat was **not** included — the aad.hpp/tape.hpp comments do not
  establish it; if it should be documented, route that separately.)

- **`docs/methodology/script_engine.md` — four new sections.**
  - `## Parser and AST` — precedence cascade (L1 `+/-` → L2 `*/` → L3 `^` → L4
    unary → atoms), reserved keywords, comparator lowering with `eps_` smoothing
    hints, `DCF(...)` literal folding. Drawn from `dal-cpp/dal/script/parser.cpp`.
  - `## Events and Schedules` — past/future event split, timeline + `SampleDef_`
    construction in `PreProcess`, schedule-expansion boundary with the
    preprocessor, variable indexing and the payoff slot. Drawn from
    `dal-cpp/dal/script/event.hpp` / `event.cpp`.
  - `## Simulation and Evaluation` — `MCSimulation<T_>` value-only vs AAD
    instantiations, RNG selection + Brownian bridge, batching/threads,
    compiled-vs-interpreted evaluation, and the per-path mark/rewind/propagate
    AAD pattern. Drawn from `dal-cpp/dal/script/simulation.hpp`.
  - `## Visitor Machinery` — what the `Visitor_<V_>` / `ConstVisitor_<V_>` /
    `Visitable_<...>` sugar does and why (double-dispatch table, default
    visit-children fallback, const-correctness), described at altitude rather
    than as a template mechanics walk. Drawn from the meta-code explanation in
    `dal-cpp/dal/script/visitor.hpp`.
  These four sections home the parser/simulation/event/visitor comments.

- **`docs/README.md` — reworded the docs-vs-code split.** The old sentence
  "Avoid duplicating information that belongs in code comments" conflicted with
  the migration principle. New wording: "Docs own the WHY (methodology, math,
  invariants); source comments own the WHAT (local intent, invariants that must
  live next to the code they constrain). When a comment grows into methodology
  prose, move the prose here and reduce the comment to a short pointer rather
  than duplicating it in both places."

- **`CHANGELOG.md` — reconciled the methodology baseline.** The
  "Existing methodology and capabilities" list named only 5 of the 8 normative
  docs. Added the four missing entries: interpolation, log_discount_curve,
  yield_curve_jacobian, script_engine.

### CHANGELOG judgment (no new dated entry)

Per `.claude/rules/code-style.md`, the changelog records breaking changes, new
methodologies, and significant new capabilities — **not** routine doc edits.
This PR documents already-implemented behaviour (AAD backend contracts that have
been in the source for releases; script-engine pipeline stages that already
exist). No new methodology, no API change, no capability change. **No dated
`## 2026-06` bullet is warranted** — only the baseline list was reconciled.

## Test plan

- [x] Doc-only change; no build or CTest run applies.
- [x] Verified no source files (`.cpp`/`.hpp`/`.h`) were modified — only
      `docs/` and `CHANGELOG.md`.
- [x] Verified no source line numbers (`file:NN`) were introduced in any doc.
- [x] Verified no trailing whitespace; every changed file ends with a newline.
- [x] Cross-reference anchors resolve: `aad.md#pathwise-adjoints-in-monte-carlo`
      and `script_engine.md#fuzzy-evaluator` both map to existing headers.
- [x] `docs/README.md` methodology index and `CLAUDE.md` `## Methodology` list
      stay in sync (no new files added in this PR — only section additions, so
      no index changes were needed beyond the README reword).
- [x] Markdown tables aligned per `.claude/rules/code-style.md`.

Co-Authored-By: Claude <noreply@anthropic.com>