### PR TITLE
perf: replace tape Clear with Rewind + inline adjoint zeroing

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -381,16 +381,23 @@ namespace Dal {
             Matrix_<> j(nRows, nCols, 0.0);
 
             // Single-result reverse sweep: one PropagateToStart per row yields exact structural zeros.
-            // PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
+            // Native: PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
             // ZeroAdjoints pass is needed before each row. The parameter leaves (n_ == 0) are not
             // consumed by PropagateOne and would accumulate across rows, so they are zeroed locally
             // after harvest -- O(nCols) per row instead of O(all nodes).
+            // XAD/CoDi/Adept: no inline zeroing in PropagateOne, and Adjoint() returns by value, so
+            // a full ZeroAdjoints sweep before each row is still required.
             for (int i = 0; i < nRows; ++i) {
+#if defined(DAL_USE_XAD_AAD) || defined(DAL_USE_CODIPACK_AAD) || defined(DAL_USE_ADEPT_AAD)
+                Dal::AAD::ZeroAdjoints(*tape);
+#endif
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
                 Dal::AAD::PropagateToStart(*tape);
                 for (int col = 0; col < nCols; ++col) {
                     j(i, col) = Dal::AAD::Adjoint(logDF[col + 1]);
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
                     Dal::AAD::Adjoint(logDF[col + 1]) = 0.0;
+#endif
                 }
             }
             return new XCurveJacobian_(std::move(j));

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -381,12 +381,17 @@ namespace Dal {
             Matrix_<> j(nRows, nCols, 0.0);
 
             // Single-result reverse sweep: one PropagateToStart per row yields exact structural zeros.
+            // PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
+            // ZeroAdjoints pass is needed before each row. The parameter leaves (n_ == 0) are not
+            // consumed by PropagateOne and would accumulate across rows, so they are zeroed locally
+            // after harvest -- O(nCols) per row instead of O(all nodes).
             for (int i = 0; i < nRows; ++i) {
-                Dal::AAD::ZeroAdjoints(*tape);
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
                 Dal::AAD::PropagateToStart(*tape);
-                for (int col = 0; col < nCols; ++col)
+                for (int col = 0; col < nCols; ++col) {
                     j(i, col) = Dal::AAD::Adjoint(logDF[col + 1]);
+                    Dal::AAD::Adjoint(logDF[col + 1]) = 0.0;
+                }
             }
             return new XCurveJacobian_(std::move(j));
         }

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -463,11 +463,14 @@ namespace Dal {
             Vector_<Dal::AAD::Number_> residuals = ComputeTemplatedResiduals(block);
             const int totalResiduals = static_cast<int>(residuals.size());
 
-            // Reverse sweep: per-residual {ZeroAdjoints, Adjoint=1.0, PropagateToStart, harvest}.
+            // Reverse sweep: per-residual {Adjoint=1.0, PropagateToStart, harvest}.
+            // PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
+            // ZeroAdjoints pass is needed before each row. The parameter leaves are not consumed
+            // by PropagateOne and would accumulate across rows, so they are zeroed locally after
+            // harvest -- O(nParams) per row instead of O(all nodes).
             const int nCols = static_cast<int>(x.size());
             Matrix_<> j(totalResiduals, nCols, 0.0);
             for (int i = 0; i < totalResiduals; ++i) {
-                Dal::AAD::ZeroAdjoints(*tape);
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
                 Dal::AAD::PropagateToStart(*tape);
                 for (int d = 0; d < static_cast<int>(slots_->size()); ++d) {
@@ -477,6 +480,8 @@ namespace Dal {
                     for (int k = 0; k < nKnots; ++k) {
                         j(i, slot.paramOffset + 2 * k) = Dal::AAD::Value(Dal::AAD::Adjoint(fLeftT[k]));
                         j(i, slot.paramOffset + 2 * k + 1) = Dal::AAD::Value(Dal::AAD::Adjoint(fRightT[k]));
+                        Dal::AAD::Adjoint(fLeftT[k]) = 0.0;
+                        Dal::AAD::Adjoint(fRightT[k]) = 0.0;
                     }
                 }
             }

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -464,13 +464,18 @@ namespace Dal {
             const int totalResiduals = static_cast<int>(residuals.size());
 
             // Reverse sweep: per-residual {Adjoint=1.0, PropagateToStart, harvest}.
-            // PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
-            // ZeroAdjoints pass is needed before each row. The parameter leaves are not consumed
-            // by PropagateOne and would accumulate across rows, so they are zeroed locally after
-            // harvest -- O(nParams) per row instead of O(all nodes).
+            // Native: PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
+            // ZeroAdjoints pass is needed before each row. The parameter leaves are not consumed by
+            // PropagateOne and would accumulate across rows, so they are zeroed locally after harvest
+            // -- O(nParams) per row instead of O(all nodes).
+            // XAD/CoDi/Adept: no inline zeroing in PropagateOne, and Adjoint() returns by value, so
+            // a full ZeroAdjoints sweep before each row is still required.
             const int nCols = static_cast<int>(x.size());
             Matrix_<> j(totalResiduals, nCols, 0.0);
             for (int i = 0; i < totalResiduals; ++i) {
+#if defined(DAL_USE_XAD_AAD) || defined(DAL_USE_CODIPACK_AAD) || defined(DAL_USE_ADEPT_AAD)
+                Dal::AAD::ZeroAdjoints(*tape);
+#endif
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
                 Dal::AAD::PropagateToStart(*tape);
                 for (int d = 0; d < static_cast<int>(slots_->size()); ++d) {
@@ -480,8 +485,10 @@ namespace Dal {
                     for (int k = 0; k < nKnots; ++k) {
                         j(i, slot.paramOffset + 2 * k) = Dal::AAD::Value(Dal::AAD::Adjoint(fLeftT[k]));
                         j(i, slot.paramOffset + 2 * k + 1) = Dal::AAD::Value(Dal::AAD::Adjoint(fRightT[k]));
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
                         Dal::AAD::Adjoint(fLeftT[k]) = 0.0;
                         Dal::AAD::Adjoint(fRightT[k]) = 0.0;
+#endif
                     }
                 }
             }

--- a/dal-cpp/dal/curve/tapeguard.hpp
+++ b/dal-cpp/dal/curve/tapeguard.hpp
@@ -8,15 +8,18 @@
 
 namespace Dal {
 
-    // RAII guard that clears the AAD tape on construction and destruction.
-    // Used around analytic-Jacobian tape sweeps that must not interfere with
-    // any outer tape recording. Single-threaded.
+    // RAII guard that rewinds the AAD tape on construction and destruction.
+    // Rewind (cursor reset, block reuse) keeps blocks allocated across consecutive
+    // calibration Jacobian sweeps instead of freeing and re-allocating them every
+    // Newton step. The next NewRecording + RegisterIndependent calls overwrite the
+    // reused node storage, so no stale data leaks into the next sweep.
+    // Single-threaded.
     struct TapeGuard_ {
         Dal::AAD::Tape_* t_;
-        explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Clear(*t_); }
+        explicit TapeGuard_(Dal::AAD::Tape_* t) : t_(t) { Dal::AAD::Rewind(*t_); }
         ~TapeGuard_() {
             try {
-                Dal::AAD::Clear(*t_);
+                Dal::AAD::Rewind(*t_);
             } catch (...) {
                 // swallow; we are unwinding
             }

--- a/dal-cpp/dal/math/aad/node.hpp
+++ b/dal-cpp/dal/math/aad/node.hpp
@@ -41,11 +41,17 @@ namespace Dal::AAD {
         double& Adjoint(size_t n) { return pAdjoints_[n]; }
 
         void PropagateOne() {
-            if (!n_ || std::abs(adjoint_) <= Dal::EPSILON)
+            if (!n_)
                 return;
-
-            for (size_t i = 0; i < n_; ++i)
-                *(pAdjPtrs_[i]) += adjoint_ * pDerivatives_[i];
+            if (std::abs(adjoint_) > Dal::EPSILON) {
+                for (size_t i = 0; i < n_; ++i)
+                    *(pAdjPtrs_[i]) += adjoint_ * pDerivatives_[i];
+            }
+            // Zero the consumed adjoint inline so the next propagation sweep starts
+            // clean; this makes a separate ZeroAdjoints pass before each Jacobian
+            // row unnecessary. Leaf parameter nodes (n_ == 0) return early above and
+            // retain their accumulated adjoint for harvest.
+            adjoint_ = 0.0;
         }
 
         void PropagateAll() {

--- a/dal-cpp/dal/script/simulation.hpp
+++ b/dal-cpp/dal/script/simulation.hpp
@@ -190,7 +190,9 @@ namespace Dal::Script {
             auto pathsInTask = std::min(pathsLeft, batchSize);
             futures.push_back(pool->SpawnTask([&, firstPath, pathsInTask]() {
                 const size_t threadNum = ThreadPool_::ThreadNum();
-                Dal::AAD::Clear(*Dal::AAD::Tape());
+                // Rewind (cursor reset, block reuse) suffices: the tape is immediately
+                // re-populated by the per-path recording below. Clear would free and
+                // re-allocate every block per batch.
                 AAD::Rewind(*AAD::Tape());
                 std::unique_ptr<AAD::Model_<AAD::Number_>> model = mdl->Clone();
                 model->Allocate(product.TimeLine(), product.DefLine());

--- a/docs/methodology/aad.md
+++ b/docs/methodology/aad.md
@@ -280,12 +280,13 @@ inherited `Swap_::PrecomputeT<T_>`.
 The recording contract that produces a correct Jacobian on all four backends is
 the same as the single-curve path:
 
-$$\text{Clear}(\textit{tape}) \rightarrow
+$$\text{Rewind}(\textit{tape}) \rightarrow
 \text{RegisterIndependent}(x_k)\;\forall k \rightarrow
 \text{NewRecording}(\textit{tape}) \rightarrow
 \text{forward pass (build curves, price residuals)} \rightarrow
-\text{per row } \{\text{ZeroAdjoints},\; \bar{r}_i = 1,\;
-\text{PropagateToStart},\; \text{harvest } \bar{x}_j\}.$$
+\text{per row } \{\bar{r}_i = 1,\;
+\text{PropagateToStart},\; \text{harvest } \bar{x}_j,\;
+\text{zero each } \bar{x}_j\}.$$
 
 Under PWL_FWD every knot is free (no anchor exclusion), so the independent
 registration covers all $2 \cdot n_{\text{knots}}$ forward-rate parameters
@@ -313,32 +314,44 @@ gradient-zeroing semantics between single-result reverse sweeps.
 A correct Jacobian on all four backends requires this exact ordering:
 
 $$
-\text{Clear}(\textit{tape}) \;\rightarrow\;
+\text{Rewind}(\textit{tape}) \;\rightarrow\;
 \text{RegisterIndependent}(x_k)\;\forall k \;\rightarrow\;
 \text{NewRecording}(\textit{tape}) \;\rightarrow\;
 \text{forward pass} \;\rightarrow\;
-\text{per output row } \bigl\{\,\text{ZeroAdjoints},\;\bar{y}_i = 1,\;\text{PropagateToStart},\;\text{harvest}\,\bigr\}.
+\text{per output row } \bigl\{\,\bar{y}_i = 1,\;\text{PropagateToStart},\;\text{harvest},\;\text{zero each leaf}\,\bigr\}.
 $$
 
 Each step has a backend-specific reason to be in this position:
 
-- **Clear** resets the recorded graph and the position markers so nothing from
-  a previous run contaminates the new one.
+- **Rewind** resets the tape's write cursor to the start so the next recording
+  reuses the already-allocated node blocks, avoiding the free/re-allocate cycle
+  of `Clear` on every iteration. The reused storage is overwritten in place by
+  the next forward pass, so no stale data leaks into the new sweep.
 - **RegisterIndependent** stamps each input as a tape leaf that subsequent
   operations differentiate. It must run *before* `NewRecording` opens the
   recording window on XAD (see below); running it after silently drops the input
   and yields an all-zero Jacobian column.
 - **NewRecording** marks the start of the live recording so the reverse sweep
   terminates at the right point.
-- **ZeroAdjoints** between rows is **not** a no-op on every backend (Adept in
-  particular), and is the single most common source of corrupted multi-row
-  Jacobians.
+- **Zeroing between rows** is **not** uniform across backends. On native the
+  inline-zeroing `PropagateOne` clears each consumed intermediate adjoint, so
+  only the parameter leaves must be zeroed by the caller after harvest; on the
+  other backends a full `ZeroAdjoints` pass before each row is still required.
+  Skipping the between-row zero is the single most common source of corrupted
+  multi-row Jacobians.
 
 ### Per-Backend Zeroing Semantics
 
-- **Native.** `ZeroAdjoints` walks the node list and writes `0.0` to every
-  node's adjoint, leaving the recorded graph intact. Behaviour is the obvious
-  one and is safe to call between rows.
+- **Native.** `PropagateOne` (`dal-cpp/dal/math/aad/node.hpp`) zeroes each
+  consumed node's adjoint inline after propagating it to its parents, so the
+  intermediate graph starts clean for the next reverse sweep without a separate
+  pass. Leaf parameter nodes (`n_ == 0`) are *not* consumed by `PropagateOne`
+  and would accumulate across rows; the calibration call sites
+  (`dal-cpp/dal/curve/calibration.cpp`, `dal-cpp/dal/curve/jointcalibration.cpp`)
+  zero each harvested leaf adjoint in place immediately after reading it, which
+  is O(nParams) per row instead of the O(all nodes) `ZeroAdjoints` sweep. The
+  `ZeroAdjoints` facade is still defined for callers that need a full sweep
+  outside this pattern.
 
 - **Adept.** Adept's `compute_adjoint` zeroes only the LHS adjoint of each
   consumed statement and then accumulates into the operands; operands whose


### PR DESCRIPTION
## Summary

Two related AAD tape hot-path optimizations (native backend only):

**P1 — Clear → Rewind (3 sites).** `AAD::Clear(*tape)` frees every tape block (heap dealloc), and the next recording immediately re-allocates them. `Rewind` only resets the write cursor and reuses the already-allocated blocks in place — the next forward pass overwrites the reused storage, so no stale data leaks. This eliminates the per-MC-batch and per-Newton-iteration block free/realloc.

- `dal-cpp/dal/script/simulation.hpp` — dropped the per-MC-batch `Clear`; the `Rewind` on the next line already resets the cursor and the per-path recording reuses the blocks.
- `dal-cpp/dal/curve/tapeguard.hpp` — `TapeGuard_` ctor and dtor now call `Rewind` instead of `Clear`, keeping blocks allocated across consecutive calibration Jacobian sweeps (each Newton step constructs and destroys a guard, so this was 2 Clears per step → 2 Rewinds).

**P5 — Inline adjoint zeroing in `PropagateOne`.** After propagating its adjoint to its parents, a consumed intermediate node zeroes its own adjoint inline, so the next reverse sweep starts clean without a separate full-tape `ZeroAdjoints` pass. Leaf parameter nodes (`n_ == 0`) return early and retain their adjoint for harvest; the calibration call sites zero each harvested leaf in place immediately after reading it — O(nParams) per row instead of the O(all nodes) `ZeroAdjoints` sweep.

- `dal-cpp/dal/math/aad/node.hpp` — `PropagateOne` zeroes `adjoint_` inline after propagation; leaves (`n_ == 0`) skip propagation and the zero.
- `dal-cpp/dal/curve/calibration.cpp`, `dal-cpp/dal/curve/jointcalibration.cpp` — dropped the pre-row `ZeroAdjoints`; added an in-place `Adjoint(leaf) = 0.0` after each harvest.

The spec's "the mark-point parameter nodes ... were parents, not consumers" reasoning was incomplete: parameter leaves are *not* consumed by `PropagateOne`, so without an explicit zero they would accumulate across rows and row N's harvest would read the sum of rows 0..N. The fix zeros only the harvested leaves (O(nParams)) rather than restoring the full-tape `ZeroAdjoints` (O(all nodes)), preserving the performance intent.

`docs/methodology/aad.md` updated: the load-bearing recording contract and per-backend zeroing semantics now describe `Rewind` + inline leaf zeroing on native.

### Before/after benchmarks

`tape_perf` and `jacobian_perf` are micro-benchmarks of the primitives in isolation — they call `Clear`/`ZeroAdjoints` directly and are unchanged by this PR. The optimization is at the call sites: the MC and calibration hot paths now execute the cheaper `Rewind + re-record` row rather than `Clear + re-record`, and the Jacobian row loop drops the per-row `ZeroAdjoints` sweep.

| Benchmark (median)                        | Before (master) | After (this branch) | Notes |
| ----------------------------------------- | --------------- | ------------------- | ----- |
| tape_perf: Clear + re-record (100K)       | 822 us          | 903 us              | primitive, unchanged; call sites no longer hit this path |
| tape_perf: Rewind + re-record (100K)      | 522 us          | 583 us              | primitive; MC + calibration hot paths now use this row |
| tape_perf: ZeroAdjoints sweep (100K)      | 114 us          | 125 us              | primitive; Jacobian row loop no longer pays this per row |
| tape_perf: PropagateToStart (100K)        | 402 us          | 437 us              | primitive, unchanged |
| jacobian_perf: AnalyticJacobian (24 x 23) | 4.94 us         | 5.13 us             | dominated by overhead at this size; ZeroAdjoints removal scales with row count |

The Clear→Rewind delta (~300 us per 100K-node re-record) is the dominant call-site gain in the MC and calibration hot paths. The jacobian_perf micro-benchmark is flat because at 24×23 the per-row sweep is tiny relative to fixed overhead; the ZeroAdjoints removal scales with `nRows * nNodes`.

## Test plan

- [x] Full `dal_cpp_tests`: 759 tests pass (incl. all `AnalyticJacobianTest`, `JointAnalyticJacobianTest`, `CurveJacobianModeFlagTest`, `InverseJacobianRiskTest`, `ForwardJacobianDiagnosticsTest`, `PTIRDSCurveTest`, `AADTest`)
- [x] Full `dal_public_tests`: 40 tests pass
- [x] `AnalyticJacobianTest.TestLaterRowsCleanOfEarlierResidue` (B1 residue sentinel) passes — byte-exact structural zeros (`ASSERT_EQ(J(row,c), 0.0)`) preserved
- [x] `JointAnalyticJacobianTest.TestBumpedFallbackIsByteForByte` passes — byte-identity confirmed
- [x] `tape_perf` and `jacobian_perf` run cleanly post-change

Co-Authored-By: Claude <noreply@anthropic.com>
