### PR TITLE
chore: trim small-residual comments, delete dead boost block

### DIFF
--- a/dal-cpp/dal/indice/index/ir.hpp
+++ b/dal-cpp/dal/indice/index/ir.hpp
@@ -43,11 +43,10 @@ namespace Dal::Index {
     class DF_ : public Index_ {
     public:
         const Ccy_ ccy_;
-        const Cell_ maturity_; // fixed end date, or days/tenor offset -- offset is from fixing, NOT from start date
-                               // (i.e., "2Y" start and "3Y" maturity does not lead to 5y final maturity)
+        // maturity/start offsets are from the fixing date; see docs/methodology/yield_curve.md §"Multi-Curve Framework".
+        const Cell_ maturity_;
         const CollateralType_ collateral_;
-        Cell_ start_; // fixed start date, or number of days offset, or tenor offset -- leave empty for the usual spot
-                      // index
+        Cell_ start_;
 
         DF_(const Ccy_& ccy,
             const Cell_& maturity,

--- a/dal-cpp/dal/storage/_repository.hpp
+++ b/dal-cpp/dal/storage/_repository.hpp
@@ -2,9 +2,7 @@
 // Created by wegam on 2022/4/3.
 //
 
-// global in-process store of objects
-// allows objects to be identified with string tags, e.g. for Excel use
-// provide this as an environment entry, so it can be shared by callers
+// In-process store of objects identified by string tags, exposed as an environment entry.
 
 #pragma once
 

--- a/dal-cpp/dal/utilities/exceptions.cpp
+++ b/dal-cpp/dal/utilities/exceptions.cpp
@@ -50,17 +50,7 @@ namespace Dal {
         }
 
         namespace {
-            /* more appropriate implementation for production
-            Vector_<XStackInfo_>& TheStack()
-            {
-                static boost::thread_specific_ptr<Vector_<XStackInfo_>> INSTANCE;
-                if (!INSTANCE.get())	// get is thread-specific
-                    INSTANCE.Reset(new Vector_<XStackInfo_>);
-                return *INSTANCE;	// so is operator*
-            }
-            */
-
-            /* less-efficient implementation, used here to avoid boost link dependency */
+            // thread_local avoids a boost link dependency.
             Vector_<XStackInfo_>* XTheStack(bool free_if_empty = false) {
                 thread_local static Vector_<XStackInfo_>* INSTANCE = nullptr;
                 if (!INSTANCE)
@@ -82,10 +72,7 @@ namespace Dal {
             if (!TheStack().empty())
                 TheStack().pop_back();
 
-            // the following statement cleans up the stack pointer when it becomes empty
-            // this prevents a memory leak (though not as reliably as a smart pointer implementation)
-            // of course there is a runtime cost to the extra delete/new cycle
-            // erase this line for production implementation using thread_specific_ptr
+            // free the per-thread stack once empty to avoid leaks.
             XTheStack(true);
         }
     } // namespace exception

--- a/dal-public/src/curveprotocol.hpp
+++ b/dal-public/src/curveprotocol.hpp
@@ -20,8 +20,7 @@ namespace Dal {
 
     FORCE_INLINE CollateralType_ CollateralType_Libor(const PeriodLength_& tenor) {
         (void)tenor;
-        // Libor collateral by tenor is represented via the projection curve
-        // mechanism; the collateral type itself remains GC.
+        // Tenor routing lives on RateIndexConvention_; see docs/methodology/yield_curve.md (Multi-Curve Framework).
         return CollateralType_(CollateralType_::Value_::GC);
     }
 


### PR DESCRIPTION
## Summary
- Phase 3 Wave 2 of the comment-simplification effort: collapse now-homed multi-line source comments to one-line pointers (or delete) and remove one block of dead code.
- `dal-cpp/dal/indice/index/ir.hpp`: replace the two `DF_::maturity_`/`start_` member offset comments with a single one-line pointer to the Multi-Curve Framework section of `docs/methodology/yield_curve.md`. Member order and constructor unchanged.
- `dal-public/src/curveprotocol.hpp`: trim the `CollateralType_Libor` body comment to a one-line pointer to `RateIndexConvention_` / Multi-Curve Framework. API (`(void)tenor;` and return value) unchanged.
- `dal-cpp/dal/storage/_repository.hpp`: collapse the 3-line design rationale to a single summary line.
- `dal-cpp/dal/utilities/exceptions.cpp`: **delete** the commented-out `boost::thread_specific_ptr` "production" block (dead code), and trim the boost-avoidance and `PopStack` rationale comments to one line each. `PopStack`/`XTheStack` logic unchanged.

Net: -17 lines across 4 files. Comment-only plus dead-code removal; no logic change.

## Test plan
- [x] Build `dal_cpp` + `dal_public` in an isolated worktree (clean, no warnings)
- [x] Full `dal_cpp_tests`: 759/759 passed
- [x] Full `dal_public_tests`: 37/37 passed
- [x] `git diff` style-reviewed: single-line `//` pointers, no `__` identifiers, no API/logic changes