### PR TITLE
chore: simplify comments in indice/risk/concurrency/storage

### DIFF
--- a/dal-cpp/dal/concurrency/threadpool.hpp
+++ b/dal-cpp/dal/concurrency/threadpool.hpp
@@ -29,7 +29,6 @@ namespace Dal {
         static thread_local size_t tlsNum_;
 
         void ThreadFunc(const size_t& num);
-        //  The constructor stays private, ensuring single instance
         ThreadPool_() : active_(false), interrupt_(false) {
             Start();
         }
@@ -61,11 +60,6 @@ namespace Dal {
             return f;
         }
 
-        /*
-         * Run queued tasks synchronously
-         * while waiting on a future,
-         * return true if at least one task was run
-         */
         bool ActiveWait(const TaskHandle_& f);
     };
 } // namespace Dal

--- a/dal-cpp/dal/risk/report.cpp
+++ b/dal-cpp/dal/risk/report.cpp
@@ -47,7 +47,6 @@ namespace Dal {
                     retval->AddHeaderRow(axis_names_[jj], kr, temp);
                 }
             }
-            // widen interface with this function that lets us set values
             retval->SetAll(vals_);
             return retval.release();
         }

--- a/dal-cpp/dal/storage/_repository.hpp
+++ b/dal-cpp/dal/storage/_repository.hpp
@@ -37,13 +37,9 @@ namespace Dal {
     public:
         [[nodiscard]] static Handle_<Storable_> Fetch(const String_& tag, bool quiet = false);
 
-        // count handles
         [[nodiscard]] static int Size();
-        // return all matching handles
         [[nodiscard]] static Vector_<Handle_<Storable_>> Find(const String_& pattern);
-        // erase all matching handles, return number erased
         [[nodiscard]] static int Erase(const String_& pattern);
-        // erase one handle
         [[nodiscard]] static bool Erase(const Storable_& object);
 
         template <class T_> static String_ Add(const Handle_<T_>& object, const RepositoryErase_& erase) {

--- a/dal-cpp/dal/storage/globals.cpp
+++ b/dal-cpp/dal/storage/globals.cpp
@@ -77,13 +77,9 @@ namespace Dal {
         return ret_val;
     }
 
-    //----------------------------------------------------------------------------
-
     // fixings history store looks very much like date store
 
     namespace {
-        // this needs to be a Meyers singleton, not a file-scope static, because we will initialize it with a file-scope
-        // static
         std::unique_ptr<Global::Store_>& XTheFixingsStore() { RETURN_STATIC(std::unique_ptr<Global::Store_>); }
         const String_ FIX_PREFIX("FixingsFor:");
     } // namespace

--- a/dal-cpp/dal/storage/splat.cpp
+++ b/dal-cpp/dal/storage/splat.cpp
@@ -137,9 +137,6 @@ namespace Dal {
             }
         };
 
-        // --------------------------------------
-        // helper functions for UnSplat
-
         struct ExtractDouble_ {
             double operator()(double d) const { return d; }
             double operator()(const String_& s) const {


### PR DESCRIPTION
## Summary
Phase 9 of the codebase-wide comment-simplification effort ("explanation belongs in docs, not raw code"). Comment-only deletion/dedup across `dal-cpp/dal/{storage,concurrency,risk}`; no code, headers, license text, or Machinist blocks changed.

- `dal-cpp/dal/storage/globals.cpp` — collapse the duplicated Meyers-singleton note to a single instance; remove the `//----...----` section divider before the fixings store. Genuine why-notes preserved (`fixings history store looks very much like date store`).
- `dal-cpp/dal/storage/splat.cpp` — remove the `// ----...---- // helper functions for UnSplat` banner block.
- `dal-cpp/dal/concurrency/threadpool.hpp` — remove the singleton restatement (`The constructor stays private...`) and the `ActiveWait` explanatory docblock. Savine/Andreasen license header kept verbatim.
- `dal-cpp/dal/risk/report.cpp` — remove the `SetAll` restatement comment. Machinist `/*IF---*/` block kept verbatim.
- `dal-cpp/dal/storage/_repository.hpp` — remove four per-method WHAT labels that restate the signature directly below them (`// count handles`, `// return all matching handles`, etc.).

Secondary sweep across all four directories found no further section banners, WHAT-comments, or dead commented-out code beyond the above. Genuine why-notes preserved: the `,5Y` swap naming note in `indice/index/ir.cpp`, the `LOCK_OBJECTS` lock-ordering note and `POSTPONED` markers in `storage/_repository.cpp`, and the wire-format note in `storage/json.cpp`.

18 comment lines removed across 5 files; 0 additions; 0 code lines changed.

## Test plan
- [x] Diff inspection: every removed line is a comment or a blank line directly neighbouring a removed comment (audited via `git diff | grep '^-'`)
- [x] Hard exclusions verified byte-identical: Savine/Andreasen license header in `threadpool.hpp`, Machinist `/*IF---*/` block in `report.cpp`, three-line file headers, `dal-cpp/dal/auto/` untouched
- [x] Built `dal_cpp_tests` target from a clean configure in the worktree (Release-linux preset) — compiles cleanly
- [x] Ran `build/dal-cpp/dal_cpp_tests` (run from the `build/` tree, not `bin/`) — all 750 tests from 68 suites pass