### PR TITLE
perf: sparse/banded Jacobian for curve calibration

### DIFF
--- a/dal-cpp/benchmarks/jacobian_perf/jacobian_perf.cpp
+++ b/dal-cpp/benchmarks/jacobian_perf/jacobian_perf.cpp
@@ -1,13 +1,19 @@
 //
-// Created by dal-implementer on 2026-6-28.
+// Created by dal-implementer on 2026/6/28.
 //
 // Curve-calibration Jacobian micro-benchmark.
 //
-// The production Jacobian (AnalyticJacobian in YieldCurveCalibrationFunc_) is a private
-// member and reachable only via a full calibration solve. To isolate the row-by-row
-// AAD sweep pattern that dominates its cost, this benchmark records N parameters on the
-// tape, computes M residuals from them, then builds the dense M x N Jacobian by, for
-// each residual row: ZeroAdjoints -> seed -> PropagateToStart -> harvest N adjoints.
+// The production Jacobian (AnalyticJacobian in YieldCurveCalibrationFunc_) is a private member
+// reachable only via a full calibration solve. To isolate the row-by-row AAD sweep that builds it,
+// this benchmark records N parameters on the tape, computes M residuals from them, then builds the
+// dense M x N Jacobian via, for each residual row: ZeroAdjoints -> seed -> PropagateToStart ->
+// harvest N adjoints.
+//
+// The Jacobian is lower-triangular by maturity: each residual touches only a leading window of
+// parameters, so columns at or beyond that window are structural zeros. The "dense harvest" case
+// reads all N adjoints per row; the "row-width harvest" case reads only the leading RowWidth(j)
+// adjoints and leaves the trailing zeros at their 0.0 fill (the production pattern after the
+// sparse-Jacobian change). The delta is the harvest cost the optimization saves.
 //
 // N = 24 (curve free nodes), M = 23 (calibration instruments).
 
