### PR TITLE
refactor: extract TapeGuard_ to shared curve header

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -18,6 +18,7 @@
 #include <dal/curve/ycimp.hpp>
 #include <dal/curve/yclogdf.hpp>
 #include <dal/math/aad/aad.hpp>
+#include <dal/curve/tapeguard.hpp>
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/matrixarithmetic.hpp>
 #include <dal/math/matrix/squarematrix.hpp>
@@ -201,21 +202,6 @@ namespace Dal {
             return std::unique_ptr<Tape::DiscountCurve_<T_>>(
                 new Tape::DiscountLogDF_<T_>(name, ccy, knotDates, logDF, dayCount, logDfScheme, baseCurve));
         }
-
-        // Clear the AAD tape on entry and exit (exception-safe), single-threaded.
-        struct TapeGuard_ {
-            Dal::AAD::Tape_* t_;
-            explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
-            ~TapeGuard_() {
-                try {
-                    Dal::AAD::Clear(*t_);
-                } catch (...) {
-                    // swallow; we are unwinding
-                }
-            }
-            TapeGuard_(const TapeGuard_&) = delete;
-            TapeGuard_& operator=(const TapeGuard_&) = delete;
-        };
 
         class YieldCurveCalibrationFunc_ : public Underdetermined::Function_ {
             // Cached eligibility avoids re-evaluating the expensive per-instrument predicate every solver iteration.

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -22,6 +22,7 @@
 #include <dal/curve/ycinstrument.hpp>
 #include <dal/curve/ycpwlf.hpp>
 #include <dal/math/aad/aad.hpp>
+#include <dal/curve/tapeguard.hpp>
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/optimization/underdetermined.hpp>
 #include <dal/math/optimization/underdeterminedutils.hpp>
@@ -236,21 +237,6 @@ namespace Dal {
             }
             return Vector_<>(nParams, spec.initialGuess_);
         }
-
-        // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
-        struct TapeGuard_ {
-            Dal::AAD::Tape_* t_;
-            explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
-            ~TapeGuard_() {
-                try {
-                    Dal::AAD::Clear(*t_);
-                } catch (...) {
-                    // swallow; we are unwinding
-                }
-            }
-            TapeGuard_(const TapeGuard_&) = delete;
-            TapeGuard_& operator=(const TapeGuard_&) = delete;
-        };
 
         // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         template <class T_, class B_ = Tape::DiscountCurve_<double>>

--- a/dal-cpp/dal/curve/tapeguard.hpp
+++ b/dal-cpp/dal/curve/tapeguard.hpp
@@ -1,0 +1,28 @@
+//
+// Created by dal-implementer on 2026/6/27.
+//
+
+#pragma once
+
+#include <dal/math/aad/aad.hpp>
+
+namespace Dal {
+
+    // RAII guard that clears the AAD tape on construction and destruction.
+    // Used around analytic-Jacobian tape sweeps that must not interfere with
+    // any outer tape recording. Single-threaded.
+    struct TapeGuard_ {
+        Dal::AAD::Tape_* t_;
+        explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
+        ~TapeGuard_() {
+            try {
+                Dal::AAD::Clear(*t_);
+            } catch (...) {
+                // swallow; we are unwinding
+            }
+        }
+        TapeGuard_(const TapeGuard_&) = delete;
+        TapeGuard_& operator=(const TapeGuard_&) = delete;
+    };
+
+} // namespace Dal


### PR DESCRIPTION
## Summary
- Add `dal-cpp/dal/curve/tapeguard.hpp` containing the RAII `TapeGuard_` struct (Clear on construction and destruction, copy and assignment deleted), placed in `namespace Dal` so it is visible across translation units.
- Remove the two byte-identical anonymous-namespace `TapeGuard_` definitions from `dal-cpp/dal/curve/calibration.cpp` and `dal-cpp/dal/curve/jointcalibration.cpp`; both files now include the shared header (placed immediately after `<dal/math/aad/aad.hpp>`).
- The two call sites (`TapeGuard_ guard(tape);` in the single-curve and joint analytic-Jacobian paths) compile unchanged via the shared definition.

This is Step 1 of the curve-module deduplication plan. The anonymous copies had already diverged in their surrounding comments and would diverge in implementation under any future change; promoting to a single header makes the ODR contract machine-enforceable and gives both analytic-Jacobian paths one definition.

## Test plan
- [x] Build `dal_cpp_tests` cleanly with the new header
- [x] `--gtest_filter='*AnalyticJacobian*:*JointAnalyticJacobian*'` — 19 tests pass (15 `AnalyticJacobianTest` + 4 `JointAnalyticJacobianTest`)
- [x] Full `dal_cpp_tests` suite — 752 tests pass, no regressions

Co-Authored-By: Claude <noreply@anthropic.com>