### PR TITLE
perf: cache PDE decomposition across Crank-Nicolson half-steps and timesteps

### DIFF
--- a/dal-cpp/dal/math/pde/fd1d.cpp
+++ b/dal-cpp/dal/math/pde/fd1d.cpp
@@ -18,6 +18,14 @@ namespace Dal::PDE {
 
         A_ = std::make_unique<Sparse::TriDiagonal_>(dx_->Size());
         vs_.Resize(dx_->Size());
+
+        cachedDecomp_.reset();
+        cachedDt_ = 0.0;
+        cachedTheta_ = 0.0;
+        cachedMu_.clear();
+        cachedVar_.clear();
+        cachedR_.clear();
+        decompCount_ = 0;
     }
 
     void FD1D_::CalcAx(double one, double dtTheta) {
@@ -34,6 +42,16 @@ namespace Dal::PDE {
         }
     }
 
+    bool FD1D_::CacheHit(double dt, double theta) const {
+        if (!cachedDecomp_)
+            return false;
+        if (dt != cachedDt_ || theta != cachedTheta_)
+            return false;
+        if (mu_ != cachedMu_ || var_ != cachedVar_ || r_ != cachedR_)
+            return false;
+        return true;
+    }
+
     void FD1D_::RollBwd(double dt, double theta, Vector_<>& res) {
         if (theta != 1.0) {
             CalcAx(1.0, dt * (1.0 - theta));
@@ -42,10 +60,18 @@ namespace Dal::PDE {
         }
 
         if (theta != 0.0) {
-            CalcAx(1.0, -dt * theta);
+            if (!CacheHit(dt, theta)) {
+                CalcAx(1.0, -dt * theta);
+                cachedDecomp_.reset(A_->Decompose());
+                cachedDt_ = dt;
+                cachedTheta_ = theta;
+                cachedMu_ = mu_;
+                cachedVar_ = var_;
+                cachedR_ = r_;
+                ++decompCount_;
+            }
             vs_ = res;
-            std::unique_ptr<SquareMatrixDecomposition_> comp(A_->Decompose());
-            comp->SolveLeft(vs_, &res);
+            cachedDecomp_->SolveLeft(vs_, &res);
         }
     }
 } // namespace Dal::PDE

--- a/dal-cpp/dal/math/pde/fd1d.hpp
+++ b/dal-cpp/dal/math/pde/fd1d.hpp
@@ -29,6 +29,11 @@ namespace Dal::PDE {
         void CalcAx(double one, double dtTheta);
         void RollBwd(double dt, double theta, Vector_<>& res);
 
+        // Number of implicit-matrix decompositions performed since the last
+        // Init(). Exposed so callers and tests can confirm that repeated
+        // time-homogeneous rolls reuse a cached decomposition.
+        [[nodiscard]] int DecompositionsSinceInit() const { return decompCount_; }
+
     private:
         const FDM1DMesher_& x_;
         Vector_<> r_;
@@ -40,6 +45,19 @@ namespace Dal::PDE {
         std::unique_ptr<Sparse::TriDiagonal_> A_;
         Vector_<> vs_;
         Vector_<> res_;
+
+        // Cached decomposition of the implicit (theta-weighted) operator,
+        // valid only while (dt, theta, mu, var, r) are unchanged. A miss on
+        // any of these rebuilds the cache.
+        std::unique_ptr<SquareMatrixDecomposition_> cachedDecomp_;
+        double cachedDt_ = 0.0;
+        double cachedTheta_ = 0.0;
+        Vector_<> cachedMu_;
+        Vector_<> cachedVar_;
+        Vector_<> cachedR_;
+        int decompCount_ = 0;
+
+        [[nodiscard]] bool CacheHit(double dt, double theta) const;
     };
 
 } // namespace Dal::PDE

