### PR TITLE
chore: trim curve source comments to doc pointers

### DIFF
--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -109,23 +109,7 @@ namespace Dal {
         Vector_<> modelRates_;
         Vector_<> residuals_;
         Matrix_<> effJacobianInverse_;
-        // Unscaled analytic forward Jacobian d(modelRate_i) / d(logDF_free_k), shape
-        // nInstruments x (nKnots - 1), produced by a single in-solver evaluation on convergence
-        // -- the solver's convergence-branch hook calls func.Gradient(xNew, fNew) ONCE at the
-        // solved x to capture the UNSCALED forward J (no DivideRows(tol_)). This is the plain
-        // Jacobian before the solver's tolerance row-scaling; an independent finite-difference
-        // bump of the solved nodes reproduces it. CONTRAST with effJacobianInverse_: that matrix
-        // is a solver-weighted, tolerance-scaled pseudoinverse formed at the solver's final
-        // iterate, used to map parameter sensitivities to quote-bucket risk
-        // (r = g^T * effJacobianInverse_ / tolerance_). jacobian_ is neither weighted nor scaled,
-        // is evaluated at the solution rather than the iterate, and is NOT the inverse of
-        // effJacobianInverse_. Populated (non-empty) iff jacobianMode_ == ANALYTIC
-        // && solveMode_ == EXACT && the calibration is eligible for the AAD-tape Jacobian;
-        // default-constructed (empty, 0 x 0) otherwise (APPROXIMATE solve, BUMPED mode, or an
-        // ANALYTIC spec that fell back to bumped). Computed by the same AAD path, carried on the
-        // public diagnostics struct so consumers (e.g. the yield_curve_jacobian example) read it
-        // directly. There is no standalone "analytic J at a point" accessor: the forward J is
-        // obtainable ONLY as a byproduct of calibration via this field.
+        // Unscaled at-solution forward Jacobian; see docs/methodology/yield_curve_jacobian.md §"The Forward Jacobian, Two Ways".
         Matrix_<> jacobian_;
         double maxAbsResidual_ = 0.0;
         double rmsResidual_ = 0.0;

--- a/dal-cpp/dal/curve/yclogdf.hpp
+++ b/dal-cpp/dal/curve/yclogdf.hpp
@@ -13,14 +13,6 @@
 #include <dal/time/daybasis.hpp>
 
 namespace Dal {
-    // Phase A templatization: DiscountLogDF_ is an alias of Tape::DiscountLogDF_<double>. The double
-    // specialization stays byte-for-byte identical to the pre-Phase-A DiscountLogDF_ (same member
-    // layout, same LogDfAt using interp_ directly, same operator() with std::exp). The Number_
-    // specialization is constructed only by the AAD-tape Gradient override in calibration.cpp, and
-    // its LogDfAt routes through the basis-weight machinery instead of interp_ (the tape records
-    // the dependence on logDF_ that way). Declared in the header so calibration and tests can read
-    // back node dates / DFs via dynamic_cast. Construction is factory-only via NewDiscountLogDF
-    // (double) -- the Number_ factory lives in calibration.cpp and is unreachable from public code.
     namespace Tape {
     template <class T_>
     class DiscountLogDF_ : public CurveWithBase_<DiscountCurve_<T_>, DiscountCurve_<double>>, public FittableCurve_ {
@@ -30,10 +22,7 @@ namespace Dal {
         Vector_<T_> logDF_;
         LogDfScheme_ scheme_;
         Handle_<Interp1_> interp_;
-        // Spline second-derivative sensitivity matrix for LOG_CUBIC_NATURAL: fppCoef_[k][j] holds
-        // d(fpp[k])/d(logDF[j]). For LOG_LINEAR / MIXED-head segments it is empty and unused. The
-        // matrix is a function of the knot abscissae yf_ only, so it is computed once at construction
-        // and is identical for any T_.
+        // LOG_CUBIC_NATURAL / MIXED second-derivative sensitivity matrix; see docs/methodology/log_discount_curve.md §"Basis Weights by Interpolation Scheme".
         Vector_<Vector_<>> fppCoef_;
         // For MIXED: index of the cutoff knot inside yf_ (set even when scheme is non-mixed, so
         // StorageBasisWeightsAt can dispatch without recomputing it). -1 when not applicable.
@@ -42,21 +31,14 @@ namespace Dal {
 
         void RebuildInterp();
         void RebuildBasisAux();
-        // double path: calls interp_(yf) directly (byte-identical to pre-Phase-A).
-        // Number_ path: accumulates the basis weights against logDF_ so the tape records the
-        // dependence on the free-node logDF values (see .claude/designs/aad-analytic-jacobian-phase-a-plan.md
-        // §5.1). Dispatch is compile-time via if constexpr.
+        // T_-dispatched log-DF at year-fraction; see docs/methodology/log_discount_curve.md §"Basis Weights by Interpolation Scheme".
         [[nodiscard]] T_ LogDfAt(double yf) const;
-        // LOG_CUBIC_NATURAL basis weights at yf, on the segment [yf_[k], yf_[k+1]] with the
-        // fppCoef_ second-derivative sensitivities. Output is the (storage node index, weight)
-        // pairs whose weight is non-zero; caller remaps storage node k to solver column k-1.
+        // LOG_CUBIC_NATURAL basis weights at yf on segment k; see docs/methodology/log_discount_curve.md §"Basis Weights by Interpolation Scheme".
         [[nodiscard]] Vector_<std::pair<int, double>> CubicBasisAt(int k, double yf) const;
         // LOG_CUBIC_NATURAL extrapolation weights for yf > yf_.back() (secant extension of the
         // last segment): only the last two free nodes carry nonzero weight.
         [[nodiscard]] Vector_<std::pair<int, double>> CubicExtrapWeights(double yf) const;
-        // Knot-position-only (no logDF dependence) basis weights at query year-fraction yf, as
-        // (storage node index, weight) pairs. Used by the Number_-typed LogDfAt forward path to
-        // accumulate the basis weights against logDF_ on the tape.
+        // Knot-position basis weights at yf; see docs/methodology/log_discount_curve.md §"Basis Weights by Interpolation Scheme".
         [[nodiscard]] Vector_<std::pair<int, double>> StorageBasisWeightsAt(double yf) const;
 
     public:

--- a/dal-cpp/dal/curve/ycpwlf.hpp
+++ b/dal-cpp/dal/curve/ycpwlf.hpp
@@ -20,17 +20,12 @@ namespace Dal {
         template <class T_, class B_ = DiscountCurve_<double>>
         class DiscountPWLF_ : public CurveWithBase_<DiscountCurve_<T_>, B_>, public FittableCurve_ {
             Vector_<Date_> knotDates_;
-            // T_-typed PWL forward parameters: fLeftT_[k], fRightT_[k] per knot k. Registered as
-            // independents on the tape (the free-parameter vector is 2 * nKnots with NO anchor
-            // exclusion -- every knot is free).
+            // T_-typed PWL-forward state; see docs/methodology/yield_curve_jacobian.md §"PWL-forward → log-DF integration".
             Vector_<T_> fLeftT_;
             Vector_<T_> fRightT_;
-            // T_-typed running integral sofarT_[k] = integral of the PWL forward from knot 0 to
-            // knot k. T_-typed so the dependence on fLeftT_/fRightT_ records on the tape.
-            // Recomputed by UpdateT() whenever fLeftT_/fRightT_ change.
+            // T_-typed PWL-forward state; see docs/methodology/yield_curve_jacobian.md §"PWL-forward → log-DF integration".
             Vector_<T_> sofarT_;
-            // Double knot abscissae (serial-day offsets from knot 0). Computed once at
-            // construction; identical for any T_.
+            // T_-typed PWL-forward state; see docs/methodology/yield_curve_jacobian.md §"PWL-forward → log-DF integration".
             Vector_<double> knotAbscissae_;
 
             void UpdateT();


### PR DESCRIPTION
## Summary
- Replace the 17-line `jacobian_` doc-block in `dal-cpp/dal/curve/calibration.hpp` with a one-line pointer to `docs/methodology/yield_curve_jacobian.md §"The Forward Jacobian, Two Ways"`.
- Delete the Phase A templatization rationale block (~lines 16-23) in `dal-cpp/dal/curve/yclogdf.hpp` entirely (design narrative already covered in `log_discount_curve.md`).
- Reduce the `fppCoef_`, `LogDfAt`, `CubicBasisAt`, and `StorageBasisWeightsAt` member doc-blocks in `yclogdf.hpp` to one-line pointers to `docs/methodology/log_discount_curve.md §"Basis Weights by Interpolation Scheme"`; drop the `.claude/designs/aad-analytic-jacobian-phase-a-plan.md §5.1` citation from `LogDfAt` (designs are not a stable reference).
- Reduce the `fLeftT_`/`fRightT_`/`sofarT_`/`knotAbscissae_` member doc-blocks in `dal-cpp/dal/curve/ycpwlf.hpp` to one-line pointers to `docs/methodology/yield_curve_jacobian.md §"PWL-forward → log-DF integration"`.

Comment-only: no logic, signatures, or declarations changed. The methodology docs are merged on `master`, so the pointers resolve.

## Test plan
- [x] `bin/dal_cpp_tests --gtest_filter='*Curve*:*Calibration*:*AnalyticJacobian*'` — 86 tests pass
- [x] Full `bin/dal_cpp_tests` — 759 tests pass (no regressions; comment-only change)