### PR TITLE
chore: migrate example prose to docs, trim in-source comments

### DIFF
--- a/dal-cpp/examples/joint_multi_curve_calibration/joint_multi_curve_calibration.cpp
+++ b/dal-cpp/examples/joint_multi_curve_calibration/joint_multi_curve_calibration.cpp
@@ -42,29 +42,12 @@ namespace {
             THROW(msg);                                                                                                                              \
     } while (false)
 
-    // BAR-A is the sole PASS gate: both paths must converge and reprice every instrument to
-    // 10 * fitTolerance_. BAR-B and BAR-C are INFORMATIONAL measurements of joint-vs-staged DF
-    // drift, printed for teaching, NOT pass/fail bars. The drift is expected and is NOT a bug.
-    // Both paths run EXACT (CurveSolveMode_::EXACT -> Underdetermined::Find) and BOTH base-layer
-    // the 3M forward curve over the OIS discount curve (the joint path via
-    // baseLayeredOverDiscount_, the staged path via ApplyStageDefaults), so both smoothers act on
-    // the OIS SPREAD forward and the stored 3M curves are structurally identical (DiscountPWLF_
-    // with base = OIS).
-    //
-    //   * OIS (BAR-B): the joint OIS slice is co-determined with the 3M-spread slice (the joint
-    //     Jacobian's OIS columns carry entries from the 3M residual rows because IBOR annuities
-    //     discount through OIS AND the 3M-spread parameters depend on the OIS base), so the coupled
-    //     Find lands a few e-7 off the OIS-only staged Find; the short knots agree more tightly.
-    //     Base layering widens this slightly vs the baseless default (3.7e-8 -> 6.4e-7) because the
-    //     spread smoothing couples the OIS and 3M-spread searches more strongly.
-    //
-    //   * 3M (BAR-C): because both paths smooth the spread, the representation mismatch that drove
-    //     the baseless short-end drift (3.3e-4) is gone. The residual drift is the joint-vs-staged
-    //     OIS-slice difference (BAR-B) propagating through the 3M base handle, plus a small
-    //     boundary contribution at the 1Y and 10Y knots where the PWL system is least constrained.
-    //     The 2Y-7Y core agrees to ~1e-7 (the OIS-agreement level); the max is ~2.4e-5 at the 1Y
-    //     pillar. This is ~14x tighter than the baseless default and confirms the base wiring: an
-    //     OIS bump now propagates into the joint 3M DFs through the base handle (B-new-2 fixed).
+    // BAR-A is the sole PASS gate (both paths reprice to 10 * fitTolerance_). BAR-B and BAR-C are
+    // INFORMATIONAL joint-vs-staged DF-drift measurements, printed for teaching, NOT pass/fail bars
+    // (the drift is expected and is NOT a bug -- see docs/methodology/yield_curve.md,
+    // "Joint simultaneous calibration"). Both paths run EXACT and base-layer the 3M forward over
+    // the OIS discount curve (joint via baseLayeredOverDiscount_, staged via ApplyStageDefaults),
+    // so the stored 3M curves are structurally identical (DiscountPWLF_ with base = OIS).
     constexpr double BAR_A_TOLERANCE = 1.0e-7;  // PASS gate: 10 * fitTolerance_, both paths
     constexpr double BAR_B_REFERENCE = 1.0e-6;  // measured EXACT OIS drift 6.42e-7, rounded up (informational)
     constexpr double BAR_C_REFERENCE = 5.0e-5;  // measured EXACT 3M drift 2.39e-5, rounded up (informational)
@@ -346,29 +329,19 @@ namespace {
             }
         }
 
