### PR TITLE
fix: guard BS Allocate and drop redundant const_cast

### DIFF
--- a/dal-cpp/dal/model/base.hpp
+++ b/dal-cpp/dal/model/base.hpp
@@ -38,7 +38,7 @@ namespace Dal {
             [[nodiscard]] virtual const Vector_<T_*>& Parameters() const = 0;
             [[nodiscard]] virtual const Vector_<String_>& ParameterLabels() const = 0;
 
-            [[nodiscard]] size_t NumParams() const { return const_cast<Model_*>(this)->Parameters().size(); }
+            [[nodiscard]] size_t NumParams() const { return Parameters().size(); }
         };
     }
 

--- a/dal-cpp/dal/model/blackscholes.hpp
+++ b/dal-cpp/dal/model/blackscholes.hpp
@@ -87,7 +87,7 @@ namespace Dal {
             }
 
             void Allocate(const Vector_<>& productTimeLine, const Vector_<SampleDef_>& defLine) override {
-                REQUIRE(!productTimeLine.empty(), "empty product timeline");
+                REQUIRE(!productTimeLine.empty(), "BlackScholes_::Allocate: empty product timeline");
                 timeLine_.clear();
                 timeLine_.push_back(0);
 

--- a/dal-cpp/dal/model/blackscholes.hpp
+++ b/dal-cpp/dal/model/blackscholes.hpp
@@ -87,6 +87,7 @@ namespace Dal {
             }
 
             void Allocate(const Vector_<>& productTimeLine, const Vector_<SampleDef_>& defLine) override {
+                REQUIRE(!productTimeLine.empty(), "empty product timeline");
                 timeLine_.clear();
                 timeLine_.push_back(0);
 


### PR DESCRIPTION
## Summary
- Add `REQUIRE(!productTimeLine.empty(), ...)` to `BlackScholes_<T_>::Allocate` so an empty product timeline throws `Dal::Exception_` instead of reading `productTimeLine[0]` as undefined behavior. `Allocate` is a public override, so the unguarded index-0 access was reachable from any caller.
- Drop the `const_cast<Model_*>(this)` in `Model_<T_>::NumParams`. `Parameters()` is already declared `const`, so the cast defeated const-correctness for no benefit; `NumParams` now simply returns `Parameters().size()`.

## Test plan
- [x] `bin/dal_cpp_tests --gtest_filter='ModelTest.*:AADTest.*:BlackScholesTest.*'` — 30/30 pass
- [x] Full `bin/dal_cpp_tests` — 752/752 pass (no regressions)
- [x] Standalone verifier compiled against the patched `dal_cpp` library: `Allocate` with an empty timeline throws `Dal::Exception_`; `Allocate` with a valid `{0.0, 1.0}` timeline still runs, `NumParams()` returns 4, and `GeneratePath` produces `spot_=100` at t=0.