### PR TITLE
chore: de-duplicate script visitors and AAD simulation path

### DIFF
--- a/dal-cpp/dal/script/simulation.hpp
+++ b/dal-cpp/dal/script/simulation.hpp
@@ -205,51 +205,46 @@ namespace Dal::Script {
 
                 double sumValue = 0.0;
                 auto& results = simResults(threadNum);
+
+                auto runPaths = [&](auto& evaluator, auto evaluate) {
+                    InitModel4ParallelAAD(product, *model, path, evaluator);
+                    for (size_t i = 0; i < pathsInTask; i++) {
+                        AAD::RewindToMark(*AAD::Tape());
+                        random->FillNormal(&gVec);
+                        model->GeneratePath(gVec, &path);
+                        evaluate(path, evaluator);
+                        AAD::Number_ res = evaluator.VarVals()[payoffIndex];
+                        Adjoint(res) = 1.0;
+                        AAD::PropagateToMark(*AAD::Tape());
+                        sumValue += Value(res);
+                    }
+                };
+
+                // Accumulate const-var risks into results.risks_ from whichever evaluator was used
+                auto accumulateConstVarRisks = [&](const auto& constVarVals) {
+                    for (size_t j = 0; j < nConstVars; ++j)
+                        results.risks_[j + nParams] += Adjoint(constVarVals[j]) / static_cast<double>(nPaths);
+                };
+
                 if (compiled) {
                     EvalState_<AAD::Number_> evalState = product.BuildEvalState<AAD::Number_>();
-                    InitModel4ParallelAAD(product, *model, path, evalState);
-
-                    for (size_t i = 0; i < pathsInTask; i++) {
-                        AAD::RewindToMark(*AAD::Tape());
-                        random->FillNormal(&gVec);
-                        model->GeneratePath(gVec, &path);
-                        product.EvaluateCompiled(path, evalState);
-                        AAD::Number_ res = evalState.VarVals()[payoffIndex];
-                        Adjoint(res) = 1.0;
-                        AAD::PropagateToMark(*AAD::Tape());
-                        sumValue += Value(res);
-                    }
-
+                    runPaths(evalState, [&](Scenario_<AAD::Number_>& p, EvalState_<AAD::Number_>& e) {
+                        product.EvaluateCompiled(p, e);
+                    });
                     AAD::PropagateMarkToStart(*AAD::Tape());
-                    for (size_t j = 0; j < nParams; ++j)
-                        results.risks_[j] += Adjoint(*model->Parameters()[j]) / static_cast<double>(nPaths);
-
-                    for (size_t j = 0; j < nConstVars; ++j)
-                        results.risks_[j + nParams] +=  Adjoint(evalState.ConstVarVals()[j]) / static_cast<double>(nPaths);
-                }
-                else {
+                    accumulateConstVarRisks(evalState.ConstVarVals());
+                } else {
                     FuzzyEvaluator_<AAD::Number_> eval = product.BuildFuzzyEvaluator<AAD::Number_>(maxNestedIfs, eps);
-                    InitModel4ParallelAAD(product, *model, path, eval);
-
-                    for (size_t i = 0; i < pathsInTask; i++) {
-                        AAD::RewindToMark(*AAD::Tape());
-                        random->FillNormal(&gVec);
-                        model->GeneratePath(gVec, &path);
-                        product.Evaluate(path, eval);
-                        AAD::Number_ res = eval.VarVals()[payoffIndex];
-                        Adjoint(res) = 1.0;
-                        AAD::PropagateToMark(*AAD::Tape());
-                        sumValue += Value(res);
-                    }
-
+                    runPaths(eval, [&](Scenario_<AAD::Number_>& p, FuzzyEvaluator_<AAD::Number_>& e) {
+                        product.Evaluate(p, e);
+                    });
                     AAD::PropagateMarkToStart(*AAD::Tape());
-                    for (size_t j = 0; j < nParams; ++j)
-                        results.risks_[j] += Adjoint(*model->Parameters()[j]) / static_cast<double>(nPaths);
-
-                    for (size_t j = 0; j < nConstVars; ++j)
-                        results.risks_[j + nParams] +=  Adjoint(eval.ConstVarVals()[j]) / static_cast<double>(nPaths);
-
+                    accumulateConstVarRisks(eval.ConstVarVals());
                 }
+
+                for (size_t j = 0; j < nParams; ++j)
+                    results.risks_[j] += Adjoint(*model->Parameters()[j]) / static_cast<double>(nPaths);
+
                 results.aggregated_ += sumValue;
                 return true;
             }));

--- a/dal-cpp/dal/script/visitor/debugger.hpp
+++ b/dal-cpp/dal/script/visitor/debugger.hpp
@@ -57,6 +57,17 @@ namespace Dal::Script {
             stack_.Push(std::move(str));
         }
 
+        void DebugComp(const CompNode_& node, const char* label) {
+            String_ s = label;
+            if (!node.isDiscrete_) {
+                s += String_("[CONT,EPS=" + std::to_string(node.eps_) + "]");
+            } else {
+                s += "[DISCRETE,";
+                s += String_("BOUNDS=" + std::to_string(node.lb_) + "," + std::to_string(node.rb_) + "]");
+            }
+            Debug(node, s);
+        }
+
     public:
         using ConstVisitor_::Visit;
 
