### PR TITLE
docs: migrate curve residual comments into methodology

### DIFF
--- a/docs/methodology/log_discount_curve.md
+++ b/docs/methodology/log_discount_curve.md
@@ -135,6 +135,19 @@ tail). `LOG_LINEAR` basis applies for $\tau \le \tau_{\text{cutoff}}$; the cubic
 cubic tail subarray and expanded back to full storage-node indices, with
 `mixedCutoffIndex_` and `mixedCutoffYf_` stored for dispatch at evaluation.
 
+### The `fppCoef_` second-derivative sensitivity matrix
+
+`fppCoef_[k][j]` holds $\partial\,\ell''_k / \partial\,\ell_j$ — the sensitivity of
+each interior knot's second derivative to each storage-node $\ell$ value. It exists
+**only** for the cubic machinery: it is computed once at construction for
+`LOG_CUBIC_NATURAL` and for the cubic tail of `MIXED`, and it is **empty and unused**
+for `LOG_LINEAR` and for the linear head of `MIXED` (the linear basis weights are
+closed-form in the knot positions and need no second-derivative solve). Because the
+matrix is a function of the knot abscissae $\tau_i$ only, the same instance serves
+the `double` and `Number_` specialisations identically — only the basis-weight
+accumulation against `logDF_` differs, and that is what the `Number_` path does on
+the tape.
+
 ### Extrapolation
 
 Beyond $\tau_{N-1}$, every scheme uses the secant slope of the last segment:

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -46,6 +46,23 @@ and evaluated at the solution, whereas `effJacobianInverse_` is a solver-weighte
 tolerance-scaled pseudoinverse formed at the solver's final iterate. They are not
 inverses in their exposed form.
 
+### How `jacobian_` is captured
+
+The forward Jacobian is not re-derived by the consumer; it is captured **once,
+inside the solver, on its convergence branch**. When the solve is eligible for
+the analytic path, the convergence hook issues a single
+`func.Gradient(xNew, fNew)` call at the solved $x^\star$, and the reverse sweep
+that fills `jacobian_` is that one evaluation. The output is the plain Jacobian
+before the solver's `DivideRows(tol_)` row-scaling, and an independent
+finite-difference bump of the solved nodes reproduces it element-wise.
+
+There is deliberately **no standalone "analytic Jacobian at a point" accessor**.
+The forward Jacobian is obtainable only as a byproduct of an eligible
+calibration, on the public diagnostics struct — never as a free-standing query
+on a curve. A consumer that wants $J$ at an arbitrary point must run an
+eligible calibration through `CalibrateYieldCurve` and read
+`result.diagnostics_.jacobian_`, or perform the bump locally.
+
 **Bump oracle.** A two-sided central difference — perturb $x_k$ by $\pm h$,
 rebuild the curve via `NewDiscountLogDF(...)`, reprice every instrument — gives
 the same $J$ with a truncation error of $O(h^2)$ and a round-off floor of
@@ -181,12 +198,14 @@ that do not layer. `PIECEWISE_CONSTANT_FWD` declarations cannot be base-layered
 `sofarT_[k] = ∫_{knot_0}^{knot_k} f(τ) dτ` is `T_`-typed (mirroring the
 `PiecewiseLinear_::sofar_` member but on `T_`), so the dependence of every
 discount-factor read on `fLeftT_` / `fRightT_` records on the tape. The
-year-fraction weights (`dt`) stay `double` — they are functions of the knot
-abscissae only, identical for any `T_`. `UpdateT()` recomputes `sofarT_`
-whenever the forward parameters change. The `double` specialization of the
-templated class is byte-for-byte identical in arithmetic to the non-templated
-`DiscountPWLF_` the bumped path uses, so the AAD-vs-bump agreement bar is
-defined against the same residual function.
+year-fraction weights (`dt`) and the knot abscissae themselves
+(`knotAbscissae_`, serial-day offsets from knot 0) stay `double` — they are
+functions of the knot positions only, computed once at construction and
+identical for any `T_`. `UpdateT()` recomputes `sofarT_` whenever the forward
+parameters change. The `double` specialization of the templated class is
+byte-for-byte identical in arithmetic to the non-templated `DiscountPWLF_` the
+bumped path uses, so the AAD-vs-bump agreement bar is defined against the same
+residual function.
 
 The `Number_`-typed curve is constructed directly from tape-registered forward
 parameters — the `AnalyticJacobian` override registers `fLeftT_` / `fRightT_`


