### PR TITLE
chore: simplify script-module comments (Phase 6)

### DIFF
--- a/dal-cpp/dal/script/node.hpp
+++ b/dal-cpp/dal/script/node.hpp
@@ -11,15 +11,11 @@
 
 
 namespace Dal::Script {
-    //  Hierarchy
-
-    //  Nodes that return a number
     struct ExprNode_ : public Node_ {
         bool isConst_ = false;
         double constVal_ = 0.0;
     };
 
-    //  Action nodes
     struct ActNode_ : public Node_ {};
 
     //  Nodes that return a bool
@@ -44,12 +40,9 @@ namespace Dal::Script {
     struct NodeUPlus_ : public Visitable_<ExprNode_, NodeUPlus_, VISITORS> {};
     struct NodeUMinus_ : public Visitable_<ExprNode_, NodeUMinus_, VISITORS> {};
 
-    //	Math operators
     struct NodeLog_ : public Visitable_<ExprNode_, NodeLog_, VISITORS> {};
     struct NodeSqrt_ : public Visitable_<ExprNode_, NodeSqrt_, VISITORS> {};
     struct NodeExp_ : public Visitable_<ExprNode_, NodeExp_, VISITORS> {};
-
-    //  Comparisons
 
     struct CompNode_ : public BoolNode_ {
         // Fuzzying stuff
@@ -73,8 +66,6 @@ namespace Dal::Script {
     struct NodeOr_ : public Visitable_<BoolNode_, NodeOr_, VISITORS> {};
 
     struct NodeNot_ : public Visitable_<BoolNode_, NodeNot_, VISITORS> {};
-
-    //  Leaves
 
     //	Market access
     struct NodeSpot_ : public Visitable_<ExprNode_, NodeSpot_, VISITORS> {};

--- a/dal-cpp/dal/script/visitor.hpp
+++ b/dal-cpp/dal/script/visitor.hpp
@@ -67,38 +67,5 @@ namespace Dal::Script {
     //  Concrete Nodes must inherit Visitable_
     //      so they (automatically) declare overrides accepts for all visitors on the list
 
-    /*
-    Note that despite the complexity of that meta code, its use is trivial:
-
-    To declare struct Node_ : VisitableBase_<Visitor1, Visitor2, ...> {};
-
-        is only sugar for :
-
-        struct Node_
-        {
-            virtual void Accept(Visitor1&) = 0;
-            virtual void Accept(Visitor2&) = 0;
-            ...
-        };
-
-    And to declare a concrete node (say, NodeAdd_) as NodeAdd_ : Visitable_<Node_, AddNode, Visitor1, Visitor2, ...> {};
-
-        is sugar for:
-
-        struct NodeAdd_ : Node_
-        {
-            void Accept(Visitor1& v) override
-            {
-                v.Visit(*this);
-            }
-
-            void Accept(Visitor2& v) override
-            {
-                v.Visit(*this);
-            }
-
-            ...
-        };
-
-    */
+    //  Visitor/CRTP machinery: see docs/methodology/script_engine.md §Visitor Machinery.
 }

--- a/dal-cpp/dal/script/visitor/constprocessor.hpp
+++ b/dal-cpp/dal/script/visitor/constprocessor.hpp
@@ -49,8 +49,6 @@ namespace Dal::Script {
     public:
         using Visitor_<ConstProcessor_>::Visit;
 
-        // Constructor, nVar = number of variables, from Product after parsing and variable indexation
-        // All variables start as constants with value 0
         explicit ConstProcessor_(const size_t nVar)
             : varConst_(nVar, true), varConstVal_(nVar, 0.0), isInConditional_(false) {}
 

--- a/dal-cpp/dal/script/visitor/domain.hpp
+++ b/dal-cpp/dal/script/visitor/domain.hpp
@@ -489,10 +489,6 @@ namespace Dal::Script {
                 }
 
                 // General case: we insert the interval in such a way that the resulting set of intervals are all distinct
-                // Find an interval in intervals_ that intersects interval, or interval.end() if none
-                // STL implementation, nice and elegant, unfortunately poor performance
-                // auto it = find_if( intervals_.begin(), intervals_.end(), [&interval] (const Interval_& i) { return intersect( i, interval); });
-                // Custom implementation, for performance, much less elegant
                 auto it = itb;
                 // First interval is on the strict right of interval, there will be no intersection
                 if (itb->Left() > r)
@@ -506,7 +502,6 @@ namespace Dal::Script {
                         it = ite;
 
                     else {
-                        // We may have an intersection, find it
                         it = intervals_.lower_bound(
                             interval); // Smallest myInterval >= interval, means it.Left() >= l
                         if (it == ite || it->Left() > r)
@@ -516,27 +511,15 @@ namespace Dal::Script {
                     }
                 }
 
-                // End of find an interval in intervals_ that intersects interval
-                // it points to an interval in intervals_ that intersects interval, or ite if none
                 // No intersection, just add the interval
                 if (it == ite) {
                     intervals_.insert(interval);
                     return;
                 }
 
-                // We have an intersection
-
-                // Merge the intersecting interval from intervals_ into interval
-
-                // We don't use the generic merge: too slow
-                // merge( interval, *it, &interval);
-                // Quick merge
                 interval.Merge(*it);
 
-                // Remove the merged interval from set
                 intervals_.erase(it);
-
-                // Go again until we find no more intersect
             }
         }
 

--- a/dal-cpp/dal/script/visitor/evaluator.hpp
+++ b/dal-cpp/dal/script/visitor/evaluator.hpp
@@ -102,8 +102,6 @@ namespace Dal::Script {
         FORCE_INLINE void SetCurEvt(size_t curEvt) { curEvt_ = curEvt; }
 
         // Visitors
-        // Expressions
-        // Binaries
         template <class OP> FORCE_INLINE void VisitBinary(const ExprNode_& node, OP op) {
             VisitNode(*node.arguments_[0]);
             VisitNode(*node.arguments_[1]);
@@ -145,7 +143,6 @@ namespace Dal::Script {
             });
         }
 
-        // Unaries
         template <class OP> FORCE_INLINE void VisitUnary(const ExprNode_& node, OP op) {
             VisitNode(*node.arguments_[0]);
             op(dStack_.Top());
@@ -159,7 +156,6 @@ namespace Dal::Script {
             VisitUnary(node, [](T_& x) { x = -x; });
         }
 
-        // Functions
         FORCE_INLINE void Visit(const NodeLog_& node) {
             VisitUnary(node, [](T_& x) { x = log(x); });
         }
@@ -172,7 +168,6 @@ namespace Dal::Script {
             VisitUnary(node, [](T_& x) { x = exp(x); });
         }
 
-        // Conditions
         template <class OP> FORCE_INLINE void VisitCondition(const BoolNode_& node, OP op) {
             VisitNode(*node.arguments_[0]);
             bStack_.Push(op(dStack_.TopAndPop()));
@@ -212,7 +207,6 @@ namespace Dal::Script {
             b = !b;
         }
 
-        // Instructions
         void Visit(const NodeIf_& node) {
             //	Eval the condition
             VisitNode(*node.arguments_[0]);
@@ -254,7 +248,6 @@ namespace Dal::Script {
             variables_[varIdx] += dStack_.TopAndPop() / (*scenario_)[curEvt_].numeraire_;
         }
 
-        // Variables and constants
         FORCE_INLINE void Visit(const NodeVar_& node) {
             //	Push value onto the stack
             dStack_.Push(variables_[node.index_]);
@@ -271,7 +264,6 @@ namespace Dal::Script {
         FORCE_INLINE void Visit(const NodeTrue_& node) { bStack_.Push(true); }
         FORCE_INLINE void Visit(const NodeFalse_& node) { bStack_.Push(false); }
 
-        // Scenario related
         FORCE_INLINE void Visit(const NodeSpot_& node) { dStack_.Push((*scenario_)[curEvt_].spot_); }
     };
 

--- a/dal-cpp/dal/script/visitor/ifprocessor.hpp
+++ b/dal-cpp/dal/script/visitor/ifprocessor.hpp
@@ -56,7 +56,7 @@ namespace Dal::Script {
             --nestedIfLvl_;
 
             //	If not out-most if, copy changed vars into the immediately outer if
-            //	Variables changed in a nested if are also changed in the in-globing if
+            //	Variables changed in a nested if are also changed in the encompassing if
             if (nestedIfLvl_)
                 copy(node.affectedVars_.begin(), node.affectedVars_.end(),
                      inserter(varStack_.Top(), varStack_.Top().end()));


### PR DESCRIPTION
## Summary
- Migrate-first comment cleanup in `dal-cpp/dal/script/`, removing in-source prose now homed in `docs/methodology/script_engine.md` (added in PR #132):
  - `visitor.hpp`: dropped the 33-line "Note that despite the complexity of that meta code..." Visitable_/CRTP prose block; replaced with a one-line pointer to `script_engine.md §Visitor Machinery`.
  - `visitor/domain.hpp`: removed the dead commented-out STL `find_if` block and the step-narration comments around the `AddInterval` merge logic ("STL implementation, nice and elegant...", "Custom implementation, for performance...", "General case: we insert...", "End of find an interval..."). Live merge/insert/erase code untouched.
  - `node.hpp`: removed the tab/space section labels (Hierarchy, Nodes that return a number, Action nodes, Leaves, Math operators, Comparisons).
  - `visitor/evaluator.hpp`: removed section-banner restatements (Expressions, Binaries, Unaries, Functions, Conditions, Instructions, Variables and constants, Scenario related).
  - `visitor/constprocessor.hpp`: removed the constructor restatement; kept the precondition notes and the "A payment is always non IsConstant because it is normalized by a possibly stochastic numeraire" note.
  - `visitor/ifprocessor.hpp`: fixed typo "in-globing if" → "encompassing if".
- Comment-only (plus the one comment-word typo fix). Every removed line is a comment or dead commented-out code; no live code altered.

## Dependency
**#132 must merge before this PR** — the pointer comments reference `docs/methodology/script_engine.md` sections (Visitor Machinery, etc.) that PR #132 adds.

## Test plan
- [x] Targeted build of `dal_cpp` + `dal_cpp_tests` with the edited headers (script module objects `parser.cpp`, `visitor/domain.cpp`, `simulation.cpp` recompiled clean; all script test TUs compiled clean)
- [x] Full `build/dal-cpp/dal_cpp_tests` — 750 tests, 68 suites, all PASSED
- [x] Diff inspection confirms comment-only (no live code lines changed)