### PR TITLE
chore: simplify math comments, migrate AAD backend prose to docs

### DIFF
--- a/dal-cpp/dal/math/aad/aad.hpp
+++ b/dal-cpp/dal/math/aad/aad.hpp
@@ -39,13 +39,10 @@ namespace Dal::AAD {
         return Clear(*tape);
     }
 
-    // Register n as a tape-tracked independent holding value v. Native: Number_::operator=(double)
-    // (expr.hpp) records a fresh node -- that IS the registration. Mirrors the curve calibration
-    // independent-registration step behind a backend-neutral name.
+    // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
     FORCE_INLINE void RegisterIndependent(Number_& n, double v) { n = v; }
 
-    // Zero every node's adjoint, leaving the recorded graph intact. Used between single-result
-    // reverse sweeps so each row's seed propagates from a clean slate.
+    // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
     FORCE_INLINE void ZeroAdjoints(Tape_& tape) {
         for (auto it = tape.nodes_.Begin(); it != tape.nodes_.End(); ++it)
             it->Adjoint() = 0.0;
@@ -66,15 +63,10 @@ namespace Dal::AAD {
         return Clear(*tape);
     }
 
-    // Register n as an independent holding value v. Adept records the assignment as a statement on
-    // the active stack; no separate registerInput call is needed.
+    // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
     FORCE_INLINE void RegisterIndependent(Number_& n, double v) { n = v; }
 
-    // Zero every gradient between single-result sweeps. NOT a no-op on Adept: the compute_adjoint
-    // override (tape.hpp) zeroes only each consumed statement's LHS, then accumulates into operands
-    // whose gradients are never cleared -- row 2's seed would land on row 1's residue and corrupt
-    // the Jacobian. ZeroGradientArray clears the live gradient array while keeping
-    // gradients_initialized_ true so the override's THROW guard stays satisfied.
+    // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
     FORCE_INLINE void ZeroAdjoints(Tape_& tape) { tape.ZeroGradientArray(); }
 
 } // namespace Dal::AAD
@@ -93,11 +85,7 @@ namespace Dal::AAD {
         return Clear(*tape);
     }
 
-    // Register n as an independent holding value v. XAD requires registerInput to run BEFORE the
-    // recording window opens (NewRecording): registering an input AFTER NewRecording silently drops
-    // it and yields an all-zero Jacobian column, so callers must RegisterIndependent first, then
-    // NewRecording, then the forward pass. The facade asserts the tape is active (clearAll does not
-    // deactivate a tape constructed with activate=true), so a passive tape fails loud here.
+    // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
     FORCE_INLINE void RegisterIndependent(Number_& n, double v) {
         auto* t = Tape();
         REQUIRE(t->tape_.isActive(), "Dal::AAD::RegisterIndependent: XAD tape is not active");
@@ -122,13 +110,12 @@ namespace Dal::AAD {
         return Clear(*tape);
     }
 
-    // Register n as an independent holding value v on the active CoDiPack tape.
+    // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
     FORCE_INLINE void RegisterIndependent(Number_& n, double v) {
         Tape()->tape_.registerInput(n);
         n.setValue(v);
     }
 
-    // Zero every adjoint (no-arg clearAdjoints zeroes up to the largest created index), graph intact.
     FORCE_INLINE void ZeroAdjoints(Tape_& tape) { tape.tape_.clearAdjoints(); }
 
 } // namespace Dal::AAD

--- a/dal-cpp/dal/math/aad/expr.hpp
+++ b/dal-cpp/dal/math/aad/expr.hpp
@@ -109,9 +109,6 @@ namespace Dal::AAD {
         FORCE_INLINE static double RightDerivative(double l, double r, double v) { return r < l ? 1.0 : 0.0; }
     };
 
