### PR TITLE
fix: COM lifetime, undefined enum decls, FX parser registration

### DIFF
--- a/dal-cpp/dal/auto/MG_Clearer_enum.hpp
+++ b/dal-cpp/dal/auto/MG_Clearer_enum.hpp
@@ -25,8 +25,6 @@ public:
     explicit Clearer_(const String_& src);
     const char* String() const;
     Value_ Switch() const {return val_;}
-	// idiosyncratic (hand-written) members:
-    CollateralType_ Collateral() const;
     Clearer_() : val_(Value_::_NOT_SET) {};
 };
 

--- a/dal-cpp/dal/auto/MG_OptionType_enum.hpp
+++ b/dal-cpp/dal/auto/MG_OptionType_enum.hpp
@@ -28,7 +28,6 @@ public:
     Value_ Switch() const {return val_;}
 	// idiosyncratic (hand-written) members:
     template<class T_> T_ Payout(T_ spot, T_ strike) const;
-    OptionType_ Opposite() const;
     OptionType_() : val_(Value_::_NOT_SET) {};
 };
 

--- a/dal-cpp/dal/indice/parser/init.cpp
+++ b/dal-cpp/dal/indice/parser/init.cpp
@@ -8,6 +8,7 @@
 #include <dal/string/strings.hpp>
 #include <dal/indice/indexparse.hpp>
 #include <dal/indice/parser/equity.hpp>
