### PR TITLE
docs: full review + reflect performance optimizations and API changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - `Uniform1DMesher_` constant spacing and endpoint pinning
   - `Concentrating1dMesher_` sinh/asinh coordinate stretch, density scaling, and snapped-knot device
   - `CoordinateMap_`, `NewSinhMap(xWidth, dxdyRange)`, and identity degeneration
+  - `FD1D_` cached implicit-operator decomposition reused across time-homogeneous rolls
 
 - **[yield_curve_jacobian.md](methodology/yield_curve_jacobian.md)** — Yield-Curve Jacobian and Inverse-Jacobian Risk
   - Forward residual Jacobian via AAD reverse sweep vs finite-difference bump
@@ -106,6 +107,7 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - `Random_` interface and the pseudo-random vs. quasi-random split
   - Brownian bridge: bisection order, conditional mean/variance, variation normalization
   - Sobol direction numbers and the Gray-code $O(1)$ recurrence
+  - Sobol normal-draw precision knobs: `precise_` (high-accuracy inverse CDF) and `polish_` (Newton polish, default off)
   - Path seeking via direct state reconstruction (`SobolSet_::SkipTo`, MRG32k32a matrix jump)
 
 ### Experimental (`experimental/`)

--- a/docs/experimental/aad-analytic-jacobian-curve-calibration.md
+++ b/docs/experimental/aad-analytic-jacobian-curve-calibration.md
@@ -54,7 +54,7 @@ the `NOTICE`s fire at most once even though `Gradient` is invoked per solver ite
 `PropagateToStart`) rather than any backend-specific API, and there is no longer a
 compile-time backend `#if` gate around it in `dal-cpp/dal/curve/calibration.cpp`. The
 recording contract that works on every backend is
-`Clear(*Tape())` → `RegisterIndependent` → `NewRecording` → forward → per-row
+`Rewind(*Tape())` → `RegisterIndependent` → `NewRecording` → forward → per-row
 `ZeroAdjoints`/seed/`PropagateToStart`.
 
 **Mechanics.** `YieldCurveCalibrationFunc_::AnalyticJacobian` registers the free-node

--- a/docs/methodology/pde.md
+++ b/docs/methodology/pde.md
@@ -192,6 +192,25 @@ The difference operators and the one-dimensional engine that consume a mesher li
   exposes the node locations through `FD1D_::X()`, which returns `Locations()`. The engine's
   drift, variance, and result vectors are all indexed against this mesh.
 
+### Cached implicit-operator decomposition
+
+`FD1D_::RollBwd` solves a $\theta$-scheme step that combines the explicit
+($1-\theta$) and implicit ($\theta$) applications of the drift-plus-diffusion
+operator assembled by `CalcAx` from the mesher-derived `Dx` / `Dxx` stencils
+and the per-node `mu_`, `var_`, `r_` coefficient vectors. The implicit solve
+factorises the operator $A$ and calls `SolveLeft` against it. For a
+time-homogeneous problem the step `dt`, the weight `theta`, and the
+coefficients (`mu_`, `var_`, `r_`) do not change between rolls, so the same
+factorisation is valid roll-to-roll. `FD1D_` caches the
+`SquareMatrixDecomposition_` of $A$ and reuses it across rolls as long as
+`CacheHit(dt, theta)` confirms that `dt`, `theta`, and the three coefficient
+vectors all still match the cached values; any of them changing rebuilds the
+cache (and the explicit-operator product is recomputed unconditionally, since
+it is not factorised). The `DecompositionsSinceInit()` counter exposes how many
+fresh factorisations the engine has performed since `Init()`, so a caller can
+confirm that a time-homogeneous sweep is reusing a single decomposition rather
+than re-factoring every step.
+
 The boundary-null convention is what makes these consumers safe: a stencil that would read
 $\Delta^+_{n-1}$ or $\Delta^-_0$ at a boundary instead gets the null sentinel, forcing the
 boundary to be handled by its one-sided inward difference.

--- a/docs/methodology/random.md
+++ b/docs/methodology/random.md
@@ -181,8 +181,28 @@ $$
 then scales each state word by $2^{-32}$ to map it into $(0,1)$. The
 trailing-zero count is obtained by shifting until the lowest bit is set; if
 $k$ reaches `directions_.Rows()` (i.e. the index has exceeded $2^{32}$
-points), the generator throws. `FillNormal` applies `InverseNCDF` (with the
-`precise_` flag) to each uniform variate.
+points), the generator throws.
+
+### Normal-Draw Precision and `polish_`
+
+`FillNormal` applies `InverseNCDF` to each uniform variate. Two flags govern the
+inverse-CDF evaluation, both defaulted on construction and stored on the
+storable wrapper `SobolRSG_` (`dal-cpp/dal/math/random/sobol.hpp`) and on
+`SobolSet_`:
+
+- `precise_` selects a higher-accuracy inverse-normal-CDF routine, mirroring the
+  pseudo-random family.
+- `polish_` toggles the Newton polish step in `InverseNCDF`. The Acklam rational
+  approximation without polish is already accurate to roughly $10^{-9}$, well
+  below quasi-Monte-Carlo sampling noise, so polish defaults to **`false`** and
+  is only enabled when a caller explicitly requests it. Skipping polish roughly
+  halves the per-deviate cost of `FillNormal` without measurably moving QMC
+  convergence.
+
+The constructor surface is therefore `NewSobol(size, iPath, precise = false,
+polish = false)` and the storable `SobolRSG_(name, iPath, nDim = 1, precise =
+false, polish = false)`; both flags are persisted by the storable markup so a
+serialised generator round-trips with its precision settings intact.
 
 ### Path Seeking
 

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -202,8 +202,11 @@ dense bumping). The `LOG_DISCOUNT` parameterization exposes the node log-discoun
 factors $\ell_1,\dots,\ell_{N-1}$ as the free parameters.
 
 **TapeGuard.** Each analytic-Jacobian cycle is bracketed by `TapeGuard_`, an RAII
