### PR TITLE
chore: dedup model + indice (MutantModel slides, matrix cast, fixing lookup)

### DIFF
--- a/dal-cpp/dal/indice/fixings.cpp
+++ b/dal-cpp/dal/indice/fixings.cpp
@@ -25,8 +25,8 @@ namespace Dal {
         return RET_VAL;
     }
 
-    double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fix_time, bool quiet) {
-        auto pf = vals.find(fix_time);
+    double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fixTime, bool quiet) {
+        auto pf = vals.find(fixTime);
         if (pf == vals.end()) {
             REQUIRE(quiet, "no fixings for that time");
             return -INF;

--- a/dal-cpp/dal/indice/fixings.cpp
+++ b/dal-cpp/dal/indice/fixings.cpp
@@ -25,16 +25,16 @@ namespace Dal {
         return RET_VAL;
     }
 
-    double FixHistory_::Find(const DateTime_& fix_time, bool quiet) const {
-        auto less_ = [](const pair<DateTime_, double>& lhs, const DateTime_& rhs) { return lhs.first < rhs; };
-
-        auto pGE = std::lower_bound(vals_.begin(), vals_.end(), fix_time, less_);
-        if (pGE == vals_.end() || pGE->first != fix_time) {
+    double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fix_time, bool quiet) {
+        auto pf = vals.find(fix_time);
+        if (pf == vals.end()) {
             REQUIRE(quiet, "no fixings for that time");
             return -INF;
         }
-        return pGE->second;
+        return pf->second;
     }
+
+    double FixHistory_::Find(const DateTime_& fix_time, bool quiet) const { return LookupFixing(vals_, fix_time, quiet); }
 
     void Fixings_::Write(Archive::Store_& dst) const {
         Fixings::XWrite(dst, name_, MapValues(vals_), Keys(vals_));

--- a/dal-cpp/dal/indice/fixings.hpp
+++ b/dal-cpp/dal/indice/fixings.hpp
@@ -38,7 +38,7 @@ namespace Dal {
         const FixHistory_& Empty();
     }
 
-    double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fix_time, bool quiet = false);
+    double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fixTime, bool quiet = false);
 
     class Fixings_ : public Storable_ {
     public:

--- a/dal-cpp/dal/indice/fixings.hpp
+++ b/dal-cpp/dal/indice/fixings.hpp
@@ -38,6 +38,8 @@ namespace Dal {
         const FixHistory_& Empty();
     }
 
+    double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fix_time, bool quiet = false);
+
     class Fixings_ : public Storable_ {
     public:
         using vals_t = std::map<DateTime_, double>;

--- a/dal-cpp/dal/indice/index.cpp
+++ b/dal-cpp/dal/indice/index.cpp
@@ -15,13 +15,8 @@ namespace Dal {
         auto fixings = hist->Fetch(indexName);
         REQUIRE(fixings || quiet, "no fixings exist");
 
-        auto vals = fixings ? fixings->vals_ : EMPTY;
-        auto pf = vals.find(fixingTime);
-        if (pf == vals.end()) {
-            REQUIRE(quiet, "No fixing for this time");
-            return -INF;
-        }
-        return pf->second;
+        const auto& vals = fixings ? fixings->vals_ : EMPTY;
+        return LookupFixing(vals, fixingTime, quiet);
     }
 
     double Index_::Fixing(_ENV, const DateTime_& fixingTime) const {

--- a/dal-cpp/dal/model/base.hpp
+++ b/dal-cpp/dal/model/base.hpp
@@ -9,6 +9,7 @@
 #include <dal/math/aad/sample.hpp>
 #include <dal/math/vectors.hpp>
 #include <dal/string/strings.hpp>
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal {
     namespace AAD {
@@ -42,19 +43,18 @@ namespace Dal {
         };
     }
 
-    class Slide_;
+    class Slide_ {
+    public:
+        virtual ~Slide_() = default;
+    };
 
     struct ModelData_: public Storable_ {
         Vector_<String_> parameterLabels_;
 
         ModelData_(const String_& type, const String_& name): Storable_(type.c_str(), name) {}
         [[nodiscard]] ModelData_* MutantModel(const String_& newName, const Vector_<Handle_<Slide_> >& slides) const {
-            std::unique_ptr<ModelData_> retval(MutantModel(&newName, nullptr));
-            for (const auto& s : slides) {
-		std::unique_ptr<ModelData_> temp(retval->MutantModel(nullptr, s.get()));
-		std::swap(retval, temp);
-            }
-	    return retval.release();
+            REQUIRE(slides.empty(), "slides are not supported for ModelData");
+            return MutantModel(&newName, nullptr);
         }
 
     private:

--- a/dal-cpp/dal/model/blackscholes.cpp
+++ b/dal-cpp/dal/model/blackscholes.cpp
@@ -18,4 +18,4 @@ namespace Dal {
         REQUIRE(!slide, "slides are not supported for BSModelData");
         return new BSModelData_(*newName, spot_, vol_, rate_, div_);
     }
-}
+} // namespace Dal

--- a/dal-cpp/dal/model/blackscholes.cpp
+++ b/dal-cpp/dal/model/blackscholes.cpp
@@ -15,9 +15,7 @@ namespace Dal {
     }
 
     BSModelData_* BSModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
-        std::unique_ptr<BSModelData_> temp(new BSModelData_(*newName, spot_, vol_, rate_, div_));
-        if (slide) {
-        }
-        return temp.release();
+        REQUIRE(!slide, "slides are not supported for BSModelData");
+        return new BSModelData_(*newName, spot_, vol_, rate_, div_);
     }
 }

--- a/dal-cpp/dal/model/dupire.cpp
+++ b/dal-cpp/dal/model/dupire.cpp
@@ -18,4 +18,4 @@ namespace Dal {
         REQUIRE(!slide, "slides are not supported for DupireModelData");
         return new DupireModelData_(*newName, spot_, rate_, repo_, spots_, times_, vols_);
     }
-}
+} // namespace Dal

