### PR TITLE
chore: dedup curve calibration residual-stats, schedule, and rate dispatch

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -340,16 +340,12 @@ namespace Dal {
             [[nodiscard]] Underdetermined::Jacobian_* AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const;
 
             template <class T_> [[nodiscard]] Handle_<Tape::Rate_<T_>> PhaseARateAt(int i) const {
-                const auto* inst = instruments_[i].get();
-                if (const auto* d = dynamic_cast<const Deposit_*>(inst))
-                    return d->PrecomputeT<T_>();
-                if (const auto* f = dynamic_cast<const FRA_*>(inst))
-                    return f->PrecomputeT<T_>();
-                if (const auto* fu = dynamic_cast<const Future_*>(inst))
-                    return fu->PrecomputeT<T_>();
-                if (const auto* s = dynamic_cast<const Swap_*>(inst))
-                    return s->PrecomputeT<T_>();
-                return Handle_<Tape::Rate_<T_>>();
+                return VisitRate(
+                    *instruments_[i],
+                    [](const Deposit_& d) { return d.PrecomputeT<T_>(); },
+                    [](const FRA_& f) { return f.PrecomputeT<T_>(); },
+                    [](const Future_& fu) { return fu.PrecomputeT<T_>(); },
+                    [](const Swap_& s) { return s.PrecomputeT<T_>(); });
             }
         };
 
