### PR TITLE
chore: unify CG and BCG Krylov iteration in bcg.cpp

### DIFF
--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -44,57 +44,77 @@ namespace Dal {
     } // namespace
 
     namespace {
-        // Unified Krylov iteration for CG (biConjugate = false) and BCG (true). CG aliases the
-        // shadow vectors onto the real ones so the shared arithmetic stays byte-identical to
-        // standalone CG; shadow maintenance is gated on the flag.
+        // Unified Krylov state for CG (biConjugate = false) and BCG (true). For CG, zzRef/ppRef
+        // alias the real vectors so the shared arithmetic is byte-identical to standalone CG.
+        struct KrylovState_ {
+            const Sparse::Square_& A;
+            const XPrecondition_& precondition;
+            const bool biConjugate;
+            Vector_<> r;
+            Vector_<> rr;
+            Vector_<> z;
+            Vector_<> zz;
+            Vector_<> p;
+            Vector_<> pp;
+            Vector_<>& zzRef; // aliases z for CG, zz for BCG
+            Vector_<>& ppRef; // aliases p for CG, pp for BCG
+            double betaPrev;
+
+            KrylovState_(const Sparse::Square_& a, const XPrecondition_& prec, bool biConjugate, int n)
+                : A(a), precondition(prec), biConjugate(biConjugate), r(n), rr(n), z(n), zz(n), p(n), pp(n), zzRef(biConjugate ? zz : z),
+                  ppRef(biConjugate ? pp : p), betaPrev(0.0) {}
+        };
+
+        double PrepareDirection_(KrylovState_& s, int ii) {
+            s.precondition.Left(s.r, &s.z);
+            if (s.biConjugate)
+                s.precondition.Right(s.rr, &s.zz);
+            const double beta = InnerProduct(s.zzRef, s.r);
+            const double multiply = ii > 0 ? beta / s.betaPrev : 0.0;
+            s.p *= multiply;
+            if (s.biConjugate)
+                s.pp *= multiply;
+            s.p += s.z;
+            if (s.biConjugate)
+                s.pp += s.zz;
+            s.betaPrev = beta;
+            return beta;
+        }
+
+        void UpdateSolution_(KrylovState_& s, double beta, Vector_<>* x) {
+            s.A.MultiplyLeft(s.p, &s.z);
+            if (s.biConjugate)
+                s.A.MultiplyRight(s.pp, &s.zz);
+            const double alphaK = beta / InnerProduct(s.z, s.ppRef);
+            Transform(x, s.p, LinearIncrement(alphaK));
+            Transform(&s.r, s.z, LinearIncrement(-alphaK));
+            if (s.biConjugate)
+                Transform(&s.rr, s.zz, LinearIncrement(-alphaK));
+        }
+
+        void ValidateKrylovParams_(int n, const Vector_<>& b, const Vector_<>* x, double tolRel, double tolAbs, int maxIterations) {
+            REQUIRE(b.size() == n && x->size() == n, "matrix size is not compatible");
+            REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters is not valid");
+        }
+
         void
         KrylovSolve_(const Sparse::Square_& A, const Vector_<>& b, double tolRel, double tolAbs, int maxIterations, bool biConjugate, Vector_<>* x) {
             const int n = A.Size();
-            REQUIRE(b.size() == n && x->size() == n, "matrix size is not compatible");
-            REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters is not valid");
+            ValidateKrylovParams_(n, b, x, tolRel, tolAbs, maxIterations);
 
-            double tNorm = tolRel * sqrt(InnerProduct(b, b)) + tolAbs;
+            const double tNorm = tolRel * sqrt(InnerProduct(b, b)) + tolAbs;
             XPrecondition_ precondition(A);
-            Vector_<> r(n);
-            Vector_<> rr(n);
-            Vector_<> z(n);
-            Vector_<> zz(n);
-            Vector_<> p(n);
-            Vector_<> pp(n);
+            KrylovState_ s(A, precondition, biConjugate, n);
 
-            A.MultiplyLeft(*x, &r);
-            Transform(b, r, std::minus<>(), &r); // r = b - Ax
+            A.MultiplyLeft(*x, &s.r);
+            Transform(b, s.r, std::minus<>(), &s.r); // r = b - Ax
             if (biConjugate)
-                rr = r;
+                s.rr = s.r;
 
-            // CG collapses each shadow vector onto its real counterpart, so beta and alphaK
-            // reduce to the standalone-CG expressions InnerProduct(z, r) and beta/InnerProduct(z, p).
-            Vector_<>& zzRef = biConjugate ? zz : z;
-            Vector_<>& ppRef = biConjugate ? pp : p;
-
-            double betaPrev;
             for (int ii = 0; ii < maxIterations; ++ii) {
-                precondition.Left(r, &z);
-                if (biConjugate)
-                    precondition.Right(rr, &zz);
-                const double beta = InnerProduct(zzRef, r);
-                const double multiply = ii > 0 ? beta / betaPrev : 0.0;
-                p *= multiply;
-                if (biConjugate)
-                    pp *= multiply;
-                p += z;
-                if (biConjugate)
-                    pp += zz;
-                betaPrev = beta;
-                A.MultiplyLeft(p, &z);
-                if (biConjugate)
-                    A.MultiplyRight(pp, &zz);
-                const double alphaK = beta / InnerProduct(z, ppRef);
-                Transform(x, p, LinearIncrement(alphaK));
-                Transform(&r, z, LinearIncrement(-alphaK));
-                if (biConjugate)
-                    Transform(&rr, zz, LinearIncrement(-alphaK));
-                if (sqrt(InnerProduct(r, r)) <= tNorm)
+                const double beta = PrepareDirection_(s, ii);
+                UpdateSolution_(s, beta, x);
+                if (sqrt(InnerProduct(s.r, s.r)) <= tNorm)
                     return;
             }
             THROW(biConjugate ? "Exhausted iterations in BCGSolve" : "Exhausted iterations in CGSolve");

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -43,82 +43,69 @@ namespace Dal {
         };
     } // namespace
 
-    void Sparse::CGSolve(const Sparse::Square_& A,
-                         const Vector_<>& b,
-                         double tolRel,
-                         double tolAbs,
-                         int maxIterations,
-                         Vector_<>* x) {
-        const int n = A.Size();
-        REQUIRE(b.size() == n && x->size() == n, "matrix size is not compatible");
-        REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters is not valid");
+    namespace {
+        // Unified Krylov iteration for CG (biConjugate = false) and BCG (true). CG aliases the
+        // shadow vectors onto the real ones so the shared arithmetic stays byte-identical to
+        // standalone CG; shadow maintenance is gated on the flag.
+        void
+        KrylovSolve_(const Sparse::Square_& A, const Vector_<>& b, double tolRel, double tolAbs, int maxIterations, bool biConjugate, Vector_<>* x) {
+            const int n = A.Size();
+            REQUIRE(b.size() == n && x->size() == n, "matrix size is not compatible");
+            REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters is not valid");
 
-        double tNorm = tolRel * sqrt(InnerProduct(b, b)) + tolAbs;
-        XPrecondition_ precondition(A);
-        Vector_<> r(n);
-        Vector_<> z(n);
-        Vector_<> p(n);
-        A.MultiplyLeft(*x, &r);
-        Transform(b, r, std::minus<>(), &r); // r = b - Ax
-        double betaPrev;
-        for (int ii = 0; ii < maxIterations; ++ii) {
-            precondition.Left(r, &z);
-            const double beta = InnerProduct(z, r);
-            p *= ii > 0 ? beta / betaPrev : 0.0;
-            p += z;
-            betaPrev = beta;
-            A.MultiplyLeft(p, &z);
-            const double alphaK = beta / InnerProduct(z, p);
-            Transform(x, p, LinearIncrement(alphaK));
-            Transform(&r, z, LinearIncrement(-alphaK));
-            if (sqrt(InnerProduct(r, r)) <= tNorm)
-                return;
+            double tNorm = tolRel * sqrt(InnerProduct(b, b)) + tolAbs;
+            XPrecondition_ precondition(A);
+            Vector_<> r(n);
+            Vector_<> rr(n);
+            Vector_<> z(n);
+            Vector_<> zz(n);
+            Vector_<> p(n);
+            Vector_<> pp(n);
+
+            A.MultiplyLeft(*x, &r);
+            Transform(b, r, std::minus<>(), &r); // r = b - Ax
+            if (biConjugate)
+                rr = r;
+
+            // CG collapses each shadow vector onto its real counterpart, so beta and alphaK
+            // reduce to the standalone-CG expressions InnerProduct(z, r) and beta/InnerProduct(z, p).
+            Vector_<>& zzRef = biConjugate ? zz : z;
+            Vector_<>& ppRef = biConjugate ? pp : p;
+
+            double betaPrev;
+            for (int ii = 0; ii < maxIterations; ++ii) {
+                precondition.Left(r, &z);
+                if (biConjugate)
+                    precondition.Right(rr, &zz);
+                const double beta = InnerProduct(zzRef, r);
+                const double multiply = ii > 0 ? beta / betaPrev : 0.0;
+                p *= multiply;
+                if (biConjugate)
+                    pp *= multiply;
+                p += z;
+                if (biConjugate)
+                    pp += zz;
+                betaPrev = beta;
+                A.MultiplyLeft(p, &z);
+                if (biConjugate)
+                    A.MultiplyRight(pp, &zz);
+                const double alphaK = beta / InnerProduct(z, ppRef);
+                Transform(x, p, LinearIncrement(alphaK));
+                Transform(&r, z, LinearIncrement(-alphaK));
+                if (biConjugate)
+                    Transform(&rr, zz, LinearIncrement(-alphaK));
+                if (sqrt(InnerProduct(r, r)) <= tNorm)
+                    return;
+            }
+            THROW(biConjugate ? "Exhausted iterations in BCGSolve" : "Exhausted iterations in CGSolve");
         }
-        THROW("Exhausted iterations in CGSolve");
+    } // namespace
+
+    void Sparse::CGSolve(const Sparse::Square_& A, const Vector_<>& b, double tolRel, double tolAbs, int maxIterations, Vector_<>* x) {
+        KrylovSolve_(A, b, tolRel, tolAbs, maxIterations, false, x);
     }
 
-    void Sparse::BCGSolve(const Sparse::Square_ &A,
-                          const Vector_<> &b,
-                          double tolRel,
-                          double tolAbs,
-                          int maxIterations, Vector_<> *x) {
-        const int n = A.Size();
-        REQUIRE(b.size() == n && x->size() == n, "matrix size is not compatible");
-        REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters is not valid");
-
-        double tNorm = tolRel * sqrt(InnerProduct(b, b)) + tolAbs;
-        XPrecondition_ precondition(A);
-        Vector_<> r(n);
-        Vector_<> rr(n);
-        Vector_<> z(n);
-        Vector_<> zz(n);
-        Vector_<> p(n);
-        Vector_<> pp(n);
-
-        A.MultiplyLeft(*x, &r);
-        Transform(b, r, std::minus<>(), &r); // r = b - Ax
-        rr = r;
-
-        double betaPrev;
-        for (int ii = 0; ii < maxIterations; ++ii) {
-            precondition.Left(r, &z);
-            precondition.Right(rr, &zz);
-            const double beta = InnerProduct(zz, r);
-            const double multiply = ii > 0 ? beta / betaPrev : 0.0;
-            p *= multiply;
-            pp *= multiply;
-            p += z;
-            pp += zz;
-            betaPrev = beta;
-            A.MultiplyLeft(p, &z);
-            A.MultiplyRight(pp, &zz);
-            const double alphaK = beta / InnerProduct(z, pp);
-            Transform(x, p, LinearIncrement(alphaK));
-            Transform(&r, z, LinearIncrement(-alphaK));
-            Transform(&rr, zz, LinearIncrement(-alphaK));
-            if (sqrt(InnerProduct(r, r)) <= tNorm)
-                return;
-        }
-        THROW("Exhausted iterations in BCGSolve");
+    void Sparse::BCGSolve(const Sparse::Square_& A, const Vector_<>& b, double tolRel, double tolAbs, int maxIterations, Vector_<>* x) {
+        KrylovSolve_(A, b, tolRel, tolAbs, maxIterations, true, x);
     }
 } // namespace Dal


### PR DESCRIPTION
## Summary
- `CGSolve` was a strict subset of `BCGSolve` — both shared the full Krylov setup (validation, `tNorm`, preconditioner, residual init) and the same per-iteration arithmetic, with BCG only doubling the bookkeeping via shadow vectors `rr`/`zz`/`pp`. Extract a single file-local `KrylovSolve_` helper parameterised by a `biConjugate` flag that both public functions delegate to.
- For the CG path, each shadow vector is collapsed onto its real counterpart via references (`zzRef` aliases `z`, `ppRef` aliases `p`), so `beta` and `alphaK` reduce to the standalone-CG expressions `InnerProduct(z, r)` and `beta/InnerProduct(z, p)`; every shadow-maintenance branch (`precondition.Right`, `pp *= multiply`, `pp += zz`, `A.MultiplyRight`, `rr` update, `rr = r`) is gated on the flag and skipped. Per-iteration operations, order, and FP values are unchanged.
- Normalises `BCGSolve`'s pointer/reference spacing to `.clang-format` (`PointerBindsToType`) and adds the missing trailing newline. The stale BCG error-message copy-paste bug is **not** re-touched (already fixed on `master` in PR #149).

## Byte-identity verification
Outputs must be byte-identical on this FP path, so I verified with a throwaway 17-significant-figure probe test (added, built, run, then removed before commit) that dumps the full `result` vectors from both `CGSolve` and `BCGSolve` on the existing `test_bcg.cpp` matrices:

```
CG  [n=10]: 0.10000000000000001 ... 0.076923076923076927 0.076923076923076927
BCG [n=10]: 0.099999999999999992 ... 0.085106382978723402 0.074468085106382975
```

`diff` of the before (standalone `CGSolve`/`BCGSolve`) vs after (`KrylovSolve_`-based) probe output: **identical, no differences**. Re-confirmed after the clang-format and comment-trim edits. No test tolerances were loosened.

## Test plan
- [x] `bin/dal_cpp_tests --gtest_filter='*Matrix*:*Solve*:*CG*:*BCG*'` → 53 tests pass (unchanged from master)
- [x] Full `dal_cpp_tests` suite → **759 tests, 68 suites, 0 failures**
- [x] 17-sig-fig before/after probe diff → byte-identical for both CG and BCG
- [x] `clang-format` clean on the changed region (remaining `clang-format` deltas are pre-existing in the file: include order and `XSolveLeft_af` brace style — left untouched to keep the diff focused)

Worktree: `.claude/worktrees/dedup-cg-bcg` on branch `chore/dedup-cg-bcg`, branched from `master` at 3269bc5.