### PR TITLE
chore: ban volatile and mutable in code style rules

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -17,6 +17,8 @@
 
 - All files must end with a newline
 - Use `nullptr` instead of `NULL`
+- **Do not use `volatile`** — it is banned in this project. Use other mechanisms (atomics, synchronization primitives, or algorithm restructuring) if you need to prevent compiler reordering or FP contraction.
+- **Do not use `mutable`** class members — const evaluators must be pure const. If a caching/hint optimization requires hidden state, redesign the API to make the caller manage the state explicitly (e.g., pass a hint by reference), or skip the optimization.
 
 | Element           | Convention                 | Examples                                          |
 |-------------------|----------------------------|---------------------------------------------------|


### PR DESCRIPTION
## Summary
- Added explicit ban on `volatile` — use atomics, synchronization primitives, or algorithm restructuring instead.
- Added explicit ban on `mutable` class members — const evaluators must be pure const; caller-managed state if caching is needed.
- These rules codify the project's requirements discovered during the performance optimization effort (P6 interp hint needed `mutable`; P7/P8 kernel fusions needed `volatile` to break clang FMA contraction).

## Test plan
- [x] Guidance-only change; no build or tests apply.