@@ -80,44 +91,16 @@ namespace Dal::Script {
         void Visit(const NodeMax_& node) { Debug(node, "MAX"); }
         void Visit(const NodeMin_& node) { Debug(node, "MIN"); }
 
-        void Visit(const NodeEqual_& node) {
-            String_ s = "EQUALZERO";
-
-            if (!node.isDiscrete_) {
-                s += String_("[CONT,EPS=" + std::to_string(node.eps_) + "]");
-            } else {
-                s += String_("[DISCRETE,");
-                s += String_("BOUNDS=" + std::to_string(node.lb_) + "," + std::to_string(node.rb_) + "]");
-            }
-            Debug(node, s);
-        }
+        void Visit(const NodeEqual_& node) { DebugComp(node, "EQUALZERO"); }
 
         void Visit(const NodeNot_& node) {
             const String_ s = "NOT";
             Debug(node, s);
         }
 
-        void Visit(const NodeSup_& node) {
-            String_ s = "GTZERO";
-            if (!node.isDiscrete_) {
-                s += String_("[CONT,EPS=" + std::to_string(node.eps_) + "]");
-            } else {
-                s += "[DISCRETE,";
-                s += String_("BOUNDS=" + std::to_string(node.lb_) + "," + std::to_string(node.rb_) + "]");
-            }
-            Debug(node, s);
-        }
+        void Visit(const NodeSup_& node) { DebugComp(node, "GTZERO"); }
 
-        void Visit(const NodeSupEqual_& node) {
-            String_ s = "GTEQUALZERO";
-            if (!node.isDiscrete_) {
-                s += String_("[CONT,EPS=" + std::to_string(node.eps_) + "]");
-            } else {
-                s += "[DISCRETE,";
-                s += String_("BOUNDS=" + std::to_string(node.lb_) + "," + std::to_string(node.rb_) + "]");
-            }
-            Debug(node, s);
-        }
+        void Visit(const NodeSupEqual_& node) { DebugComp(node, "GTEQUALZERO"); }
 
         void Visit(const NodeAnd_& node) {
             const String_ s = "AND";

--- a/dal-cpp/dal/script/visitor/domainproc.hpp
+++ b/dal-cpp/dal/script/visitor/domainproc.hpp
@@ -52,29 +52,24 @@ namespace Dal::Script {
 
         // Expressions — binaries
 
-        void Visit(NodeAdd_& node) {
+        template <class OP_> void VisitBinary(Node_& node, const OP_& op) {
             VisitArguments(node);
-            Domain_ res = domStack_[1] + domStack_[0];
+            Domain_ res = op(domStack_[1], domStack_[0]);
             domStack_.Pop(2);
             domStack_.Push(std::move(res));
+        }
+
+        void Visit(NodeAdd_& node) {
+            VisitBinary(node, [](const Domain_& x, const Domain_& y) { return x + y; });
         }
         void Visit(NodeSub_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_[1] - domStack_[0];
-            domStack_.Pop(2);
-            domStack_.Push(std::move(res));
+            VisitBinary(node, [](const Domain_& x, const Domain_& y) { return x - y; });
         }
         void Visit(NodeMulti_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_[1] * domStack_[0];
-            domStack_.Pop(2);
-            domStack_.Push(std::move(res));
+            VisitBinary(node, [](const Domain_& x, const Domain_& y) { return x * y; });
         }
         void Visit(NodeDiv_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_[1] / domStack_[0];
-            domStack_.Pop(2);
-            domStack_.Push(std::move(res));
+            VisitBinary(node, [](const Domain_& x, const Domain_& y) { return x / y; });
         }
         void Visit(NodePow_& node) {
             VisitArguments(node);


### PR DESCRIPTION
## Summary
Phase 2 (duplication unify), Wave 1, cluster `dal-cpp/dal/script/`. Three byte-identical refactorings, outputs unchanged.

- **`dal-cpp/dal/script/visitor/debugger.hpp`** — extract `DebugComp(const CompNode_&, const char*)` private helper. `NodeEqual_`, `NodeSup_`, `NodeSupEqual_` `Visit` methods were byte-for-byte identical except the label string; they become one-line delegations.
- **`dal-cpp/dal/script/visitor/domainproc.hpp`** — introduce `template <class OP_> void VisitBinary(Node_&, const OP_&)` mirroring the existing pattern in `constprocessor.hpp` and `evaluator.hpp`. The four `Visit(NodeAdd_/NodeSub_/NodeMulti_/NodeDiv_)` bodies collapse to one-line delegations. `NodePow`/`NodeMax`/`NodeMin` and unaries left untouched (genuinely distinct stack semantics).
- **`dal-cpp/dal/script/simulation.hpp`** (`MCSimulation<AAD::Number_>`) — the per-path recording loop was duplicated in the `compiled`/`else` branches, differing only by evaluator type (`EvalState_` vs `FuzzyEvaluator_`) and the product call (`EvaluateCompiled` vs `Evaluate`). Factored into a `runPaths(evaluator, evaluate)` generic lambda. The verbatim params risk-accumulation loop is hoisted out of the branch (no evaluator dependency); the const-vars risk loop is hoisted into an `accumulateConstVarRisks(constVarVals)` lambda called per branch with the branch-local evaluator. AAD recording order (`RewindToMark` per path, `PropagateToMark` per path, `PropagateMarkToStart` before reading adjoints) preserved exactly.

No result or tolerance shifts.

## Test plan
- [x] `dal_cpp_tests` built and run on **adept** backend: 752/752 pass (171/171 on focused `*Script*:*Compiler*:*Evaluator*:*Fuzzy*:*Debugger*:*Domain*` filter)
- [x] `dal_cpp_tests` built and run on **xad** backend: 752/752 pass (171/171 focused)
- [x] Code style review against `.claude/rules/code-style.md`: no violations