### PR TITLE
refactor: hoist shared curve calibration and leg-period helpers

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -18,6 +18,7 @@
 #include <dal/curve/ycimp.hpp>
 #include <dal/curve/yclogdf.hpp>
 #include <dal/math/aad/aad.hpp>
+#include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/tapeguard.hpp>
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/matrixarithmetic.hpp>
@@ -96,20 +97,6 @@ namespace Dal {
             default:
                 return "unknown";
             }
-        }
-
-        Vector_<Handle_<YCInstrument_>> OrderInstruments(const Vector_<Handle_<YCInstrument_>>& instruments) {
-            auto ordered = instruments;
-            std::sort(ordered.begin(), ordered.end(), [](const Handle_<YCInstrument_>& lhs, const Handle_<YCInstrument_>& rhs) {
-                const auto lhsSpan = lhs->TimeSpan();
-                const auto rhsSpan = rhs->TimeSpan();
-                if (lhsSpan.second != rhsSpan.second)
-                    return lhsSpan.second < rhsSpan.second;
-                if (lhsSpan.first != rhsSpan.first)
-                    return lhsSpan.first < rhsSpan.first;
-                return lhs->Name() < rhs->Name();
-            });
-            return ordered;
         }
 
         Vector_<Date_> UniqueSortedDates(const Vector_<Date_>& dates) {
@@ -323,21 +310,9 @@ namespace Dal {
                 return true;
             }
 
-            [[nodiscard]] static const RateIndexConvention_* PhaseAFloatConvention(const YCInstrument_* inst) {
-                if (const auto* deposit = dynamic_cast<const Deposit_*>(inst))
-                    return &deposit->FloatConvention();
-                if (const auto* fra = dynamic_cast<const FRA_*>(inst))
-                    return &fra->FloatConvention();
-                if (const auto* future = dynamic_cast<const Future_*>(inst))
-                    return &future->FloatConvention();
-                if (const auto* swap = dynamic_cast<const Swap_*>(inst))
-                    return &swap->FloatConvention();
-                return nullptr;
-            }
-
             [[nodiscard]] bool InstrumentEligibleForAnalyticJacobian(const YCInstrument_* inst) const {
                 const String_ name = inst->Name();
-                const RateIndexConvention_* floatConv = PhaseAFloatConvention(inst);
+                const RateIndexConvention_* floatConv = FloatConventionOf(*inst);
                 if (!floatConv) {
                     const String_ msg = String_("AAD Jacobian has no templated rate for instrument '")
                                         + name + "'; falling back to bumped";

--- a/dal-cpp/dal/curve/calibration_internal.hpp
+++ b/dal-cpp/dal/curve/calibration_internal.hpp
@@ -1,0 +1,72 @@
+//
+// Created by dal-implementer on 2026/6/27.
+//
+
+#pragma once
+
+#include <algorithm>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/platform/platform.hpp>
+#include <dal/protocol/accrualperiod.hpp>
+#include <dal/protocol/rateconvention.hpp>
+#include <dal/time/schedules.hpp>
+
+namespace Dal {
+
+    // Shared internal helpers for single-curve and joint-curve calibration and leg-period
+    // construction. Hoisted from calibration.cpp / jointcalibration.cpp / ycinstrument.cpp /
+    // xccyinstrument.cpp to eliminate byte-identical duplication. Marked inline so the header-only
+    // definitions do not violate the ODR across translation units.
+
+    // Stable ordering of curve-calibration instruments: by maturity, then by start, then by name.
+    inline Vector_<Handle_<YCInstrument_>> OrderInstruments(const Vector_<Handle_<YCInstrument_>>& instruments) {
+        auto ordered = instruments;
+        std::sort(ordered.begin(), ordered.end(), [](const Handle_<YCInstrument_>& lhs, const Handle_<YCInstrument_>& rhs) {
+            const auto lhsSpan = lhs->TimeSpan();
+            const auto rhsSpan = rhs->TimeSpan();
+            if (lhsSpan.second != rhsSpan.second)
+                return lhsSpan.second < rhsSpan.second;
+            if (lhsSpan.first != rhsSpan.first)
+                return lhsSpan.first < rhsSpan.first;
+            return lhs->Name() < rhs->Name();
+        });
+        return ordered;
+    }
+
+    // Resolve the float index convention of a curve instrument, or nullptr if it has none.
+    // Used by Phase-A analytic-Jacobian eligibility checks (single-curve) and projection-curve
+    // routing (joint). Returns a borrowed pointer; the instrument outlives the call.
+    inline const RateIndexConvention_* FloatConventionOf(const YCInstrument_& inst) {
+        if (const auto* deposit = dynamic_cast<const Deposit_*>(&inst))
+            return &deposit->FloatConvention();
+        if (const auto* fra = dynamic_cast<const FRA_*>(&inst))
+            return &fra->FloatConvention();
+        if (const auto* future = dynamic_cast<const Future_*>(&inst))
+            return &future->FloatConvention();
+        if (const auto* swap = dynamic_cast<const Swap_*>(&inst))
+            return &swap->FloatConvention();
+        return nullptr;
+    }
+
+    // Wrap a schedule period as an accrual period with unit notional under the given day basis.
+    inline AccrualPeriod_ MakeAccrualPeriod(const SchedulePeriod_& period, const DayBasis_& basis) {
+        return AccrualPeriod_(period.accrualStart_, period.accrualEnd_, 1.0, basis, period.dayCountContext_, period.isStub_);
+    }
+
+    // Build a leg's coupon periods. PeriodT must be an aggregate initializable as
+    // {SchedulePeriod_, AccrualPeriod_} (e.g. CouponPeriod_, XccyCouponPeriod_).
+    template <class PeriodT_>
+    Vector_<PeriodT_> BuildLegPeriods(
+        const Date_& start, const Date_& maturity, const RateLegConvention_& legConvention, int fixingLag, const Holidays_& fixingHolidays) {
+        Vector_<PeriodT_> retval;
+        for (const auto& period :
+             MakeSchedulePeriods(start, maturity, legConvention.paymentFrequency_, legConvention.accrualHolidays_, fixingLag, fixingHolidays,
+                                 legConvention.paymentLag_, legConvention.paymentHolidays_, DateGeneration_("Forward"),
+                                 legConvention.businessDayConvention_, legConvention.paymentConvention_, legConvention.endOfMonth_)) {
+            retval.push_back({period, MakeAccrualPeriod(period, legConvention.dayBasis_)});
+        }
+        return retval;
+    }
+
+} // namespace Dal

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -22,6 +22,7 @@
 #include <dal/curve/ycinstrument.hpp>
 #include <dal/curve/ycpwlf.hpp>
 #include <dal/math/aad/aad.hpp>
+#include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/tapeguard.hpp>
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/optimization/underdetermined.hpp>
@@ -84,18 +85,6 @@ namespace Dal {
             }
         }
 
-        const RateIndexConvention_* FloatConventionOf(const YCInstrument_& inst) {
-            if (const auto* deposit = dynamic_cast<const Deposit_*>(&inst))
-                return &deposit->FloatConvention();
-            if (const auto* fra = dynamic_cast<const FRA_*>(&inst))
-                return &fra->FloatConvention();
-            if (const auto* future = dynamic_cast<const Future_*>(&inst))
-                return &future->FloatConvention();
-            if (const auto* swap = dynamic_cast<const Swap_*>(&inst))
-                return &swap->FloatConvention();
-            return nullptr;
-        }
-
         // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
         String_ ForwardDeclarationOffendingInstrument(const JointCurveDeclaration_& decl) {
             for (const auto& inst : decl.instruments_) {
@@ -104,20 +93,6 @@ namespace Dal {
                     return inst->Name();
             }
             return String_();
-        }
-
-        Vector_<Handle_<YCInstrument_>> OrderInstruments(const Vector_<Handle_<YCInstrument_>>& instruments) {
-            auto ordered = instruments;
-            std::sort(ordered.begin(), ordered.end(), [](const Handle_<YCInstrument_>& lhs, const Handle_<YCInstrument_>& rhs) {
-                const auto lhsSpan = lhs->TimeSpan();
-                const auto rhsSpan = rhs->TimeSpan();
-                if (lhsSpan.second != rhsSpan.second)
-                    return lhsSpan.second < rhsSpan.second;
-                if (lhsSpan.first != rhsSpan.first)
-                    return lhsSpan.first < rhsSpan.first;
-                return lhs->Name() < rhs->Name();
-            });
-            return ordered;
         }
 
         struct CurveSlot_ {

--- a/dal-cpp/dal/curve/xccyinstrument.cpp
+++ b/dal-cpp/dal/curve/xccyinstrument.cpp
@@ -4,6 +4,7 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
+#include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/discount.hpp>
 #include <dal/curve/xccycalibration.hpp>
 #include <dal/curve/xccyinstrument.hpp>
@@ -18,33 +19,6 @@ namespace Dal {
             SchedulePeriod_ schedule_;
             AccrualPeriod_ accrual_;
         };
-
-        AccrualPeriod_ MakeAccrualPeriod(const SchedulePeriod_& period, const DayBasis_& basis) {
-            return AccrualPeriod_(period.accrualStart_, period.accrualEnd_, 1.0, basis, period.dayCountContext_, period.isStub_);
-        }
-
-        Vector_<XccyCouponPeriod_> BuildLegPeriods(const Date_& start,
-                                                   const Date_& maturity,
-                                                   const RateLegConvention_& legConvention,
-                                                   int fixingLag,
-                                                   const Holidays_& fixingHolidays) {
-            Vector_<XccyCouponPeriod_> retval;
-            for (const auto& period : MakeSchedulePeriods(start,
-                                                          maturity,
-                                                          legConvention.paymentFrequency_,
-                                                          legConvention.accrualHolidays_,
-                                                          fixingLag,
-                                                          fixingHolidays,
-                                                          legConvention.paymentLag_,
-                                                          legConvention.paymentHolidays_,
-                                                          DateGeneration_("Forward"),
-                                                          legConvention.businessDayConvention_,
-                                                          legConvention.paymentConvention_,
-                                                          legConvention.endOfMonth_)) {
-                retval.push_back({period, MakeAccrualPeriod(period, legConvention.dayBasis_)});
-            }
-            return retval;
-        }
 
         double ForwardRate(const DiscountCurve_& forecast,
                            const XccyCouponPeriod_& period,
@@ -251,12 +225,12 @@ namespace Dal {
     Handle_<CrossCurrencySwap_::Rate_> CrossCurrencySwap_::Precompute() const {
         REQUIRE(!convention_.resettableNotional_, "Resettable cross-currency notionals are not implemented");
         REQUIRE(!convention_.markToMarketNotional_, "Mark-to-market cross-currency notionals are not implemented");
-        const auto domesticPeriods = BuildLegPeriods(start_,
+        const auto domesticPeriods = BuildLegPeriods<XccyCouponPeriod_>(start_,
                                                      maturity_,
                                                      convention_.domesticLeg_,
                                                      convention_.domesticIndex_.fixingLag_,
                                                      convention_.domesticIndex_.fixingHolidays_);
-        const auto foreignPeriods = BuildLegPeriods(start_,
+        const auto foreignPeriods = BuildLegPeriods<XccyCouponPeriod_>(start_,
                                                     maturity_,
                                                     convention_.foreignLeg_,
                                                     convention_.foreignIndex_.fixingLag_,

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -4,6 +4,7 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
+#include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/discount.hpp>
 #include <dal/curve/jointrate.hpp>
@@ -60,37 +61,10 @@ namespace Dal {
             return fallback->Forward(convention.forecastTenor_, convention.collateral_);
         }
 
-        AccrualPeriod_ MakeAccrualPeriod(const SchedulePeriod_& period, const DayBasis_& basis) {
-            return AccrualPeriod_(period.accrualStart_, period.accrualEnd_, 1.0, basis, period.dayCountContext_, period.isStub_);
-        }
-
         struct CouponPeriod_ {
             SchedulePeriod_ schedule_;
             AccrualPeriod_ accrual_;
         };
-
-        Vector_<CouponPeriod_> BuildLegPeriods(const Date_& start,
-                                               const Date_& maturity,
-                                               const RateLegConvention_& legConvention,
-                                               int fixingLag,
-                                               const Holidays_& fixingHolidays) {
-            Vector_<CouponPeriod_> retval;
-            for (const auto& period : MakeSchedulePeriods(start,
-                                                          maturity,
-                                                          legConvention.paymentFrequency_,
-                                                          legConvention.accrualHolidays_,
-                                                          fixingLag,
-                                                          fixingHolidays,
-                                                          legConvention.paymentLag_,
-                                                          legConvention.paymentHolidays_,
-                                                          DateGeneration_("Forward"),
-                                                          legConvention.businessDayConvention_,
-                                                          legConvention.paymentConvention_,
-                                                          legConvention.endOfMonth_)) {
-                retval.push_back({period, MakeAccrualPeriod(period, legConvention.dayBasis_)});
-            }
-            return retval;
-        }
 
         class DepositRate_ : public YCInstrument_::Rate_ {
             Date_ start_;
@@ -580,12 +554,12 @@ namespace Dal {
     pair<Date_, Date_> Swap_::TimeSpan() const { return {start_, maturity_}; }
 
     Handle_<YCInstrument_::Rate_> Swap_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
-        const auto fixedPeriods = BuildLegPeriods(start_,
+        const auto fixedPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                   maturity_,
                                                   fixedLegConvention_,
                                                   0,
                                                   Holidays::None());
-        const auto floatPeriods = BuildLegPeriods(start_,
+        const auto floatPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                   maturity_,
                                                   floatLegConvention_,
                                                   floatIndexConvention_.fixingLag_,
@@ -594,12 +568,12 @@ namespace Dal {
     }
 
     template <class T_> Handle_<Tape::Rate_<T_>> Swap_::PrecomputeT() const {
-        const auto fixedPeriods = BuildLegPeriods(start_,
+        const auto fixedPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                   maturity_,
                                                   fixedLegConvention_,
                                                   0,
                                                   Holidays::None());
-        const auto floatPeriods = BuildLegPeriods(start_,
+        const auto floatPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                   maturity_,
                                                   floatLegConvention_,
                                                   floatIndexConvention_.fixingLag_,
@@ -608,12 +582,12 @@ namespace Dal {
     }
 
     template <class T_> Handle_<Tape::JointRate_<T_>> Swap_::PrecomputeProjectionT() const {
-        const auto fixedPeriods = BuildLegPeriods(start_,
+        const auto fixedPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                   maturity_,
                                                   fixedLegConvention_,
                                                   0,
                                                   Holidays::None());
-        const auto floatPeriods = BuildLegPeriods(start_,
+        const auto floatPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                   maturity_,
                                                   floatLegConvention_,
                                                   floatIndexConvention_.fixingLag_,
@@ -685,12 +659,12 @@ namespace Dal {
     pair<Date_, Date_> BasisSwap_::TimeSpan() const { return {start_, maturity_}; }
 
     Handle_<YCInstrument_::Rate_> BasisSwap_::Precompute(const Handle_<YieldCurve_>& funding_yc) const {
-        const auto spreadPeriods = BuildLegPeriods(start_,
+        const auto spreadPeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                    maturity_,
                                                    spreadLegConvention_,
                                                    spreadIndexConvention_.fixingLag_,
                                                    spreadIndexConvention_.fixingHolidays_);
-        const auto referencePeriods = BuildLegPeriods(start_,
+        const auto referencePeriods = BuildLegPeriods<CouponPeriod_>(start_,
                                                       maturity_,
                                                       referenceLegConvention_,
                                                       referenceIndexConvention_.fixingLag_,


### PR DESCRIPTION
## Summary
- Add `dal-cpp/dal/curve/calibration_internal.hpp` (internal, header-only, all helpers `inline`) holding four byte-identical helpers previously duplicated across the single-curve and joint-curve paths.
- Hoist `OrderInstruments` (was in `calibration.cpp` and `jointcalibration.cpp` anonymous namespaces).
- Unify the float-convention lookup as `FloatConventionOf(const YCInstrument_&)`, merging the `jointcalibration.cpp` free function with the `calibration.cpp` `PhaseAFloatConvention(const YCInstrument_*)` static method. The single pointer call site is updated to `FloatConventionOf(*inst)`.
- Hoist `MakeAccrualPeriod(period, basis)` (was in `ycinstrument.cpp` and `xccyinstrument.cpp`).
- Templatize `BuildLegPeriods` on the period struct. `ycinstrument.cpp` now calls `BuildLegPeriods<CouponPeriod_>` (8 sites) and `xccyinstrument.cpp` calls `BuildLegPeriods<XccyCouponPeriod_>` (2 sites). Both period structs are `{SchedulePeriod_, AccrualPeriod_}` aggregates, so one template body serves both.
- `ParamsPerKnot` is intentionally left duplicated: the single-curve version accepts `LOG_DISCOUNT` while the joint version throws, so they are semantically divergent and out of scope for this refactor.

## Test plan
- [x] Build `dal_cpp_tests` from a clean `build/` in an isolated worktree (from-scratch configure + build).
- [x] Step 4 filter `*Calibration*:*JointCalibration*` — 31 tests pass.
- [x] Step 5 filter `*YCInstrument*:*Xccy*` — 32 tests pass (combined run: 57 tests pass).
- [x] Full `dal_cpp_tests` suite — all 752 tests pass.
- [x] `clang-format` clean on the new header; the four edited `.cpp` files retain pre-existing formatting drift (unchanged from `origin/master`) and my edits match the surrounding style.

Co-Authored-By: Claude <noreply@anthropic.com>