--- a/dal-cpp/tests/math/pde/test_fd1d.cpp
+++ b/dal-cpp/tests/math/pde/test_fd1d.cpp
@@ -1,0 +1,175 @@
+//
+// Created by dal-implementer on 2026-6-28.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/math/pde/fd1d.hpp>
+#include <dal/math/pde/meshers/uniform1dmesher.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/utilities/algorithms.hpp>
+
+using namespace Dal;
+using namespace Dal::PDE;
+
+namespace {
+    // Builds a Black-Scholes-like FD1D_ over a uniform spot grid. Coefficients
+    // are time-homogeneous (depend on spot only), so the operator is identical
+    // at every timestep.
+    struct BlackScholesSetup_ {
+        static constexpr int kN = 41;
+        static constexpr double kStrike = 100.0;
+        static constexpr double kRate = 0.05;
+        static constexpr double kVol = 0.2;
+        Uniform1DMesher_ x{0.0, 200.0, kN};
+        std::unique_ptr<FD1D_> fd;
+
+        BlackScholesSetup_() {
+            fd = std::make_unique<FD1D_>(x);
+            fd->Init();
+            fd->Mu() = kRate * x.Locations();
+            fd->R() = Vector_<>(kN, kRate);
+            fd->Var() = kVol * kVol * x.Locations() * x.Locations();
+            fd->Res() = Apply([](double s) { return std::max(s - kStrike, 0.0); }, x.Locations());
+        }
+    };
+} // namespace
+
+TEST(FD1DTest, TestInitZeroDecompositions) {
+    BlackScholesSetup_ s;
+    // After Init, no implicit decomposition has been built yet.
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 0);
+}
+
+TEST(FD1DTest, TestTimeHomogeneousReusesDecomposition) {
+    BlackScholesSetup_ s;
+    const double dt = 0.01;
+    const double theta = 0.5;
+
+    for (int n = 0; n < 50; ++n)
+        s.fd->RollBwd(dt, theta, s.fd->Res());
+
+    // Time-homogeneous coefficients + constant (dt, theta): the implicit
+    // operator is byte-identical at every step, so the decomposition must be
+    // built exactly once and reused for the remaining 49 steps.
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 1);
+
+    // Sanity: a positive payoff rolled back should produce a positive price.
+    ASSERT_GT(s.fd->Res()[s.kN / 2], 0.0);
+}
+
+TEST(FD1DTest, TestChangingCoefficientsBustsCache) {
+    BlackScholesSetup_ s;
+    const double dt = 0.01;
+    const double theta = 0.5;
+
+    s.fd->RollBwd(dt, theta, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 1);
+
+    // Mutate mu_ (as a time-dependent-coefficient Dupire step would). The
+    // cached decomposition is now stale and must be rebuilt.
+    s.fd->Mu()[s.kN / 2] += 1.0;
+    s.fd->RollBwd(dt, theta, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 2);
+
+    // Same coefficients again -> cache hit, no new decomposition.
+    s.fd->RollBwd(dt, theta, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 2);
+}
+
+TEST(FD1DTest, TestChangingDtBustsCache) {
+    BlackScholesSetup_ s;
+    const double theta = 0.5;
+
+    s.fd->RollBwd(0.01, theta, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 1);
+
+    // Different dt -> different implicit operator -> cache miss.
+    s.fd->RollBwd(0.02, theta, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 2);
+
+    // Back to the original dt with unchanged coeffs -> the operator matches
+    // the most recent (dt=0.02) cache only if dt matches; here it does not,
+    // so a new decomposition is required.
+    s.fd->RollBwd(0.01, theta, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 3);
+}
+
+TEST(FD1DTest, TestExplicitThetaSkipsDecomposition) {
+    BlackScholesSetup_ s;
+    // Pure explicit (theta = 0): only the MultiplyLeft branch runs, no
+    // decomposition is needed at all.
+    s.fd->RollBwd(0.01, 0.0, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 0);
+}
+
+TEST(FD1DTest, TestReinitClearsCache) {
+    BlackScholesSetup_ s;
+    s.fd->RollBwd(0.01, 0.5, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 1);
+
+    s.fd->Init();
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 0);
+
+    // After re-init the cache is empty, so the next roll decomposes again.
+    s.fd->RollBwd(0.01, 0.5, s.fd->Res());
+    ASSERT_EQ(s.fd->DecompositionsSinceInit(), 1);
+}
+
+TEST(FD1DTest, TestCachedPathByteIdenticalToUncached) {
+    // The cached decomposition must produce bit-for-bit identical results to a
+    // fresh Decompose() on the same operator. Run the same rollout twice from
+    // identical initial conditions: once with cache hits (time-homogeneous
+    // coefficients, 1 decomposition total) and once where every step busts the
+    // cache by calling Init() between rolls (which clears the cache but leaves
+    // the operator byte-identical since coefficients are re-set the same way).
+    // The final states must be identical.
+    const double dt = 0.01;
+    const double theta = 0.5;
+    const int steps = 30;
+
+    auto setup = [](FD1D_& fd, const Uniform1DMesher_& x, const Vector_<>& v0) {
+        fd.Init();
+        fd.Mu() = BlackScholesSetup_::kRate * x.Locations();
+        fd.R() = Vector_<>(BlackScholesSetup_::kN, BlackScholesSetup_::kRate);
+        fd.Var() = BlackScholesSetup_::kVol * BlackScholesSetup_::kVol * x.Locations() * x.Locations();
+        fd.Res() = v0;
+    };
+
+    Uniform1DMesher_ x(0.0, 200.0, BlackScholesSetup_::kN);
+    Vector_<> v0 = Apply(
+        [](double s) { return std::max(s - BlackScholesSetup_::kStrike, 0.0); }, x.Locations());
+
+    // Cached rollout: 1 decomposition shared across all steps.
+    Vector_<> cached;
+    {
+        FD1D_ fd(x);
+        setup(fd, x, v0);
+        for (int n = 0; n < steps; ++n)
+            fd.RollBwd(dt, theta, fd.Res());
+        cached = fd.Res();
+        ASSERT_EQ(fd.DecompositionsSinceInit(), 1);
+    }
+
+    // Bust-per-step rollout: Init() clears the cache before each roll, so each
+    // step performs a fresh Decompose() on the same operator. (Init() also
+    // resets the decomposition counter, so the count after the loop reflects
+    // only the final step.)
+    Vector_<> busted;
+    {
+        FD1D_ fd(x);
+        setup(fd, x, v0);
+        for (int n = 0; n < steps; ++n) {
+            fd.Init();
+            fd.Mu() = BlackScholesSetup_::kRate * x.Locations();
+            fd.R() = Vector_<>(BlackScholesSetup_::kN, BlackScholesSetup_::kRate);
+            fd.Var() = BlackScholesSetup_::kVol * BlackScholesSetup_::kVol * x.Locations() * x.Locations();
+            fd.RollBwd(dt, theta, fd.Res());
+        }
+        busted = fd.Res();
+    }
+
+    ASSERT_EQ(cached.size(), busted.size());
+    for (int i = 0; i < static_cast<int>(cached.size()); ++i)
+        ASSERT_DOUBLE_EQ(cached[i], busted[i]);
+}