@@ -25,9 +31,9 @@ namespace {
     constexpr int kN = 24; // parameters (free log-DF nodes)
     constexpr int kM = 23; // residuals (instruments)
 
-    // A non-trivial residual function: weighted sum of exp(params) minus target.
-    // Each residual touches a small contiguous window of parameters so the Jacobian
-    // has banded structure (as real curve-instrument exposures do).
+    // A non-trivial residual function: weighted sum of params over a small contiguous window.
+    // Each residual touches a leading window of parameters so the Jacobian has the lower-triangular
+    // structure real curve-instrument exposures do.
     Number_ Residual(const std::vector<Number_>& params, int rowIdx) {
         const int start = std::max(0, rowIdx - 1);
         const int end = std::min(kN, rowIdx + 3);
@@ -37,6 +43,11 @@ namespace {
             acc += Number_(weight) * params[static_cast<size_t>(i)];
         return acc;
     }
+
+    // Row width = the last parameter each residual touches + 1. The production AnalyticJacobian
+    // harvests only this leading prefix per row; columns at or beyond it are structural zeros and
+    // are left at the 0.0 fill. This mirrors RowWidthForMaturity in calibration_internal.hpp.
+    int RowWidth(int rowIdx) { return std::min(kN, rowIdx + 3); }
 } // namespace
 
 int main() {
@@ -54,22 +65,39 @@ int main() {
     for (int j = 0; j < kM; ++j)
         residuals[static_cast<size_t>(j)] = Residual(params, j);
 
-    // Build the dense M x N Jacobian via the row-by-row sweep pattern.
-    Matrix_<double> jacobian(kM, kN, 0.0);
+    // Dense harvest: read all N adjoints per row (the pre-optimization pattern).
+    Matrix_<double> jacobianDense(kM, kN, 0.0);
     {
-        auto r = Bench::Run("AnalyticJacobian (24 x 23)", [&]() {
+        auto r = Bench::Run("AnalyticJacobian dense harvest (24 x 23)", [&]() {
             for (int j = 0; j < kM; ++j) {
                 ZeroAdjoints(*Tape());
                 Adjoint(residuals[static_cast<size_t>(j)]) = 1.0;
                 PropagateToStart(*Tape());
                 for (int i = 0; i < kN; ++i)
-                    jacobian(static_cast<size_t>(j), i) = Adjoint(params[static_cast<size_t>(i)]);
+                    jacobianDense(static_cast<size_t>(j), i) = Adjoint(params[static_cast<size_t>(i)]);
             }
         }, 3, kRepeats);
         Bench::Print(r);
     }
 
-    double sink = jacobian(0, 0);
+    // Row-width harvest: read only the leading RowWidth(j) adjoints per row, leaving the trailing
+    // structural zeros at the 0.0 fill (the post-optimization pattern in calibration.cpp).
+    Matrix_<double> jacobianSparse(kM, kN, 0.0);
+    {
+        auto r = Bench::Run("AnalyticJacobian row-width harvest (24 x 23)", [&]() {
+            for (int j = 0; j < kM; ++j) {
+                const int width = RowWidth(j);
+                ZeroAdjoints(*Tape());
+                Adjoint(residuals[static_cast<size_t>(j)]) = 1.0;
+                PropagateToStart(*Tape());
+                for (int i = 0; i < width; ++i)
+                    jacobianSparse(static_cast<size_t>(j), i) = Adjoint(params[static_cast<size_t>(i)]);
+            }
+        }, 3, kRepeats);
+        Bench::Print(r);
+    }
+
+    double sink = jacobianDense(0, 0) + jacobianSparse(0, 0);
     Bench::DoNotOptimize(&sink);
 
     return 0;

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -381,24 +381,26 @@ namespace Dal {
             Matrix_<> j(nRows, nCols, 0.0);
 
             // Single-result reverse sweep: one PropagateToStart per row yields exact structural zeros.
-            // Native: PropagateOne zeroes each consumed intermediate adjoint inline, so no full-tape
-            // ZeroAdjoints pass is needed before each row. The parameter leaves (n_ == 0) are not
-            // consumed by PropagateOne and would accumulate across rows, so they are zeroed locally
-            // after harvest -- O(nCols) per row instead of O(all nodes).
-            // XAD/CoDi/Adept: no inline zeroing in PropagateOne, and Adjoint() returns by value, so
-            // a full ZeroAdjoints sweep before each row is still required.
+            // The Jacobian is lower-triangular by maturity, so harvest only the leading RowWidthForMaturity
+            // columns per row and leave the trailing structural zeros at their 0.0 fill. Solver ops stay
+            // dense: SecantUpdate is a rank-1 correction that fills trailing zeros, so the width does not
+            // outlive the first update and is not carried on the XCurveJacobian_.
             for (int i = 0; i < nRows; ++i) {
+                const int width = RowWidthForMaturity(knotDates_, instruments_[i]->TimeSpan().second);
 #if defined(DAL_USE_XAD_AAD) || defined(DAL_USE_CODIPACK_AAD) || defined(DAL_USE_ADEPT_AAD)
+                // No inline zeroing in PropagateOne; full-tape ZeroAdjoints is still required per row.
                 Dal::AAD::ZeroAdjoints(*tape);
 #endif
                 Dal::AAD::Adjoint(residuals[i]) = 1.0;
                 Dal::AAD::PropagateToStart(*tape);
-                for (int col = 0; col < nCols; ++col) {
+                for (int col = 0; col < width; ++col)
                     j(i, col) = Dal::AAD::Adjoint(logDF[col + 1]);
 #if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
+                // Native leaf-zeroing must cover every parameter leaf, not just the harvested prefix:
+                // unzeroed leaves accumulate across rows and corrupt later rows that DO depend on them.
+                for (int col = 0; col < nCols; ++col)
                     Dal::AAD::Adjoint(logDF[col + 1]) = 0.0;
 #endif
-                }
             }
             return new XCurveJacobian_(std::move(j));
         }

--- a/dal-cpp/dal/curve/calibration_internal.hpp
+++ b/dal-cpp/dal/curve/calibration_internal.hpp
@@ -23,6 +23,19 @@ namespace Dal {
     // xccyinstrument.cpp to eliminate byte-identical duplication. Marked inline so the header-only
     // definitions do not violate the ODR across translation units.
 
+    // Number of free knots (LOG_DISCOUNT solver columns) an instrument can have sensitivity to:
+    // the leading columns whose knot date is at or before the instrument maturity. Columns at or
+    // beyond it are structural zeros and need not be harvested. A cashflow strictly past the anchor
+    // still couples to the first free knot via short-end interpolation even when it lands before that
+    // knot, so any maturity past the anchor yields a minimum width of 1.
+    inline int RowWidthForMaturity(const Vector_<Date_>& knotDates, const Date_& maturity) {
+        REQUIRE(!knotDates.empty(), "RowWidthForMaturity: knot dates must be non-empty");
+        const auto it = std::upper_bound(knotDates.begin(), knotDates.end(), maturity);
+        const int lastKnotAtOrBefore = static_cast<int>(it - knotDates.begin()) - 1;
+        const int clamped = std::max(0, lastKnotAtOrBefore);
+        return (maturity > knotDates.front()) ? std::max(1, clamped) : clamped;
+    }
+
     // Stable ordering of curve-calibration instruments: by maturity, then by start, then by name.
     inline Vector_<Handle_<YCInstrument_>> OrderInstruments(const Vector_<Handle_<YCInstrument_>>& instruments) {
         auto ordered = instruments;

--- a/dal-cpp/tests/curve/test_row_width.cpp
+++ b/dal-cpp/tests/curve/test_row_width.cpp
@@ -1,0 +1,64 @@
+//
+// Created by dal-implementer on 2026/6/28.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/curve/calibration_internal.hpp>
+#include <dal/time/date.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+// The lower-triangular Jacobian optimization maps each instrument's maturity to the count of free
+// knots at or before it: that count is the row width (the number of leading columns that can be
+// nonzero for that row). Columns at or beyond the row width are guaranteed structural zero and are
+// never harvested. These tests pin the maturity -> row-width mapping for the LOG_DISCOUNT knot
+// layout (anchor at knot 0, free knots at indices 1..nKnots-1 mapping to solver columns 0..nCols-1).
+
+TEST(RowWidthTest, TestMaturityAtFreeKnotReturnsKnotIndex) {
+    const Vector_<Date_> knots = {
+        Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1), Date_(2024, 1, 1), Date_(2025, 1, 1),
+    };
+    // 3M swap maturing exactly at knot 1 (2022-04-01): only column 0 (knot 1) is touched.
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2022, 4, 1)), 1);
+    // 6M swap maturing exactly at knot 2 (2022-07-01): columns 0..1 (knots 1..2).
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2022, 7, 1)), 2);
+    // 5Y swap maturing at the last knot: all 5 free columns.
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2025, 1, 1)), 5);
+}
+
+TEST(RowWidthTest, TestMaturityBetweenKnotsRoundsDownToPriorKnot) {
+    const Vector_<Date_> knots = {
+        Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1), Date_(2024, 1, 1), Date_(2025, 1, 1),
+    };
+    // Maturity 2022-05-01 falls between knot 1 (2022-04-01) and knot 2 (2022-07-01): cashflows can
+    // only land on or before knot 1, so the row width is 1 (column 0 only).
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2022, 5, 1)), 1);
+}
+
+TEST(RowWidthTest, TestMaturityBeforeFirstFreeKnotIsZeroWidth) {
+    const Vector_<Date_> knots = {Date_(2022, 1, 1), Date_(2022, 4, 1)};
+    // Maturity at the anchor itself: no free knot is at or before it (the anchor is excluded), so
+    // the row width is 0 -- the harvest loop is skipped entirely and the row stays zero-filled.
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2022, 1, 1)), 0);
+}
+
+TEST(RowWidthTest, TestMaturityAfterAnchorBeforeFirstFreeKnotIsWidthOne) {
+    const Vector_<Date_> knots = {
+        Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1), Date_(2023, 1, 1), Date_(2024, 1, 1), Date_(2025, 1, 1),
+    };
+    // A cashflow strictly after the anchor but before the first free knot (e.g. a 1-business-day
+    // swap maturing 2022-01-03, before the 2022-04-01 knot) still couples to the first free knot:
+    // the DF is bracketed by the anchor (DF=1) and the first free knot, so short-end interpolation
+    // gives nonzero sensitivity to column 0. The width is therefore 1, not 0.
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2022, 1, 3)), 1);
+    // Maturity at the anchor: no coupling (the anchor DF is pinned at 1), so width 0.
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2022, 1, 1)), 0);
+}
+
+TEST(RowWidthTest, TestMaturityBeyondLastKnotClampsToColumnCount) {
+    const Vector_<Date_> knots = {Date_(2022, 1, 1), Date_(2022, 4, 1), Date_(2022, 7, 1)};
+    // Maturity after the last knot: every free column (0..1) is at or before it. Clamped to nCols.
+    ASSERT_EQ(RowWidthForMaturity(knots, Date_(2023, 1, 1)), 2);
+}


