### PR TITLE
perf: fuse banded TriMultiply neighbour-correction loops

### DIFF
--- a/dal-cpp/dal/math/matrix/banded.cpp
+++ b/dal-cpp/dal/math/matrix/banded.cpp
@@ -17,13 +17,32 @@ namespace Dal {
             const Vector_<>& x, const Vector_<>& diag, const Vector_<>& above, const Vector_<>& below, Vector_<>* r) {
             REQUIRE(x.size() == diag.size(), "");
             r->Resize(x.size());
+            // Pass 1 (vectorizable elementwise, identical to the unfused Transform) seeds r = diag * x.
             Transform(x, diag, std::multiplies<>(), r);
-            auto pr = r->begin();
-            for (auto px = x.begin() + 1, pa = above.begin(); pa != above.end(); ++px, ++pa, ++pr)
-                *pr += *px * *pa;
-            pr = r->begin() + 1;
-            for (auto px = x.begin(), pb = below.begin(); pb != below.end(); ++px, ++pb, ++pr)
-                *pr += *px * *pb;
+            // Pass 2 fuses the two strided neighbour corrections into one sweep:
+            //   r[i] += above[i] * x[i+1]  (superdiagonal, i = 0..n-2)
+            //   r[i] += below[i-1] * x[i-1] (subdiagonal, i = 1..n-1)
+            // The accumulator order (above term first, then below) matches the unfused code so
+            // -ffp-contract=fast forms the same FMAs.
+            const int n = static_cast<int>(x.size());
+            if (n < 2)
+                return;
+            auto xNext = x.begin() + 1; // x[i+1], walks with i
+            auto xPrev = x.begin();     // x[i-1], lags by one; valid for i >= 1
+            auto rIt = r->begin();
+            auto aboveIt = above.begin();
+            auto belowPrev = below.begin(); // below[i-1], lags by one; valid for i >= 1
+            // i = 0: superdiagonal only (below has no i-1 term yet).
+            *rIt += *aboveIt * *xNext;
+            ++rIt;
+            ++aboveIt;
+            ++xNext;
+            for (int ii = 1; ii < n - 1; ++ii, ++rIt, ++aboveIt, ++belowPrev, ++xNext, ++xPrev) {
+                *rIt += *aboveIt * *xNext;
+                *rIt += *belowPrev * *xPrev;
+            }
+            // i = n-1: subdiagonal only (above has no term at the last row).
+            *rIt += *belowPrev * *xPrev;
         }
 
         Vector_<> TridagBetaInverse(const Vector_<>& diag, const Vector_<>& above, const Vector_<>& below) {

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -4,11 +4,11 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
-#include <functional>
 #include <dal/math/matrix/bcg.hpp>
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/utilities/algorithms.hpp>
 #include <dal/utilities/numerics.hpp>
+#include <dal/utilities/functionals.hpp>
 
 namespace Dal {
     namespace {
@@ -71,24 +71,12 @@ namespace Dal {
                 s.precondition.Right(s.rr, &s.zz);
             const double beta = InnerProduct(s.zzRef, s.r);
             const double multiply = ii > 0 ? beta / s.betaPrev : 0.0;
-            // Fused AXPY sweep mirroring the unfused operation order (p *= multiply; p += z)
-            // so -ffp-contract=fast forms the same FMAs as the original two-pass code.
-            {
-                auto pIt = s.p.begin();
-                auto zIt = s.z.begin();
-                const auto pEnd = s.p.end();
-                if (s.biConjugate) {
-                    auto ppIt = s.pp.begin();
-                    auto zzIt = s.zz.begin();
-                    for (; pIt != pEnd; ++pIt, ++zIt, ++ppIt, ++zzIt) {
-                        *pIt = *pIt * multiply + *zIt;
-                        *ppIt = *ppIt * multiply + *zzIt;
-                    }
-                } else {
-                    for (; pIt != pEnd; ++pIt, ++zIt)
-                        *pIt = *pIt * multiply + *zIt;
-                }
-            }
+            s.p *= multiply;
+            if (s.biConjugate)
+                s.pp *= multiply;
+            s.p += s.z;
+            if (s.biConjugate)
+                s.pp += s.zz;
             s.betaPrev = beta;
             return beta;
         }
@@ -98,30 +86,10 @@ namespace Dal {
             if (s.biConjugate)
                 s.A.MultiplyRight(s.pp, &s.zz);
             const double alphaK = beta / InnerProduct(s.z, s.ppRef);
-            // Fused AXPY sweep mirroring LinearIncrement(scale) = dst + scale * src, so the
-            // FMA pattern matches the unfused Transform calls (r + (-alphaK)*z, not r - alphaK*z).
-            const double negAlphaK = -alphaK;
-            {
-                auto xIt = x->begin();
-                auto pIt = s.p.begin();
-                auto rIt = s.r.begin();
-                auto zIt = s.z.begin();
-                const auto xEnd = x->end();
-                if (s.biConjugate) {
-                    auto rrIt = s.rr.begin();
-                    auto zzIt = s.zz.begin();
-                    for (; xIt != xEnd; ++xIt, ++pIt, ++rIt, ++zIt, ++rrIt, ++zzIt) {
-                        *xIt = *xIt + alphaK * *pIt;
-                        *rIt = *rIt + negAlphaK * *zIt;
-                        *rrIt = *rrIt + negAlphaK * *zzIt;
-                    }
-                } else {
-                    for (; xIt != xEnd; ++xIt, ++pIt, ++rIt, ++zIt) {
-                        *xIt = *xIt + alphaK * *pIt;
-                        *rIt = *rIt + negAlphaK * *zIt;
-                    }
-                }
-            }
+            Transform(x, s.p, LinearIncrement(alphaK));
+            Transform(&s.r, s.z, LinearIncrement(-alphaK));
+            if (s.biConjugate)
+                Transform(&s.rr, s.zz, LinearIncrement(-alphaK));
         }
 
         void ValidateKrylovParams_(int n, const Vector_<>& b, const Vector_<>* x, double tolRel, double tolAbs, int maxIterations) {

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -4,11 +4,11 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
+#include <functional>
 #include <dal/math/matrix/bcg.hpp>
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/utilities/algorithms.hpp>
 #include <dal/utilities/numerics.hpp>
-#include <dal/utilities/functionals.hpp>
 
 namespace Dal {
     namespace {
@@ -71,12 +71,24 @@ namespace Dal {
                 s.precondition.Right(s.rr, &s.zz);
             const double beta = InnerProduct(s.zzRef, s.r);
             const double multiply = ii > 0 ? beta / s.betaPrev : 0.0;
-            s.p *= multiply;
-            if (s.biConjugate)
-                s.pp *= multiply;
-            s.p += s.z;
-            if (s.biConjugate)
-                s.pp += s.zz;
+            // Fused AXPY sweep mirroring the unfused operation order (p *= multiply; p += z)
+            // so -ffp-contract=fast forms the same FMAs as the original two-pass code.
+            {
+                auto pIt = s.p.begin();
+                auto zIt = s.z.begin();
+                const auto pEnd = s.p.end();
+                if (s.biConjugate) {
+                    auto ppIt = s.pp.begin();
+                    auto zzIt = s.zz.begin();
+                    for (; pIt != pEnd; ++pIt, ++zIt, ++ppIt, ++zzIt) {
+                        *pIt = *pIt * multiply + *zIt;
+                        *ppIt = *ppIt * multiply + *zzIt;
+                    }
+                } else {
+                    for (; pIt != pEnd; ++pIt, ++zIt)
+                        *pIt = *pIt * multiply + *zIt;
+                }
+            }
             s.betaPrev = beta;
             return beta;
         }
@@ -86,10 +98,30 @@ namespace Dal {
             if (s.biConjugate)
                 s.A.MultiplyRight(s.pp, &s.zz);
             const double alphaK = beta / InnerProduct(s.z, s.ppRef);
-            Transform(x, s.p, LinearIncrement(alphaK));
-            Transform(&s.r, s.z, LinearIncrement(-alphaK));
-            if (s.biConjugate)
-                Transform(&s.rr, s.zz, LinearIncrement(-alphaK));
+            // Fused AXPY sweep mirroring LinearIncrement(scale) = dst + scale * src, so the
+            // FMA pattern matches the unfused Transform calls (r + (-alphaK)*z, not r - alphaK*z).
+            const double negAlphaK = -alphaK;
+            {
+                auto xIt = x->begin();
+                auto pIt = s.p.begin();
+                auto rIt = s.r.begin();
+                auto zIt = s.z.begin();
+                const auto xEnd = x->end();
+                if (s.biConjugate) {
+                    auto rrIt = s.rr.begin();
+                    auto zzIt = s.zz.begin();
+                    for (; xIt != xEnd; ++xIt, ++pIt, ++rIt, ++zIt, ++rrIt, ++zzIt) {
+                        *xIt = *xIt + alphaK * *pIt;
+                        *rIt = *rIt + negAlphaK * *zIt;
+                        *rrIt = *rrIt + negAlphaK * *zzIt;
+                    }
+                } else {
+                    for (; xIt != xEnd; ++xIt, ++pIt, ++rIt, ++zIt) {
+                        *xIt = *xIt + alphaK * *pIt;
+                        *rIt = *rIt + negAlphaK * *zIt;
+                    }
+                }
+            }
         }
 
         void ValidateKrylovParams_(int n, const Vector_<>& b, const Vector_<>* x, double tolRel, double tolAbs, int maxIterations) {

--- a/dal-cpp/tests/math/matrix/test_banded.cpp
+++ b/dal-cpp/tests/math/matrix/test_banded.cpp
@@ -108,3 +108,36 @@ TEST(MatrixTest, TestTriDiagonalSolve) {
     for (int i = 0; i < n; ++i)
         ASSERT_NEAR(calculated[i], expected[i], 1e-6);
 }
+
+// Varying x with distinct, asymmetric above/below bands exercises every branch of
+// the fused TriMultiply (interior points combine all three bands; both boundaries
+// drop one term). Hand-computed expected values lock the fused contract.
+TEST(MatrixTest, TestTriDiagonalMultiplyAsymmetricFused) {
+    const auto n = 5;
+    Sparse::TriDiagonal_ trig(n);
+    trig.Set(0, 0, 2.0);
+    trig.Set(0, 1, 3.0); // above[0]
+    trig.Set(1, 0, 4.0); // below[0]
+    trig.Set(1, 1, 5.0);
+    trig.Set(1, 2, 6.0); // above[1]
+    trig.Set(2, 1, 7.0); // below[1]
+    trig.Set(2, 2, 8.0);
+    trig.Set(2, 3, 9.0); // above[2]
+    trig.Set(3, 2, 10.0); // below[2]
+    trig.Set(3, 3, 11.0);
+    trig.Set(3, 4, 12.0); // above[3]
+    trig.Set(4, 3, 13.0); // below[3]
+    trig.Set(4, 4, 14.0);
+
+    Vector_<> x = {1.0, 2.0, 3.0, 4.0, 5.0};
+    Vector_<> calculated(n);
+    trig.MultiplyLeft(x, &calculated);
+    // r[0] = diag[0]*x[0] + above[0]*x[1]
+    // r[1] = diag[1]*x[1] + above[1]*x[2] + below[0]*x[0]
+    // r[2] = diag[2]*x[2] + above[2]*x[3] + below[1]*x[1]
+    // r[3] = diag[3]*x[3] + above[3]*x[4] + below[2]*x[2]
+    // r[4] = diag[4]*x[4] + below[3]*x[3]
+    Vector_<> expected = {2 * 1 + 3 * 2, 5 * 2 + 6 * 3 + 4 * 1, 8 * 3 + 9 * 4 + 7 * 2, 11 * 4 + 12 * 5 + 10 * 3, 14 * 5 + 13 * 4};
+    for (int i = 0; i < n; ++i)
+        ASSERT_DOUBLE_EQ(calculated[i], expected[i]);
+}

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -3,6 +3,8 @@
 //
 
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <cmath>
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/math/matrix/bcg.hpp>
@@ -41,5 +43,69 @@ TEST(MatrixTest, TestBCGSolve) {
 
     ASSERT_NEAR(result[8], 0.08510638, 1e-8);
     ASSERT_NEAR(result[9], 0.07446809, 1e-8);
+}
+
+// Tri-diagonal systems with distinct band values exercise every branch of the
+// fused Krylov sweeps. CG requires a symmetric positive-definite matrix, so it
+// gets a symmetric system; BCG handles the asymmetric case (and its shadow path).
+// The contract is residual ||Ax - b||_inf near machine precision after a tight solve.
+namespace {
+    void BuildSymmetricTridiag(Sparse::Square_* mat, int n) {
+        for (int i = 0; i < n; ++i) {
+            mat->Set(i, i, 4.0 + 0.1 * static_cast<double>(i));
+            if (i > 0) {
+                const double off = -0.5 - 0.01 * static_cast<double>(i);
+                mat->Set(i, i - 1, off);
+                mat->Set(i - 1, i, off);
+            }
+        }
+    }
+
+    void BuildAsymmetricTridiag(Sparse::Square_* mat, int n) {
+        for (int i = 0; i < n; ++i) {
+            mat->Set(i, i, 4.0 + 0.1 * static_cast<double>(i));
+            if (i > 0)
+                mat->Set(i, i - 1, -0.5 - 0.01 * static_cast<double>(i));
+            if (i + 1 < n)
+                mat->Set(i, i + 1, -0.3 + 0.02 * static_cast<double>(i));
+        }
+    }
+
+    double ResidualInfNorm(const Sparse::Square_& A, const Vector_<>& x, const Vector_<>& b) {
+        Vector_<> ax(x.size());
+        A.MultiplyLeft(x, &ax);
+        double worst = 0.0;
+        for (int i = 0; i < static_cast<int>(ax.size()); ++i)
+            worst = std::max(worst, std::fabs(ax[i] - b[i]));
+        return worst;
+    }
+} // namespace
+
+TEST(MatrixTest, TestCGSolveSymmetricLowResidual) {
+    const int n = 40;
+    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    BuildSymmetricTridiag(mat, n);
+
+    Vector_<> b(n);
+    for (int i = 0; i < n; ++i)
+        b[i] = 1.0 + 0.1 * static_cast<double>(i % 7);
+    Vector_<> x(n, 0.0);
+
+    Sparse::CGSolve(*mat, b, 1e-12, 1e-14, 500, &x);
+    ASSERT_LT(ResidualInfNorm(*mat, x, b), 1e-8);
+}
+
+TEST(MatrixTest, TestBCGSolveAsymmetricLowResidual) {
+    const int n = 40;
+    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    BuildAsymmetricTridiag(mat, n);
+
+    Vector_<> b(n);
+    for (int i = 0; i < n; ++i)
+        b[i] = 1.0 + 0.1 * static_cast<double>(i % 7);
+    Vector_<> x(n, 0.0);
+
+    Sparse::BCGSolve(*mat, b, 1e-12, 1e-14, 500, &x);
+    ASSERT_LT(ResidualInfNorm(*mat, x, b), 1e-8);
 }
 


### PR DESCRIPTION
## Summary

- **P8 — Banded TriMultiply hybrid fusion** (`dal-cpp/dal/math/matrix/banded.cpp`): keeps the dominant `diag*x` `Transform` pass (vectorization-identical to the unfused code) and fuses the two strided neighbour-correction loops into one sweep. A full single-pass interleave was tested and rejected — it changes auto-vectorization scheduling and cascades FP drift through the joint calibration.
- **P7 — CG/BCG Krylov fusion reverted**: the fused AXPY sweeps pass on GCC (4.58e-6 drift, under the 1e-5 bar) but break on clang (2.17e-5) because clang's auto-vectorizer produces a different instruction stream from GCC's even with `-ffp-contract=fast` on both. This is not an FMA issue — it's a cross-compiler auto-vectorization divergence near a knife-edge tolerance.
- Adds an asymmetric `TriMultiply` regression test covering all three bands and both boundaries.
- No `volatile`, no `mutable` (both banned per `.claude/rules/code-style.md`).

## Test plan

Benchmarks (GCC `-O3 -march=native -ffp-contract=fast`, median of 20/1000 reps):

| Benchmark                          | Before    | After     | Delta  |
|------------------------------------|-----------|-----------|--------|
| TriDecomp MultiplyLeft (10K)       | 5.533 us  | 4.337 us  | -21.6% |
| TriDiagonal MultiplyLeft (10K)     | 5.325 us  | 4.274 us  | -19.7% |
| TriDiagonal Decompose (10K)        | 83.070 us | 76.021 us | -8.5%  |
| CGSolve (500x500 tridiag)          | 15.241 us | 15.241 us | ~0%    |
| BCGSolve (500x500 tridiag)         | 19.396 us | 19.396 us | ~0%    |

- [x] **`JointCalibrationTest.TestJointOisCurveAgreesWithStagedOis` PASSES** on both GCC (4.64e-6) and clang (4.64e-6) vs 1e-5 bar.
- [x] Full `dal_cpp_tests` on GCC native: **774/774 pass**.
- [x] Full `dal_cpp_tests` on clang (local): **774/774 pass**.
- [x] Full `dal_cpp_tests` on Adept AAD backend: **773/773 pass**.
- [x] CI matrix: 45/45 green (gcc-13/14, clang-18/19, msvc × all AAD backends).
- [x] All 12 other `JointCalibrationTest.*` pass.
- [x] All 8 `UnderdeterminedTest.*` pass.

Co-Authored-By: Claude <noreply@anthropic.com>