### PR TITLE
docs: migrate small residuals into yield_curve

### DIFF
--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -124,6 +124,13 @@ falling back to OIS when a specific collateral curve is absent; forecasting is
 routed to the relevant tenor curve, falling back to the single discount curve in a
 single-curve setup.
 
+The `CollateralType_` enum distinguishes only the curve families the framework
+actually builds (OIS, GC); tenor-specific collateral is **not** encoded as a
+distinct enum value. The `CollateralType_Libor(tenor)` factory therefore returns
+`GC` and ignores its `tenor` argument — tenor distinctions live on the
+projection-curve side (the `useProjectionCurve_` / `forecastTenor_` fields of
+`RateIndexConvention_`), not on the collateral type.
+
 Because the spread is multiplicative in discount factors (additive in the
 integrated forward rate), the dependency of derived curves on their base is exact
 and is tracked so that a bump to the base curve flows consistently through every
@@ -174,6 +181,16 @@ maturities, or formed from the union of both. After the solve, repricing residua
 without re-solving the system. That inverse carries a `tolerance_` factor from the
 solver's residual scaling — see [Yield-Curve Jacobian and Inverse-Jacobian
 Risk](yield_curve_jacobian.md) before consuming it.
+
+### Curve Instrument Date and Tenor Conventions
+
+The discount-factor index `DF_` (in `dal-cpp/dal/indice/index/ir.hpp`) fixes the
+date semantics of curve instruments. Its `maturity_` and `start_` cells may each
+hold a fixed date, a number-of-days offset, or a tenor offset. Both offsets are
+measured **from the fixing date**, not from the start date. A forward-started
+quote with `"2Y"` as `start_` and `"3Y"` as `maturity_` therefore matures at
+$T_{\text{fixing}} + 3Y$, not at $T_{\text{fixing}} + 2Y + 3Y$. Leaving `start_`
+empty denotes the usual spot-started index.
 
 ### Single-Curve AAD Calibration Internals
 


### PR DESCRIPTION
## Summary
- Migrate the `DF_::maturity_`/`start_` offset convention (from `dal-cpp/dal/indice/index/ir.hpp`) into `docs/methodology/yield_curve.md` as a new **Curve Instrument Date and Tenor Conventions** note under the calibration section. Captures the "offset from fixing date, not start date" rule and the 2Y-start/3Y-maturity example.
- Fold the `CollateralType_Libor(tenor)` aside (from `dal-public/src/curveprotocol.hpp`) into the **Multi-Curve Framework** section of the same doc: the `CollateralType_` enum only distinguishes OIS/GC; tenor collateral rides the projection-curve mechanism (`useProjectionCurve_`/`forecastTenor_`), not a distinct enum value.
- No source edited (DOC-ONLY). The now-redundant source comments are left in place for a follow-up implementer trim wave; this PR only lands the doc homes.

### Items deliberately NOT migrated (recommended for the trim wave)
The two infrastructure comments below have no methodology home and are best reduced or deleted by the trim wave rather than forced into a doc:
- `dal-cpp/dal/storage/_repository.hpp` header rationale (global in-process store, string tags for Excel, environment entry) — C++ infra, not quant methodology. `CLAUDE.md`'s architecture section already covers `dal-cpp/dal/storage/`. Recommend: reduce to a one-line pointer or delete.
- `dal-cpp/dal/utilities/exceptions.cpp` — the commented-out `boost::thread_specific_ptr` block is dead code (recommend delete); the boost-avoidance note and the `PopStack` memory-leak-prevention rationale are infra design notes with no doc home. Recommend: delete the dead block and reduce the rationale comments to a single line or delete.

## Test plan
- [x] No test suite applies (docs-only change).
- [x] Read current source at `dal-cpp/dal/indice/index/ir.hpp`, `dal-public/src/curveprotocol.hpp`, `dal-cpp/dal/protocol/collateraltype.hpp` to capture accurate semantics.
- [x] Cross-checked `CLAUDE.md` methodology list and `docs/README.md` — no new doc added, so no index/methodology-list update needed.
- [x] Verified the changed file has no trailing whitespace and ends with a newline.
- [x] No CHANGELOG entry warranted: doc-only migration of existing comments, no fundamental/breaking change.