### PR TITLE
fix: latent infra bugs in storage/concurrency/platform/time/string/composite

### DIFF
--- a/dal-cpp/dal/concurrency/threadpool.cpp
+++ b/dal-cpp/dal/concurrency/threadpool.cpp
@@ -23,7 +23,7 @@ namespace Dal {
 
     void ThreadPool_::Start(size_t n_threads, bool restart) {
         const size_t hw = std::max<unsigned>(1u, std::thread::hardware_concurrency());
-        if (n_threads <= 0 || n_threads > hw)
+        if (n_threads == 0 || n_threads > hw)
             n_threads = hw;
 
         if (active_ && restart)

--- a/dal-cpp/dal/concurrency/threadpool.cpp
+++ b/dal-cpp/dal/concurrency/threadpool.cpp
@@ -22,8 +22,9 @@ namespace Dal {
     }
 
     void ThreadPool_::Start(size_t n_threads, bool restart) {
-        if (n_threads <= 0 || n_threads > std::thread::hardware_concurrency())
-            n_threads = std::thread::hardware_concurrency();
+        const size_t hw = std::max<unsigned>(1u, std::thread::hardware_concurrency());
+        if (n_threads <= 0 || n_threads > hw)
+            n_threads = hw;
 
         if (active_ && restart)
             Stop();

--- a/dal-cpp/dal/platform/platform.hpp
+++ b/dal-cpp/dal/platform/platform.hpp
@@ -60,12 +60,14 @@ namespace Dal {
     template <class T_> constexpr bool IsNegative(const T_& x) { return x <= -Dal::EPSILON; }
 
     template <class T_> constexpr bool IsClose(const T_& x, const T_& y) {
-        T_ diff = std::abs(x-y);
+        const T_ diff = x < y ? y - x : x - y;
         constexpr double tolerance = 42 * Dal::EPSILON;
 
         if (x == 0.0 || y == 0.0)
             return diff < (tolerance * tolerance);
-        return diff <= tolerance * std::abs(x) && diff <= tolerance * std::abs(y);
+        const T_ absX = x < T_(0) ? -x : x;
+        const T_ absY = y < T_(0) ? -y : y;
+        return diff <= tolerance * absX && diff <= tolerance * absY;
     }
 
     FORCE_INLINE constexpr double Square(double x) { return x * x; }

--- a/dal-cpp/dal/storage/globals.cpp
+++ b/dal-cpp/dal/storage/globals.cpp
@@ -13,6 +13,7 @@
 #include <dal/math/matrix/matrixs.hpp>
 #include <dal/math/matrix/matrixutils.hpp>
 #include <dal/time/dateutils.hpp>
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal {
 
@@ -90,9 +91,9 @@ namespace Dal {
         FixHistory_ retval;
         if (stored.Empty())
             return retval;
-        assert(stored.Cols() == 2);
-        assert(AllOf(stored.Col(0), Cell::TypeCheck_<DateTime_>()));
-        assert(AllOf(stored.Col(0), Cell::TypeCheck_<double>()));
+        REQUIRE(stored.Cols() == 2, "Fixings store must have 2 columns (date, value)");
+        REQUIRE(AllOf(stored.Col(0), Cell::TypeCheck_<DateTime_>()), "Fixings store column 0 must hold dates");
+        REQUIRE(AllOf(stored.Col(1), Cell::TypeCheck_<double>()), "Fixings store column 1 must hold values");
         const int n = stored.Rows();
         retval.vals_.Resize(n);
         for (int ii = 0; ii < n; ++ii)

--- a/dal-cpp/dal/string/strings.hpp
+++ b/dal-cpp/dal/string/strings.hpp
@@ -60,7 +60,7 @@ namespace Dal {
         String_(const base_t& src) : base_t(src) {}
         String_(const size_t size, const char val) : base_t(size, val) {}
         template <class I_> String_(I_ begin, I_ end) : base_t(begin, end) {}
-        explicit String_(const std::string& src) : base_t(*reinterpret_cast<const String_*>(&src)) {}
+        explicit String_(const std::string& src) : base_t(src.begin(), src.end()) {}
         void Swap(String_* other) { swap(*other); }
         friend std::ostream& operator<<(std::ostream& os, const String_& src);
     };

--- a/dal-cpp/dal/time/daybasis.cpp
+++ b/dal-cpp/dal/time/daybasis.cpp
@@ -77,8 +77,7 @@ namespace Dal {
         case Value_::BOND:
             return Bond(from, to);
         default:
-            assert(!"Unrecognized day basis");
-            return 0.0;
+            THROW("Unrecognized day basis");
         }
     }
 } // namespace Dal

--- a/dal-cpp/dal/utilities/composite.hpp
+++ b/dal-cpp/dal/utilities/composite.hpp
@@ -53,19 +53,19 @@ namespace Dal {
         T_& operator=(const T_& rhs);
     };
 
-    template <class T_> Composite_<T_>& CastComposite(T_* src) { return dynamic_cast<Composite_<T_>*>(src); }
+    template <class T_> Composite_<T_>* CastComposite(T_* src) { return dynamic_cast<Composite_<T_>*>(src); }
 
     template <class T_> Composite_<T_>& CoerceComposite(T_* src) {
         assert(dynamic_cast<Composite_<T_>*>(src));
         return static_cast<Composite_<T_>&>(*src);
     }
 
-    template <class T_> const Composite_<T_>& CastComposite(const T_* src) {
-        return dynamic_cast<Composite_<T_>*>(src);
+    template <class T_> const Composite_<T_>* CastComposite(const T_* src) {
+        return dynamic_cast<const Composite_<T_>*>(src);
     }
 
     template <class T_> const Composite_<T_>& CoerceComposite(const T_* src) {
-        assert(dynamic_cast<Composite_<T_>*>(src));
-        return static_cast<Composite_<T_>&>(*src);
+        assert(dynamic_cast<const Composite_<T_>*>(src));
+        return static_cast<const Composite_<T_>&>(*src);
     }
 } // namespace Dal


### PR DESCRIPTION
## Summary

Minimal fixes for a 7-bug cluster in core infrastructure (risk/storage/concurrency/platform/time/utilities/string). Six real fixes land; one item from the spec was already fixed on master.

- **storage/globals.cpp** — fixings-store type checks were debug-only `assert` (no-ops in NDEBUG) and the `double` check inspected `Col(0)` (the dates column) instead of `Col(1)` (the values column) due to a copy-paste. Promoted all three to `REQUIRE` and pointed the value check at `Col(1)`.
- **concurrency/threadpool.cpp** — when `std::thread::hardware_concurrency()` returns 0, `n_threads` became 0 and the `n_threads - 1` `size_t` reserve underflowed. Clamped `hardware_concurrency()` to >= 1.
- **platform/platform.hpp** — `IsClose` is declared `constexpr` but called `std::abs`, which is not `constexpr` in C++17, so the `constexpr` was ill-formed. Replaced `std::abs` with `constexpr` ternary expressions; behavior unchanged.
- **time/daybasis.cpp** — unknown day-count fell through to `assert + return 0.0`, silently yielding a valid 0.0 year-fraction in release builds. Replaced with `THROW` so unrecognized day-counts fail loudly.
- **string/strings.hpp** — `String_(const std::string&)` used `reinterpret_cast` between `std::string` and `String_` (different `char_traits`), which is strict-aliasing UB. Now constructs `base_t` from the source iterators.
- **utilities/composite.hpp** — `CastComposite` declared a reference return but returned a (possibly-null) `dynamic_cast` pointer, and the const overload could not legally cast away const. Returns a nullable pointer and uses a const-correct `dynamic_cast` in the const overload.
- **risk/report.cpp** — the `SetAll` self-compare tautology (`vals.size() >= vals.size()`) called out in the spec is **already fixed on master** (`vals_.size()`); no change needed.

### Design choices worth flagging

- **composite.hpp (bug 6):** chose the nullable-pointer return form for `CastComposite` over `THROW`-on-failure. `CastComposite` is the "maybe" variant (vs `CoerceComposite`, the assert-then-cast "I'm sure" variant), so a nullable result is semantically correct. It also has zero callers in the repo, so the signature change is safe. Also fixed a latent const-correctness bug in the const `CoerceComposite` overload (was `dynamic_cast<Composite_<T_>*>` on a `const T_*`, which is ill-formed — now `dynamic_cast<const Composite_<T_>*>`).
- **strings.hpp (bug 7):** did **not** mark `String_(const char*)` `explicit` (spec said "optionally"). 168+ call sites rely on implicit construction from string literals, including copy-init patterns like `String_ s = "..."`. Marking it explicit would break those and is out of scope for a minimal fix.

## Test plan

- [x] Baseline: full `dal_cpp_tests` on unmodified master — 752 tests pass
- [x] Rebuild `dal_cpp` + `dal_cpp_tests` with all fixes (Release/NDEBUG build, which is what reveals the NDEBUG-only bugs 2 and 5)
- [x] Full `dal_cpp_tests` after fixes — **752 tests pass** (zero regressions)
- [x] Full `dal_public_tests` after fixes — **37 tests pass**
- [x] Targeted: `DayBasisTest` (4), `StringTest`/`StringUtilsTest` (6), storage/fixings (22), concurrency (4), `MeshersTest` (exercises `IsClose`, 2) — all green
- [x] Full workspace build (lib + public + examples + benchmarks) compiles clean against the header changes