### PR TITLE
docs: add PDE finite-difference mesher methodology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Cross-Currency Calibration** — [Cross-currency calibration](docs/methodology/xccy_calibration.md)
 - **Interpolation** — [Interpolation](docs/methodology/interpolation.md)
 - **Log-Discount Curve** — [Log-discount curve](docs/methodology/log_discount_curve.md)
+- **PDE Finite-Difference Meshers and Coordinate Maps** — [PDE meshers](docs/methodology/pde.md)
 - **Yield-Curve Jacobian and Inverse-Jacobian Risk** — [Yield-curve Jacobian](docs/methodology/yield_curve_jacobian.md)
 - **Script Engine** — [Script engine](docs/methodology/script_engine.md)
 - **Dupire Local Volatility** — [Dupire local volatility](docs/methodology/dupire.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,12 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - Serialization version design (v1 without scheme, v2 with named scheme)
   - Why `LOG_DISCOUNT` is the parameterization that supports the analytic Jacobian
 
+- **[pde.md](methodology/pde.md)** — PDE Finite-Difference Meshers and Coordinate Maps
+  - `FDM1DMesher_` interface, `locations_` / `dplus_` / `dminus_`, and the boundary-null convention
+  - `Uniform1DMesher_` constant spacing and endpoint pinning
+  - `Concentrating1dMesher_` sinh/asinh coordinate stretch, density scaling, and snapped-knot device
+  - `CoordinateMap_`, `NewSinhMap(xWidth, dxdyRange)`, and identity degeneration
+
 - **[yield_curve_jacobian.md](methodology/yield_curve_jacobian.md)** — Yield-Curve Jacobian and Inverse-Jacobian Risk
   - Forward residual Jacobian via AAD reverse sweep vs finite-difference bump
   - Inverse-Jacobian IR-risk transform `r = gᵀ · effJacobianInverse_ / tolerance_`

--- a/docs/methodology/pde.md
+++ b/docs/methodology/pde.md
@@ -1,0 +1,197 @@
+# PDE Finite-Difference Meshers and Coordinate Maps
+
+This note documents the one-dimensional finite-difference mesh generators under
+`dal-cpp/dal/math/pde/meshers/` and the coordinate-map abstraction in
+`dal-cpp/dal/math/pde/pde.hpp` that the operator machinery uses to remap the spatial
+coordinate. The meshers only lay out grid points and their forward/backward spacings; the
+actual difference operators are built downstream by `Dal::PDE::Dx()` and `Dal::PDE::Dxx()`
+from a mesher, and the one-dimensional finite-difference engine `Dal::PDE::FD1D_` holds a
+mesher by const-reference and exposes its node locations through `FD1D_::X()`.
+
+## The Mesher Interface
+
+Every concrete mesher derives from `Dal::FDM1DMesher_`
+(`dal-cpp/dal/math/pde/meshers/fdm1dmesher.hpp`), which fixes the contract a downstream
+differencer relies on. The base class is constructed with a node count `size` and populates
+three parallel vectors of that length:
+
+- `locations_` — the physical grid abscissae $x_0, x_1, \dots, x_{n-1}$,
+- `dplus_` — the forward spacing $\Delta^+_i = x_{i+1} - x_i$,
+- `dminus_` — the backward spacing $\Delta^-_i = x_i - x_{i-1}$.
+
+These are exposed through the getters `Size()`, `DPlus(int i)`, `DMinus(int i)`,
+`Location(int i)`, and `Locations()`. The interior convention is consistent:
+$\Delta^+_i = \Delta^-_{i+1} = x_{i+1} - x_i$, so a forward step out of node $i$ equals the
+backward step into node $i+1$.
+
+### Boundary-null convention
+
+At the two boundaries there is no "next" node past the last and no "previous" node before the
+first. The protected helper `FinalizeSpacings()` sets
+
+$$
+\Delta^+_{n-1} = \text{Null\_}<\text{double}>(), \qquad \Delta^-_0 = \text{Null\_}<\text{double}>().
+$$
+
+The `Null_<double>()` sentinel is intentional: downstream code that needs a one-sided
+difference at the boundary must use the inward spacing only ($\Delta^-_{n-1}$ on the right,
+$\Delta^+_0$ on the left). A differencer that accidentally reads the out-of-bounds slot gets
+the null sentinel rather than a silently-stale neighbour value, making the bug detectable.
+Every concrete mesher calls `FinalizeSpacings()` as its last step.
+
+## Uniform Mesher
+
+`Dal::Uniform1DMesher_` (`dal-cpp/dal/math/pde/meshers/uniform1dmesher.hpp`) lays out a
+constant-spacing grid on $[\text{start}, \text{end}]$ with $n$ nodes. The constructor requires
+$\text{end} > \text{start}$ and uses the spacing
+
+$$
+\Delta x = \frac{\text{end} - \text{start}}{n - 1}, \qquad x_i = \text{start} + i\,\Delta x.
+$$
+
+Each interior forward/backward pair is set to $\Delta x$.
+
+The last node is **pinned** to `end` directly (`locations_.back() = end`) rather than computed
+as $\text{start} + (n-1)\Delta x$. This is deliberate: the closed-form $x_{n-1}$ accumulates
+floating-point round-off through the repeated-addition form, so a grid that computed the
+endpoint would not close exactly on $[\text{start}, \text{end}]$. Assigning the endpoint
+verbatim guarantees the domain closes to machine precision, and the trailing
+`FinalizeSpacings()` nulls $\Delta^+_{n-1}$.
+
+## Concentrating Mesher
+
+`Dal::Concentrating1dMesher_`
+(`dal-cpp/dal/math/pde/meshers/concentrating1dmesher.{hpp,cpp}`) lays out a grid on
+$[\text{start}, \text{end}]$ that concentrates nodes around a chosen interior point. The
+constructor takes
+
+- `cPoints.first` — the concentration point $\mu$ (`cPoint`), required to lie in
+  $[\text{start}, \text{end}]$,
+- `cPoints.second` — a dimensionless density budget; the implementation sets
+  $\rho = \texttt{cPoints.second} \cdot (\text{end} - \text{start})$ and requires $\rho > 0$,
+- `requireCPoint` — when true, guarantees a node lands exactly on $\mu$.
+
+### The sinh/asinh coordinate stretch
+
+The grid is the image of a uniform sample on $y \in [0,1]$ under the transform
+
+$$
+x(y) = \mu + \rho \sinh\!\big(\alpha(1-y) + \beta y\big),
+$$
+
+where the endpoint constraints $x(0) = \text{start}$ and $x(1) = \text{end}$ fix
+
+$$
+\alpha = \operatorname{asinh}\!\left(\frac{\text{start} - \mu}{\rho}\right), \qquad
+\beta  = \operatorname{asinh}\!\left(\frac{\text{end} - \mu}{\rho}\right).
+$$
+
+Concentration arises because $\sinh$ has near-unit slope at the origin but grows like
+$\tfrac{1}{2}e^{|t|}$ for large $|t|$. The local node density is governed by
+
+$$
+\frac{\mathrm{d}x}{\mathrm{d}y} = \rho(\beta - \alpha)\cosh\!\big(\alpha(1-y) + \beta y\big).
+$$
+
+Where $\mathrm{d}x/\mathrm{d}y$ is small the grid is fine; where it is large the grid is coarse.
+Choosing $\rho$ small relative to $|\text{end} - \text{start}|$ drives $|\alpha|$ and $|\beta|$
+to large magnitudes, sharpening the $\cosh$ peak around the $y$ where the argument crosses
+zero — that is, around $x = \mu$. This is the concentration mechanism.
+
+The scaling $\rho = \texttt{cPoints.second} \cdot (\text{end} - \text{start})$ makes the
+user-supplied second element a dimensionless density budget: a larger value produces a coarser
+grid near $\mu$ and a more uniform overall spacing; a smaller value tightens the concentration
+near $\mu$.
+
+### The snapped-knot device
+
+With `requireCPoint = false` the implementation samples the transform directly at the uniform
+pre-image $y_i = i/(n-1)$. The resulting grid concentrates around $\mu$ but, except by
+coincidence, no node sits exactly on $\mu$.
+
+With `requireCPoint = true` the mesher forces a node onto $\mu$. The continuous pre-image that
+maps to $\mu$ solves $\alpha(1-z_0) + \beta z_0 = 0$, giving
+
+$$
+z_0 = \frac{-\alpha}{\beta - \alpha}.
+$$
+
+The implementation snaps $z_0$ to the nearest grid fraction $u_0 = \operatorname{round}(z_0
+(n-1))/(n-1)$, clamped to the interior range $[1, n-2]$, then builds a piecewise-linear
+`Interp1_` on the knots $(0,0)$, $(u_0, z_0)$, $(1,1)$. Each grid index $i$ is mapped through
+this interpolant to its effective pre-image $y_i$ before being fed to the $\sinh$ transform.
+The snap-and-clamp ensures $u_0$ is a valid interior node and that the $z_0 \mapsto \mu$ image
+is realized exactly by the linear interpolation. (When $\mu$ coincides with `start` or `end`
+the snapped knot is not inserted, since the endpoint pin already places a node there.)
+
+After computing the interior `locations_`, the mesher pins
+`locations_.front() = start` and `locations_.back() = end` (closing the domain exactly, as in
+the uniform case), derives $\Delta^+_i = \Delta^-_{i+1} = x_{i+1} - x_i$ from the final
+locations, and calls `FinalizeSpacings()`.
+
+## Coordinate Maps for Operators
+
+`Dal::PDE::CoordinateMap_` (`dal-cpp/dal/math/pde/pde.hpp`) is the operator-side counterpart
+of the mesher. Where a mesher lays out physical grid points, a coordinate map reparametrizes
+the spatial coordinate so that a uniform mesh in the computational coordinate $y$ corresponds
+to a stretched mesh in the physical coordinate $x$. The abstract interface is
+
+```cpp
+virtual double operator()(double y, double* dxDy, double* d2xDy2) const = 0;
+virtual double Y(double x) const = 0;
+```
+
+`operator()` maps $y \mapsto x$ and writes the first and second derivatives $\mathrm{d}x/\mathrm{d}y$,
+$\mathrm{d}^2x/\mathrm{d}y^2$ through the out-parameters; `Y()` is the inverse $x \mapsto y$.
+
+### `NewSinhMap(xWidth, dxdyRange)`
+
+The free factory `Dal::PDE::NewSinhMap(double xWidth, double dxdyRange)` returns a
+`SinhMap_` implementing
+
+$$
+x = \lambda \sinh(y/\lambda), \qquad
+\frac{\mathrm{d}x}{\mathrm{d}y} = \cosh(y/\lambda), \qquad
+\frac{\mathrm{d}^2x}{\mathrm{d}y^2} = \frac{1}{\lambda}\sinh(y/\lambda), \qquad
+y(x) = \lambda\,\operatorname{asinh}(x/\lambda),
+$$
+
+with
+
+$$
+\lambda = \frac{\text{xWidth}}{y_{\max}}, \qquad y_{\max} = \sqrt{\text{dxdyRange}^2 - 1}.
+$$
+
+Because $\mathrm{d}x/\mathrm{d}y = \cosh(y/\lambda) \ge 1$, the map is monotone
+non-decreasing and stretches $y$-space outward: near the origin $y/x \to 1/\lambda$ (dense
+sampling in $x$), while for large $|x|$ the tails compress as
+$|y| \sim \lambda \ln(2|x|/\lambda)$. The `dxdyRange` parameter caps the stretching at the
+boundary — the maximum value of $\mathrm{d}x/\mathrm{d}y$ is exactly `dxdyRange`, attained
+where $y/\lambda = y_{\max}$. `xWidth` sets $\lambda$ and hence the physical half-width of the
+central high-resolution band. The factory requires `xWidth > 0` and `dxdyRange >= 1`.
+
+### Degeneration to identity
+
+When $\text{dxdyRange} = 1$ we have $y_{\max} = 0$, so $\sinh(y/\lambda) = y/\lambda$ collapses
+to the identity $x = y$ and the parametrization above degenerates. The factory detects this and
+returns an `IdentityMap_` instead. `NewIdentityMap()` is the explicit convenience for this
+case — it simply calls `NewSinhMap(1.0, 1.0)`.
+
+## Downstream Consumers
+
+The difference operators and the one-dimensional engine that consume a mesher live in
+`dal-cpp/dal/math/pde/`:
+
+- `Dal::PDE::Dx(const FDM1DMesher_&)` and `Dal::PDE::Dxx(const FDM1DMesher_&)`
+  (`dal-cpp/dal/math/pde/finitedifference.hpp`) build tridiagonal first- and
+  second-difference operators from the mesher's `dplus_`, `dminus_`, and `locations_` arrays.
+  The non-uniform spacing is exactly why those arrays exist: a one-sided first difference at
+  node $i$ uses $\Delta^\pm_i$, and the second-difference stencil weights its three nodes by
+  the local $\Delta^+ / \Delta^-$ ratio.
+- `Dal::PDE::FD1D_` (`dal-cpp/dal/math/pde/fd1d.hpp`) holds a `const FDM1DMesher_&` and
+  exposes the node locations through `FD1D_::X()`, which returns `Locations()`. The engine's
+  drift, variance, and result vectors are all indexed against this mesh.
+
+The boundary-null convention is what makes these consumers safe: a stencil that would read
+$\Delta^+_{n-1}$ or $\Delta^-_0$ at a boundary instead gets the null sentinel, forcing the
+boundary to be handled by its one-sided inward difference.


### PR DESCRIPTION
## Summary
- Add new methodology note `docs/methodology/pde.md` documenting the 1-D finite-difference mesh generators under `dal-cpp/dal/math/pde/meshers/` and the coordinate-map abstraction in `dal-cpp/dal/math/pde/pde.hpp`. The mesher source is currently uncommented, so this fills a documentation gap.
- Cover the `FDM1DMesher_` interface (`locations_` / `dplus_` / `dminus_` getters and the `FinalizeSpacings()` boundary-null sentinel convention), `Uniform1DMesher_` constant spacing with endpoint pinning, the `Concentrating1dMesher_` sinh/asinh coordinate-stretch derivation (density scaling and the `requireCPoint` snapped-knot device), and the operator-side `CoordinateMap_` / `NewSinhMap(xWidth, dxdyRange)` / `NewIdentityMap()` stretch with its `dxdyRange == 1` degeneration to identity. Brief downstream-consumer section noting `Dx` / `Dxx` and `FD1D_::X()` without documenting their internals.
- Index the new note in `docs/README.md` (Methodology section) and `CLAUDE.md` (Methodology list).

## Test plan
No test suite applies to a docs-only change. Manual verification performed:
- [x] Read current mesher and coordinate-map headers in `dal-cpp/dal/math/pde/` (`fdm1dmesher.hpp`, `uniform1dmesher.hpp`, `concentrating1dmesher.{hpp,cpp}`, `pde.hpp`, `fd1d.hpp`, `finitedifference.hpp`) to ground every signature, member name, and behavioural claim in current source.
- [x] Verified all three touched files contain no trailing whitespace and end with a single newline.
- [x] Confirmed no source line-number citations in the new doc (struct/function/file names only).
- [x] Cross-checked the `CLAUDE.md` methodology list and `docs/README.md` methodology index for consistent entry style and correct relative paths.
- [x] Intentionally did **not** edit `CHANGELOG.md` — this is a doc-gap fill, not a fundamental change, so it does not meet the changelog bar.

Draft PR; left for the user to merge.