### PR TITLE
refactor: brace-init Build() + add CurveSolverOptions_ vocabulary type

### DIFF
--- a/dal-public/src/curvespec.cpp
+++ b/dal-public/src/curvespec.cpp
@@ -9,30 +9,14 @@
 namespace Dal {
 
     CurveCalibrationSpec_ CurveCalibrationSpecBuilder_::Build() const {
-        CurveCalibrationSpec_ spec;
-        spec.today_ = today_;
-        spec.ccy_ = ccy_;
-        spec.curveName_ = curveName_;
-        spec.instruments_ = instruments_;
-        spec.knotDates_ = knotDates_;
-        spec.discountCurves_ = discountCurves_;
-        spec.forwardCurves_ = forwardCurves_;
-        spec.baseCurve_ = baseCurve_;
-        spec.targetCollateral_ = targetCollateral_;
-        spec.targetTenor_ = targetTenor_;
-        spec.calibrateDiscountCurve_ = calibrateDiscountCurve_;
-        spec.liborBasis_ = liborBasis_;
-        spec.smoothingWeight_ = smoothingWeight_;
-        spec.tolerance_ = tolerance_;
-        spec.fitTolerance_ = fitTolerance_;
-        spec.maxEvaluations_ = maxEvaluations_;
-        spec.maxRestarts_ = maxRestarts_;
-        spec.initialGuess_ = initialGuess_;
-        spec.solveMode_ = solveMode_;
-        spec.parameterization_ = parameterization_;
-        spec.knotPolicy_ = knotPolicy_;
-        spec.initialGuessPerNode_ = initialGuessPerNode_;
-        spec.logDfScheme_ = logDfScheme_;
+        CurveCalibrationSpec_ spec{
+            today_, ccy_, curveName_, instruments_, knotDates_,
+            discountCurves_, forwardCurves_, baseCurve_, targetCollateral_,
+            targetTenor_, calibrateDiscountCurve_, liborBasis_,
+            smoothingWeight_, tolerance_, fitTolerance_, maxEvaluations_,
+            maxRestarts_, initialGuess_, solveMode_, parameterization_,
+            knotPolicy_, initialGuessPerNode_, logDfScheme_
+        };
         ValidateCurveCalibrationSpec(spec);
         return spec;
     }

--- a/dal-public/src/curvespec.hpp
+++ b/dal-public/src/curvespec.hpp
@@ -12,6 +12,19 @@
 
 namespace Dal {
 
+    // Shared solver-tuning knobs and single-curve defaults. Not embedded in the builders: they
+    // keep flat fields so dal-python's member-pointer bindings stay source-compatible. The xccy
+    // builder/spec override tolerance_ to 1e-10 and initialGuess_ to 0.0.
+    struct CurveSolverOptions_ {
+        double smoothingWeight_ = 1.0;
+        double tolerance_ = 1.0e-8;
+        double fitTolerance_ = 1.0e-6;
+        double initialGuess_ = 0.05;
+        int maxEvaluations_ = 200;
+        int maxRestarts_ = 20;
+        CurveSolveMode_ solveMode_ = CurveSolveMode_::Value_::EXACT;
+    };
+
     struct CalibrationResult_ {
         Handle_<DiscountCurve_> curve_;
         CurveCalibrationDiagnostics_ diagnostics_;
@@ -30,6 +43,7 @@ namespace Dal {
         PeriodLength_ targetTenor_;
         bool calibrateDiscountCurve_ = true;
         DayBasis_ liborBasis_ = DayBasis_("ACT_365F");
+        // keep in sync with CurveSolverOptions_
         double smoothingWeight_ = 1.0;
         double tolerance_ = 1.0e-8;
         double fitTolerance_ = 1.0e-6;

--- a/dal-public/src/xccycalibration.cpp
+++ b/dal-public/src/xccycalibration.cpp
@@ -9,23 +9,12 @@
 namespace Dal {
 
     CrossCurrencyCalibrationSpec_ CrossCurrencyCalibrationSpecBuilder_::Build() const {
-        CrossCurrencyCalibrationSpec_ spec;
-        spec.today_ = today_;
-        spec.basisPair_ = basisPair_;
-        spec.domesticCurveBlock_ = domesticCurveBlock_;
-        spec.foreignCurveBlock_ = foreignCurveBlock_;
-        spec.fxSpot_ = fxSpot_;
-        spec.fxForwardCollateral_ = fxForwardCollateral_;
-        spec.instruments_ = instruments_;
-        spec.knotDates_ = knotDates_;
-        spec.smoothingWeight_ = smoothingWeight_;
-        spec.tolerance_ = tolerance_;
-        spec.fitTolerance_ = fitTolerance_;
-        spec.initialGuess_ = initialGuess_;
-        spec.maxEvaluations_ = maxEvaluations_;
-        spec.maxRestarts_ = maxRestarts_;
-        spec.solveMode_ = solveMode_;
-        return spec;
+        return CrossCurrencyCalibrationSpec_{
+            today_, basisPair_, domesticCurveBlock_, foreignCurveBlock_,
+            fxSpot_, fxForwardCollateral_, instruments_, knotDates_,
+            smoothingWeight_, tolerance_, fitTolerance_, initialGuess_,
+            maxEvaluations_, maxRestarts_, solveMode_
+        };
     }
 
     CrossCurrencyCalibrationResult_ CalibrateXccyMarket(const CrossCurrencyCalibrationSpec_& spec) {

--- a/dal-public/src/xccycalibration.hpp
+++ b/dal-public/src/xccycalibration.hpp
@@ -18,6 +18,7 @@ namespace Dal {
         CollateralType_ fxForwardCollateral_ = CollateralType_(CollateralType_::Value_::OIS);
         Vector_<Handle_<CrossCurrencySwap_>> instruments_;
         Vector_<Date_> knotDates_;
+        // keep in sync with CurveSolverOptions_ in curvespec.hpp
         double smoothingWeight_ = 1.0;
         double tolerance_ = 1.0e-10;
         double fitTolerance_ = 1.0e-6;

--- a/dal-public/tests/test_curvespec.cpp
+++ b/dal-public/tests/test_curvespec.cpp
@@ -14,12 +14,15 @@ using Dal::CalibrateSingleCurve;
 using Dal::CalibrationResult_;
 using Dal::CollateralType_OIS;
 using Dal::CurveCalibrationSpecBuilder_;
+using Dal::CurveKnotPolicy_;
 using Dal::CurveParameterization_;
 using Dal::CurveSolveMode_;
+using Dal::CurveSolverOptions_;
 using Dal::Date_;
 using Dal::DayBasis_New;
 using Dal::DepositNew;
 using Dal::DiscountPWLFNew;
+using Dal::LogDfScheme_;
 using Dal::MultiCurveCalibrationSpec_;
 using Dal::OISSwapNew;
 using Dal::PeriodLength_New;
@@ -205,4 +208,75 @@ TEST(CurveSpecTest, TestCalibrateMultiCurveBundle) {
     // Check stage 1 diagnostics
     ASSERT_LT(result.diagnostics_[0].maxAbsResidual_, 1.0e-6);
     ASSERT_LT(result.diagnostics_[0].rmsResidual_, 1.0e-6);
+}
+
+// CurveSolverOptions_ centralizes the shared knob names and the single-curve defaults.
+
+TEST(CurveSpecTest, TestCurveSolverOptionsDefaults) {
+    CurveSolverOptions_ opts;
+    ASSERT_NEAR(opts.smoothingWeight_, 1.0, 1e-15);
+    ASSERT_NEAR(opts.tolerance_, 1.0e-8, 1e-15);
+    ASSERT_NEAR(opts.fitTolerance_, 1.0e-6, 1e-15);
+    ASSERT_NEAR(opts.initialGuess_, 0.05, 1e-15);
+    ASSERT_EQ(opts.maxEvaluations_, 200);
+    ASSERT_EQ(opts.maxRestarts_, 20);
+    ASSERT_EQ(opts.solveMode_.Switch(), CurveSolveMode_::Value_::EXACT);
+}
+
+// Round-trip every builder field through Build() to guard against brace-init
+// order/count drift between the builder and CurveCalibrationSpec_.
+
+TEST(CurveSpecTest, TestBuildRoundTripsEveryField) {
+    CurveCalibrationSpecBuilder_ b;
+    b.today_ = Today();
+    b.ccy_ = "USD";
+    b.curveName_ = "roundtrip";
+    b.calibrateDiscountCurve_ = true;
+    b.targetCollateral_ = CollateralType_OIS();
+    b.liborBasis_ = DayBasis_New("ACT_365F");
+
+    // Distinct scalar sentinels catch any adjacent-field reorder in the brace-init.
+    b.smoothingWeight_ = 1.5;
+    b.tolerance_ = 3.0e-9;
+    b.fitTolerance_ = 4.0e-7;
+    b.initialGuess_ = 0.037;
+    b.maxEvaluations_ = 177;
+    b.maxRestarts_ = 13;
+    b.solveMode_ = CurveSolveMode_::Value_::APPROXIMATE;
+    b.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+    b.knotPolicy_ = CurveKnotPolicy_::Value_::AUGMENTED;
+    b.logDfScheme_ = LogDfScheme_::Value_::LOG_CUBIC_NATURAL;
+    b.initialGuessPerNode_ = Vector_<>{0.04, 0.04, 0.04, 0.04};
+
+    Vector_<Date_> knotDates;
+    knotDates.push_back(b.today_); // LOG_DISCOUNT anchor knot
+    for (int y : {2, 5, 10}) {
+        Date_ maturity = Spot().AddDays(y * 365);
+        knotDates.push_back(maturity);
+        b.instruments_.push_back(
+            OISSwapNew(Today(), Spot(), maturity, 0.04, Fixed6M(), OvernightIndex(), Float3M()));
+    }
+    b.knotDates_ = knotDates;
+
+    auto spec = b.Build();
+
+    ASSERT_EQ(spec.today_, b.today_);
+    ASSERT_EQ(spec.ccy_, b.ccy_);
+    ASSERT_EQ(spec.curveName_, String_("roundtrip"));
+    ASSERT_EQ(spec.calibrateDiscountCurve_, true);
+    ASSERT_EQ(spec.targetCollateral_.Switch(), b.targetCollateral_.Switch());
+    ASSERT_EQ(spec.liborBasis_, b.liborBasis_);
+    ASSERT_NEAR(spec.smoothingWeight_, 1.5, 1e-15);
+    ASSERT_NEAR(spec.tolerance_, 3.0e-9, 1e-15);
+    ASSERT_NEAR(spec.fitTolerance_, 4.0e-7, 1e-15);
+    ASSERT_NEAR(spec.initialGuess_, 0.037, 1e-15);
+    ASSERT_EQ(spec.maxEvaluations_, 177);
+    ASSERT_EQ(spec.maxRestarts_, 13);
+    ASSERT_EQ(spec.solveMode_.Switch(), CurveSolveMode_::Value_::APPROXIMATE);
+    ASSERT_EQ(spec.parameterization_.Switch(), CurveParameterization_::Value_::LOG_DISCOUNT);
+    ASSERT_EQ(spec.knotPolicy_.Switch(), CurveKnotPolicy_::Value_::AUGMENTED);
+    ASSERT_EQ(spec.logDfScheme_.Switch(), LogDfScheme_::Value_::LOG_CUBIC_NATURAL);
+    ASSERT_EQ(spec.instruments_.size(), static_cast<size_t>(3));
+    ASSERT_EQ(spec.knotDates_.size(), static_cast<size_t>(4));
+    ASSERT_EQ(spec.initialGuessPerNode_.size(), static_cast<size_t>(4));
 }

--- a/dal-public/tests/test_xccy_calibration.cpp
+++ b/dal-public/tests/test_xccy_calibration.cpp
@@ -148,3 +148,45 @@ TEST(XccyCalibrationTest, TestCalibrateXccyMarket) {
     ASSERT_EQ(result.fxForwardCurve_.dates_.size(),
               result.fxForwardCurve_.forwards_.size());
 }
+
+// Round-trip every builder field through Build() to guard against brace-init
+// order/count drift between the builder and CrossCurrencyCalibrationSpec_.
+
+TEST(XccyCalibrationTest, TestBuildRoundTripsEveryField) {
+    auto curves = MakeBaselineCurves();
+
+    CrossCurrencyCalibrationSpecBuilder_ b;
+    b.today_ = Today();
+    b.basisPair_ = CurrencyPair_New("USD", "EUR");
+    b.domesticCurveBlock_ = curves.domesticBlock_;
+    b.foreignCurveBlock_ = curves.foreignBlock_;
+    b.fxSpot_ = 1.0825;
+    b.fxForwardCollateral_ = CollateralType_OIS();
+    b.smoothingWeight_ = 1.25;
+    b.tolerance_ = 5.0e-11;
+    b.fitTolerance_ = 6.0e-7;
+    b.initialGuess_ = 0.0025;
+    b.maxEvaluations_ = 233;
+    b.maxRestarts_ = 17;
+    b.solveMode_ = CurveSolveMode_::Value_::APPROXIMATE;
+    b.knotDates_ = Vector_<Date_>{Spot(), Spot().AddDays(3650)};
+    b.instruments_ = Vector_<Dal::Handle_<Dal::CrossCurrencySwap_>>{};
+
+    auto spec = b.Build();
+
+    ASSERT_EQ(spec.today_, b.today_);
+    ASSERT_TRUE(spec.basisPair_ == b.basisPair_);
+    ASSERT_EQ(spec.domesticCurveBlock_.get(), b.domesticCurveBlock_.get());
+    ASSERT_EQ(spec.foreignCurveBlock_.get(), b.foreignCurveBlock_.get());
+    ASSERT_NEAR(spec.fxSpot_, 1.0825, 1e-15);
+    ASSERT_EQ(spec.fxForwardCollateral_.Switch(), b.fxForwardCollateral_.Switch());
+    ASSERT_NEAR(spec.smoothingWeight_, 1.25, 1e-15);
+    ASSERT_NEAR(spec.tolerance_, 5.0e-11, 1e-15);
+    ASSERT_NEAR(spec.fitTolerance_, 6.0e-7, 1e-15);
+    ASSERT_NEAR(spec.initialGuess_, 0.0025, 1e-15);
+    ASSERT_EQ(spec.maxEvaluations_, 233);
+    ASSERT_EQ(spec.maxRestarts_, 17);
+    ASSERT_EQ(spec.solveMode_.Switch(), CurveSolveMode_::Value_::APPROXIMATE);
+    ASSERT_EQ(spec.knotDates_.size(), static_cast<size_t>(2));
+    ASSERT_TRUE(spec.instruments_.empty());
+}


### PR DESCRIPTION
## Summary

Implements the **safe (non-breaking)** parts of the API-shape dedup from `.claude/designs/api-shape-dedup.md`. No caller, binding, or `Spec_` layout changes; the breaking structural collapse (embedding `CurveSolverOptions_` into the builders) is deliberately deferred.

**Duplication 1 — `Build()` brace-init (fully backward-compatible).** Rewrote both spec-builder `Build()` bodies as aggregate brace-init of the underlying `Spec_` from the builder fields, replacing the member-by-member copy:
- `dal-public/src/curvespec.cpp` — `CurveCalibrationSpecBuilder_::Build()` (23 fields)
- `dal-public/src/xccycalibration.cpp` — `CrossCurrencyCalibrationSpecBuilder_::Build()` (15 fields)

The compiler now enforces field-count agreement between builder and `Spec_`; the residual risk is declaration-order drift, which the new round-trip tests guard against. Brace-init order was verified against each `Spec_`'s declaration order (`dal-cpp/dal/curve/calibration.hpp`, `dal-cpp/dal/curve/xccycalibration.hpp`).

**Duplication 2 — `CurveSolverOptions_` vocabulary anchor (additive, non-breaking).** Added `CurveSolverOptions_` to `dal-public/src/curvespec.hpp` as a public type centralizing the seven shared knob names and the single-curve defaults (`smoothingWeight_`, `tolerance_=1e-8`, `fitTolerance_`, `initialGuess_=0.05`, `maxEvaluations_`, `maxRestarts_`, `solveMode_`). The builders keep their own flat fields so dal-python's member-pointer bindings (`def_readwrite(&Builder_::tolerance_)` etc.) and dal-excel glue stay source-compatible. Added a one-line `// keep in sync with CurveSolverOptions_` comment in both builder headers.

## Test plan

- [x] `make -j32 dal_cpp_tests dal_public_tests _dal` (worktree-local build, all three targets green; Python bindings recompile against new headers — confirms non-breaking)
- [x] `bin/dal_public_tests` (via `build/dal-public/dal_public_tests`): **40 tests pass** (was 37; +3 new)
- [x] `bin/dal_cpp_tests` (via `build/dal-cpp/dal_cpp_tests`): **759 tests pass** (no regressions)
- [x] Python import smoke test: `CurveCalibrationSpecBuilder_` / `CrossCurrencyCalibrationSpecBuilder_` fields read/write correctly via `def_readwrite` (single-curve `tolerance_=1e-8`, xccy `tolerance_=1e-10`)
- [x] New round-trip tests verified load-bearing: temporarily swapping two adjacent brace-init fields fails the sentinel assertions, restoring passes

New tests:
- `dal-public/tests/test_curvespec.cpp` — `CurveSpecTest.TestCurveSolverOptionsDefaults`, `CurveSpecTest.TestBuildRoundTripsEveryField`
- `dal-public/tests/test_xccy_calibration.cpp` — `XccyCalibrationTest.TestBuildRoundTripsEveryField`

Draft — do not merge.