### PR DESCRIPTION
## Summary

- The LOG_DISCOUNT curve-calibration Jacobian (`YieldCurveCalibrationFunc_::AnalyticJacobian` in `dal-cpp/dal/curve/calibration.cpp`) is **lower-triangular by maturity**: instrument *i* (sorted by maturity) only has cashflow sensitivity to free knots at or before its maturity, so columns at or beyond that knot are structural zeros. The previous code harvested all `nCols` adjoints per row, reading stale structural-zero adjoints that contribute nothing to the Jacobian.
- Add `RowWidthForMaturity` (inline helper in `dal-cpp/dal/curve/calibration_internal.hpp`) and harvest only the leading `width` columns per row in `AnalyticJacobian`, leaving trailing entries at their `0.0` fill. The native-backend leaf-zeroing still covers every parameter leaf so unzeroed adjoints do not accumulate into later rows.
- New `RowWidthTest` suite (5 tests) pins the maturity → row-width mapping, including the short-end coupling invariant (a cashflow strictly past the anchor but before the first free knot still couples to column 0 via short-end interpolation, so the minimum width is 1).
- Extended `dal-cpp/benchmarks/jacobian_perf/jacobian_perf.cpp` with a `row-width harvest` case alongside the existing `dense harvest` case so the before/after harvest cost is measurable.