-scope that calls `Dal::AAD::Clear` on the active tape at construction and (via its
-destructor) at scope exit, even on exception. The guard does **not** open a
+scope that calls `Dal::AAD::Rewind` on the active tape at construction and (via its
+destructor) at scope exit, even on exception. `Rewind` resets the tape's write
+cursor so the next recording reuses the already-allocated node blocks, avoiding
+the free/re-allocate cycle of `Clear` on every iteration; the reused storage is
+overwritten in place by the next forward pass. The guard does **not** open a
 recording — the recording is opened explicitly by `AnalyticJacobian` after
 `RegisterIndependent` (the canonical order across all four AAD backends).
 
@@ -292,7 +295,7 @@ rather than running $P+1$ dense-bump evaluations.
 backends (native, XAD, CoDiPack, Adept) is:
 
 $$
-\text{Clear} \rightarrow \text{RegisterIndependent}(x_k) \;\forall k \;
+\text{Rewind} \rightarrow \text{RegisterIndependent}(x_k) \;\forall k \;
 \rightarrow \text{NewRecording} \rightarrow \text{forward pass} \rightarrow
 \text{per-row } \{\text{ZeroAdjoints},\; \bar{r}_i = 1,\;
 \text{PropagateToStart},\; \text{harvest}\}.

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -135,7 +135,7 @@ eligibility: the joint path supports `PIECEWISE_LINEAR_FWD` and
 (it throws `Dal::Exception_`) on **both** the `BUMPED` and `ANALYTIC` paths —
 the joint residual function has no log-DF or zero-rate machinery, and there is
 no fallback. `CalibrateJointMultiCurve` is single-threaded: the AAD tape is
-thread-local and a `TapeGuard_` clears it on entry and exit (also under
+thread-local and a `TapeGuard_` rewinds it on entry and exit (also under
 exception unwind), so concurrent calls would corrupt the tape.
 
 ### Discount-vs-forward routing, and the OIS post-2008 fallback


### PR DESCRIPTION
## Summary

Full review of `docs/` for structure, conciseness, readability, formatting, and cross-references, plus reconciliation against the current `master` source after recent performance and API changes. Every edit is grounded in the current source.

**Documented (confirmed on `master`):**
- `docs/methodology/random.md` — Sobol `polish_` member and the 5-arg `NewSobol` / `SobolRSG_` constructors (`polish` defaults to `false`, halving per-deviate `InverseNCDF` cost at unchanged QMC accuracy; persisted by the storable markup). Source: `dal-cpp/dal/math/random/sobol.hpp`, `sobol.cpp`.
- `docs/methodology/pde.md` — `FD1D_` cached implicit-operator decomposition (`cachedDecomp_`, `CacheHit`, `DecompositionsSinceInit`), reused across time-homogeneous rolls. Source: `dal-cpp/dal/math/pde/fd1d.hpp`, `fd1d.cpp`.

**Stale references fixed (`Clear` → `Rewind`):**
- `docs/methodology/yield_curve.md` — `TapeGuard_` description and the joint-path recording contract now correctly state `Rewind`. `TapeGuard_` calls `Dal::AAD::Rewind` on construction and destruction (not `Clear`); verified in `dal-cpp/dal/curve/tapeguard.hpp`.
- `docs/methodology/yield_curve_jacobian.md` — `TapeGuard_` "rewinds" (was "clears").
- `docs/experimental/aad-analytic-jacobian-curve-calibration.md` — recording contract starts with `Rewind(*Tape())`.

**Index sync:** `docs/README.md` bullets for `random.md` and `pde.md` updated. `docs/README.md` and `CLAUDE.md` methodology lists are complete and in sync (all 14 methodology docs).

**Deliberately NOT documented (exist only on unmerged feature branches, not on `master`):**
- P8 banded `TriMultiply` neighbour-correction loop fusion — only on `perf/p7-p8-fused-sweeps` (commit `61115fa` is not an ancestor of `master`); `master` ships the original unfused three-pass `TriMultiply`. `matrix.md` is already correct.
- `-ffp-contract=fast` / `/fp:contract` in `Platform.cmake` — only on `perf/enable-fp-contract-all-compilers`. `installation.md` is already correct.
- `volatile` / `mutable` / no-large-comments style rules — not present in `.claude/rules/code-style.md`; no doc references them.

**No CHANGELOG entry** — this is a docs polish/reconciliation pass, below the fundamental-change bar.

## Test plan

No test suite applies to a docs-only change. Manual verification performed:

- [x] Read current headers/sources (`sobol.hpp`, `sobol.cpp`, `fd1d.hpp`, `fd1d.cpp`, `tapeguard.hpp`, `calibration.cpp`, `jointcalibration.cpp`) to ground each edit.
- [x] Confirmed P1 Rewind, P3 PDE caching, P4 Sobol polish, and `CurveSolverOptions_` are on `master`; confirmed P8 fusion and fp-contract are NOT ancestors of `master`.
- [x] Cross-checked the `aad.md` Rewind methodology against the updated `yield_curve.md` / `yield_curve_jacobian.md` / experimental note for vocabulary consistency.
- [x] Verified `docs/README.md` and `CLAUDE.md` methodology lists match (14 docs each).
- [x] Verified no trailing whitespace and every changed file ends with a newline.
- [x] Verified math delimiters (`$$`) are balanced in the changed methodology docs.
- [x] Confirmed no source files (`.cpp`/`.hpp`/`.h`) or `dal-cpp/dal/auto/` files were modified.

Co-Authored-By: Claude <noreply@anthropic.com>