### PR DESCRIPTION
## Summary

Phase 3 (comment migration), Wave 1, curve-residuals cluster. Absorbs the WHY
content from the last methodology-prose source comments in `dal-cpp/dal/curve/`
into the docs that already own those topics, so a follow-up implementer wave can
reduce the comments to one-line pointers. DOC-ONLY — no source touched.

- **`docs/methodology/yield_curve_jacobian.md`**
  - New subsection **"How `jacobian_` is captured"**: the forward Jacobian is
    captured once, inside the solver, on its convergence branch via a single
    `func.Gradient(xNew, fNew)` call at the solved $x^\star$ (unscaled, before
    `DivideRows(tol_)`); and there is deliberately **no standalone "analytic J
    at a point" accessor** — the forward J is a calibration byproduct only.
  - Extended the **"PWL-forward → log-DF integration"** section with the
    `knotAbscissae_` invariant (double-typed, computed once at construction,
    identical for any `T_`), paralleling the existing `dt`-stays-double rule.

- **`docs/methodology/log_discount_curve.md`**
  - New subsection **"The `fppCoef_` second-derivative sensitivity matrix"**:
    `fppCoef_[k][j] = ∂ℓ''_k/∂ℓ_j` exists only for the cubic machinery
    (`LOG_CUBIC_NATURAL` and the cubic tail of `MIXED`) and is **empty / unused**
    for `LOG_LINEAR` and the linear head of `MIXED`; it is a function of knot
    abscissae only, so one instance serves the `double` and `Number_` paths.

### Source comments now "homed" (ready for the follow-up trim wave)

- `dal-cpp/dal/curve/calibration.hpp` — the block comment on
  `CurveCalibrationDiagnostics_::jacobian_` (unscaled / at-solution /
  populated-iff / contrast with `effJacobianInverse_` / no standalone accessor)
  → `yield_curve_jacobian.md` §"How `jacobian_` is captured".
- `dal-cpp/dal/curve/yclogdf.hpp` —
  - (a) the templatization-rationale block: its load-bearing WHY is **already**
    fully covered by `log_discount_curve.md` §"Representation", §"Why
    Log-Discount is the Analytic-Jacobian Parameterization", and §"Double vs
    Number_ Dispatch"; nothing new migrated. The comment is pure
    design-narrative ("Phase A", "pre-Phase-A", `.claude/designs/…` citation)
    and reduces to a one-line pointer with no doc delta.
  - (b) the member docs on `fppCoef_` / `LogDfAt` / `CubicBasisAt` /
    `StorageBasisWeightsAt`: the spline basis-weight derivation is already in
    §"Basis Weights by Interpolation Scheme"; the one missing invariant
    (fppCoef_ empty for LOG_LINEAR / MIXED-head) → new §"The `fppCoef_`
    second-derivative sensitivity matrix".
- `dal-cpp/dal/curve/ycpwlf.hpp` — the member docs on `fLeftT_` / `fRightT_` /
  `sofarT_` / `knotAbscissae_`: the `T_`-typed running-sum / records-on-tape
  invariant is already in `yield_curve_jacobian.md` §"PWL-forward → log-DF
  integration"; the `knotAbscissae_` double/computed-once detail was added
  there in this PR.

## Test plan

- [x] No test suite applies (DOC-ONLY; no source, build, or test changes).
- [x] Manual verification: read current `calibration.hpp`, `yclogdf.hpp`,
      `ycpwlf.hpp` headers and confirmed each migrated claim matches the
      current signatures and members.
- [x] Cross-checked that `docs/README.md` index and `CLAUDE.md` methodology
      list need no changes (no new top-level doc, no renamed doc).
- [x] Verified no trailing whitespace and both edited files end with a newline.
- [x] Confirmed no source line numbers cited; current-state voice throughout;
      no Phase A/B design narrative migrated (that history is CHANGELOG-only,
      and nothing fundamental enough for a CHANGELOG entry shipped here).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>