### PR TITLE
refactor: unify ForwardRate onto Tape::ForwardRate template

### DIFF
--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -17,6 +17,15 @@
 
 namespace Dal {
 
+    namespace Tape {
+        template <class T_>
+        T_ ForwardRate(const DiscountCurve_<T_>& forecast,
+                       const Date_& start,
+                       const Date_& maturity,
+                       const DayBasis_& basis,
+                       const Handle_<DayBasis::Context_>& context);
+    } // namespace Tape
+
     namespace {
         PeriodLength_ PeriodFromMonths(int months) {
             REQUIRE(months == 1 || months == 3 || months == 6 || months == 12, "Unsupported calibration instrument frequency");
@@ -49,15 +58,6 @@ namespace Dal {
             REQUIRE(fallback, "Instrument pricing requires a forecast curve context");
             REQUIRE(fallback->HasForward(convention.forecastTenor_), "Fallback pricing context does not contain requested forward curve");
             return fallback->Forward(convention.forecastTenor_, convention.collateral_);
-        }
-
-        double ForwardRate(const DiscountCurve_& forecast,
-                           const Date_& start,
-                           const Date_& maturity,
-                           const DayBasis_& basis,
-                           const Handle_<DayBasis::Context_>& context) {
-            const double fwdDf = forecast(start, maturity);
-            return (1.0 / fwdDf - 1.0) / basis(start, maturity, context.get());
         }
 
         AccrualPeriod_ MakeAccrualPeriod(const SchedulePeriod_& period, const DayBasis_& basis) {
@@ -112,11 +112,11 @@ namespace Dal {
                 period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
                 period.dayCountContext_ = SinglePeriodContext(start_, maturity_, CouponMonths(start_, maturity_));
                 const DiscountCurve_& forecast = ResolveForecastCurve(yc, fallback_, convention_);
-                return ForwardRate(forecast,
-                                   period.accrualStart_,
-                                   period.accrualEnd_,
-                                   convention_.dayBasis_,
-                                   period.dayCountContext_);
+                return Tape::ForwardRate<double>(forecast,
+                                                 period.accrualStart_,
+                                                 period.accrualEnd_,
+                                                 convention_.dayBasis_,
+                                                 period.dayCountContext_);
             }
         };
 
@@ -150,11 +150,11 @@ namespace Dal {
                                                                   ? convention_.forecastTenor_.Months()
                                                                   : CouponMonths(start_, maturity_));
                 const DiscountCurve_& forecast = ResolveForecastCurve(yc, fallback_, convention_);
-                return ForwardRate(forecast,
-                                   period.accrualStart_,
-                                   period.accrualEnd_,
-                                   convention_.dayBasis_,
-                                   period.dayCountContext_) - convexityAdjustment_;
+                return Tape::ForwardRate<double>(forecast,
+                                                 period.accrualStart_,
+                                                 period.accrualEnd_,
+                                                 convention_.dayBasis_,
+                                                 period.dayCountContext_) - convexityAdjustment_;
             }
         };
 
@@ -187,11 +187,11 @@ namespace Dal {
 
                 double floatPv = 0.0;
                 for (const auto& period : floatPeriods_) {
-                    const double fixing = ForwardRate(forecast,
-                                                      period.schedule_.accrualStart_,
-                                                      period.schedule_.accrualEnd_,
-                                                      floatIndexConvention_.dayBasis_,
-                                                      period.schedule_.dayCountContext_);
+                    const double fixing = Tape::ForwardRate<double>(forecast,
+                                                                    period.schedule_.accrualStart_,
+                                                                    period.schedule_.accrualEnd_,
+                                                                    floatIndexConvention_.dayBasis_,
+                                                                    period.schedule_.dayCountContext_);
                     floatPv += fixing * period.accrual_.dcf_ * discount(tradeDate_, period.schedule_.paymentDate_);
                 }
                 return floatPv / annuity;
@@ -227,11 +227,11 @@ namespace Dal {
                 double spreadBasePv = 0.0;
                 double spreadAnnuity = 0.0;
                 for (const auto& period : spreadPeriods_) {
-                    const double fixing = ForwardRate(spreadForecast,
-                                                      period.schedule_.accrualStart_,
-                                                      period.schedule_.accrualEnd_,
-                                                      spreadIndexConvention_.dayBasis_,
-                                                      period.schedule_.dayCountContext_);
+                    const double fixing = Tape::ForwardRate<double>(spreadForecast,
+                                                                    period.schedule_.accrualStart_,
+                                                                    period.schedule_.accrualEnd_,
+                                                                    spreadIndexConvention_.dayBasis_,
+                                                                    period.schedule_.dayCountContext_);
                     const double df = discount(tradeDate_, period.schedule_.paymentDate_);
                     spreadBasePv += fixing * period.accrual_.dcf_ * df;
                     spreadAnnuity += period.accrual_.dcf_ * df;
@@ -240,11 +240,11 @@ namespace Dal {
 
                 double referencePv = 0.0;
                 for (const auto& period : referencePeriods_) {
-                    const double fixing = ForwardRate(referenceForecast,
-                                                      period.schedule_.accrualStart_,
-                                                      period.schedule_.accrualEnd_,
-                                                      referenceIndexConvention_.dayBasis_,
-                                                      period.schedule_.dayCountContext_);
+                    const double fixing = Tape::ForwardRate<double>(referenceForecast,
+                                                                    period.schedule_.accrualStart_,
+                                                                    period.schedule_.accrualEnd_,
+                                                                    referenceIndexConvention_.dayBasis_,
+                                                                    period.schedule_.dayCountContext_);
                     referencePv += fixing * period.accrual_.dcf_ * discount(tradeDate_, period.schedule_.paymentDate_);
                 }
 


### PR DESCRIPTION
## Summary
- Remove the anonymous-namespace `double ForwardRate(...)` free function in `dal-cpp/dal/curve/ycinstrument.cpp` (a pure `T_=double` specialization of the `Tape::ForwardRate` template)
- Redirect its 5 call sites (DepositRate_, ForwardRate_, SwapRate_, BasisSwapRate_ spread & reference legs) to `Tape::ForwardRate<double>(...)`
- Add a forward declaration of `Tape::ForwardRate` before the anonymous namespace: the call sites sit above the `namespace Tape { }` definition containing the template, so qualified lookup needs an earlier declaration to resolve

This is Step 2 of the curve-dedup plan (`.claude/designs/curve-dedup-plan.md`). No behavior change: the template instantiated for `double` is identical to the removed free function.

## Test plan
- [x] `dal_cpp_tests --gtest_filter='*YCInstrument*:*Calibration*:*JointCalibration*:*AnalyticJacobian*:*JointAnalyticJacobian*'` — 60 tests pass (7 suites)
- [x] Full `dal_cpp_tests` — 750 tests pass (68 suites), no regressions

Verification method: built the `dal_cpp` / `dal_cpp_tests` targets in the repo's existing `build/` tree against `master` + this change only. The single edited file was synced into the main source for an incremental rebuild, then restored so the main tree is clean; the stale `bin/` binary was not used.

Co-Authored-By: Claude <noreply@anthropic.com>