-    // operator overloading for binary expression
-    // build the corresponding expressions
-
     template <class LHS_, class RHS_>
     FORCE_INLINE BinaryExpression_<LHS_, RHS_, OPMult_> operator*(const Expression_<LHS_>& lhs, const Expression_<RHS_>& rhs) {
         return BinaryExpression_<LHS_, RHS_, OPMult_>(lhs, rhs);
@@ -146,10 +143,6 @@ namespace Dal::AAD {
     FORCE_INLINE BinaryExpression_<LHS_, RHS_, OPMin_> min(const Expression_<LHS_>& lhs, const Expression_<RHS_>& rhs) {
         return BinaryExpression_<LHS_, RHS_, OPMin_>(lhs, rhs);
     }
-
-    // Unary expression: same logic with one argument
-
-    // the CRTP class
 
     template <class ARG_, class OP_> class UnaryExpression_ : public Expression_<UnaryExpression_<ARG_, OP_>> {
         const double value_;
@@ -217,8 +210,6 @@ namespace Dal::AAD {
         FORCE_INLINE static double Derivative(double r, double v, double d) { return -1.12837916709551 * std::exp(-r*r); }
     };
 
-    // binary operators with a double on one side
-
     struct OPMultD_ {
         FORCE_INLINE static double Eval(double r, double d) { return r * d; }
 
@@ -279,8 +270,6 @@ namespace Dal::AAD {
         FORCE_INLINE static double Derivative(double r, double v, double d) { return r < d ? 1.0 : 0.0; }
     };
 
-    // overloading
-
     template <class ARG_>
     FORCE_INLINE UnaryExpression_<ARG_, OPExp_> exp(const Expression_<ARG_>& arg) {
         return UnaryExpression_<ARG_, OPExp_>(arg);
@@ -315,8 +304,6 @@ namespace Dal::AAD {
     FORCE_INLINE UnaryExpression_<ARG_, OPErfc_> erfc(const Expression_<ARG_>& arg) {
         return UnaryExpression_<ARG_, OPErfc_>(arg);
     }
-
-    // binary operators with a double on one side
 
     template <class ARG_>
     FORCE_INLINE UnaryExpression_<ARG_, OPMultD_> operator*(double d, const Expression_<ARG_>& rhs) {
@@ -388,8 +375,6 @@ namespace Dal::AAD {
         return UnaryExpression_<ARG_, OPMinD_>(lhs, d);
     }
 
-    // comparison same as traditional
-
     template <class E_, class F_>
     FORCE_INLINE bool operator==(const Expression_<E_>& lhs, const Expression_<F_>& rhs) { return Value(lhs) == Value(rhs); }
 
@@ -454,8 +439,6 @@ namespace Dal::AAD {
     template <class E_>
     FORCE_INLINE bool operator>=(double lhs, const Expression_<E_>& rhs) { return lhs >= Value(rhs); }
 
-    // unary operators +/-
-
     template <class RHS_>
     FORCE_INLINE UnaryExpression_<RHS_, OPSubDL_> operator-(const Expression_<RHS_>& rhs) {
         return 0.0 - rhs;
@@ -465,8 +448,6 @@ namespace Dal::AAD {
     FORCE_INLINE UnaryExpression_<RHS_, OPAddD_> operator+(const Expression_<RHS_>& rhs) {
         return rhs + 0.0;
     }
-
-    // the Number type, also an expression
 
     class Number_ : public Expression_<Number_> {
         double value_;
@@ -516,8 +497,6 @@ namespace Dal::AAD {
 
         friend double Value(const Number_&);
         friend double& Adjoint(const Number_&);
-
-        // unary operators
 
         template <class E_>
         FORCE_INLINE Number_& operator+=(const Expression_<E_>& e) {

--- a/dal-cpp/dal/math/aad/tape.hpp
+++ b/dal-cpp/dal/math/aad/tape.hpp
@@ -120,15 +120,7 @@ namespace Dal::AAD {
             }
         }
 
-        // Zero the live gradient array, leaving gradients_initialized_ true and the statement graph
-        // intact. compute_adjoint above zeroes only each consumed statement's LHS, then accumulates
-        // into operands whose gradients are never cleared; in a single-result reverse-sweep loop row
-        // 2's seed would land on row 1's operand residue and corrupt the Jacobian. Called by the
-        // Dal::AAD::ZeroAdjoints facade between sweeps. initialize_gradients() (protected on
-        // adept::Stack, reachable because Tape_ inherits it publicly) allocates gradient_ to
-        // max_gradient_ on first call and zeroes every entry on every call -- it touches only
-        // gradient_, n_allocated_gradients_, and gradients_initialized_, never the statement graph,
-        // so it is safe to call between sweeps and satisfies the compute_adjoint THROW guard above.
+        // Per-backend recording + gradient-zeroing contract: see docs/methodology/aad.md §Backends.
         void ZeroGradientArray() { initialize_gradients(); }
     };
 

--- a/dal-cpp/dal/math/interp/interpmixed.cpp
+++ b/dal-cpp/dal/math/interp/interpmixed.cpp
@@ -15,8 +15,7 @@
 namespace Dal {
     namespace {
         // Composite interpolator: linear on log(DF) up to cutoffYf_, natural cubic on log(DF) beyond.
-        // The cutoff must be one of the knot abscissae so both sub-interpolators reproduce its value
-        // (C0 continuity). The cubic domain is the tail subarray at and beyond the cutoff.
+        // C0-continuity invariant: see docs/methodology/interpolation.md §Mixed Log-DF.
         class MixedLogDF_ : public Interp1_ {
             Vector_<> yf_;
             Vector_<> logDF_;
@@ -38,8 +37,7 @@ namespace Dal {
                 REQUIRE(yf_.size() == logDF_.size(), "Mixed log-DF interpolator: yf and logDF must have equal length");
                 REQUIRE(yf_.size() >= 4, "Mixed log-DF interpolator: need at least 4 abscissae (cutoff + 3 cubic points)");
                 REQUIRE(IsMonotonic(yf_), "Mixed log-DF interpolator: yf must be strictly increasing");
-                // The cutoff must land exactly on a knot so both sub-interpolators reproduce its value
-                // (C0 continuity at the join). Locate the knot whose abscissa equals cutoffYf_.
+                // Cutoff must equal a knot abscissa (C0 continuity): see docs/methodology/interpolation.md §Mixed Log-DF.
                 for (int i = 0; i < static_cast<int>(yf_.size()); ++i) {
                     if (yf_[i] == cutoffYf_)
                         cutoffIndex_ = i;

--- a/dal-cpp/dal/math/matrix/banded.cpp
+++ b/dal-cpp/dal/math/matrix/banded.cpp
@@ -252,14 +252,12 @@ namespace Dal {
                 REQUIRE(j_mat.Cols() == Size(), "j_mat size should match with this matrix's size");
                 Vector_<Vector_<>> temp(j_mat.Rows());
 
-                // compute L^{-1}
                 for (int ii = 0; ii < j_mat.Rows(); ++ii) {
                     temp[ii].Resize(Size());
                     Copy(j_mat[ii], &temp[ii]);
                     BandedLSolve(val_, temp[ii], &temp[ii]);
                 }
 
-                // compute result
                 form->Resize(j_mat.Rows());
                 for (int io = 0; io < j_mat.Rows(); ++io)
                     for (int k = 0; k <= io; ++k)
@@ -278,7 +276,6 @@ namespace Dal {
             void MultiplyRight(const Vector_<>& x, Vector_<>* b) const override { BandedMultiply<true>(val_, x, b); }
 
             [[nodiscard]] bool IsSymmetric() const override {
-                // brute-force check
                 const int n = Size();
                 const int width = max(val_.nBelow_, val_.view_.Cols() - val_.nBelow_ - 1);
                 for (int ii = 0; ii < n; ++ii) {
@@ -331,8 +328,6 @@ namespace Dal {
             return new Banded_(size, nAbove, nBelow);
         }
     } // namespace Sparse
-
-    // ----------------------------------------------------------------
 
     namespace {
         Vector_<> PadAtFront(const Vector_<>& src, int size) {

--- a/dal-cpp/dal/math/stacks.hpp
+++ b/dal-cpp/dal/math/stacks.hpp
@@ -15,8 +15,6 @@ namespace Dal {
         int sp_;
 
     public:
-        //	Constructor, destructor
-
         explicit Stack_(int chunk_size = DefaultSize) {
             size_ = chunk_size;
             if (size_)
@@ -30,8 +28,6 @@ namespace Dal {
             if (data_)
                 delete[] data_;
         }
-
-        //	Copier, mover
 
         Stack_(const Stack_& rhs) {
             size_ = rhs.size_;
@@ -140,7 +136,6 @@ namespace Dal {
 
         FORCE_INLINE const T& Top() const { return data_[sp_]; }
 
-        //	Random access
         FORCE_INLINE T& operator[](int i) { return data_[sp_ - i]; }
 
         FORCE_INLINE const T& operator[](int i) const { return data_[sp_ - i]; }

--- a/docs/methodology/interpolation.md
+++ b/docs/methodology/interpolation.md
@@ -98,6 +98,13 @@ fraction `cutoffYf_` and linear in $\ln P$ beyond it. This gives the smoothness 
 where the term structure is data-rich and the robustness of log-linear extrapolation at the
 long end, where knots are sparse and a spline would oscillate.
 
+The cutoff must coincide with one of the knot abscissae so that both sub-interpolators
+reproduce its value exactly. The linear head and the cubic tail are built on overlapping
+sub-arrays that both include the cutoff knot; because each sub-interpolator is exact at its
+own knots, the two pieces agree at the cutoff and the composite curve is $C^0$ continuous
+across the join. Construction therefore searches the knot vector for the abscissa equal to
+`cutoffYf_` rather than interpolating between knots, which would introduce a discontinuity.
+
 Factory: `NewMixedLogDF(name, yf, logDF, spec)` where `spec` is a `MixedSchemeSpec_`
 carrying `cutoffYf_` and the two cubic `Boundary_` conditions
 (`dal-cpp/dal/math/interp/interpmixed.hpp`). This scheme backs the `MIXED` value of


### PR DESCRIPTION
## Summary
- Reduce the per-backend `RegisterIndependent` / `ZeroAdjoints` comment blocks in `dal-cpp/dal/math/aad/aad.hpp` and the `ZeroGradientArray` block in `dal-cpp/dal/math/aad/tape.hpp` to one-line pointers now that the contract prose is homed in `docs/methodology/aad.md` §Backends (migrate-first policy).
- Remove WHAT-noise section labels from `dal-cpp/dal/math/aad/expr.hpp` (~9 labels), the tab-indented labels in `dal-cpp/dal/math/stacks.hpp`, and the step-label/divider comments in `dal-cpp/dal/math/matrix/banded.cpp` (keeping the Numerical-Recipes storage note).
- Migrate the `interpmixed` C0-continuity derivation to `docs/methodology/interpolation.md` §Mixed Log-DF and reduce the in-source comments to one-line pointers.

Comment-only on the C++ side. The only non-comment edits are the `interpolation.md` addition and the one-line pointer additions.

Note: the AAD pointers reference `docs/methodology/aad.md §Backends`, which lands via #132. **#132 should merge before this PR** so the pointers do not dangle on master.

## Test plan
- [x] Built `dal_cpp` + `dal_cpp_tests` from a clean `build/` in the worktree (Release-linux preset, `DAL_BUILD_PYTHON=OFF`); all changed translation units compiled.
- [x] Ran `dal_cpp_tests` — 750 tests from 68 suites, all PASSED.
- [x] Verified GUARDRAIL: every removed source line is a comment; Savine license headers, Numerical-Recipes storage note, cell.hpp overload-guard note, interpcubic/pseudorandom/pde references, and vectors.hpp private-inheritance block all intact.

Co-Authored-By: Claude <noreply@anthropic.com>
