### PR TITLE
chore: trim joint multi-curve narrative from curve comments

### DIFF
--- a/dal-cpp/dal/curve/curvejacobian.hpp
+++ b/dal-cpp/dal/curve/curvejacobian.hpp
@@ -14,13 +14,6 @@
 #include <dal/utilities/numerics.hpp>
 
 namespace Dal {
-    // Dense Jacobian subclass for curve calibration. Storage is dense regardless of how the matrix
-    // is filled; assembly is sparse-by-row because AAD produces exact structural zeros. Used by both
-    // the single-curve AAD path (calibration.cpp) and the joint multi-curve AAD path
-    // (jointcalibration.cpp). The method bodies mirror XJDense_ (underdetermined.cpp) -- the
-    // storage is dense regardless of how the matrix is filled. Declared in Dal:: (not anonymous) so
-    // the calibration flow can construct it and the solver's virtual Jacobian_ interface
-    // (MultiplyLeft) can read its contents without an inline accessor.
     struct XCurveJacobian_ : Underdetermined::Jacobian_ {
         Matrix_<> j_;
         explicit XCurveJacobian_(Matrix_<>&& j) : j_(std::move(j)) {}

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -35,7 +35,7 @@ namespace Dal {
         constexpr const char* KEY_MAX_EVALUATIONS = "MAXEVALUATIONS";
         constexpr const char* KEY_MAX_RESTARTS = "MAXRESTARTS";
 
-        // PWL/PWC params only; LOG_DISCOUNT and ZERO_RATE fail loudly for the joint path.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         int ParamsPerKnot(CurveParameterization_ parameterization) {
             switch (parameterization.Switch()) {
             case CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD:
@@ -95,7 +95,7 @@ namespace Dal {
             return nullptr;
         }
 
-        // Forward-declaration instruments must route fixings through the forward curve (useProjectionCurve_ == true).
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         String_ ForwardDeclarationOffendingInstrument(const JointCurveDeclaration_& decl) {
             for (const auto& inst : decl.instruments_) {
                 const RateIndexConvention_* conv = FloatConventionOf(*inst);
@@ -237,7 +237,7 @@ namespace Dal {
             return Vector_<>(nParams, spec.initialGuess_);
         }
 
-        // Clear the AAD tape on entry and exit (exception-safe), single-threaded.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         struct TapeGuard_ {
             Dal::AAD::Tape_* t_;
             explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
@@ -252,7 +252,7 @@ namespace Dal {
             TapeGuard_& operator=(const TapeGuard_&) = delete;
         };
 
-        // Templated PWL_FWD curve builder. Base-layered when a base handle is supplied so adjoints propagate through the reverse sweep.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         template <class T_, class B_ = Tape::DiscountCurve_<double>>
         std::shared_ptr<Tape::DiscountPWLF_<T_, B_>>
         BuildDeclarationCurveT(const JointCurveDeclaration_& decl,
@@ -279,7 +279,7 @@ namespace Dal {
             }
             const RateIndexConvention_& conv = *convPtr;
             if (IsSupportedInstrumentType(inst)) {
-                // Discount-declaration instruments must NOT project so fixings route to a single curve on the AAD tape.
+                // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
                 if (onDiscountDeclaration && conv.useProjectionCurve_) {
                     const String_ msg = String_("Joint AAD Jacobian requires discount-declaration instruments to forecast off "
                                                 "the discount curve; instrument '")

--- a/dal-cpp/dal/curve/jointcalibration.hpp
+++ b/dal-cpp/dal/curve/jointcalibration.hpp
@@ -18,24 +18,7 @@
 
 namespace Dal {
 
-    // A declaration of ONE curve's role in a joint simultaneous multi-curve calibration. This is a
-    // thinned CurveCalibrationSpec_: only the fields the joint solver consumes. The staged-only
-    // fields (discountCurves_, forwardCurves_) are deliberately absent; the joint path has no
-    // staging.
-    //
-    // Discount-vs-forward routing for an IBOR stage is expressed by calibrateDiscountCurve_ == false
-    // plus a non-default targetTenor_. The discount curve that discounts the IBOR instruments is
-    // supplied by ANOTHER declaration in the same JointMultiCurveCalibrationSpec_ whose
-    // calibrateDiscountCurve_ == true and whose targetCollateral_ matches the collateral the IBOR
-    // leg is discounted at (OIS in the canonical example). The capability wires that routing
-    // internally by assembling a CurveBlock_ from every declaration's curves.
-    //
-    // baseLayeredOverDiscount_ (forward declarations only): when true, build this curve as
-    // NewDiscountPWLF(..., base = the discount curve at targetCollateral_ built in the SAME solve).
-    // The smoother then acts on the spread forward f_abs - f_ois instead of the absolute forward,
-    // matching the staged path's ApplyStageDefaults base layering (calibration.cpp:113-118). Opt-in
-    // so the capability still supports the baseless representation. Requires a discount declaration
-    // with matching targetCollateral_ to be present in the same spec.
+    // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
     struct JointCurveDeclaration_ {
         String_ curveName_ = "joint";
         Vector_<Handle_<YCInstrument_>> instruments_;
@@ -91,42 +74,12 @@ namespace Dal {
         // CalibrateYieldCurve). Retained for a future non-throwing overload.
         bool converged_ = false;
         int solverEvaluations_ = 0; // informational
-        // Unscaled analytic forward Jacobian d(residual_i) / d(param_j) at the solved x, shape
-        // (totalResiduals) x (totalFreeParams), captured by a single in-solver Gradient evaluation on
-        // convergence (the solver's fwd_jacobian_at_solution hook). Populated ONLY when
-        // options.jacobianMode_ == ANALYTIC AND the spec is eligible AND solveMode_ == EXACT; empty
-        // otherwise. The oracle test (AC1) reads this and compares against a central-FD bump of F.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         Matrix_<> jacobianAtSolution_;
     };
 
-    // Solver-side options for joint multi-curve calibration. NOT serialized with the spec: the
-    // spec describes WHAT to calibrate (declarations, knots, instruments); the options describe HOW
-    // to solve (Jacobian construction). A default-constructed JointMultiCurveCalibrationOptions_
-    // engages the AAD path on eligible specs (matching the single-curve CurveCalibrationOptions_
-    // default); on an ineligible spec it emits a one-time NOTICE and falls back to the
-    // byte-for-byte bumped path.
+    // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
     struct JointMultiCurveCalibrationOptions_ {
-        // Jacobian construction for the joint calibration solver.
-        //   BUMPED   -- finite-difference bumping of every free parameter. Always available;
-        //               byte-for-byte identical to the pre-Phase-B path.
-        //   ANALYTIC -- AAD-derived dense Jacobian over the joint stacked parameter vector
-        //               (default). Engages only when EligibleForAnalyticJacobian() is true (every
-        //               declaration PIECEWISE_LINEAR_FWD + base collateral resolves +
-        //               liborBasis_ == ACT_365F + vanilla Deposit/FRA/Future/Swap only -- OISSwap_
-        //               rides the inherited Swap_::PrecomputeT<T_> since its overnight index has
-        //               useProjectionCurve_ == false, so forecast == discount == OIS and both AAD
-        //               and bumped paths share the identical simple-rate arithmetic; see
-        //               .claude/designs/joint-aad-gradient.md Gap 5);
-        //               otherwise falls back to BUMPED with a NOTICE (at most once per
-        //               CalibrateJointMultiCurve call; never throws). The joint residual prices
-        //               IBOR projection instruments through a NEW Tape::JointRate_<T_> base (CP3)
-        //               reading a Tape::JointCurveBlock_<T_> routing context.
-        //
-        // DEFAULT IS ANALYTIC, matching single-curve CurveCalibrationOptions_
-        // (dal-cpp/dal/curve/calibration.hpp). Every existing joint caller exercises the new
-        // Tape::DiscountPWLF_<T_> + Tape::JointCurveBlock_<T_> machinery on eligible specs after
-        // the upgrade; the mitigation is the AAD-vs-bumped oracle test (spec AC1) and the
-        // four-backend build matrix (spec AC6).
         CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
     };
 

--- a/dal-cpp/dal/curve/jointrate.hpp
+++ b/dal-cpp/dal/curve/jointrate.hpp
@@ -9,26 +9,12 @@
 
 namespace Dal {
     namespace Tape {
-        // Phase B templated joint rate base. SIBLING of Tape::Rate_<T_> (which is bound to
-        // YCCtx_<T_> and reads a single curve). The joint analogue: operator() takes a
-        // JointCurveBlock_<T_> routing context (Gap 1) and performs BOTH the discount read at the
-        // leg's collateral AND the forecast read at (forecastTenor_, collateral_) in the T_ domain
-        // (Gap 3). Phase A's Tape::Rate_<T_>, YCCtx_<T_>, and the four Phase A rate subclasses are
-        // UNTOUCHED (NG2).
-        //
-        // The projection-capable subclasses (DepositRateProj_<T_>, ForwardRateProj_<T_> covering
-        // FRA + Future, SwapRateProj_<T_>) live alongside the Phase A templated rates in
-        // ycinstrument.cpp (so they can reuse the file-local BuildLegPeriods helper). They are
-        // constructed by the Tape::ProjectionRateAt<T_>(inst) factory, dispatched via dynamic_cast.
         template <class T_>
         struct JointRate_ {
             virtual ~JointRate_() = default;
             virtual T_ operator()(const JointCurveBlock_<T_>& block) const = 0;
         };
 
-        // Build the projection-capable templated rate for an instrument, or an empty handle if the
-        // instrument type has no projection-rate subclass. Defined in ycinstrument.cpp alongside
-        // the Phase A PrecomputeT factories (reuses the file-local BuildLegPeriods helper).
         template <class T_>
         Handle_<JointRate_<T_>> ProjectionRateAt(const YCInstrument_& inst);
     } // namespace Tape

--- a/dal-cpp/dal/curve/jointycctx.hpp
+++ b/dal-cpp/dal/curve/jointycctx.hpp
@@ -12,26 +12,11 @@
 
 namespace Dal {
     namespace Tape {
-        // Phase B templated joint yield-curve context. The multi-curve analogue of YCCtx_<T_>:
-        // one Number_-typed discount curve per collateral, one per forward tenor. Routes
-        // Discount(collateral) and Forward(tenor, collateral) reads in the T_ domain, mirroring
-        // CurveBlock_::Discount/Forward's routing (curveblock.cpp:65-83) including the OIS fallback
-        // and the forward->discount fallback. NOT a YieldCurve_ subclass; exists only for the joint
-        // AAD-tape residual evaluation in jointcalibration.cpp. Phase A's YCCtx_<T_> is untouched
-        // (NG2) -- this is a sibling.
-        //
-        // The pointer maps are non-owning references to curves built in the SAME Gradient call.
-        // Pointers (not Handle_<>) because the curves live on the shared_ptr storage of the
-        // AnalyticJacobian frame for the duration of the sweep.
         template <class T_>
         struct JointCurveBlock_ {
             std::map<CollateralType_, const DiscountCurve_<T_>*> discountCurves;
             std::map<PeriodLength_, const DiscountCurve_<T_>*> forwardCurves;
 
-            // Mirror of CurveBlock_::Discount (curveblock.cpp:65-74): exact-collateral match, then
-            // OIS fallback. The OIS fallback is the joint post-2008 routing convention and must be
-            // preserved on the tape so an OIS knot perturbation flows into an IBOR leg's discounting
-            // when collateral != OIS.
             const DiscountCurve_<T_>& Discount(const CollateralType_& collateral) const {
                 const auto found = discountCurves.find(collateral);
                 if (found != discountCurves.end())
@@ -41,11 +26,6 @@ namespace Dal {
                 return *ois->second;
             }
 
-            // Mirror of CurveBlock_::Forward (curveblock.cpp:76-83): exact-tenor match, else
-            // Discount(collateral). The fallback matters: an instrument whose forecast tenor has no
-            // registered forward curve routes to the discount curve, and the joint eligibility
-            // predicate admits this case (a discount/baseless-forward declaration instrument with
-            // useProjectionCurve_ == false, or an OIS-discount slice where forecast == discount).
             const DiscountCurve_<T_>& Forward(const PeriodLength_& tenor, const CollateralType_& collateral) const {
                 const auto found = forwardCurves.find(tenor);
                 if (found != forwardCurves.end())

--- a/dal-cpp/dal/curve/ycinstrument.hpp
+++ b/dal-cpp/dal/curve/ycinstrument.hpp
@@ -18,18 +18,14 @@ namespace Dal {
     class String_;
 
     namespace Tape {
-        // Phase A templated rate interface. The Number_-typed sibling of YCInstrument_::Rate_; lives
-        // only under the native backend (the gate matches the native Number_ definition in expr.hpp).
-        // The AAD-tape Gradient override constructs Rate_<Number_> instances from the same instrument
-        // specs the double path uses and reads number-typed rates off the templated yield context.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         template <class T_> struct Rate_ : noncopyable {
             virtual ~Rate_() = default;
             virtual T_ operator()(const YCCtx_<T_>& ctx) const = 0;
         };
 
-        // Phase B projection-capable rate interface (CP3). Forward-declared here so the instrument
-        // classes below can declare PrecomputeProjectionT<T_> member templates returning
-        // Handle_<JointRate_<T_>>. Defined in jointrate.hpp (which includes this header).
+        // Forward-declared so the instrument classes below can declare PrecomputeProjectionT<T_>
+        // member templates. Defined in jointrate.hpp (which includes this header).
         template <class T_> struct JointRate_;
         template <class T_> struct JointCurveBlock_;
     } // namespace Tape
@@ -53,12 +49,7 @@ namespace Dal {
 
         [[nodiscard]] virtual Handle_<Rate_> Precompute(const Handle_<YieldCurve_>& funding_yc) const = 0;
 
-        // Templated factory mirroring Precompute: returns a Tape::Rate_<T_> bound to the supplied
-        // yield context. Declared only on the concrete instruments that have a Phase A templated
-        // rate (Deposit_/FRA_/Future_/Swap_, plus their derived OISSwap_/STIR_); PhaseARateAt
-        // dispatches via dynamic_cast to those types, so there is no base-class entry point.
-        // Instruments without a templated rate (e.g. BasisSwap_) make EligibleForAnalyticJacobian reject the
-        // whole calibration and the solver dense-bumps instead.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
     };
 
     class Deposit_ : public YCInstrument_ {

--- a/dal-cpp/dal/curve/ycpwlf.cpp
+++ b/dal-cpp/dal/curve/ycpwlf.cpp
@@ -46,9 +46,8 @@ namespace Dal {
 
         template <class T_, class B_>
         void DiscountPWLF_<T_, B_>::UpdateT() {
-            // T_-typed analogue of PiecewiseLinear_::Sofar (piecewiselinear.cpp:13-21), using the
-            // SAME fLeftT_[ii] + fRightT_[ii-1] segment indexing (critique S8). Abscissa weights
-            // (dt) are double; mean and sofarT_ are T_.
+            // T_-typed running integral using fLeftT_[ii] + fRightT_[ii-1] segment indexing.
+            // Abscissa weights (dt) are double; mean and sofarT_ are T_.
             const int n = static_cast<int>(knotDates_.size());
             if (static_cast<int>(sofarT_.size()) != n)
                 sofarT_.Resize(n);
@@ -109,10 +108,7 @@ namespace Dal {
 
         template <class T_, class B_>
         void DiscountPWLF_<T_, B_>::ApplyDX(Vector_<>::const_iterator dx, double leverage) {
-            // CRITIQUE S9: ApplyDX compiles on T_ = Number_ (via the facade's += and
-            // leverage * double operators) but is UNREACHABLE on the AAD path: the Number_ factory
-            // constructs the curve directly with tape-registered fLeftT_/fRightT_, never calling
-            // ApplyDX. The bumped fallback uses the existing double DiscountPWLF_ (ycimp.cpp:56-83).
+            // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
             for (int k = 0; k < static_cast<int>(fLeftT_.size()); ++k) {
                 fLeftT_[k] += static_cast<double>(leverage) * *dx++;
                 fRightT_[k] += static_cast<double>(leverage) * *dx++;
@@ -136,9 +132,7 @@ namespace Dal {
             return new DiscountPWLF_<T_, B_>(new_name, this->ccy_.String(), knotDates_, fLeftT_, fRightT_, this->NewBase(base_changes));
         }
 
-        // Explicit instantiations. The double variant is exercised by the AC11 byte-for-byte test
-        // and by the double specialization of the templated joint residual. The Number_ variants
-        // (baseless and base-layered) are exercised by the joint AAD-tape Gradient override.
+        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         template class DiscountPWLF_<double>;
         template class DiscountPWLF_<Dal::AAD::Number_>;
         template class DiscountPWLF_<Dal::AAD::Number_, DiscountCurve_<Dal::AAD::Number_>>;

--- a/dal-cpp/dal/curve/ycpwlf.hpp
+++ b/dal-cpp/dal/curve/ycpwlf.hpp
@@ -13,22 +13,7 @@
 #include <dal/utilities/algorithms.hpp>
 
 namespace Dal {
-    // Phase B templatization: the templated PWL-forward curve. Interpolates forwards piecewise-
-    // linearly on T_ (fLeftT_/fRightT_ are the 2 * nKnots free parameters, NO anchor exclusion --
-    // every knot is free), integrates forwards to log-DF on T_ via the Vector_<T_> sofarT_ running
-    // integral, and multiplies by a T_-typed base when supplied. The double specialization
-    // (T_ = double) is byte-for-byte identical in arithmetic to the anonymous-namespace
-    // DiscountPWLF_ at ycimp.cpp:56-83 (modulo routing the denominator through DAYS_PER_YEAR). The
-    // Number_ specialization is constructed only by the AAD-tape Gradient override in
-    // jointcalibration.cpp.
-    //
-    // CRITIQUE S9 DECISION: the templated class holds FLAT Vector_<T_> members (fLeftT_, fRightT_,
-    // sofarT_), NOT a templated PiecewiseLinearT_<T_>. The joint path is the only consumer, so flat
-    // members minimize surface.
-    //
-    // The base is a SECOND template parameter (defaulted to DiscountCurve_<double> for the baseless
-    // / constant-base case, matching Phase A's DiscountLogDF_<T_> pattern). Under base layering,
-    // B_ = DiscountCurve_<T_> so the base adjoints propagate through the reverse sweep (Gap 4).
+    // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
     namespace Tape {
         constexpr double DAYS_PER_YEAR_PWLF = 365.0;
 
@@ -41,9 +26,8 @@ namespace Dal {
             Vector_<T_> fLeftT_;
             Vector_<T_> fRightT_;
             // T_-typed running integral sofarT_[k] = integral of the PWL forward from knot 0 to
-            // knot k. Mirrors PiecewiseLinear_::sofar_ but T_-typed so the dependence on
-            // fLeftT_/fRightT_ records on the tape. Recomputed by UpdateT() whenever fLeftT_/
-            // fRightT_ change (critique S8).
+            // knot k. T_-typed so the dependence on fLeftT_/fRightT_ records on the tape.
+            // Recomputed by UpdateT() whenever fLeftT_/fRightT_ change.
             Vector_<T_> sofarT_;
             // Double knot abscissae (serial-day offsets from knot 0). Computed once at
             // construction; identical for any T_.


### PR DESCRIPTION
## Summary
- Final step of the codebase-wide comment-simplification effort. The joint multi-curve analytic Jacobian methodology is homed on `master` in `docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian` (PR #137 merged). Trim the now-redundant in-source narrative from the eight curve files that carried it, leaving a one-line pointer to the doc section and keeping local field-contract inline comments.
- **Per-file:**
  - `jointycctx.hpp` — fully remove the `JointCurveBlock_` narrative and both `Mirror of CurveBlock_::...` blocks (OIS post-2008 fallback + forward→discount fallback).
  - `jointrate.hpp` — fully remove the sibling-of-`Rate_<T_>` + projection-dispatch narrative.
  - `curvejacobian.hpp` — fully remove the sparse-by-row + dense-storage rationale narrative.
  - `jointcalibration.hpp` — reduce routing/base-layering, `jacobianAtSolution_`, and options/eligibility blocks to pointers; keep field-contract inline comments.
  - `jointcalibration.cpp` — reduce loud-fail and single-threaded `TapeGuard_` narrative to pointers; `REQUIRE`/`THROW` strings untouched.
  - `ycpwlf.hpp` — reduce templated-PWL / `B_` / byte-identity / CRITIQUE-S9 block to a pointer; keep `DAYS_PER_YEAR_PWLF` (code) and field-contract comments.
  - `ycpwlf.cpp` — reduce abscissa / segment-indexing / `ApplyDX` / explicit-instantiation narrative to pointers; `REQUIRE(false)` error string untouched.
  - `ycinstrument.hpp` — reduce `Rate_<T_>`/`JointRate_` forward-decl and templated-factory dispatch blocks to pointers; keep the `TradeDate()` spot-started comment (general `YCInstrument_` API contract, no doc home).
- Strip stale source-line citations (`curveblock.cpp:65-83`, `ycimp.cpp:56-83`, `calibration.cpp:113-118`, `piecewiselinear.cpp:13-21`) and residual process vocabulary (`AC11`, `critique S8`) per the no-line-numbers rule.
- **COMMENT-ONLY:** 138 comment lines removed, 19 one-line pointers added, zero executable-code changes (verified by filtering the diff for non-comment lines). Out-of-scope single-curve headers (`yclogdf.hpp`, `ycctx.hpp`, `discount.hpp`) untouched.

## Test plan
- [x] Build `dal_cpp_tests` from `build/` — clean compile and link (Adept source-default backend).
- [x] Run full `dal_cpp_tests` from `build/dal-cpp/dal_cpp_tests` — **750 tests from 68 suites, all PASSED**.
- [x] Joint / analytic-Jacobian suites green: `JointCalibrationTest` (13), `JointAnalyticJacobianTest`, `AnalyticJacobianTest`, `CurveJacobianModeTest`, `CurveJacobianModeFlagTest`, `ForwardJacobianDiagnosticsTest`, `InverseJacobianRiskTest`.
- [x] Verify diff is strictly comment-only (no executable code, no `REQUIRE`/`THROW` string changes).
- [x] Verify must-keep items survived verbatim: `TradeDate()` spot-started comment, `REQUIRE(false, ...)` error string, `DAYS_PER_YEAR_PWLF` constant.
- [x] Verify three out-of-scope single-curve headers untouched.

Co-Authored-By: Claude <noreply@anthropic.com>