--- a/dal-cpp/dal/model/dupire.cpp
+++ b/dal-cpp/dal/model/dupire.cpp
@@ -15,9 +15,7 @@ namespace Dal {
     }
 
     DupireModelData_* DupireModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
-        std::unique_ptr<DupireModelData_> temp(new DupireModelData_(*newName, spot_, rate_, repo_, spots_, times_, vols_));
-        if (slide) {
-        }
-        return temp.release();
+        REQUIRE(!slide, "slides are not supported for DupireModelData");
+        return new DupireModelData_(*newName, spot_, rate_, repo_, spots_, times_, vols_);
     }
 }

--- a/dal-cpp/dal/model/factory.hpp
+++ b/dal-cpp/dal/model/factory.hpp
@@ -38,5 +38,5 @@ namespace Dal {
 
         THROW("can't find matched model type");
     }
-}
+} // namespace Dal
 

--- a/dal-cpp/dal/model/factory.hpp
+++ b/dal-cpp/dal/model/factory.hpp
@@ -10,6 +10,14 @@
 
 namespace Dal {
 
+    template <class D_> Matrix_<D_> CastMatrix(const Matrix_<>& src) {
+        Matrix_<D_> dst(src.Rows(), src.Cols());
+        for (int i = 0; i < src.Rows(); ++i)
+            for (int j = 0; j < src.Cols(); ++j)
+                dst(i, j) = D_(src(i, j));
+        return dst;
+    }
+
     template <class T_>
     std::unique_ptr<AAD::Model_<T_>> CreateModel(const Handle_<ModelData_>& model_data) {
         auto modelBSImp = dynamic_cast<const BSModelData_*>(model_data.get());
@@ -20,20 +28,14 @@ namespace Dal {
                                                      T_(modelBSImp->div_));
 
         auto modelDupireImp = dynamic_cast<const DupireModelData_*>(model_data.get());
-        if (modelDupireImp) {
-            const auto& src = modelDupireImp->vols_;
-            Matrix_<T_> dst(src.Rows(), src.Cols());
-            for (int i = 0; i < dst.Rows(); ++i)
-                for (int j = 0; j < dst.Cols(); ++j)
-                    dst(i, j) = T_(src(i, j));
-
+        if (modelDupireImp)
             return std::make_unique<AAD::Dupire_<T_>>(T_(modelDupireImp->spot_),
-                                             T_(modelDupireImp->rate_),
-                                             T_(modelDupireImp->repo_),
-                                               modelDupireImp->spots_,
-                                               modelDupireImp->times_,
-                                               dst);
-        }
+                                                      T_(modelDupireImp->rate_),
+                                                      T_(modelDupireImp->repo_),
+                                                      modelDupireImp->spots_,
+                                                      modelDupireImp->times_,
+                                                      CastMatrix<T_>(modelDupireImp->vols_));
+
         THROW("can't find matched model type");
     }
 }