## Approach taken (Option B, scoped to the build)

The spec offered three options (A: full sparse `TriDiagonal_` storage + sparse solver ops; B: build efficiently, keep the solver dense; C: profile and target the real bottleneck). I took **Option B** and scoped it to the Jacobian **build/harvest**, after discovering through implementation that Option A's solver-op half is not safely byte-identical:

- The `Underdetermined::Jacobian_` interface (`MultiplyRight` / `MultiplyLeft` / `QForm` / `SecantUpdate`) operates on the Jacobian every solver iteration. `SecantUpdate` is a **rank-1 correction** (`row += (excess/x2) * dx`) that deliberately fills the trailing structural zeros on the first call. Once the Jacobian has been secant-updated, the row-width prefix is no longer a correct description of the nonzero structure, so `MultiplyLeft` / `MultiplyRight` / `SecantUpdate` cannot skip trailing columns without diverging from the dense path. I verified this directly: a row-width-aware `SecantUpdate` / `MultiplyLeft` broke 3 `PTIRDSCurveTest` cases (rateslib reference comparisons) because the solver's descent-direction logic depends on the rank-1-updated dense rows.
- `QForm` (`Sparse::SymmetricDecomposition_::QForm`) takes `const Matrix_<>&` by value type and the downstream `CholeskySolve` is O(N³) dense; converting to a sparse storage would require changing the solver core's signatures and risks the byte-identity guarantee. Out of scope.
- The byte-identical, low-risk win is the **harvest**: skip reading adjoints for structural-zero columns. The harvested `Matrix_<>` is identical to the dense version (structural zeros stay exactly `0.0`), and no solver op changes.

The joint-calibration path (`jointcalibration.cpp::JointResidualFunction_::AnalyticJacobian`) has a similar dense harvest but with a more intricate block structure (each instrument's support spans its own slot's parameters up to its maturity knot, with zero support for other slots' parameters). A single leading-prefix width does not model that, so the joint path keeps its dense harvest (byte-identical, no regression) — a per-row column-range list for the joint case is a clean follow-up PR.

## Byte-identity

The Jacobian values are byte-identical: structural zeros stay exactly `0.0` (they were `0.0` from the matrix fill before, and are `0.0` from the same fill now — never written). Every `ASSERT_EQ(J(row, col), 0.0)` structural-zero assertion in `test_analytic_jacobian.cpp` still passes, every finite-difference check matches at `1e-9`, and the PTIRDSCurve rateslib reference DFs match at `1e-6`.

## Test plan

- [x] `bin/dal_cpp_tests --gtest_filter='AnalyticJacobianTest.*'` — 15 tests, all pass (FD agreement + structural zeros + tape isolation).
- [x] `bin/dal_cpp_tests --gtest_filter='PTIRDSCurveTest.*'` — 9 tests, all pass (rateslib log-linear / log-cubic / mixed references; this is the regression that caught the short-end coupling bug and the `SecantUpdate` issue during development).
- [x] `bin/dal_cpp_tests --gtest_filter='RowWidthTest.*'` — 5 new tests, all pass.
- [x] `bin/dal_cpp_tests --gtest_filter='JointAnalyticJacobianTest.*:JointCalibrationTest.*:CalibrationTest.*:CurveJacobianModeTest.*:ForwardJacobianDiagnosticsTest.*:InverseJacobianRiskTest.*'` — joint + diagnostics + inverse-risk, all pass (joint path unchanged, dense fallback).
- [x] Full `bin/dal_cpp_tests` on the **native** backend — **764 tests, 0 failures**.
- [x] `jacobian_perf` before/after on the native backend (5 runs, stable medians):

| Benchmark (24 x 23, native)       | Before (dense harvest) | After (row-width harvest) | Change |
|-----------------------------------|------------------------|---------------------------|--------|
| Median                            | 5.81 - 6.15 us         | 5.01 - 5.34 us            | -8 to -13% |
| Min                               | 5.48 - 5.84 us         | 4.95 - 5.25 us            | -7 to -11% |
| Max                               | 7.7 - 31.5 us          | 6.3 - 21.1 us             | lower tail latency |

The harvest win is modest because `PropagateToStart` (a full tape traversal per row) dominates the per-row cost and is unchanged; the harvest is the smaller, variable fraction. The more visible effect is the lower tail latency (max), since the dense harvest occasionally stalled reading stale adjoints beyond the row's support. The build is one piece of the calibration cost — the O(N³) `QForm` + `CholeskySolve` in the solver dominates overall and is unchanged by this PR (see Option A note above).

Co-Authored-By: Claude <noreply@anthropic.com>