### PR TITLE
perf(curve): avoid redundant map copy in calibration solver loop

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -283,13 +283,16 @@ namespace Dal {
             // Slot a calibrated discount curve into the discount or forward position (per
             // calibrateDiscountCurve_) and return the yield-curve context the rates read from.
             CurveBlock_ YieldCurveWith(const Handle_<DiscountCurve_>& dc) const {
-                auto discountCurves = discountCurves_;
-                auto forwardCurves = forwardCurves_;
-                if (calibrateDiscountCurve_)
+                // F() runs this on every solver iteration, so copy only the map that is
+                // actually mutated and forward the unchanged member directly.
+                if (calibrateDiscountCurve_) {
+                    auto discountCurves = discountCurves_;
                     discountCurves[targetCollateral_] = dc;
-                else
-                    forwardCurves[targetTenor_] = dc;
-                return CurveBlock_(curveName_, ccy_, discountCurves, forwardCurves, liborBasis_);
+                    return CurveBlock_(curveName_, ccy_, discountCurves, forwardCurves_, liborBasis_);
+                }
+                auto forwardCurves = forwardCurves_;
+                forwardCurves[targetTenor_] = dc;
+                return CurveBlock_(curveName_, ccy_, discountCurves_, forwardCurves, liborBasis_);
             }
 
             // Returns AAD-tape Jacobian when ANALYTIC + eligible; nullptr otherwise (solver falls back to dense bumping).


### PR DESCRIPTION
## Summary

While auditing the library for performance improvements, this PR fixes the **highest-impact, lowest-effort** finding: a redundant container copy on the curve-calibration hot path.

`CurveCalibrationObjective::YieldCurveWith()` is invoked from `F(const Vector_<>& x)` on **every iteration** of the `Underdetermined` solver. The old code unconditionally copied **both** the discount-curve map and the forward-curve map, even though only one of them is ever mutated per call. The `CurveBlock_` constructor then copies the maps again internally — so each call incurred **four** map copies.

This change copies only the map that is actually modified and forwards the unchanged member directly, eliminating one full map copy per solver iteration. Behaviour is identical.

### Before
```cpp
CurveBlock_ YieldCurveWith(const Handle_<DiscountCurve_>& dc) const {
    auto discountCurves = discountCurves_;   // copy 1
    auto forwardCurves = forwardCurves_;     // copy 2 (one of these is never touched)
    if (calibrateDiscountCurve_)
        discountCurves[targetCollateral_] = dc;
    else
        forwardCurves[targetTenor_] = dc;
    return CurveBlock_(curveName_, ccy_, discountCurves, forwardCurves, liborBasis_);
}
```

### After
```cpp
CurveBlock_ YieldCurveWith(const Handle_<DiscountCurve_>& dc) const {
    if (calibrateDiscountCurve_) {
        auto discountCurves = discountCurves_;
        discountCurves[targetCollateral_] = dc;
        return CurveBlock_(curveName_, ccy_, discountCurves, forwardCurves_, liborBasis_);
    }
    auto forwardCurves = forwardCurves_;
    forwardCurves[targetTenor_] = dc;
    return CurveBlock_(curveName_, ccy_, discountCurves_, forwardCurves, liborBasis_);
}
```

## Verification
- Built `dal_cpp_tests` (MSVC, Release).
- `CalibrationTest.*` + `JointCalibrationTest.*`: **18/18 passed**.
- Full suite: **750/750 tests passed**.

## Other performance opportunities identified (not in this PR)
For follow-up, the audit also surfaced:
1. `utilities/file.cpp` — `std::endl` flushes the buffer every line on write.
2. `math/matrix/matrixarithmetic.cpp` — `Multiply` copies a whole operand to handle aliasing.
3. `curve/piecewiseconstant.cpp` — `Sofar()` accumulation loop missing `reserve()`.
4. `math/pde/fd1d.cpp` — `RollBwd` does a full vector copy twice per step.
5. `string/strings.cpp` — `Condensed()` builds a string without `reserve()`.
6. `script/simulation.hpp` — `SimResults_` uses a `map<String_,*>` lookup in the Monte Carlo loop.
7. `math/integral/quadrature.cpp` — `sqrt()` recomputed each Newton iteration in Gauss-Hermite init.
8. `utilities/dictionary.cpp` — `Has()` uses `count()` and re-`Condensed()`s keys.
9. `time/schedules.cpp` — `MakeSchedule` missing `reserve()` before its `push_back` loop.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>