--- a/dal-cpp/tests/indice/index/test_fx.cpp
+++ b/dal-cpp/tests/indice/index/test_fx.cpp
@@ -32,3 +32,19 @@ TEST(IndexTest, TestIndexFxFixing) {
         ASSERT_DOUBLE_EQ(index->Fixing(_env, fixing_time), 2.0);
     }
 }
+
+TEST(IndexTest, TestPastFixingQuietMissingReturnsNegInf) {
+    String_ name("FX[USD/GBP]");
+    FixingsAccess_ fixings_access;
+    std::map<DateTime_, double> vals;
+    DateTime_ hit(Date_(2023, 1, 24));
+    vals.insert(std::make_pair(hit, 2.0));
+    Handle_<Fixings_> fixings(new Fixings_(name, vals));
+    fixings_access.fixings_.insert(std::make_pair(name, fixings));
+    ENV_SEED(fixings_access);
+
+    DateTime_ miss(Date_(2023, 1, 25));
+    ASSERT_DOUBLE_EQ(Index::PastFixing(_env, name, miss, true), -Dal::INF);
+    ASSERT_DOUBLE_EQ(Index::PastFixing(_env, name, hit, true), 2.0);
+    ASSERT_THROW(Index::PastFixing(_env, name, miss), std::runtime_error);
+}

--- a/dal-cpp/tests/indice/index/test_fx.cpp
+++ b/dal-cpp/tests/indice/index/test_fx.cpp
@@ -46,5 +46,5 @@ TEST(IndexTest, TestPastFixingQuietMissingReturnsNegInf) {
     DateTime_ miss(Date_(2023, 1, 25));
     ASSERT_DOUBLE_EQ(Index::PastFixing(_env, name, miss, true), -Dal::INF);
     ASSERT_DOUBLE_EQ(Index::PastFixing(_env, name, hit, true), 2.0);
-    ASSERT_THROW(Index::PastFixing(_env, name, miss), std::runtime_error);
+    ASSERT_THROW(Index::PastFixing(_env, name, miss), Dal::Exception_);
 }

--- a/dal-cpp/tests/model/test_blackscholes.cpp
+++ b/dal-cpp/tests/model/test_blackscholes.cpp
@@ -18,3 +18,24 @@ TEST(ModelTest, TestBlackScholesModelData) {
     ASSERT_NEAR(std::dynamic_pointer_cast<const BSModelData_>(rtn)->spot_, 100.0, 1e-8);
     ASSERT_NEAR(std::dynamic_pointer_cast<const BSModelData_>(rtn)->vol_, 0.20, 1e-8);
 }
+
+TEST(ModelTest, TestBlackScholesMutantModelRename) {
+    BSModelData_ model_data("my_model", 100.0, 0.20, 0.05, 0.01);
+    ModelData_& base = model_data;
+    Vector_<Handle_<Slide_>> noSlides;
+    std::unique_ptr<ModelData_> renamed(base.MutantModel(String_("renamed"), noSlides));
+    auto bs = dynamic_cast<const BSModelData_*>(renamed.get());
+    ASSERT_TRUE(bs != nullptr);
+    ASSERT_EQ(bs->Name(), String_("renamed"));
+    ASSERT_NEAR(bs->spot_, 100.0, 1e-10);
+    ASSERT_NEAR(bs->vol_, 0.20, 1e-10);
+    ASSERT_NEAR(bs->rate_, 0.05, 1e-10);
+    ASSERT_NEAR(bs->div_, 0.01, 1e-10);
+}
+
+TEST(ModelTest, TestBlackScholesMutantModelRejectsSlides) {
+    BSModelData_ model_data("my_model", 100.0, 0.20, 0.05, 0.01);
+    ModelData_& base = model_data;
+    Vector_<Handle_<Slide_>> slides{Handle_<Slide_>(std::make_shared<Slide_>())};
+    ASSERT_THROW((void)base.MutantModel(String_("renamed"), slides), Dal::Exception_);
+}