### PR DESCRIPTION
## Summary
- `FD1D_::RollBwd` rebuilt and re-decomposed the implicit (theta-weighted) tridiagonal operator on every call. For time-homogeneous PDEs (Black-Scholes: `mu`/`var`/`r` depend on spot only), the operator is byte-identical at every timestep, so the decomposition was redone N times for the same matrix.
- Add a single-slot decomposition cache keyed on `(dt, theta, mu, var, r)`. On a hit the stored `SquareMatrixDecomposition_` is reused directly (skipping both `CalcAx` and `Decompose`); on a miss the operator is rebuilt, decomposed, and the snapshot refreshed. Byte-identity is automatic — reuse only happens when every input matches.
- **Time-homogeneous (Black-Scholes):** 1 decomposition total instead of N. **Time-dependent (Dupire local vol):** the snapshot check misses each step and falls back to a fresh decomposition, so behaviour is unchanged.
- Exposed `FD1D_::DecompositionsSinceInit()` so callers and tests can confirm cache reuse.

## Test plan
- [x] New `FD1DTest` suite (7 tests): zero-decomp after init, time-homogeneous reuse, coefficient/dt bust, explicit-theta skip, reinit clears cache, and a byte-identity test that rolls out the same PDE twice (cached vs. forced-bust-per-step) and asserts `ASSERT_DOUBLE_EQ` on every grid point.
- [x] `bin/dal_cpp_tests --gtest_filter='FD1DTest.*:MeshersTest.*'` — 9/9 pass.
- [x] Full `bin/dal_cpp_tests` — **771/771 pass** (764 original + 7 new), no regressions.
- [x] `bin/pde_perf` before/after (200x200 Crank-Nicolson, 10 repeats, median):

| Benchmark | Before (median) | After (median) | Speedup |
|---|---|---|---|
| FD1D RollBwd (200x200 CN) | 1.404 ms | 0.665 ms | **2.11x** |

Co-Authored-By: Claude <noreply@anthropic.com>