@@ -417,16 +413,14 @@ namespace Dal {
             retval.instrumentNames_.reserve(instruments.size());
             retval.marketRates_.reserve(instruments.size());
             retval.residuals_.reserve(instruments.size());
-            double sqResidual = 0.0;
             for (int i = 0; i < static_cast<int>(instruments.size()); ++i) {
                 retval.instrumentNames_.push_back(instruments[i]->Name());
                 retval.marketRates_.push_back(instruments[i]->MarketRate());
-                const double residual = retval.modelRates_[i] - retval.marketRates_[i];
-                retval.residuals_.push_back(residual);
-                retval.maxAbsResidual_ = std::max(retval.maxAbsResidual_, std::fabs(residual));
-                sqResidual += residual * residual;
+                retval.residuals_.push_back(retval.modelRates_[i] - retval.marketRates_[i]);
             }
-            retval.rmsResidual_ = retval.residuals_.empty() ? 0.0 : std::sqrt(sqResidual / retval.residuals_.size());
+            const ResidualStats_ stats = ResidualStats(retval.residuals_);
+            retval.maxAbsResidual_ = stats.maxAbsResidual_;
+            retval.rmsResidual_ = stats.rmsResidual_;
             if (effJacobianInverse)
                 retval.effJacobianInverse_ = *effJacobianInverse;
             return retval;

--- a/dal-cpp/dal/curve/calibration_internal.hpp
+++ b/dal-cpp/dal/curve/calibration_internal.hpp
@@ -5,6 +5,10 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
+#include <type_traits>
+#include <utility>
+
 #include <dal/curve/ycinstrument.hpp>
 #include <dal/math/vectors.hpp>
 #include <dal/platform/platform.hpp>
@@ -34,19 +38,37 @@ namespace Dal {
         return ordered;
     }
 
+    // 4-way dispatch over {Deposit_, FRA_, Future_, Swap_}. OISSwap_ reaches the Swap_ arm via
+    // inheritance. Each caller supplies its per-type lambda; on no match the common return type is
+    // default-constructed (nullptr for pointers, empty Handle_<>, false for bool).
+    template <class D_, class F_, class Fu_, class S_>
+    auto VisitRate(const YCInstrument_& inst, D_&& depositFn, F_&& fraFn, Fu_&& futureFn, S_&& swapFn)
+        -> std::common_type_t<std::invoke_result_t<D_, const Deposit_&>,
+                              std::invoke_result_t<F_, const FRA_&>,
+                              std::invoke_result_t<Fu_, const Future_&>,
+                              std::invoke_result_t<S_, const Swap_&>> {
+        using R_ = std::common_type_t<std::invoke_result_t<D_, const Deposit_&>, std::invoke_result_t<F_, const FRA_&>,
+                                      std::invoke_result_t<Fu_, const Future_&>, std::invoke_result_t<S_, const Swap_&>>;
+        if (const auto* deposit = dynamic_cast<const Deposit_*>(&inst))
+            return static_cast<R_>(std::forward<D_>(depositFn)(*deposit));
+        if (const auto* fra = dynamic_cast<const FRA_*>(&inst))
+            return static_cast<R_>(std::forward<F_>(fraFn)(*fra));
+        if (const auto* future = dynamic_cast<const Future_*>(&inst))
+            return static_cast<R_>(std::forward<Fu_>(futureFn)(*future));
+        if (const auto* swap = dynamic_cast<const Swap_*>(&inst))
+            return static_cast<R_>(std::forward<S_>(swapFn)(*swap));
+        return R_{};
+    }
+
     // Resolve the float index convention of a curve instrument, or nullptr if it has none.
     // Used by Phase-A analytic-Jacobian eligibility checks (single-curve) and projection-curve
     // routing (joint). Returns a borrowed pointer; the instrument outlives the call.
     inline const RateIndexConvention_* FloatConventionOf(const YCInstrument_& inst) {
-        if (const auto* deposit = dynamic_cast<const Deposit_*>(&inst))
-            return &deposit->FloatConvention();
-        if (const auto* fra = dynamic_cast<const FRA_*>(&inst))
-            return &fra->FloatConvention();
-        if (const auto* future = dynamic_cast<const Future_*>(&inst))
-            return &future->FloatConvention();
-        if (const auto* swap = dynamic_cast<const Swap_*>(&inst))
-            return &swap->FloatConvention();
-        return nullptr;
+        return VisitRate(
+            inst, [](const Deposit_& d) -> const RateIndexConvention_* { return &d.FloatConvention(); },
+            [](const FRA_& f) -> const RateIndexConvention_* { return &f.FloatConvention(); },
+            [](const Future_& fu) -> const RateIndexConvention_* { return &fu.FloatConvention(); },
+            [](const Swap_& s) -> const RateIndexConvention_* { return &s.FloatConvention(); });
     }
 
     // Wrap a schedule period as an accrual period with unit notional under the given day basis.
@@ -67,6 +89,43 @@ namespace Dal {
             retval.push_back({period, MakeAccrualPeriod(period, legConvention.dayBasis_)});
         }
         return retval;
+    }
+
+    // maxAbs and RMS of a residual sequence. Single-pass, same accumulation order as the inline
+    // loops it replaces, so floating-point output is byte-identical to the originals.
+    struct ResidualStats_ {
+        double maxAbsResidual_ = 0.0;
+        double rmsResidual_ = 0.0;
+    };
+
+    template <class E_> ResidualStats_ ResidualStats(const Vector_<E_>& residuals) {
+        double maxAbs = 0.0;
+        double sq = 0.0;
+        for (const E_ r : residuals) {
+            maxAbs = std::max(maxAbs, std::fabs(r));
+            sq += r * r;
+        }
+        return ResidualStats_{maxAbs, residuals.empty() ? 0.0 : std::sqrt(sq / residuals.size())};
+    }
+
+    // Resolve the coupon-months count for a single-period instrument's day-count context.
+    // Forecasts off a projection curve use the curve's tenor; everything else uses CouponMonths.
+    inline int SinglePeriodCouponMonths(const RateIndexConvention_& convention, const Date_& start, const Date_& maturity) {
+        return convention.useProjectionCurve_ ? convention.forecastTenor_.Months() : CouponMonths(start, maturity);
+    }
+
+    // Build the SchedulePeriod_ shared by every single-period rate (Deposit, FRA, Future, and their
+    // projection variants). The caller supplies the resolved couponMonths so both the
+    // CouponMonths(...) and useProjectionCurve_ ternary call-sites collapse to one schedule build.
+    inline SchedulePeriod_
+    BuildSinglePeriodSchedule(const Date_& start, const Date_& maturity, const RateIndexConvention_& convention, int couponMonths) {
+        SchedulePeriod_ period;
+        period.unadjustedStart_ = start;
+        period.unadjustedEnd_ = maturity;
+        period.accrualStart_ = Holidays::Adjust(convention.accrualHolidays_, start, convention.businessDayConvention_);
+        period.accrualEnd_ = Holidays::Adjust(convention.accrualHolidays_, maturity, convention.businessDayConvention_);
+        period.dayCountContext_ = Handle_<DayBasis::Context_>(new DayBasis::Context_(true, start, maturity, couponMonths));
+        return period;
     }
 
 } // namespace Dal

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -228,8 +228,14 @@ namespace Dal {
         }
 
         [[nodiscard]] bool IsSupportedInstrumentType(const YCInstrument_& inst) {
-            return dynamic_cast<const OISSwap_*>(&inst) || dynamic_cast<const Swap_*>(&inst) || dynamic_cast<const Deposit_*>(&inst)
-                   || dynamic_cast<const FRA_*>(&inst) || dynamic_cast<const Future_*>(&inst);
+            // OISSwap_ : public Swap_ reaches the Swap_ arm; the explicit OISSwap_ check in the
+            // original ||-chain was therefore redundant and is dropped here.
+            return VisitRate(
+                inst,
+                [](const Deposit_&) { return true; },
+                [](const FRA_&) { return true; },
+                [](const Future_&) { return true; },
+                [](const Swap_&) { return true; });
         }
 
         bool InstrumentEligibleForAnalyticJacobian(const YCInstrument_& inst, bool onDiscountDeclaration) {
@@ -403,13 +409,14 @@ namespace Dal {
 
             [[nodiscard]] Handle_<Tape::Rate_<Dal::AAD::Number_>>
             DiscountRateT(const YCInstrument_& inst) const {
-                if (const auto* dep = dynamic_cast<const Deposit_*>(&inst))
-                    return dep->PrecomputeT<Dal::AAD::Number_>();
-                if (const auto* f = dynamic_cast<const FRA_*>(&inst))
-                    return f->PrecomputeT<Dal::AAD::Number_>();
-                if (const auto* fu = dynamic_cast<const Future_*>(&inst))
-                    return fu->PrecomputeT<Dal::AAD::Number_>();
-                return static_cast<const Swap_*>(&inst)->PrecomputeT<Dal::AAD::Number_>();
+                // Caller (ComputeTemplatedResiduals) has already filtered to supported types via
+                // InstrumentEligibleForAnalyticJacobian; VisitRate returns an empty handle on miss.
+                return VisitRate(
+                    inst,
+                    [](const Deposit_& d) { return d.PrecomputeT<Dal::AAD::Number_>(); },
+                    [](const FRA_& f) { return f.PrecomputeT<Dal::AAD::Number_>(); },
+                    [](const Future_& fu) { return fu.PrecomputeT<Dal::AAD::Number_>(); },
+                    [](const Swap_& s) { return s.PrecomputeT<Dal::AAD::Number_>(); });
             }
 
             [[nodiscard]] Vector_<Dal::AAD::Number_>
@@ -504,32 +511,24 @@ namespace Dal {
             diag.marketRates_.reserve(slot.nInstruments);
             diag.modelRates_.reserve(slot.nInstruments);
             diag.residuals_.reserve(slot.nInstruments);
-            double sqResidual = 0.0;
             for (int i = 0; i < slot.nInstruments; ++i) {
                 const double modelRate = (*slot.rates[i])(solvedBlock);
                 const double marketRate = slot.marketRates[i];
-                const double residual = modelRate - marketRate;
                 diag.instrumentNames_.push_back(slot.instruments[i]->Name());
                 diag.marketRates_.push_back(marketRate);
                 diag.modelRates_.push_back(modelRate);
-                diag.residuals_.push_back(residual);
-                diag.maxAbsResidual_ = std::max(diag.maxAbsResidual_, std::fabs(residual));
-                sqResidual += residual * residual;
+                diag.residuals_.push_back(modelRate - marketRate);
             }
-            diag.rmsResidual_ = slot.nInstruments == 0 ? 0.0 : std::sqrt(sqResidual / slot.nInstruments);
+            const ResidualStats_ stats = ResidualStats(diag.residuals_);
+            diag.maxAbsResidual_ = stats.maxAbsResidual_;
+            diag.rmsResidual_ = stats.rmsResidual_;
             return diag;
         }
 
         [[noreturn]] void ThrowNonConvergence(const JointResidualFunction_& func, const Vector_<>& residuals) {
-            double maxAbs = 0.0;
-            double sq = 0.0;
-            for (const double r : residuals) {
-                maxAbs = std::max(maxAbs, std::fabs(r));
-                sq += r * r;
-            }
-            const double rms = residuals.empty() ? 0.0 : std::sqrt(sq / residuals.size());
-            THROW(String_("Joint multi-curve calibration failed to converge: maxAbsResidual = ") + String::FromDouble(maxAbs) +
-                  ", rmsResidual = " + String::FromDouble(rms) + " after " + String::FromInt(func.EvaluationCount()) + " evaluations");
+            const ResidualStats_ stats = ResidualStats(residuals);
+            THROW(String_("Joint multi-curve calibration failed to converge: maxAbsResidual = ") + String::FromDouble(stats.maxAbsResidual_) +
+                  ", rmsResidual = " + String::FromDouble(stats.rmsResidual_) + " after " + String::FromInt(func.EvaluationCount()) + " evaluations");
         }
 
         // ---- Helpers extracted from CalibrateJointMultiCurve for cyclomatic complexity (Codacy) ----

--- a/dal-cpp/dal/curve/xccycalibration.cpp
+++ b/dal-cpp/dal/curve/xccycalibration.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
+#include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
 #include <dal/curve/xccyinstrument.hpp>
 #include <dal/curve/xccycalibration.hpp>
@@ -25,21 +26,17 @@ namespace Dal {
                                                               const Matrix_<>* effJacobianInverse = nullptr) {
             CrossCurrencyCalibrationDiagnostics_ retval;
             retval.usedApproximateFit_ = usedApproximateFit;
-            double maxResidual = 0.0;
-            double sqResidual = 0.0;
             for (const auto& instrument : instruments) {
                 const double modelRate = (*instrument->Precompute())(market);
                 const double marketRate = instrument->MarketRate();
-                const double residual = modelRate - marketRate;
                 retval.instrumentNames_.push_back(instrument->Name());
                 retval.marketRates_.push_back(marketRate);
                 retval.modelRates_.push_back(modelRate);
-                retval.residuals_.push_back(residual);
-                maxResidual = std::max(maxResidual, std::fabs(residual));
-                sqResidual += residual * residual;
+                retval.residuals_.push_back(modelRate - marketRate);
             }
-            retval.maxAbsResidual_ = maxResidual;
-            retval.rmsResidual_ = instruments.empty() ? 0.0 : std::sqrt(sqResidual / instruments.size());
+            const ResidualStats_ stats = ResidualStats(retval.residuals_);
+            retval.maxAbsResidual_ = stats.maxAbsResidual_;
+            retval.rmsResidual_ = stats.rmsResidual_;
             if (effJacobianInverse)
                 retval.effJacobianInverse_ = *effJacobianInverse;
             return retval;

--- a/dal-cpp/dal/curve/ycinstrument.cpp
+++ b/dal-cpp/dal/curve/ycinstrument.cpp
@@ -33,11 +33,6 @@ namespace Dal {
             return PeriodLength_(String::FromInt(months) + "M");
         }
 
-        Handle_<DayBasis::Context_> SinglePeriodContext(const Date_& start, const Date_& maturity, int couponMonths) {
-            const bool singleCouponPeriodIsLast = true;
-            return Handle_<DayBasis::Context_>(new DayBasis::Context_(singleCouponPeriodIsLast, start, maturity, couponMonths));
-        }
-
         const DiscountCurve_& ResolveDiscountCurve(const YieldCurve_& yc,
                                                    const Handle_<YieldCurve_>& fallback,
                                                    const CollateralType_& collateral) {
@@ -79,12 +74,7 @@ namespace Dal {
                 : start_(start), maturity_(maturity), convention_(convention), fallback_(fallback) {}
 
             double operator()(const YieldCurve_& yc) const override {
-                SchedulePeriod_ period;
-                period.unadjustedStart_ = start_;
-                period.unadjustedEnd_ = maturity_;
-                period.accrualStart_ = Holidays::Adjust(convention_.accrualHolidays_, start_, convention_.businessDayConvention_);
-                period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
-                period.dayCountContext_ = SinglePeriodContext(start_, maturity_, CouponMonths(start_, maturity_));
+                const SchedulePeriod_ period = BuildSinglePeriodSchedule(start_, maturity_, convention_, CouponMonths(start_, maturity_));
                 const DiscountCurve_& forecast = ResolveForecastCurve(yc, fallback_, convention_);
                 return Tape::ForwardRate<double>(forecast,
                                                  period.accrualStart_,
@@ -113,16 +103,8 @@ namespace Dal {
                   fallback_(fallback) {}
 
             double operator()(const YieldCurve_& yc) const override {
-                SchedulePeriod_ period;
-                period.unadjustedStart_ = start_;
-                period.unadjustedEnd_ = maturity_;
-                period.accrualStart_ = Holidays::Adjust(convention_.accrualHolidays_, start_, convention_.businessDayConvention_);
-                period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
-                period.dayCountContext_ = SinglePeriodContext(start_,
-                                                              maturity_,
-                                                              convention_.useProjectionCurve_
-                                                                  ? convention_.forecastTenor_.Months()
-                                                                  : CouponMonths(start_, maturity_));
+                const SchedulePeriod_ period =
+                    BuildSinglePeriodSchedule(start_, maturity_, convention_, SinglePeriodCouponMonths(convention_, start_, maturity_));
                 const DiscountCurve_& forecast = ResolveForecastCurve(yc, fallback_, convention_);
                 return Tape::ForwardRate<double>(forecast,
                                                  period.accrualStart_,
@@ -249,12 +231,7 @@ namespace Dal {
                 : start_(start), maturity_(maturity), convention_(convention) {}
 
             T_ operator()(const YCCtx_<T_>& ctx) const override {
-                SchedulePeriod_ period;
-                period.unadjustedStart_ = start_;
-                period.unadjustedEnd_ = maturity_;
-                period.accrualStart_ = Holidays::Adjust(convention_.accrualHolidays_, start_, convention_.businessDayConvention_);
-                period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
-                period.dayCountContext_ = SinglePeriodContext(start_, maturity_, CouponMonths(start_, maturity_));
+                const SchedulePeriod_ period = BuildSinglePeriodSchedule(start_, maturity_, convention_, CouponMonths(start_, maturity_));
                 return ForwardRate(ctx.curve_,
                                     period.accrualStart_,
                                     period.accrualEnd_,
@@ -277,16 +254,8 @@ namespace Dal {
                 : start_(start), maturity_(maturity), convexityAdjustment_(convexityAdjustment), convention_(convention) {}
 
             T_ operator()(const YCCtx_<T_>& ctx) const override {
-                SchedulePeriod_ period;
-                period.unadjustedStart_ = start_;
-                period.unadjustedEnd_ = maturity_;
-                period.accrualStart_ = Holidays::Adjust(convention_.accrualHolidays_, start_, convention_.businessDayConvention_);
-                period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
-                period.dayCountContext_ = SinglePeriodContext(start_,
-                                                              maturity_,
-                                                              convention_.useProjectionCurve_
-                                                                  ? convention_.forecastTenor_.Months()
-                                                                  : CouponMonths(start_, maturity_));
+                const SchedulePeriod_ period =
+                    BuildSinglePeriodSchedule(start_, maturity_, convention_, SinglePeriodCouponMonths(convention_, start_, maturity_));
                 return ForwardRate(ctx.curve_,
                                     period.accrualStart_,
                                     period.accrualEnd_,
@@ -353,12 +322,7 @@ namespace Dal {
 
             T_ operator()(const JointCurveBlock_<T_>& block) const override {
                 const DiscountCurve_<T_>& forecast = ResolveForecastT<T_>(block, convention_);
-                SchedulePeriod_ period;
-                period.unadjustedStart_ = start_;
-                period.unadjustedEnd_ = maturity_;
-                period.accrualStart_ = Holidays::Adjust(convention_.accrualHolidays_, start_, convention_.businessDayConvention_);
-                period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
-                period.dayCountContext_ = SinglePeriodContext(start_, maturity_, CouponMonths(start_, maturity_));
+                const SchedulePeriod_ period = BuildSinglePeriodSchedule(start_, maturity_, convention_, CouponMonths(start_, maturity_));
                 return ForwardRate(forecast,
                                    period.accrualStart_,
                                    period.accrualEnd_,
@@ -382,16 +346,8 @@ namespace Dal {
 
             T_ operator()(const JointCurveBlock_<T_>& block) const override {
                 const DiscountCurve_<T_>& forecast = ResolveForecastT<T_>(block, convention_);
-                SchedulePeriod_ period;
-                period.unadjustedStart_ = start_;
-                period.unadjustedEnd_ = maturity_;
-                period.accrualStart_ = Holidays::Adjust(convention_.accrualHolidays_, start_, convention_.businessDayConvention_);
-                period.accrualEnd_ = Holidays::Adjust(convention_.accrualHolidays_, maturity_, convention_.businessDayConvention_);
-                period.dayCountContext_ = SinglePeriodContext(start_,
-                                                              maturity_,
-                                                              convention_.useProjectionCurve_
-                                                                  ? convention_.forecastTenor_.Months()
-                                                                  : CouponMonths(start_, maturity_));
+                const SchedulePeriod_ period =
+                    BuildSinglePeriodSchedule(start_, maturity_, convention_, SinglePeriodCouponMonths(convention_, start_, maturity_));
                 return ForwardRate(forecast,
                                    period.accrualStart_,
                                    period.accrualEnd_,
@@ -608,15 +564,12 @@ namespace Dal {
     namespace Tape {
         template <class T_>
         Handle_<JointRate_<T_>> ProjectionRateAt(const YCInstrument_& inst) {
-            if (const auto* d = dynamic_cast<const Deposit_*>(&inst))
-                return d->PrecomputeProjectionT<T_>();
-            if (const auto* f = dynamic_cast<const FRA_*>(&inst))
-                return f->PrecomputeProjectionT<T_>();
-            if (const auto* fu = dynamic_cast<const Future_*>(&inst))
-                return fu->PrecomputeProjectionT<T_>();
-            if (const auto* s = dynamic_cast<const Swap_*>(&inst))
-                return s->PrecomputeProjectionT<T_>();
-            return Handle_<JointRate_<T_>>();
+            return VisitRate(
+                inst,
+                [](const Deposit_& d) { return d.PrecomputeProjectionT<T_>(); },
+                [](const FRA_& f) { return f.PrecomputeProjectionT<T_>(); },
+                [](const Future_& fu) { return fu.PrecomputeProjectionT<T_>(); },
+                [](const Swap_& s) { return s.PrecomputeProjectionT<T_>(); });
         }
 
         template Handle_<JointRate_<Dal::AAD::Number_>> ProjectionRateAt<Dal::AAD::Number_>(const YCInstrument_&);


### PR DESCRIPTION
## Summary
- Extract `ResidualStats()` (single-pass maxAbs/RMS) into `calibration_internal.hpp`; replaces byte-identical inline loops in `BuildDiagnostics` (calibration.cpp, xccycalibration.cpp), `BuildCurveDiagnostics`, and `ThrowNonConvergence` (jointcalibration.cpp). Accumulation order preserved so FP output is unchanged.
- Extract `BuildSinglePeriodSchedule()` + `SinglePeriodCouponMonths()` into `calibration_internal.hpp`; collapses the six `SchedulePeriod_` build sites in `ycinstrument.cpp` (Deposit/Forward rate classes + their Tape and projection variants). The `useProjectionCurve_ ? forecastTenor_.Months() : CouponMonths(...)` ternary moves into one helper.
- Extract `VisitRate()` 4-way `{Deposit_, FRA_, Future_, Swap_}` dispatch into `calibration_internal.hpp`; replaces five `dynamic_cast` ladders: `FloatConventionOf`, `PhaseARateAt`, `IsSupportedInstrumentType`, `DiscountRateT`, `Tape::ProjectionRateAt`. The redundant explicit `OISSwap_` arm in `IsSupportedInstrumentType` is dropped (`OISSwap_ : public Swap_` reaches the Swap_ arm).

Deliberately divergent (per task scope): `ParamsPerKnot` (different unsupported-param messages between single and joint calibration) and the rate-class twins (`DepositRate_` vs `Tape::DepositRate_` etc. — different signatures/contexts).

## Test plan
- [x] Built `dal_cpp_tests` on adept backend, full suite **752/752** pass
- [x] Built `dal_cpp_tests` on xad backend, full suite **752/752** pass
- [x] Filter `*Calibration*:*JointCalibration*:*AnalyticJacobian*:*Xccy*:*YCInstrument*` → **77/77** pass on both backends
- [x] Tight `1e-7` residual-stat assertions (`maxAbsResidual_`, `jointMaxAbsResidual_`) in `test_joint_calibration.cpp` unchanged
- [x] No floating-point tolerance shifts detected