### PR TITLE
fix: avoid CG shadow-vector alloc and fix REQUIRE message grammar

### DIFF
--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -61,8 +61,8 @@ namespace Dal {
             double betaPrev;
 
             KrylovState_(const Sparse::Square_& a, const XPrecondition_& prec, bool biConjugate, int n)
-                : A(a), precondition(prec), biConjugate(biConjugate), r(n), rr(n), z(n), zz(n), p(n), pp(n), zzRef(biConjugate ? zz : z),
-                  ppRef(biConjugate ? pp : p), betaPrev(0.0) {}
+                : A(a), precondition(prec), biConjugate(biConjugate), r(n), rr(biConjugate ? n : 0), z(n), zz(biConjugate ? n : 0), p(n),
+                  pp(biConjugate ? n : 0), zzRef(biConjugate ? zz : z), ppRef(biConjugate ? pp : p), betaPrev(0.0) {}
         };
 
         double PrepareDirection_(KrylovState_& s, int ii) {
@@ -93,8 +93,8 @@ namespace Dal {
         }
 
         void ValidateKrylovParams_(int n, const Vector_<>& b, const Vector_<>* x, double tolRel, double tolAbs, int maxIterations) {
-            REQUIRE(b.size() == n && x->size() == n, "matrix size is not compatible");
-            REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters is not valid");
+            REQUIRE(b.size() == n && x->size() == n, "matrix dimensions are incompatible");
+            REQUIRE((IsPositive(tolRel) || IsPositive(tolAbs)) && maxIterations > 0, "parameters are invalid");
         }
 
         void


### PR DESCRIPTION
Addresses the two post-merge Copilot review items on `bcg.cpp` from PR #155.

## Summary
- **Shadow-vector allocation (Copilot, `KrylovState_` ctor)**: `rr`/`zz`/`pp` are now sized to `n` only when `biConjugate = true` (BCG). For CG they remain empty — CG never reads them because `zzRef`/`ppRef` alias `z`/`p`. This restores the standalone-`CGSolve` memory and cache footprint that the unification regressed (the original `CGSolve` allocated only `r`/`z`/`p`).
- **REQUIRE message grammar (Copilot, `ValidateKrylovParams_`)**: `"matrix size is not compatible"` → `"matrix dimensions are incompatible"`; `"parameters is not valid"` → `"parameters are invalid"`. No tests assert on these strings.

## Byte-identity confirmation
The CG path never touches `rr`/`zz`/`pp`, so not allocating them changes no arithmetic. Verified with the 17-significant-figure CG/BCG probe (existing `test_bcg.cpp` matrices) against the master canonical values, on **both** AAD backends:

```
CG  [n=10]: 0.10000000000000001 ... 0.076923076923076927 0.076923076923076927
BCG [n=10]: 0.099999999999999992 ... 0.085106382978723402 0.074468085106382975
```

`diff` of fix-branch probe vs master: **empty (byte-identical)** for both CG and BCG, under aadet (native) and xad. No tolerances loosened.

## Test plan
- [x] `dal_cpp_tests --gtest_filter='*Matrix*:*Solve*:*CG*:*BCG*'` (aadet) → 53 tests pass
- [x] Full `dal_cpp_tests` (aadet) → **761 tests, 69 suites, 0 failures**
- [x] Same targeted filter + full suite under **xad** backend → 55 targeted / **760 full, 0 failures**
- [x] 17-sig-fig probe diff vs master → empty on both backends
- [x] clang-format clean on the changed region

Branched from `origin/master` at 929c69a. Worktree: `.claude/worktrees/fix-cg-shadow`.