### PR TITLE
chore: dedup RNG-fill, repository, and single-curve calibration in dal-public

### DIFF
--- a/dal-public/src/curvespec.cpp
+++ b/dal-public/src/curvespec.cpp
@@ -38,11 +38,7 @@ namespace Dal {
     }
 
     CalibrationResult_ CalibrateSingleCurve(const CurveCalibrationSpec_& spec) {
-        auto result = CalibrateYieldCurve(spec);
-        CalibrationResult_ rtn;
-        rtn.curve_ = Handle_<DiscountCurve_>(result.curve_.release());
-        rtn.diagnostics_ = std::move(result.diagnostics_);
-        return rtn;
+        return CalibrateSingleCurve(spec, CurveJacobianMode_::Value_::ANALYTIC);
     }
 
     CalibrationResult_ CalibrateSingleCurve(const CurveCalibrationSpec_& spec,

--- a/dal-public/src/random.hpp
+++ b/dal-public/src/random.hpp
@@ -20,12 +20,12 @@ namespace Dal {
     }
 
     template <class RSG_>
-    FORCE_INLINE void FillRSG_(const Handle_<RSG_>& f, int numPath, void (RSG_::*fill)(Vector_<>*), Matrix_<>* y) {
+    FORCE_INLINE void FillRSG_(const Handle_<RSG_>& f, int numPath, void (RSG_::*fill)(Vector_<>* ) const, Matrix_<>* y) {
         int n_dim = f->NDim();
         y->Resize(numPath, n_dim);
         Vector_<> deviates(n_dim);
         for(int i = 0; i < numPath; ++i) {
-            (f.Get()->*fill)(&deviates);
+            (f.get()->*fill)(&deviates);
             for(int j = 0; j < n_dim; ++j)
                 (*y)(i, j) = deviates[j];
         }

--- a/dal-public/src/random.hpp
+++ b/dal-public/src/random.hpp
@@ -19,46 +19,31 @@ namespace Dal {
         return Handle_<SobolRSG_>(new SobolRSG_(name, iPath, ndim));
     }
 
-    FORCE_INLINE void GetPseudoRSGUniform(const Handle_<PseudoRSG_>& f, int numPath, Matrix_<>* y) {
+    template <class RSG_>
+    FORCE_INLINE void FillRSG_(const Handle_<RSG_>& f, int numPath, void (RSG_::*fill)(Vector_<>*), Matrix_<>* y) {
         int n_dim = f->NDim();
         y->Resize(numPath, n_dim);
         Vector_<> deviates(n_dim);
         for(int i = 0; i < numPath; ++i) {
-            f->FillUniform(&deviates);
+            (f.Get()->*fill)(&deviates);
             for(int j = 0; j < n_dim; ++j)
                 (*y)(i, j) = deviates[j];
         }
+    }
+
+    FORCE_INLINE void GetPseudoRSGUniform(const Handle_<PseudoRSG_>& f, int numPath, Matrix_<>* y) {
+        FillRSG_(f, numPath, &PseudoRSG_::FillUniform, y);
     }
 
     FORCE_INLINE void GetSobolRSGUniform(const Handle_<SobolRSG_>& f, int numPath, Matrix_<>* y) {
-        int n_dim = f->NDim();
-        y->Resize(numPath, n_dim);
-        Vector_<> deviates(n_dim);
-        for(int i = 0; i < numPath; ++i) {
-            f->FillUniform(&deviates);
-            for(int j = 0; j < n_dim; ++j)
-                (*y)(i, j) = deviates[j];
-        }
+        FillRSG_(f, numPath, &SobolRSG_::FillUniform, y);
     }
+
     FORCE_INLINE void GetPseudoRSGNormal(const Handle_<PseudoRSG_>& f, int numPath, Matrix_<>* y) {
-        int n_dim = f->NDim();
-        y->Resize(numPath, n_dim);
-        Vector_<> deviates(n_dim);
-        for(int i = 0; i < numPath; ++i) {
-            f->FillNormal(&deviates);
-            for(int j = 0; j < n_dim; ++j)
-                (*y)(i, j) = deviates[j];
-        }
+        FillRSG_(f, numPath, &PseudoRSG_::FillNormal, y);
     }
 
     FORCE_INLINE void GetSobolRSGNormal(const Handle_<SobolRSG_>& f, int numPath, Matrix_<>* y) {
-        int n_dim = f->NDim();
-        y->Resize(numPath, n_dim);
-        Vector_<> deviates(n_dim);
-        for(int i = 0; i < numPath; ++i) {
-            f->FillNormal(&deviates);
-            for(int j = 0; j < n_dim; ++j)
-                (*y)(i, j) = deviates[j];
-        }
+        FillRSG_(f, numPath, &SobolRSG_::FillNormal, y);
     }
 } // namespace Dal

--- a/dal-public/src/repository.cpp
+++ b/dal-public/src/repository.cpp
@@ -9,11 +9,17 @@
 
 namespace Dal {
 
-    int EraseRepository(const Vector_<Handle_<Storable_>>& objects) {
-        ENV_SEED_TYPE(ObjectAccess_); // POSTPONED -- mark this function as taking _ENV input
-        auto repo = Environment::Find<ObjectAccess_>(_env);
-        REQUIRE(repo, "no repo found");
+    namespace {
+        const ObjectAccess_* RequireRepo_() {
+            ENV_SEED_TYPE(ObjectAccess_); // POSTPONED -- mark this function as taking _ENV input
+            auto repo = Environment::Find<ObjectAccess_>(_env);
+            REQUIRE(repo, "no repo found");
+            return repo;
+        }
+    } // namespace
 
+    int EraseRepository(const Vector_<Handle_<Storable_>>& objects) {
+        auto* repo = RequireRepo_();
         int num_erased = 0;
         for (const auto& obj : objects)
             if (repo->Erase(*obj))
@@ -23,18 +29,13 @@ namespace Dal {
 
 
     Vector_<Handle_<Storable_>> FindRepository(const String_& pattern) {
-        ENV_SEED_TYPE(ObjectAccess_); // POSTPONED -- mark this function as taking _ENV input
-        auto repo = Environment::Find<ObjectAccess_>(_env);
-        REQUIRE(repo, "no repo found");
-        Vector_<Handle_<Storable_>> objects = std::move(repo->Find(pattern));
-        return objects;
+        auto* repo = RequireRepo_();
+        return repo->Find(pattern);
     }
 
 
     int SizeRepository() {
-        ENV_SEED_TYPE(ObjectAccess_); // POSTPONED -- mark this function as taking _ENV input
-        auto repo = Environment::Find<ObjectAccess_>(_env);
-        REQUIRE(repo, "no repo found");
+        auto* repo = RequireRepo_();
         return repo->Size();
     }
 } // namespace Dal


### PR DESCRIPTION
## Summary

Phase 2 (duplication unify), Wave 1 — `dal-public/src/`. Three byte-identical refactors; net `-18` lines (25 insertions, 43 deletions). No public API surface changed, no behavior changed.

- **`dal-public/src/random.hpp`** — the four `GetPseudoRSGUniform` / `GetSobolRSGUniform` / `GetPseudoRSGNormal` / `GetSobolRSGNormal` bodies differed only in handle type (`PseudoRSG_` vs `SobolRSG_`) and fill method (`FillUniform` vs `FillNormal`). Collapsed to one `template <class RSG_> FillRSG_(handle, numPath, pointer-to-member-fill, y)` helper; the four public names are now one-line wrappers.
- **`dal-public/src/repository.cpp`** — `EraseRepository` / `FindRepository` / `SizeRepository` each repeated the three-line env-lookup preamble (`ENV_SEED_TYPE(ObjectAccess_)` → `Environment::Find<ObjectAccess_>(_env)` → `REQUIRE(repo, "no repo found")`). Extracted a file-local `static const ObjectAccess_* RequireRepo_()` in an anonymous namespace; each public wrapper now keeps only its distinguishing line.
- **`dal-public/src/curvespec.cpp`** — the two `CalibrateSingleCurve` overloads duplicated the three-line `CalibrationResult_` tail. The no-options overload now forwards to the options overload with the default jacobian mode (`CurveJacobianMode_::Value_::ANALYTIC`), which is byte-identical to the original (the underlying `CalibrateYieldCurve(spec)` already delegates to `CalibrateYieldCurve(spec, CurveCalibrationOptions_())` whose default `jacobianMode_` is `ANALYTIC`).

Out of scope (left untouched as instructed): the `Build()` aggregate-init duplication and the shared solver-option fields — those are API-shape changes routed separately.

## Test plan

Built `dal_public` + `dal_cpp` in an isolated worktree (`build_dedup/`, submodules initialized; the shared `build/` was not touched). Captured full `dal_public_tests` and `dal_cpp_tests` output before and after the refactor and diffed them: **all non-timing lines are byte-identical** (the only diffs are wall-clock `ms` values, which are machine-load noise — every test still reports `[  OK  ]`, no `[  FAILED  ]`, same test names, same ordering, same counts). No numerical drift, no tolerance shifted.

- [x] `bin/dal_public_tests` equivalent — **37/37 passed**
- [x] `bin/dal_cpp_tests` equivalent — **752/752 passed**
- [x] `ctest` (project-documented runner) — **789/789 passed (100%)**
- [x] Output diff vs baseline: byte-identical modulo timing

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>