-        // BAR-B (informational, OIS): joint-vs-staged OIS DF drift under EXACT (Underdetermined::Find).
-        // NOT a pass/fail bar. The joint OIS slice is co-determined with the 3M-spread slice -- the
-        // OIS columns of the joint Jacobian carry entries from the 3M residual rows (IBOR annuities
-        // discount through OIS) AND the 3M-spread parameters depend on the OIS base -- so the coupled
-        // Find lands the OIS knots a few e-7 off the OIS-only staged Find. Base layering couples the
-        // OIS and 3M-spread searches more strongly than the baseless default, widening this drift
-        // slightly (3.7e-8 -> 6.4e-7). Reported, not gated.
+        // BAR-B (informational, OIS): joint-vs-staged OIS DF drift -- NOT a pass/fail bar. Reported,
+        // not gated. Driven by joint OIS<->3M-spread cross-curve coupling (see
+        // docs/methodology/yield_curve.md, "Joint simultaneous calibration").
         double maxOisDiff = 0.0;
         for (const int months : pillarMonths) {
             const Date_ pillar = Date::AddMonths(today, months);
             maxOisDiff = std::max(maxOisDiff, std::fabs(jointOis(today, pillar) - stagedOis(today, pillar)));
         }
 
-        // BAR-C (informational, 3M): joint-vs-staged 3M DF drift under EXACT (Underdetermined::Find).
-        // NOT a pass/fail bar. Both paths base-layer the 3M forward over the OIS discount curve
-        // (joint via baseLayeredOverDiscount_, staged via ApplyStageDefaults), so both smoothers act
-        // on the OIS SPREAD forward and the representation mismatch that drove the baseless
-        // short-end drift (3.3e-4) is gone. The residual drift is the joint-vs-staged OIS-slice
-        // difference (BAR-B) propagating through the 3M base handle, plus a small boundary
-        // contribution at the 1Y and 10Y knots. The 2Y-7Y core agrees to ~1e-7 (the OIS-agreement
-        // level); the max is ~2.4e-5 at the 1Y pillar, ~14x tighter than the baseless default.
-        // Reported, not gated. (A mis-routing bug -- B-new-1, fixing off OIS -- would show up as
-        // ~1e-2 drift, well above what is measured here, so the diagnostic still discriminates.)
+        // BAR-C (informational, 3M): joint-vs-staged 3M DF drift -- NOT a pass/fail bar. Reported,
+        // not gated. The OIS-slice difference (BAR-B) propagating through the 3M base handle, plus
+        // a boundary contribution at the least-constrained 1Y/10Y knots. A mis-routing bug (fixing
+        // off OIS) would show up at ~1e-2 here, so the diagnostic still discriminates.
         double max3mDiff = 0.0;
         for (const int months : pillarMonths) {
             const Date_ pillar = Date::AddMonths(today, months);

--- a/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+++ b/dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
@@ -38,40 +38,18 @@ using namespace Dal;
             THROW(msg);                                                                                                                             \
     } while (false)
 