--- a/dal-cpp/tests/model/test_dupire.cpp
+++ b/dal-cpp/tests/model/test_dupire.cpp
@@ -17,3 +17,24 @@ TEST(ModelTest, TestDupireModelData) {
     ASSERT_NEAR(std::dynamic_pointer_cast<const DupireModelData_>(rtn)->spot_, 100.0, 1e-8);
     ASSERT_NEAR(std::dynamic_pointer_cast<const DupireModelData_>(rtn)->rate_, 0.05, 1e-8);
 }
+
+TEST(ModelTest, TestDupireMutantModelRename) {
+    Vector_<> spots = {90.0, 100.0, 110.0};
+    Vector_<> times = {0.25, 0.5, 1.0};
+    Matrix_<> vols(3, 3, 0.2);
+    DupireModelData_ model_data("my_model", 100.0, 0.05, 0.01, spots, times, vols);
+    ModelData_& base = model_data;
+    Vector_<Handle_<Slide_>> noSlides;
+    std::unique_ptr<ModelData_> renamed(base.MutantModel(String_("renamed"), noSlides));
+    auto dup = dynamic_cast<const DupireModelData_*>(renamed.get());
+    ASSERT_TRUE(dup != nullptr);
+    ASSERT_EQ(dup->Name(), String_("renamed"));
+    ASSERT_NEAR(dup->spot_, 100.0, 1e-10);
+    ASSERT_NEAR(dup->rate_, 0.05, 1e-10);
+    ASSERT_NEAR(dup->repo_, 0.01, 1e-10);
+    ASSERT_EQ(dup->spots_, spots);
+    ASSERT_EQ(dup->times_, times);
+    ASSERT_EQ(dup->vols_.Rows(), vols.Rows());
+    ASSERT_EQ(dup->vols_.Cols(), vols.Cols());
+    ASSERT_NEAR(dup->vols_(0, 0), 0.2, 1e-10);
+}


### PR DESCRIPTION
## Summary
Phase 2 (duplication unify), Wave 1, cluster: model + indice. Three deduplication refactors with byte-identical outputs (item 1 also fixes a latent silent-ignore bug).

- **`MutantModel` slide centralization (model):** `BSModelData_::MutantModel` and `DupireModelData_::MutantModel` both had an empty `if (slide) {}` body that silently dropped any slide passed via the base `ModelData_::MutantModel(newName, slides)` overload — a latent bug (rename-then-slide produced an unmodified copy). `Slide_` was only forward-declared and never defined. Centralized the rejection in ONE place: defined `Slide_` with a virtual destructor and added a `REQUIRE(slides.empty(), ...)` guard in the base public overload; deleted the duplicated dead branches in both subclasses (which now `REQUIRE(!slide, ...)` defensively).
- **`CreateModel` factory (model):** Factored the Dupire `Matrix_<T_>` element-wise cast (nested `for` with `int` indices) into a reusable `template<class D_> Matrix_<D_> CastMatrix(const Matrix_<>&)` helper in `factory.hpp`. Kept the `dynamic_cast` chain (standard DAL polymorphic-dispatch idiom; only two models, a registry would be over-engineering).
- **`PastFixing` / `FixHistory_::Find` unify (indice):** `Index::PastFixing` reimplemented the exact "lookup fixing by datetime, return -INF if missing when quiet" of `FixHistory_::Find` — two sources of truth for the load-bearing -INF contract (FX fixings rely on it). Extracted a single `LookupFixing(vals, t, quiet)` in `fixings.hpp/cpp` used by both. `FixHistory_::Find` now uses `map::find` (O(log n)) instead of the prior O(n) `std::lower_bound` over map iterators; results are identical for exact-key lookup.

## MutantModel decision
**Safest option chosen:** slides are unsupported (never implemented, `Slide_` had no definition). Rather than implement slide semantics speculatively, the rejection is centralized in the base `ModelData_::MutantModel` public overload with a `REQUIRE` guard, and `Slide_` is given a minimal definition (virtual destructor) so the guard is reachable and unit-testable. The empty branches are deleted, not left as dead code.

## Test plan
- [x] `bin/dal_cpp_tests --gtest_filter='ModelTest.*:IndexTest.*'` — 16 tests pass (3 new model tests + 1 new indice test)
- [x] Full `dal_cpp_tests` on three AAD backends (native/AADET, Adept, XAD): **756 tests pass** on each (was 752 baseline + 4 new), no regressions, no tolerance shifts
- [x] No tolerance shifts observed; only behavior change is the previously-silent slide drop now throws (unreachable before since `Slide_` was undefined)