### PR TITLE
refactor: dedupe Black/Bachelier numerical paths

### DIFF
--- a/dal-cpp/dal/math/distribution/black.cpp
+++ b/dal-cpp/dal/math/distribution/black.cpp
@@ -28,8 +28,9 @@ namespace Dal {
                 Converged_ done(TOL * max(1.0, fwd), TOL * max(1.0, price));
                 for (int i = 0; i < MAX_ITERATIONS; ++i) {
                     const double vol = exp(task.NextX());
-                    if (done(task, pricer(vol) - price))
+                    if (done(task, pricer(vol) - price)) {
                         return vol;
+                    }
                 }
                 THROW("exhausted iterations in " + String_(caller));
             }
@@ -79,7 +80,7 @@ namespace Dal {
         double BachelierIV(double fwd, double strike, const OptionType_& type, double price, double guess) {
             REQUIRE(price >= type.Payout(fwd, strike), "value below intrinsic value in BachelierIV");
             auto pricer = [&](double vol) { return BachelierOpt(fwd, vol, strike, type); };
-            auto guessTransform = [](double g, double fwd) { return g > 0.0 ? g : -1.5 * fwd; };
+            auto guessTransform = [](double g, double fwdIn) { return g > 0.0 ? g : -1.5 * fwdIn; };
             return SolveIV(fwd, price, "BachelierIV", pricer, guessTransform, guess);
         }
 

--- a/dal-cpp/dal/math/distribution/black.cpp
+++ b/dal-cpp/dal/math/distribution/black.cpp
@@ -11,98 +11,94 @@
 
 namespace Dal {
     namespace Distribution {
-        double BlackIV(double fwd, double strike, const OptionType_& type, double price, double guess) {
-            static const int MAX_ITERATIONS = 30;
-            static const double TOL = 1.0e-10;
-            REQUIRE(price >= type.Payout(fwd, strike), "value below intrinsic value in BlackIV");
-            Brent_ task(guess > 0.0 ? log(guess) : -1.5);
-            Converged_ done(TOL * max(1.0, fwd), TOL * max(1.0, price));
-            for (int i = 0; i < MAX_ITERATIONS; ++i) {
-                const double vol = exp(task.NextX());
-                if (done(task, BlackOpt(fwd, vol, strike, type) - price))
-                    return vol;
+        namespace {
+            // Shared Brent-on-log-vol implied-vol solver. The iteration sequence
+            // (NextX -> exp -> pricer -> done) matches the original BlackIV/BachelierIV
+            // implementations exactly, so floating-point results are byte-identical.
+            template <class Pricer_, class GuessTransform_>
+            double SolveIV(double fwd,
+                           double price,
+                           const char* caller,
+                           Pricer_ pricer,
+                           GuessTransform_ guessTransform,
+                           double guess) {
+                static const int MAX_ITERATIONS = 30;
+                static const double TOL = 1.0e-10;
+                Brent_ task(guessTransform(guess, fwd));
+                Converged_ done(TOL * max(1.0, fwd), TOL * max(1.0, price));
+                for (int i = 0; i < MAX_ITERATIONS; ++i) {
+                    const double vol = exp(task.NextX());
+                    if (done(task, pricer(vol) - price))
+                        return vol;
+                }
+                THROW("exhausted iterations in " + String_(caller));
             }
-            THROW("exhausted iterations in BlackIV");
+
+            // Shared OptionType_ switch + push_back scaffolding for the (delta, vega) pair.
+            // vegaScale is `fwd` for Black and `1.0` for Bachelier, reproducing the original
+            // `fwd * NPDF(dPlus)` / `NPDF(d)` expressions verbatim.
+            Vector_<> GreeksFromD(double d, double vegaScale, const OptionType_& type) {
+                double fwdDelta = 0.0;
+                double vega = 0.0;
+                switch (type.Switch()) {
+                case OptionType_::Value_::CALL:
+                    fwdDelta = NCDF(d);
+                    vega = vegaScale * NPDF(d);
+                    break;
+                case OptionType_::Value_::PUT:
+                    fwdDelta = -NCDF(-d);
+                    vega = vegaScale * NPDF(d);
+                    break;
+                case OptionType_::Value_::STRADDLE:
+                    fwdDelta = NCDF(d) - NCDF(-d);
+                    vega = 2.0 * vegaScale * NPDF(d);
+                    break;
+                default:
+                    THROW("invalid option type");
+                }
+                Vector_<> ret_val;
+                ret_val.push_back(fwdDelta);
+                ret_val.push_back(vega);
+                return ret_val;
+            }
+        } // namespace
+
+        double BlackIV(double fwd, double strike, const OptionType_& type, double price, double guess) {
+            REQUIRE(price >= type.Payout(fwd, strike), "value below intrinsic value in BlackIV");
+            auto pricer = [&](double vol) { return BlackOpt(fwd, vol, strike, type); };
+            auto guessTransform = [](double g, double) { return g > 0.0 ? log(g) : -1.5; };
+            return SolveIV(fwd, price, "BlackIV", pricer, guessTransform, guess);
         }
 
         Vector_<> BlackGreeks(double fwd, double vol, double strike, const OptionType_& type) {
             const double dMinus = log(fwd / strike) / vol - 0.5 * vol;
             const double dPlus = dMinus + vol;
-            double fwdDelta = 0.0;
-            double vega = 0.0;
-            switch (type.Switch()) {
-            case OptionType_::Value_::CALL:
-                fwdDelta = NCDF(dPlus);
-                vega = fwd * NPDF(dPlus);
-                break;
-            case OptionType_::Value_::PUT:
-                fwdDelta = -NCDF(-dPlus);
-                vega = fwd * NPDF(dPlus);
-                break;
-            case OptionType_::Value_::STRADDLE:
-                fwdDelta = NCDF(dPlus) - NCDF(-dPlus);
-                vega = 2.0 * fwd * NPDF(dPlus);
-                break;
-            default:
-                THROW("invalid option type");
-            }
-            Vector_<> ret_val;
-            ret_val.push_back(fwdDelta);
-            ret_val.push_back(vega);
-            return ret_val;
+            return GreeksFromD(dPlus, fwd, type);
         }
 
         double BachelierIV(double fwd, double strike, const OptionType_& type, double price, double guess) {
-            static const int MAX_ITERATIONS = 30;
-            static const double TOL = 1.0e-10;
             REQUIRE(price >= type.Payout(fwd, strike), "value below intrinsic value in BachelierIV");
-            Brent_ task(guess > 0.0 ? guess : -1.5 * fwd);
-            Converged_ done(TOL * max(1.0, fwd), TOL * max(1.0, price));
-            for (int i = 0; i < MAX_ITERATIONS; ++i) {
-                const double vol = exp(task.NextX());
-                if (done(task, BachelierOpt(fwd, vol, strike, type) - price))
-                    return vol;
-            }
-            THROW("exhausted iterations in BachelierIV");
+            auto pricer = [&](double vol) { return BachelierOpt(fwd, vol, strike, type); };
+            auto guessTransform = [](double g, double fwd) { return g > 0.0 ? g : -1.5 * fwd; };
+            return SolveIV(fwd, price, "BachelierIV", pricer, guessTransform, guess);
         }
 
         Vector_<> BachelierGreeks(double fwd, double vol, double strike, const OptionType_& type) {
             const double diff = fwd - strike;
             const double d = diff / vol;
-            double fwdDelta = 0.0;
-            double vega = 0.0;
-            switch (type.Switch()) {
-            case OptionType_::Value_::CALL:
-                fwdDelta = NCDF(d);
-                vega = NPDF(d);
-                break;
-            case OptionType_::Value_::PUT:
-                fwdDelta = -NCDF(-d);
-                vega = NPDF(d);
-                break;
-            case OptionType_::Value_::STRADDLE:
-                fwdDelta = NCDF(d) - NCDF(-d);
-                vega = 2.0 * NPDF(d);
-                break;
-            default:
-                THROW("invalid option type");
-            }
-            Vector_<> ret_val;
-            ret_val.push_back(fwdDelta);
-            ret_val.push_back(vega);
-            return ret_val;
+            return GreeksFromD(d, 1.0, type);
         }
-    }
+    } // namespace Distribution
 
-    double DistributionBlack_::VolVega(double strike, const OptionType_& type) const {
-        Vector_<> greeks = Distribution::BlackGreeks(f_, vol_, strike, type);
+    double DistributionNormalLike_::VolVega(double strike, const OptionType_& type) const {
+        Vector_<> greeks = Greeks(strike, type);
         return vol_ * greeks[1];
     }
 
-    std::map<String_, double> DistributionBlack_::ParameterDerivatives(double strike,
-                                                                       const OptionType_& type,
-                                                                       const Vector_<String_>& to_report) const {
-        Vector_<> greeks = Distribution::BlackGreeks(f_, vol_, strike, type);
+    std::map<String_, double> DistributionNormalLike_::ParameterDerivatives(double strike,
+                                                                             const OptionType_& type,
+                                                                             const Vector_<String_>& to_report) const {
+        Vector_<> greeks = Greeks(strike, type);
         std::map<String_, double> ret_val;
         for (const auto& name: to_report) {
             if (name == "delta")
@@ -116,27 +112,4 @@ namespace Dal {
         }
         return ret_val;
     }
-
-    double DistributionBachelier_::VolVega(double strike, const OptionType_& type) const {
-        const Vector_<> greeks = Distribution::BachelierGreeks(f_, vol_, strike, type);
-        return vol_ * greeks[1];
-    }
-
-    std::map<String_, double> DistributionBachelier_::ParameterDerivatives(double strike,
-                                                                           const OptionType_& type,
-                                                                           const Vector_<String_>& to_report) const {
-        Vector_<> greeks = Distribution::BachelierGreeks(f_, vol_, strike, type);
-        std::map<String_, double> ret_val;
-        for (const auto& name: to_report) {
-            if (name == "delta")
-                ret_val.insert({String_("delta"), greeks[0]});
-            else if (name == "vega")
-                ret_val.insert({String_("vega"), greeks[1]});
-            else if (name == "volvega")
-                ret_val.insert({String_("volvega"), vol_ * greeks[1]});
-            else
-                THROW("not known greek name " + name);
-        }
-        return ret_val;
-    }
-}
+} // namespace Dal

--- a/dal-cpp/dal/math/distribution/black.hpp
+++ b/dal-cpp/dal/math/distribution/black.hpp
@@ -110,4 +110,4 @@ namespace Dal {
             return Distribution::BachelierGreeks(f_, vol_, strike, type);
         }
     };
-}
+} // namespace Dal

--- a/dal-cpp/dal/math/distribution/black.hpp
+++ b/dal-cpp/dal/math/distribution/black.hpp
@@ -51,21 +51,24 @@ namespace Dal {
 
         double BachelierIV(double fwd, double strike, const OptionType_& type, double price, double guess = 0.0);
         Vector_<> BachelierGreeks(double fwd, double vol, double strike, const OptionType_& type);
-
     }
 
-    class DistributionBlack_: public Distribution_ {
+    // Shared storage and reporting for lognormal (Black) and normal (Bachelier) distributions.
+    // The two public types remain distinct because their pricing math differs; only the
+    // vol/forward storage, VolVega, ParameterNames, and the ParameterDerivatives dispatch
+    // (which depend solely on the greeks vector) are shared here.
+    class DistributionNormalLike_: public Distribution_ {
+    protected:
         double f_;
         double vol_;
 
+        [[nodiscard]] virtual Vector_<> Greeks(double strike, const OptionType_& type) const = 0;
+
     public:
-        DistributionBlack_(double fwd, double deannVol): f_(fwd), vol_(deannVol) {}
+        DistributionNormalLike_(double fwd, double deannVol): f_(fwd), vol_(deannVol) {}
 
         [[nodiscard]] double Forward() const override { return f_; }
-        [[nodiscard]] double OptionPrice(double strike, const OptionType_& type) const override {
-            return Distribution::BlackOpt(f_, vol_, strike, type);
-        }
-        double & Vol() override { return vol_; }
+        double& Vol() override { return vol_; }
         [[nodiscard]] const double& Vol() const override { return vol_; }
         [[nodiscard]] double VolVega(double strike, const OptionType_& type) const override;
         [[nodiscard]] Vector_<String_> ParameterNames() const override {
@@ -80,28 +83,31 @@ namespace Dal {
                                                                      const Vector_<String_>& to_report) const override;
     };
 
-    class DistributionBachelier_: public Distribution_ {
-        double f_;
-        double vol_;
-
+    class DistributionBlack_: public DistributionNormalLike_ {
     public:
-        DistributionBachelier_(double fwd, double deannVol): f_(fwd), vol_(deannVol) {}
-        [[nodiscard]] double Forward() const override { return f_; }
+        DistributionBlack_(double fwd, double deannVol): DistributionNormalLike_(fwd, deannVol) {}
+
+        [[nodiscard]] double OptionPrice(double strike, const OptionType_& type) const override {
+            return Distribution::BlackOpt(f_, vol_, strike, type);
+        }
+
+    protected:
+        [[nodiscard]] Vector_<> Greeks(double strike, const OptionType_& type) const override {
+            return Distribution::BlackGreeks(f_, vol_, strike, type);
+        }
+    };
+
+    class DistributionBachelier_: public DistributionNormalLike_ {
+    public:
+        DistributionBachelier_(double fwd, double deannVol): DistributionNormalLike_(fwd, deannVol) {}
+
         [[nodiscard]] double OptionPrice(double strike, const OptionType_& type) const override {
             return Distribution::BachelierOpt(f_, vol_, strike, type);
         }
-        double & Vol() override { return vol_; }
-        [[nodiscard]] const double& Vol() const override { return vol_; }
-        [[nodiscard]] double VolVega(double strike, const OptionType_& type) const override;
-        [[nodiscard]] Vector_<String_> ParameterNames() const override {
-            Vector_<String_> ret_val;
-            ret_val.push_back("forward");
-            ret_val.push_back("vol");
-            return ret_val;
-        }
 
-        [[nodiscard]] std::map<String_, double> ParameterDerivatives(double strike,
-                                                                     const OptionType_& type,
-                                                                     const Vector_<String_>& to_report) const override;
+    protected:
+        [[nodiscard]] Vector_<> Greeks(double strike, const OptionType_& type) const override {
+            return Distribution::BachelierGreeks(f_, vol_, strike, type);
+        }
     };
 }


### PR DESCRIPTION
## Summary
- Unify `BlackIV`/`BachelierIV` via a shared templated `SolveIV(pricer, guessTransform)` helper in an anonymous namespace. The Brent iteration sequence (`NextX` -> `exp` -> `pricer` -> `Converged_`) is preserved verbatim, so floating-point output is byte-identical.
- Unify `BlackGreeks`/`BachelierGreeks` via `GreeksFromD(d, vegaScale, type)` holding the shared `OptionType_` switch + `push_back` scaffolding. Black passes `(dPlus, fwd)`, Bachelier `(d, 1.0)`, reproducing the original `fwd * NPDF(dPlus)` / `NPDF(d)` expressions exactly.
- Introduce `DistributionNormalLike_` base holding `f_`/`vol_` storage and implementing `VolVega`, `ParameterNames`, and `ParameterDerivatives` (which differ only in which `*Greeks` feeds them, via a virtual `Greeks()` hook). `DistributionBlack_`/`DistributionBachelier_` keep their distinct `OptionPrice` overrides. The two public types remain distinct (lognormal Black vs normal Bachelier is a genuine interface distinction).
- `BlackOpt<T_>`/`BachelierOpt<T_>` templates are unchanged.

## Byte-identity verification
A full-precision (17 significant figures) probe exercises option prices, greeks (delta, vega), implied vols (5 price levels x 6 scenarios), `VolVega`, and all three `ParameterDerivatives` for Call/Put/Straddle. The probe is compiled once against the original `black.{hpp,cpp}` (from `master`) and once against the refactored version, both linked against the same `libdal_cpp.a`. Output diff is empty — **byte-identical**.

## Test plan
- [x] `bin/dal_cpp_tests` native (all 759 tests pass)
- [x] adept backend full suite: 758 tests pass
- [x] xad backend full suite: 758 tests pass
- [x] codipack backend full suite: 758 tests pass
- [x] `--gtest_filter='*Distribution*:*Black*:*Bachelier*:*Analytic*'` passes on all four builds (45 tests each)
- [x] Full-precision probe diff: byte-identical (no tolerance loosened; no shift to reconcile)

Draft — not merging per project convention.