+#include <dal/indice/parser/fx.hpp>
 
 namespace Dal {
 
@@ -16,6 +17,7 @@ namespace Dal {
     void IndexParsers_::Init() {
         if (!init_) {
             Index::RegisterParser("EQ", Index::EquityParser);
+            Index::RegisterParser("FX", Index::FxParser);
             init_ = true;
         }
     }

--- a/dal-cpp/dal/io/exceldriverlite.cpp
+++ b/dal-cpp/dal/io/exceldriverlite.cpp
@@ -59,33 +59,23 @@ namespace Dal {
         THROW(String_(description));
     }
 
-    class ComInitializer_ {
-    private:
-        bool initialized_;
-    public:
-        ComInitializer_() : initialized_(false) {
-            HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-            if (SUCCEEDED(hr)) {
-                initialized_ = true;
-            } else if (hr != S_FALSE) {
-                // S_FALSE means COM is already initialized on this thread, which is OK
-                THROW(String_("CoInitializeEx failed"));
-            }
+    ComInitializer_::ComInitializer_() : initialized_(false) {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        if (SUCCEEDED(hr)) {
+            initialized_ = true;
+        } else if (hr != S_FALSE) {
+            // S_FALSE means COM is already initialized on this thread, which is OK
+            THROW(String_("CoInitializeEx failed"));
         }
+    }
 
-        ~ComInitializer_() {
-            if (initialized_) {
-                CoUninitialize();
-            }
+    ComInitializer_::~ComInitializer_() {
+        if (initialized_) {
+            CoUninitialize();
         }
+    }
 
-        ComInitializer_(const ComInitializer_&) = delete;
-        ComInitializer_& operator=(const ComInitializer_&) = delete;
-    };
-
-    ExcelDriver_::ExcelDriver_(int currentColumn) : curDataColumn_(currentColumn) {
-        ComInitializer_ comInit;
-
+    ExcelDriver_::ExcelDriver_(int currentColumn) : comInit_(), curDataColumn_(currentColumn) {
         try {
             xl_.CreateInstance(L"Excel.Application");
             xl_->Workbooks->Add((long)Excel::xlWorksheet);
@@ -113,7 +103,8 @@ namespace Dal {
         } catch (...) {
             // Destructors must not throw; continue with COM uninitialization.
         }
-        // COM is automatically uninitialized when ComInitializer_ is destroyed during static destruction
+        // comInit_ is destroyed after xl_ (reverse declaration order), so COM
+        // stays valid while xl_ is released above.
     }
 
 

--- a/dal-cpp/dal/io/exceldriverlite.cpp
+++ b/dal-cpp/dal/io/exceldriverlite.cpp
@@ -61,10 +61,13 @@ namespace Dal {
 
     ComInitializer_::ComInitializer_() : initialized_(false) {
         HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        // SUCCEEDED treats both S_OK and S_FALSE as success. S_FALSE means COM
+        // was already initialized on this thread; either way we own a matching
+        // CoUninitialize call, so record initialization. Any other HRESULT is a
+        // real failure.
         if (SUCCEEDED(hr)) {
             initialized_ = true;
-        } else if (hr != S_FALSE) {
-            // S_FALSE means COM is already initialized on this thread, which is OK
+        } else {
             THROW(String_("CoInitializeEx failed"));
         }
     }

--- a/dal-cpp/dal/io/exceldriverlite.hpp
+++ b/dal-cpp/dal/io/exceldriverlite.hpp
@@ -15,8 +15,26 @@
 #include <dal/io/excelimport.hpp>
 
 namespace Dal {
+    // Initializes COM for the lifetime of the enclosing object. Declared as the
+    // first member of ExcelDriver_ so it is destroyed after xl_, keeping COM
+    // available for every COM call issued through the driver.
+    class ComInitializer_ {
+    private:
+        bool initialized_;
+
+    public:
+        ComInitializer_();
+        ~ComInitializer_();
+
+        ComInitializer_(const ComInitializer_&) = delete;
+        ComInitializer_& operator=(const ComInitializer_&) = delete;
+    };
+
     class ExcelDriver_ {
     private:
+        // Declaration order matters: comInit_ must outlive xl_ so that COM is
+        // still initialized when xl_ is released in the destructor.
+        ComInitializer_ comInit_;
         Excel::_ApplicationPtr xl_;
 
         int curDataColumn_;

--- a/dal-cpp/dal/protocol/clearer.hpp
+++ b/dal-cpp/dal/protocol/clearer.hpp
@@ -6,7 +6,6 @@
 
 #include <dal/math/vectors.hpp>
 #include <dal/utilities/exceptions.hpp>
-#include <dal/protocol/collateraltype.hpp>
 
 /*IF--------------------------------------------------------------------------
 enumeration Clearer
@@ -14,7 +13,6 @@ enumeration Clearer
 switchable
 alternative CME
 alternative LCH
-method CollateralType_ Collateral() const;
 -IF-------------------------------------------------------------------------*/
 
 namespace Dal {

--- a/dal-cpp/dal/protocol/optiontype.hpp
+++ b/dal-cpp/dal/protocol/optiontype.hpp
@@ -16,7 +16,6 @@ alternative CALL C
 alternative PUT P
 alternative STRADDLE V C+P
 method template<class T_> T_ Payout(T_ spot, T_ strike) const;
-method OptionType_ Opposite() const;
 -IF------------------------------------------------------*/
 
 namespace Dal {

--- a/dal-cpp/tests/indice/parser/test_fx.cpp
+++ b/dal-cpp/tests/indice/parser/test_fx.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <dal/platform/platform.hpp>
 #include <dal/indice/index.hpp>
+#include <dal/indice/indexparse.hpp>
 #include <dal/string/strings.hpp>
 #include <dal/indice/parser/fx.hpp>
 
@@ -13,5 +14,14 @@ using namespace Dal;
 TEST(IndexTest, TestFxParser) {
     String_ name = "FX[USD/JPY]";
     std::unique_ptr<Index_> index(Index::FxParser(name));
+    ASSERT_EQ(index->Name(), name);
+}
+
+TEST(IndexTest, TestFxParserRegisteredWithIndexParse) {
+    // The parser must be reachable via Index::Parse, not only by calling
+    // Index::FxParser directly. Without registration Index::Parse falls through
+    // to a REQUIRE failure ("no parser for 'FX[USD/JPY]'").
+    String_ name = "FX[USD/JPY]";
+    std::unique_ptr<Index_> index(Index::Parse(name));
     ASSERT_EQ(index->Name(), name);
 }


### PR DESCRIPTION
## Summary

Three minimal bug fixes in io/protocol/indice.

### 1. `dal-cpp/dal/io/exceldriverlite.{hpp,cpp}` — COM initializer lifetime
The `ExcelDriver_` constructor declared `ComInitializer_ comInit;` as a function-local, so `~ComInitializer_()` (which calls `CoUninitialize()`) ran at constructor exit. Every later COM call through the driver therefore ran with COM uninitialized.

**Fix:** promote `ComInitializer_` to a class declared in the header, and make `comInit_` the first member of `ExcelDriver_` (declared before `xl_`). Members are destroyed in reverse declaration order, so `xl_` is released before `comInit_` tears down COM. The constructor now initialises `comInit_()` in the member-initializer list.

> Note: this file is Windows/MSVC-only (`USE_EXCEL_REPORT` + `#import`), so it does **not** build on Linux and is not locally build-verified. The CI `msvc` job will verify it compiles.

### 2. `dal-cpp/dal/protocol/optiontype.hpp` & `clearer.hpp` — never-defined methods (investigation)
The Machinist markup declared `OptionType_::Opposite()` and `Clearer_::Collateral()`, producing declarations in the generated headers but no definitions — a latent link error the moment either is called.

**Investigation result:** `grep` across the whole repo (excluding `externals/`, `build/`, `auto/`, and stale `.claude/worktrees/` copies) finds **zero call sites** for `.Opposite()` on `OptionType_` and zero for `.Collateral()` on `Clearer_`.

**Decision: remove the `method` lines from the markup** and regenerate via Machinist. The undefined declarations disappear from `dal-cpp/dal/auto/MG_OptionType_enum.hpp` and `MG_Clearer_enum.hpp`. The now-unused `#include <dal/protocol/collateraltype.hpp>` is dropped from `clearer.hpp`. If a caller is added later, the method can be re-introduced with a definition.

### 3. `dal-cpp/dal/indice/parser/` — FxParser never registered (investigation)
`FxParser` (`parser/fx.cpp`) is defined and exported but never registered in `IndexParsers_::Init` (only `EquityParser` is). `Index::Parse("FX[USD/JPY]")` extracts the `FX` prefix, fails to find it in `TheIndexParsers()`, and throws via `REQUIRE("no parser for 'FX[USD/JPY]'")`.

**Investigation result:** `Index::Parse` is clearly designed to dispatch by prefix, and FX parsing is expected — there are existing tests at `dal-cpp/tests/indice/parser/test_fx.cpp` and `dal-cpp/tests/indice/index/test_fx.cpp` that exercise `Index::FxParser` directly (so they never hit the registration gap). No callers depend on `Index::Parse` rejecting FX.

**Decision: register it** — `Index::RegisterParser("FX", Index::FxParser)` in `IndexParsers_::Init`, mirroring the EquityParser line. This is the safe, additive option flagged in the task.

Added a TDD regression test `TestFxParserRegisteredWithIndexParse` that calls `Index::Parse("FX[USD/JPY]")` (confirmed RED before the fix with the exact `no parser for 'FX[USD/JPY]'` failure, then GREEN after).

## Test plan
- [x] Built `dal_cpp` in an isolated `build-fix-io/` directory (did **not** touch the shared `build/`)
- [x] `bin`-equivalent run: new test confirmed RED before fix #3, GREEN after
- [x] Full `dal_cpp_tests` suite: **753 tests from 68 suites, all passing** (run via `./dal-cpp/dal_cpp_tests` in the isolated build dir)
- [x] Indice/protocol tests green
- [ ] Fix #1 (Excel COM) is Windows-only — **not locally build-verified on Linux**; CI `msvc` job will verify
- [x] Style self-review against `.claude/rules/code-style.md` and `unit-test-style.md` — clean (also added a missing trailing newline to `parser/init.cpp`)