-// This example demonstrates two teaching arcs on a single-curve Phase A calibration:
-//
-//   (a) The calibration residual Jacobian J = d(modelRate_i) / d(logDF_free_k) computed two
-//       independent ways -- a central-difference bump oracle and an AAD reverse sweep -- and shown
-//       to agree element-wise to 1e-9 relative.
-//   (b) The inverse-Jacobian IR-risk transform: take the par-rate parameter-sensitivity g of one
-//       off-anchor swap (an independent bump oracle, NOT the AAD tape from arc (a)), left-multiply
-//       by the calibration inverse Jacobian effJacobianInverse_ (the solver-scaled pseudoinverse;
-//       see the units note in TransformToQuoteRisk), and read off bucketed risk per calibration
-//       instrument.
-//
-// AAD is always compiled in this library (dal-cpp/dal/math/aad/aad.hpp:17 defines the native AAET
-// backend on the "no DAL_USE_*_AAD flag set" branch) and the analytic Jacobian it produces runs
-// identically under native AAET, Adept, XAD, and CoDiPack. Arc (a) does not record its own tape:
-// it reads the forward Jacobian the calibration already computed -- CalibrateYieldCurve requests
-// CurveCalibrationDiagnostics_::jacobian_ from the solver, whose convergence-branch hook calls
-// YieldCurveCalibrationFunc_::Gradient(xNew, fNew) ONCE at the solved x (the same AnalyticJacobian
-// machinery in dal-cpp/dal/curve/calibration.cpp) -- so the AAD recording contract and backend-
-// portability rules live in exactly one place. The bump oracle below remains an independent finite-
-// difference check; the AAD-vs-bump comparison is what makes arc (a) a real cross-check rather than
-// a tautology.
+// Demonstrates two arcs on a single-curve Phase A calibration (methodology in
+// docs/methodology/yield_curve_jacobian.md): (a) the residual Jacobian d(modelRate_i)/d(logDF_k)
+// computed two independent ways -- a central-difference bump oracle and the analytic AAD reverse
+// sweep read from diagnostics_.jacobian_ -- and shown to agree; (b) the inverse-Jacobian IR-risk
+// transform turning a portfolio par-rate sensitivity into bucketed risk per market quote.
 
 namespace {
-    // Self-check bars (see .claude/specs/yield-curve-jacobian-example.md "AAD-vs-Bump Tolerance
-    // Choice"). The 1e-9 AAD-vs-bump bar holds because the Phase A LOG_DISCOUNT residual Jacobian
-    // is O(1) and well-conditioned at the chosen 1.0%-2.5% par rates; central-difference round-off
-    // at h=1e-6 is ~eps/h ~= 2e-10 relative, leaving ~5x margin, and it is size-invariant. The FR6
-    // re-solve is a genuine nonlinear operation: bumping a long-end quote propagates through every
-    // intervening LOG_DISCOUNT knot, accumulating second-order terms the linear prediction cannot
-    // capture, so the worst observed rel grows with ladder length (~7e-7 at 5 instruments, ~1.8e-5
-    // at 10 instruments, ~1.3e-4 at 16 instruments). The 1e-4 bar at the 10-instrument size gives
-    // ~5x headroom over the observed worst rel; tighten it back toward 1e-6 if the ladder is
-    // shortened. (docs-sync follow-up: the FR6 bar scales with ladder length -- re-measure and
-    // record the trend alongside the spec's bar methodology when it is finalized.)
+    // Self-check bars (tolerance derivation in docs/methodology/yield_curve_jacobian.md). The 1e-9
+    // AAD-vs-bump bar is set by the central-difference round-off floor at h=1e-6 (~eps/h ~= 2e-10
+    // relative for O(1) entries). The FR6 re-solve bar is looser because the nonlinear re-solve
+    // accumulates second-order terms the linear prediction cannot capture; it scales with ladder
+    // length, so re-measure if the instrument count changes.
     constexpr double BUMP_STEP = 1.0e-6;
     constexpr double AAD_TOL = 1.0e-9;
     constexpr double RE_SOLVE_TOL = 1.0e-4;
@@ -122,14 +100,9 @@ namespace {
         return idx;
     }
 
-    // The 10-instrument vanilla-swap Phase A calibration. Stays eligible for the analytic (AAD-tape)
-    // Jacobian by mirroring the shape validated in dal-cpp/tests/curve/test_analytic_jacobian.cpp
-    // (LOG_DISCOUNT, EXACT, anchor == today_, no projection curve, vanilla Swap_ only) -- only the
-    // ladder length changes. The system is square: 10 instruments on 11 annual knots (10 free params
-    // + the today_ anchor), so EXACT converges to the fitTolerance_ and requesting
-    // CurveJacobianMode_::ANALYTIC engages the tape rather than silently falling back to bumping.
-    // Par rates rise smoothly from ~1.0% to ~2.5% across 1Y..10Y so the LOG_DISCOUNT system is well-
-    // conditioned and the 1e-9 AAD-vs-bump bar still holds.
+    // 10-instrument vanilla-swap Phase A calibration: square (10 instruments on 11 annual knots ->
+    // 10 free params + the today_ anchor), so EXACT converges and CurveJacobianMode_::ANALYTIC
+    // engages the AAD tape on this LOG_DISCOUNT, no-projection-curve, vanilla-Swap_ shape.
     CurveCalibrationSpec_ BuildCalibrationSpec() {
         CurveCalibrationSpec_ spec;
         spec.today_ = Date_(2022, 1, 1);
@@ -160,13 +133,8 @@ namespace {
         const auto mkSwap = [&](const Date_& end, double parPct) {
             return Handle_<YCInstrument_>(new Swap_(spec.today_, spec.today_, end, parPct / 100.0, fixedLeg, floatIdx, floatLeg));
         };
-        // Annual swaps maturing at 1Y..10Y with a smoothly rising par-rate term structure
-        // (1.00% -> 2.50%): a gentle linear ramp keeps the 10x10 LOG_DISCOUNT system well-
-        // conditioned so the 1e-9 AAD-vs-bump bar holds. The FR6 nonlinear re-solve bar is set to
-        // 1e-4 at this size (see RE_SOLVE_TOL) because the linear-vs-nonlinear gap grows
-        // intrinsically with the number of knots -- bumping a long-end quote propagates through
-        // every intervening LOG_DISCOUNT knot, accumulating second-order terms that the linear
-        // prediction cannot capture.
+        // Annual swaps at 1Y..10Y with a smoothly rising par-rate ramp (1.00% -> 2.50%) keep the
+        // 10x10 LOG_DISCOUNT system well-conditioned so the AAD-vs-bump and re-solve bars hold.
         spec.instruments_.reserve(nInstruments);
         for (int y = 1; y <= nInstruments; ++y) {
             const double frac = static_cast<double>(y - 1) / static_cast<double>(nInstruments - 1);
@@ -492,18 +460,9 @@ namespace {
             std::cout << "  Verdict : PASS  (all rel <= " << RE_SOLVE_TOL << ")\n";
     }
 
-    // (i) Calibration elapsed time -- BUMPED vs ANALYTIC. Both modes run the same EXACT Phase A
-    // solve; the only difference is how the forward Jacobian is obtained (n serial finite-difference
-    // re-calibrations for BUMPED vs one AAD reverse sweep for ANALYTIC). Each CalibrateYieldCurve
-    // call resets its own tape internally, so repeated calls are independent and safe to time.
-    //
-    // Honesty note: the ANALYTIC time includes the at-solution forward-Jacobian evaluation -- a
-    // single extra func.Gradient call the solver makes on its convergence branch to populate the
-    // diagnostics jacobian_ field -- which BUMPED does not perform. So ANALYTIC may trail BUMPED by
-    // that one convergence-J evaluation; the fair read of the ratio is "ANALYTIC solve-with-Jacobian
-    // vs BUMPED solve-without-Jacobian", not a pure like-for-like solve cost. BUMPED would need its
-    // own separate finite-difference Jacobian pass to match the ANALYTIC output, which it does not
-    // do here.
+    // (i) Calibration elapsed time -- BUMPED vs ANALYTIC (both EXACT Phase A solves; ANALYTIC also
+    // pays the single at-solution forward-J eval that populates diagnostics_.jacobian_). See the
+    // timing caveat in docs/methodology/yield_curve_jacobian.md.
     void RunCalibrationTimingComparison(const CurveCalibrationSpec_& spec) {
         constexpr int nRuns = 5;
         CurveCalibrationOptions_ optsBumped;
@@ -567,7 +526,6 @@ int main() {
     std::cout << "Parameterization: LOG_DISCOUNT   Solve mode: EXACT   Jacobian mode: ANALYTIC\n";
     std::cout << "Bump step h: " << std::scientific << std::setprecision(6) << BUMP_STEP << std::fixed << "\n";
 
-    // ---- (a) Calibrate with the analytic Jacobian engaged ----
     CurveCalibrationOptions_ options;
     options.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
     const auto result = CalibrateYieldCurve(spec, options);
@@ -583,12 +541,10 @@ int main() {
     std::cout << "\nSolved free-node log-DF params x (anchor pinned at 0):\n";
     PrintFreeParamVector("", x, freeKnots);
 
-    // ---- (b) Bump Jacobian (oracle) ----
     const Matrix_<> jBump = BumpJacobian(spec, x, BUMP_STEP);
     PrintSection("(b) Bump Jacobian  J_bump = d(modelRate_i) / d(logDF_free_k)");
     PrintMatrix("", jBump, "rows = instruments, cols = free params; central diff h = 1e-6", maturities, freeKnots);
 
-    // ---- (c) AAD Jacobian (analytic reverse sweep, read from the calibration diagnostics) ----
     // jacobian_ is populated by the solver's convergence-branch hook on the EXACT + ANALYTIC +
     // eligible path via a single func.Gradient(xNew, fNew) call at the solved x -- the same point
     // the bump oracle evaluates -- so the AAD-vs-bump comparison below cross-checks the library's
@@ -603,7 +559,6 @@ int main() {
     PrintSection("(c) AAD Jacobian  J_aad = d(modelRate_i) / d(logDF_free_k)");
     PrintMatrix("", jAad, "rows = instruments, cols = free params; reverse sweep, 1 per row", maturities, freeKnots);
 
-    // ---- (d) AAD-vs-bump agreement (verbatim two-branch form, tol = 1e-9) ----
     PrintSection("(d) AAD-vs-bump agreement  (verbatim two-branch form, tol = 1e-9)");
     const AgreementResult_ agree = RunAgreementCheck(jBump, jAad);
     std::cout << std::fixed << std::setprecision(12);
@@ -611,7 +566,6 @@ int main() {
     std::cout << "  max rel discrepancy : " << agree.maxRel_ << "\n";
     std::cout << "  Verdict              : PASS  (rel <= 1e-9)\n";
 
-    // ---- (e) effJacobianInverse_ from the EXACT solve ----
     // The solver returns the inverse Jacobian pre-scaled by tolerance_ (each residual row is
     // divided by tolerance_ before the pseudoinverse is formed), so the raw effJacobianInverse_(k,i)
     // has units d(params) * tolerance_ / d(decimal-rate perturbation) and is ~1e-10 here -- invisible
@@ -626,7 +580,6 @@ int main() {
     PrintMatrix("", effJacobianInverse, "rows = free params, cols = instruments; = effJacobianInverse_ / tolerance_", freeKnots, maturities,
                 1.0 / spec.tolerance_);
 
-    // ---- (f) Portfolio parameter sensitivity g ----
     const Vector_<> g = PortfolioParamSensitivity(spec, x, BUMP_STEP);
     PrintSection("(f) Portfolio parameter-sensitivity  g = d(modelParRate_portfolio) / d(logDF_free_k)");
     std::cout << "  portfolio = swap " << PORTFOLIO_INDEX << " (maturity " << IsoDate(maturities[PORTFOLIO_INDEX]) << "); length = nFree = " << g.size()
@@ -634,14 +587,12 @@ int main() {
     std::cout << "  units: par-rate per unit log-DF bump (annuity-scaled PV not exposed by YCInstrument_)\n";
     PrintFreeParamVector("", g, freeKnots);
 
-    // ---- (g) Bucketed IR risk r = g^T * effJacobianInverse_ ----
     const Vector_<> r = TransformToQuoteRisk(g, effJacobianInverse, spec.tolerance_);
     PrintSection("(g) Bucketed IR risk  r = g^T * effJacobianInverse_");
     std::cout << "  length = nInstruments = " << r.size() << "\n";
     std::cout << "  units: par-rate per absolute decimal quote bump\n";
     PrintQuoteRisk(r, maturities);
 
-    // ---- (h) FR6 inverse-Jacobian nonlinear re-solve sanity ----
     PrintSection("(h) FR6 inverse-Jacobian nonlinear re-solve sanity");
     std::cout << "  bump each marketRate by +1e-4, re-run CalibrateYieldCurve (ANALYTIC),\n";
     std::cout << "  compare true delta vs linear prediction effJacobianInverse_(k,i) * 1e-4 / tolerance_ (tol = " << RE_SOLVE_TOL << " rel)\n";
@@ -654,7 +605,6 @@ int main() {
     // effJacobianInverse_ * delta_m, which is off by the tolerance factor).
     RunFR6ReSolve(spec, options, effJacobianInverse, x, maturities, nInst, nFree);
 
-    // ---- (i) Calibration elapsed time -- BUMPED vs ANALYTIC ----
     PrintSection("(i) Calibration elapsed time  (BUMPED vs ANALYTIC, mean over N runs)");
     RunCalibrationTimingComparison(spec);
 

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -351,6 +351,50 @@ by element-wise agreement against a central finite-difference bump of the
 joint residual function. The oracle tests live at
 `dal-cpp/tests/curve/test_joint_analytic_jacobian.cpp`.
 
+### Joint vs staged calibration drift
+
+`CalibrateJointMultiCurve` (simultaneous) and `CalibrateMultiCurve` (sequential
+stages) both repricing the same instrument set to the same `fitTolerance_` do
+not produce byte-identical curves: the joint solve lands a few parts in
+$10^7$ off the staged solve on the OIS slice and up to a few parts in $10^5$
+on the 3M slice. The drift is expected and is not a bug — it is the
+mathematical consequence of solving the two curves together rather than one at
+a time.
+
+When both paths base-layer the 3M forward over the OIS discount curve (the
+joint path via `JointCurveDeclaration_::baseLayeredOverDiscount_`, the staged
+path via `ApplyStageDefaults`), both smoothers act on the OIS **spread**
+forward $f_{\text{abs}} - f_{\text{ois}}$, so the stored 3M curves are
+structurally identical (`DiscountPWLF_` with base = OIS). This eliminates the
+much larger representation-mismatch drift (around $3\times10^{-4}$ on the 3M
+short end) that appears when the two paths smooth different quantities.
+
+The residual drift has two sources:
+
+- **OIS slice (BAR-B, informational).** The joint OIS slice is co-determined
+  with the 3M-spread slice: the OIS columns of the joint Jacobian carry entries
+  from the 3M residual rows (IBOR annuities discount through OIS), and the
+  3M-spread parameters depend on the OIS base. The coupled solve therefore lands
+  the OIS knots a few $10^{-7}$ off the OIS-only staged solve. Base layering
+  widens this slightly (from $\sim4\times10^{-8}$ to $\sim6\times10^{-7}$)
+  because the spread smoothing couples the OIS and 3M-spread searches more
+  strongly.
+- **3M slice (BAR-C, informational).** With both paths smoothing the spread,
+  the residual drift is the OIS-slice difference above propagating through the
+  3M base handle, plus a small boundary contribution at the 1Y and 10Y knots
+  where the piecewise-linear system is least constrained. The 2Y–7Y core agrees
+  to $\sim10^{-7}$ (the OIS-agreement level); the maximum is $\sim2.4\times10^{-5}$
+  at the 1Y pillar — about $14\times$ tighter than the baseless default.
+
+These drift figures are reported by the example
+`dal-cpp/examples/joint_multi_curve_calibration/joint_multi_curve_calibration.cpp`
+as informational measurements (BAR-B, BAR-C), not gated. The example's sole
+pass/fail gate (BAR-A) checks that both paths converge and reprice every
+instrument to `10 * fitTolerance_`. A curve-routing bug — for example, the joint
+3M leg fixing off the wrong curve — would show up at the $10^{-2}$ level, far
+above the measured drift, so the informational diagnostic still discriminates
+correct wiring from mis-routing.
+
 ## Examples
 
 The snippets below are condensed from the standalone example programs under

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -105,6 +105,40 @@ new `NodeLogDF()` against the linear prediction). That re-solve path is the
 honest sanity check: the alternative "analytic forward map" prediction is
 tautological and is deliberately not used.
 
+### Nonlinear re-solve tolerance
+
+The re-solve sanity check compares the linear inverse-Jacobian prediction
+`effJacobianInverse_ · Δquote / tolerance_` against the true rebumped parameter
+delta from a fresh `CalibrateYieldCurve`. The two diverge at a relative error
+that **grows with the number of knots**: bumping a long-end quote propagates
+through every intervening LOG_DISCOUNT knot, accumulating second-order terms the
+linear map cannot capture. The observed worst-case relative error scales roughly
+as $7\times10^{-7}$ at 5 instruments, $1.8\times10^{-5}$ at 10, and
+$1.3\times10^{-4}$ at 16. A bar of $10^{-4}$ relative at the 10-instrument size
+leaves about $5\times$ headroom over the observed worst case; it should be
+re-measured (and tightened back toward $10^{-6}$ for shorter ladders, or relaxed
+for longer ones) whenever the ladder length changes. This is looser than the
+$10^{-9}$ forward-Jacobian agreement bar by design, because the re-solve is a
+genuine nonlinear operation rather than a finite-difference check of an analytic
+derivative.
+
+## Timing: BUMPED vs ANALYTIC
+
+The example also times `CurveJacobianMode_::{BUMPED,ANALYTIC}` calibrations on
+the same EXACT solve. Both modes run the identical Phase A Newton solve; the only
+difference is how the forward Jacobian is obtained — $n$ serial finite-difference
+re-calibrations for `BUMPED` versus one AAD reverse sweep per residual row for
+`ANALYTIC`. Each `CalibrateYieldCurve` call resets its own tape internally, so
+repeated calls are independent and safe to time.
+
+The comparison is not pure like-for-like. The `ANALYTIC` time includes the
+single at-solution forward-Jacobian evaluation the solver makes on its
+convergence branch to populate `CurveCalibrationDiagnostics_::jacobian_`, which
+`BUMPED` does not perform. The honest reading of the ratio is therefore
+"`ANALYTIC` solve-with-Jacobian vs `BUMPED` solve-without-Jacobian". A truly
+matched comparison would give `BUMPED` its own separate finite-difference
+Jacobian pass to produce the same diagnostic, which the example does not do.
+
 ### Parameter sensitivity $g$
 
 The transform needs $g$ as a *portfolio* sensitivity, computed independently of


### PR DESCRIPTION
## Summary
- Migrate the dense methodology/tolerance essays out of the two heaviest example programs into the methodology docs they reference, then reduce the in-source comments to short why-notes and pointers. Pure comment + doc edits; no example logic or output changes.
- `dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp`: replace the 21-line teaching preamble with a 5-line header; trim the `BUMP_STEP`/`AAD_TOL`/`RE_SOLVE_TOL` tolerance essay to a short note; remove the 9 `// ---- (a) ----`..`(i)` main() section banners; trim the timing honesty note to a pointer. Kept verbatim: aliasing-ctor leak note, par-rate DV01 units note, `effJacobianInverse_` tolerance-scaling note, B2 sentinel note.
- `dal-cpp/examples/joint_multi_curve_calibration/joint_multi_curve_calibration.cpp`: migrate the BAR-A/BAR-C joint-vs-staged drift essay (OIS-slice coupling, 3M base-handle propagation, 1Y/10Y pillar underdeterminacy) to `yield_curve.md`; kept the trailing PASS-gate/informational notes on the assertion constants and the load-bearing-include note for AAD backend builds.
- `docs/methodology/yield_curve_jacobian.md`: add "Nonlinear re-solve tolerance" subsection (FR6 bar scales with ladder length) and a "Timing: BUMPED vs ANALYTIC" subsection (at-solution forward-J eval caveat). Current-state voice, WHY altitude, no source line numbers.
- `docs/methodology/yield_curve.md`: add "Joint vs staged calibration drift" subsection explaining why simultaneous and sequential calibrations of the same instrument set diverge at the 1e-7/1e-5 level.

## Test plan
- [x] Rebuilt `yield_curve_jacobian` and `joint_multi_curve_calibration` in the main `build/` tree with the edited sources: both compile clean and exit 0.
- [x] Diffed program output before vs after the comment edits: byte-identical apart from non-deterministic timing lines (`mean (ms)` over N runs, integer ms timings). All residuals, Jacobians, sensitivities, risk vectors, DF comparisons, and pass/fail verdicts are unchanged.
- [x] No `bin/` binaries used for verification; ran `build/dal-cpp/examples/<name>/<name>` directly.
- [x] Source diff is comment-only (zero executable lines changed); main tree left clean.