### PR TITLE
feat: add Windows pwsh start/stop scripts for dal-web

### DIFF
--- a/.claude/skills/dal-web-setup/SKILL.md
+++ b/.claude/skills/dal-web-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dal-web-setup
-description: Start or stop the DAL derivatives portfolio web UI (FastAPI backend + React/Vite frontend). Use when the user says "start the web UI", "run the Web UI", "stop the web UI", "shut down the Web UI", "launch the dashboard", or anything about bringing the DAL web UI up or down.
+description: Start or stop the DAL derivatives portfolio web UI (FastAPI backend + React/Vite frontend). Use when the user says "start the web UI", "run the Web UI", "stop the web UI", "shut down the Web UI", "launch the dashboard", or anything about bringing the DAL web UI up or down. On Windows/PowerShell 7 it uses the `.ps1` scripts; elsewhere it uses the `.sh` scripts.
 user-invocable: true
 ---
 
@@ -8,30 +8,47 @@ user-invocable: true
 
 Brings up or tears down the two-service web UI that sits on top of the DAL Python public API.
 
-Two scripts handle the actual work:
+Four launcher scripts handle the actual work — pick by platform:
 
-| Command                                 | What it does                                                                                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `./dal-web/scripts/start.sh`            | Checks prerequisites, starts backend (uvicorn on `:8001`) and frontend (vite on `:5173`), waits for both, runs a smoke test. |
-| `./dal-web/scripts/stop.sh [--force]`   | Stops both services (by PID file, falling back to port-based kill). Use `--force` to escalate to SIGKILL.                    |
-| `./dal-web/scripts/setup-playwright.sh` | One-time setup for the frontend e2e suite: downloads Chrome and its NSS runtime libraries used by Playwright.                |
+| Platform            | Start                                                                                  | Stop (graceful → force)                                                                                                |
+|---------------------|----------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Linux / macOS       | `./dal-web/scripts/start.sh`                                                           | `./dal-web/scripts/stop.sh` → `./dal-web/scripts/stop.sh --force`                                                      |
+| Windows (pwsh 7+)   | `pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/start.ps1`              | `pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1` → add `-Force`                               |
+
+`dal-web/scripts/setup-playwright.sh` (one-time frontend e2e browser/runtime setup) has no PowerShell equivalent; run it under bash/git-bash on Windows.
+
+## Platform dispatch
+
+Choose the launcher by platform, not by guess:
+
+- **Windows** — when `pwsh` is on `PATH` (PowerShell 7+) or the session platform is `win32`, use the `.ps1` scripts.
+- **Linux / macOS / WSL / git-bash** — otherwise use the `.sh` scripts.
+
+The two families are behaviourally equivalent (same prereqs, ports, health checks, smoke test, PID/log files, exit codes). Two platform differences are worth remembering:
+
+- **Prereq command name:** the bash script checks `python3`; the PowerShell script checks `python`.
+- **Log files:** on Linux/macOS each service writes a single merged `.server.log`. On Windows each service writes two files — `.server.log` (stdout) and `.server.log.err` (stderr).
+- **Force flag spelling:** `--force` (bash) versus `-Force` (PowerShell). Do not mix them.
 
 ## When to use
 
-- **User wants to start the web UI** → run `./dal-web/scripts/start.sh`
-- **User wants to stop the web UI** → run `./dal-web/scripts/stop.sh`
+- **User wants to start the web UI** → run the start script for the current platform.
+- **User wants to stop the web UI** → run the stop script for the current platform.
 - **User wants to run tests** → the skill can also invoke the test suites directly (see below).
 
 ## Startup flow
 
-When the user asks to start the web UI:
+When the user asks to start the web UI, run the launcher for the current platform:
 
 ```bash
-./dal-web/scripts/start.sh
+./dal-web/scripts/start.sh                                              # Linux/macOS
+```
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/start.ps1  # Windows
 ```
 
 The script:
-1. Verifies prerequisites (python ≥ 3.13, uv, node, npm)
+1. Verifies prerequisites (python ≥ 3.13, uv, node, npm; `python3` on bash, `python` on PowerShell)
 2. Reads the backend port from `dal-web/frontend/vite.config.ts` (currently `:8001`)
 3. Checks that both ports are free
 4. Runs `uv sync` in `dal-web/backend/`
@@ -43,24 +60,28 @@ The script:
 10. Smoke-tests the proxy (frontend → backend)
 11. Prints the URLs
 
-Logs go to `dal-web/backend/.server.log` and `dal-web/frontend/.server.log`.
+Logs go to `.server.log` next to each server (plus a separate `.server.log.err` for stderr on Windows).
 
 ## Shutdown flow
 
-When the user asks to stop the web UI:
+When the user asks to stop the web UI, run the stopper for the current platform:
 
 ```bash
-./dal-web/scripts/stop.sh
+./dal-web/scripts/stop.sh                  # Linux/macOS; add --force to escalate
+```
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1   # Windows; add -Force to escalate
 ```
 
 The script:
 1. Reads the backend port from `vite.config.ts`
-2. Kills the backend by PID (from `.server.pid`), or by port if no PID file
+2. Kills the backend by PID (from `.server.pid`). On Windows it walks the PID's process tree first so child workers (uvicorn `--reload` worker, node/vite children) are terminated.
 3. Kills the frontend the same way
-4. Removes PID files
-5. Verifies both ports are free
+4. Falls back to a port-based kill if a child still holds the socket after the PID kill
+5. Removes PID files
+6. Verifies both ports are free
 
-If a service refuses to stop within 5s, the script warns. Re-run with `--force` to escalate to SIGKILL.
+If a service refuses to stop within 5s, the script warns. Re-run with `--force` (bash) or `-Force` (PowerShell) to escalate to a hard kill.
 
 ## Running tests
 
@@ -92,11 +113,17 @@ The start script respects environment variables, so you can do:
 DAL_REQUIRE_NATIVE=1 ./dal-web/scripts/start.sh
 ```
 
+On Windows the launcher inherits the caller's environment, so set the variable first:
+
+```powershell
+$env:DAL_REQUIRE_NATIVE=1; pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/start.ps1
+```
+
 ## Troubleshooting
 
-- **Port already in use** — run `./dal-web/scripts/stop.sh` first, or manually free the port with `sudo fuser -k <port>/tcp`.
-- **Backend fails to start** — check `dal-web/backend/.server.log`. Common causes: missing dependencies, port conflict, Python version mismatch.
-- **Frontend fails to start** — check `dal-web/frontend/.server.log`. Common causes: port conflict, node_modules out of date (try `rm -rf node_modules && npm install`).
+- **Port already in use** — run the stop script for your platform first, or manually free the port: `sudo fuser -k <port>/tcp` on Linux/macOS; on Windows, `Get-NetTCPConnection -LocalPort <port> -State Listen` then `Stop-Process -Id <pid> -Force`.
+- **Backend fails to start** — check `dal-web/backend/.server.log` (and `.server.log.err` on Windows). Common causes: missing dependencies, port conflict, Python version mismatch.
+- **Frontend fails to start** — check `dal-web/frontend/.server.log` (and `.server.log.err` on Windows). Common causes: port conflict, node_modules out of date (try `rm -rf node_modules && npm install`).
 - **Proxy not forwarding** — verify `dal-web/frontend/vite.config.ts` has the correct `proxy.target` port, and that the backend is actually running.
 
 ## Reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,9 @@ The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Ea
 **Web UI (`dal-web/`, not built by CMake)** — FastAPI backend + React frontend:
 - `dal-web/backend/` — Python FastAPI application, uses `dal-python` bindings or stub
 - `dal-web/frontend/` — React + TypeScript SPA, uses Vite
-- `dal-web/scripts/` — `start.sh`, `stop.sh`, and `setup-playwright.sh`
+- `dal-web/scripts/` — `start.sh`/`stop.sh` (Linux/macOS), `start.ps1`/`stop.ps1` (Windows/PowerShell 7), and `setup-playwright.sh`
 
-Start the web UI with `./dal-web/scripts/start.sh` (requires Python 3.13+, uv, Node.js 20+, npm). Frontend at http://localhost:5173, backend API docs at http://127.0.0.1:8001/docs. For frontend e2e, run `./dal-web/scripts/setup-playwright.sh` once, then `cd dal-web/frontend && npm run test:e2e`.
+Start the web UI with `./dal-web/scripts/start.sh` on Linux/macOS or `dal-web/scripts/start.ps1` on Windows (requires Python 3.13+, uv, Node.js 20+, npm). Frontend at http://localhost:5173, backend API docs at http://127.0.0.1:8001/docs. For frontend e2e, run `./dal-web/scripts/setup-playwright.sh` once, then `cd dal-web/frontend && npm run test:e2e`.
 
 **Code generation** — `dal-cpp/config/dal.ifc` is processed by the Machinist tool. `build_linux.sh` runs Machinist twice:
 - once with `-d ./dal-cpp/dal` to produce core enum and serialization files under `dal-cpp/dal/auto/`

--- a/dal-web/README.md
+++ b/dal-web/README.md
@@ -12,8 +12,11 @@ Derivatives Algorithms Library (DAL).
 ```
 dal-web/
 ├── scripts/
-│   ├── start.sh             start both services (backend + frontend)
-│   └── stop.sh              stop both services (with optional --force)
+│   ├── start.sh             start both services (backend + frontend) — Linux/macOS
+│   ├── start.ps1            Windows/PowerShell 7 equivalent of start.sh
+│   ├── stop.sh              stop both services (with optional --force) — Linux/macOS
+│   ├── stop.ps1             Windows/PowerShell 7 equivalent of stop.sh (with -Force)
+│   └── setup-playwright.sh  one-time browser/runtime setup for the frontend e2e suite
 ├── backend/                 FastAPI service
 │   ├── app/
 │   │   ├── main.py          app factory + router wiring
@@ -74,29 +77,47 @@ strict). The `/api/health` endpoint reports which backend is active.
 
 ### Quick Start (both services)
 
-The easiest way to start and stop the web UI is with the scripts in `dal-web/scripts/`:
+The easiest way to start and stop the web UI is with the scripts in `dal-web/scripts/`.
+Use the `.sh` scripts on Linux/macOS and the `.ps1` scripts on Windows (PowerShell 7+):
 
 ```bash
-# Start both services
+# Start both services — Linux/macOS
 ./dal-web/scripts/start.sh
 
-# Stop both services
+# Stop both services — Linux/macOS
 ./dal-web/scripts/stop.sh          # SIGTERM
 ./dal-web/scripts/stop.sh --force  # escalate to SIGKILL if needed
 ```
 
-`start.sh` checks prerequisites (Python ≥ 3.13, uv, node, npm), verifies ports
-`8001` (backend) and `5173` (frontend) are free, installs dependencies
-(`uv sync` in `dal-web/backend/`, `npm install` in `dal-web/frontend/`), launches
-both servers in the background, waits for the backend `/api/health` endpoint and
-the frontend to become ready, then smoke-tests the vite proxy (`/api` → backend).
-PIDs are saved to `dal-web/{backend,frontend}/.server.pid` and logs to
-`.server.log` next to each server.
+```powershell
+# Start both services — Windows (PowerShell 7+)
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/start.ps1
 
-`stop.sh` kills by PID from those files, verifies each port is actually free,
-and falls back to port-based kill if an orphaned child is holding the socket
-(for example when the launcher spawns a wrapper process). With `--force` it
-escalates to SIGKILL after 5s.
+# Stop both services — Windows
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1           # graceful
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1 -Force    # escalate to force kill
+```
+
+Both launchers check prerequisites (Python ≥ 3.13, uv, node, npm, curl), verify
+ports `8001` (backend) and `5173` (frontend) are free, install dependencies
+(`uv sync` in `dal-web/backend/`, `npm install` in `dal-web/frontend/`), launch
+both servers in the background, wait for the backend `/api/health` endpoint and
+the frontend to become ready, then smoke-test the vite proxy (`/api` → backend).
+PIDs are saved to `dal-web/{backend,frontend}/.server.pid`.
+
+Log files differ by platform. On Linux/macOS both streams are merged into a
+single `.server.log` next to each server. On Windows each service writes two
+files: `.server.log` (stdout) and `.server.log.err` (stderr).
+
+Note the one prerequisite-name difference: the bash script checks `python3`,
+the PowerShell script checks `python`.
+
+`stop.sh` / `stop.ps1` kill by PID from those files, verify each port is
+actually free, and fall back to port-based kill if an orphaned child is holding
+the socket. The Windows stopper additionally walks the recorded PID's process
+tree so child workers (the uvicorn `--reload` worker, vite/node children) are
+terminated before the port-based fallback. With `--force` (bash) or `-Force`
+(PowerShell) the stopper escalates to a hard kill after a 5s grace period.
 
 Once running, open **http://localhost:5173** in your browser. The Vite dev
 server proxies `/api` requests to the backend automatically (target port is
@@ -134,15 +155,19 @@ port, update the `proxy.target` in that file and restart the frontend.
 
 > **Note:** Run vite directly rather than `npm run dev` when launching by hand.
 > `npm run` wraps the command in a parent process that does not forward SIGTERM,
-> which leaves an orphan holding the port on shutdown. The `start.sh` script
-> already does this for you.
+> which leaves an orphan holding the port on shutdown. Both `start.sh` and
+> `start.ps1` already do this for you.
 
 ### Stopping
 
-If you started the services with `start.sh`, stop them with:
+If you started the services with a start script, stop them with the matching
+stop script:
 
 ```bash
-./dal-web/scripts/stop.sh
+./dal-web/scripts/stop.sh                       # Linux/macOS
+```
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1   # Windows
 ```
 
 If you started them manually, press `Ctrl+C` in each terminal, or use the stop
@@ -151,7 +176,8 @@ script (it will fall back to port-based kill if no PID files exist).
 ### Troubleshooting
 
 **Port 8001 already in use.** If the backend fails with `[Errno 98] Address
-already in use`, either free the port or run on a different one:
+already in use` (Linux/macOS) or reports the port is bound (Windows), either
+free the port or run on a different one:
 
 ```bash
 # Option A — stop any running web UI
@@ -162,6 +188,17 @@ fuser -k 8001/tcp
 
 # Option C — use a different port (e.g. 8002)
 uv run python -m uvicorn app.main:app --reload --port 8002
+```
+
+On Windows the equivalents are:
+
+```powershell
+# Option A — stop any running web UI
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1
+
+# Option B — find what owns the port, then kill it
+Get-NetTCPConnection -LocalPort 8001 -State Listen
+Stop-Process -Id <pid from above> -Force
 ```
 
 If you choose Option C, also update the proxy target in

--- a/dal-web/scripts/start.ps1
+++ b/dal-web/scripts/start.ps1
@@ -1,0 +1,269 @@
+#Requires -Version 7.0
+# Start the DAL web UI (FastAPI backend + React/Vite frontend) on Windows.
+#
+# Usage:
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/start.ps1
+#
+# What it does:
+#   1. Verifies prerequisites (python 3.13+, uv, node, npm, curl).
+#   2. Reads the backend port from dal-web/frontend/vite.config.ts.
+#   3. Checks that both ports (backend + 5173) are free.
+#   4. Starts the backend (uvicorn) in the background.
+#   5. Starts the frontend (vite) in the background.
+#   6. Waits for both to be ready, then runs a smoke test.
+#   7. Prints the URLs.
+#
+# Logs are written to dal-web/backend/.server.log and
+# dal-web/frontend/.server.log. PIDs are stored in .server.pid next to
+# the respective server directory, so stop.ps1 can kill them cleanly.
+#
+# Exit codes:
+#   0  both services started successfully
+#   1  prerequisites missing or ports already in use
+#   2  backend failed to start
+#   3  frontend failed to start
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Resolve paths (this script lives in dal-web/scripts/)
+# ---------------------------------------------------------------------------
+$ScriptDir    = $PSScriptRoot
+$WebRoot      = Split-Path -Parent $ScriptDir        # dal-web
+$BackendDir   = Join-Path $WebRoot 'backend'
+$FrontendDir  = Join-Path $WebRoot 'frontend'
+$FrontendPort = 5173
+
+$BackendPidFile  = Join-Path $BackendDir  '.server.pid'
+$BackendLogFile  = Join-Path $BackendDir  '.server.log'
+$FrontendPidFile = Join-Path $FrontendDir '.server.pid'
+$FrontendLogFile = Join-Path $FrontendDir '.server.log'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Info  { param([string]$Msg) Write-Host "[info]  $Msg" -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Host "[warn]  $Msg" -ForegroundColor Yellow }
+function Write-ErrLn { param([string]$Msg) Write-Host "[error] $Msg" -ForegroundColor Red }
+
+function Test-PortFree {
+    param([int]$Port)
+    $c = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    $null -eq $c -or $c.Count -eq 0
+}
+
+function Read-BackendPort {
+    param([string]$ViteConfigPath, [int]$Default = 8001)
+    if (-not (Test-Path $ViteConfigPath)) { return $Default }
+    $content = Get-Content -Raw $ViteConfigPath
+    # Matches lines like: target: "http://127.0.0.1:<port>"
+    if ($content -match 'target\s*:\s*"http://127\.0\.0\.1:(\d+)"') {
+        return [int]$Matches[1]
+    }
+    $Default
+}
+
+function Get-Health {
+    param([string]$Uri, [int]$TimeoutSec = 3)
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $Uri -TimeoutSec $TimeoutSec
+    } catch {
+        $null
+    }
+}
+
+# Read backend port from vite.config.ts proxy target.
+$BackendPort = Read-BackendPort -ViteConfigPath (Join-Path $FrontendDir 'vite.config.ts')
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisites
+# ---------------------------------------------------------------------------
+Write-Info "Checking prerequisites..."
+
+function Assert-Command {
+    param([string]$Name)
+    if ($null -eq (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Write-ErrLn "$Name is not installed. Please install it and retry."
+        return $false
+    }
+    $true
+}
+
+$failed = $false
+foreach ($c in 'python','uv','node','npm','curl') {
+    if (-not (Assert-Command $c)) { $failed = $true }
+}
+if ($failed) { exit 1 }
+
+$pyVer   = & python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+$pyParts = $pyVer.Split('.')
+$pyMajor = [int]$pyParts[0]
+$pyMinor = [int]$pyParts[1]
+if ($pyMajor -lt 3 -or ($pyMajor -eq 3 -and $pyMinor -lt 13)) {
+    Write-ErrLn "Python >= 3.13 is required (found $pyVer)"
+    exit 1
+}
+$uvVer  = (& uv --version).Split(' ')[1]
+$nodeV  = & node --version
+$npmVer = & npm --version
+Write-Info "  python $pyVer, uv $uvVer, node $nodeV, npm $npmVer"
+
+# ---------------------------------------------------------------------------
+# 2. Check ports are free
+# ---------------------------------------------------------------------------
+Write-Info "Checking ports (backend=$BackendPort, frontend=$FrontendPort)..."
+
+if (-not (Test-PortFree $BackendPort)) {
+    Write-ErrLn "Port $BackendPort is already in use. Run dal-web/scripts/stop.ps1 first, or pick a different port in frontend/vite.config.ts."
+    exit 1
+}
+if (-not (Test-PortFree $FrontendPort)) {
+    Write-ErrLn "Port $FrontendPort is already in use. Run dal-web/scripts/stop.ps1 first."
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 3. Backend setup
+# ---------------------------------------------------------------------------
+Write-Info "Installing backend dependencies (uv sync)..."
+Push-Location $BackendDir
+try { uv sync --quiet } finally { Pop-Location }
+
+Write-Info "Starting backend on port $BackendPort..."
+# uv run launches uvicorn; with --reload uvicorn spawns a reloader parent plus
+# a worker child. We capture the parent PID and rely on stop.ps1's process-tree
+# walk plus port-based fallback to clean up the worker holding the socket.
+$backendProc = Start-Process -FilePath 'uv' `
+    -ArgumentList @('run','python','-m','uvicorn','app.main:app','--reload','--host','127.0.0.1','--port',"$BackendPort") `
+    -WorkingDirectory $BackendDir `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $BackendLogFile `
+    -RedirectStandardError  "$BackendLogFile.err" `
+    -PassThru
+$BackendPid = $backendProc.Id
+Set-Content -Path $BackendPidFile -Value $BackendPid -NoNewline
+Write-Info "  backend PID $BackendPid, log: backend/.server.log"
+
+# Wait for backend to accept connections (up to 20s).
+Write-Info "Waiting for backend health check..."
+$backendUp = $false
+for ($i = 0; $i -lt 40; $i++) {
+    if (Get-Health "http://127.0.0.1:$BackendPort/api/health") {
+        Write-Info "  backend is up"
+        $backendUp = $true
+        break
+    }
+    if ($backendProc.HasExited) {
+        Write-ErrLn "Backend process exited before becoming healthy. Check $BackendLogFile :"
+        if (Test-Path $BackendLogFile) { Get-Content $BackendLogFile -Tail 20 | ForEach-Object { Write-Host $_ } }
+        Remove-Item $BackendPidFile -ErrorAction SilentlyContinue
+        exit 2
+    }
+    Start-Sleep -Milliseconds 500
+}
+if (-not $backendUp) {
+    Write-ErrLn "Backend did not become healthy within 20s. Check $BackendLogFile."
+    Stop-Process -Id $BackendPid -Force -ErrorAction SilentlyContinue
+    Remove-Item $BackendPidFile -ErrorAction SilentlyContinue
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# 4. Frontend setup
+# ---------------------------------------------------------------------------
+Write-Info "Installing frontend dependencies (npm install)..."
+Push-Location $FrontendDir
+try { npm install --silent --no-audit --no-fund *> $null } finally { Pop-Location }
+
+Write-Info "Starting frontend on port $FrontendPort..."
+# Run vite directly rather than `npm run dev` so the PID we save is the actual
+# node process holding the port. npm wraps the script in a parent process that
+# doesn't forward termination to its child, which previously left orphaned node
+# processes behind on stop. On Windows we invoke vite's JS entry via node so the
+# recorded PID is the single port-holding node process (and stop.ps1 walks its
+# children as defense in depth).
+$viteJs   = Join-Path $FrontendDir 'node_modules\vite\vite.js'
+$viteShim = Join-Path $FrontendDir 'node_modules\.bin\vite.cmd'
+if (Test-Path $viteJs) {
+    $frontendProc = Start-Process -FilePath 'node' `
+        -ArgumentList @($viteJs) `
+        -WorkingDirectory $FrontendDir `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $FrontendLogFile `
+        -RedirectStandardError  "$FrontendLogFile.err" `
+        -PassThru
+} elseif (Test-Path $viteShim) {
+    $frontendProc = Start-Process -FilePath 'cmd.exe' `
+        -ArgumentList @('/c',$viteShim) `
+        -WorkingDirectory $FrontendDir `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $FrontendLogFile `
+        -RedirectStandardError  "$FrontendLogFile.err" `
+        -PassThru
+} else {
+    Write-ErrLn "vite binary not found under $FrontendDir\node_modules. Run npm install first."
+    Stop-Process -Id $BackendPid -Force -ErrorAction SilentlyContinue
+    Remove-Item $BackendPidFile -ErrorAction SilentlyContinue
+    exit 3
+}
+$FrontendPid = $frontendProc.Id
+Set-Content -Path $FrontendPidFile -Value $FrontendPid -NoNewline
+Write-Info "  frontend PID $FrontendPid, log: frontend/.server.log"
+
+# Wait for frontend to accept connections (up to 30s).
+Write-Info "Waiting for frontend to be ready..."
+$frontendUp = $false
+for ($i = 0; $i -lt 60; $i++) {
+    if (Get-Health "http://localhost:$FrontendPort") {
+        Write-Info "  frontend is up"
+        $frontendUp = $true
+        break
+    }
+    if ($frontendProc.HasExited) {
+        Write-ErrLn "Frontend process exited before becoming healthy. Check $FrontendLogFile :"
+        if (Test-Path $FrontendLogFile) { Get-Content $FrontendLogFile -Tail 20 | ForEach-Object { Write-Host $_ } }
+        Remove-Item $FrontendPidFile -ErrorAction SilentlyContinue
+        Stop-Process -Id $BackendPid -Force -ErrorAction SilentlyContinue
+        Remove-Item $BackendPidFile -ErrorAction SilentlyContinue
+        exit 3
+    }
+    Start-Sleep -Milliseconds 500
+}
+if (-not $frontendUp) {
+    Write-ErrLn "Frontend did not become ready within 30s. Check $FrontendLogFile."
+    Stop-Process -Id $FrontendPid -Force -ErrorAction SilentlyContinue
+    Remove-Item $FrontendPidFile -ErrorAction SilentlyContinue
+    Stop-Process -Id $BackendPid -Force -ErrorAction SilentlyContinue
+    Remove-Item $BackendPidFile -ErrorAction SilentlyContinue
+    exit 3
+}
+
+# ---------------------------------------------------------------------------
+# 5. Smoke test -- proxy should forward /api to the backend
+# ---------------------------------------------------------------------------
+Write-Info "Smoke test (frontend -> backend proxy)..."
+$smoke = Get-Health "http://localhost:$FrontendPort/api/health"
+if ($null -eq $smoke) {
+    Write-Warn "Frontend is up but /api proxy is not forwarding to the backend. Check vite.config.ts."
+} else {
+    Write-Info "  /api/health via proxy -> $($smoke.Content)"
+}
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "[ok] DAL web UI is running" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Frontend:  http://localhost:$FrontendPort"
+Write-Host "  Backend:   http://127.0.0.1:$BackendPort"
+Write-Host "  API docs:  http://127.0.0.1:$BackendPort/docs"
+Write-Host "  Backend:   PID $BackendPid"
+Write-Host "  Frontend:  PID $FrontendPid"
+Write-Host ""
+Write-Host "To stop:     pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1"
+Write-Host "Logs:        backend/.server.log, frontend/.server.log"
+exit 0

--- a/dal-web/scripts/start.ps1
+++ b/dal-web/scripts/start.ps1
@@ -13,9 +13,10 @@
 #   6. Waits for both to be ready, then runs a smoke test.
 #   7. Prints the URLs.
 #
-# Logs are written to dal-web/backend/.server.log and
-# dal-web/frontend/.server.log. PIDs are stored in .server.pid next to
-# the respective server directory, so stop.ps1 can kill them cleanly.
+# Logs are written under each server directory: .server.log (stdout) and
+# .server.log.err (stderr) for both dal-web/backend/ and dal-web/frontend/.
+# PIDs are stored in .server.pid next to the respective server directory, so
+# stop.ps1 can kill them cleanly.
 #
 # Exit codes:
 #   0  both services started successfully
@@ -145,7 +146,7 @@ $backendProc = Start-Process -FilePath 'uv' `
     -PassThru
 $BackendPid = $backendProc.Id
 Set-Content -Path $BackendPidFile -Value $BackendPid -NoNewline
-Write-Info "  backend PID $BackendPid, log: backend/.server.log"
+Write-Info "  backend PID $BackendPid, log: backend/.server.log (+ .server.log.err)"
 
 # Wait for backend to accept connections (up to 20s).
 Write-Info "Waiting for backend health check..."
@@ -185,7 +186,7 @@ Write-Info "Starting frontend on port $FrontendPort..."
 # processes behind on stop. On Windows we invoke vite's JS entry via node so the
 # recorded PID is the single port-holding node process (and stop.ps1 walks its
 # children as defense in depth).
-$viteJs   = Join-Path $FrontendDir 'node_modules\vite\vite.js'
+$viteJs   = Join-Path $FrontendDir 'node_modules\vite\bin\vite.js'
 $viteShim = Join-Path $FrontendDir 'node_modules\.bin\vite.cmd'
 if (Test-Path $viteJs) {
     $frontendProc = Start-Process -FilePath 'node' `
@@ -211,7 +212,7 @@ if (Test-Path $viteJs) {
 }
 $FrontendPid = $frontendProc.Id
 Set-Content -Path $FrontendPidFile -Value $FrontendPid -NoNewline
-Write-Info "  frontend PID $FrontendPid, log: frontend/.server.log"
+Write-Info "  frontend PID $FrontendPid, log: frontend/.server.log (+ .server.log.err)"
 
 # Wait for frontend to accept connections (up to 30s).
 Write-Info "Waiting for frontend to be ready..."
@@ -265,5 +266,5 @@ Write-Host "  Backend:   PID $BackendPid"
 Write-Host "  Frontend:  PID $FrontendPid"
 Write-Host ""
 Write-Host "To stop:     pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1"
-Write-Host "Logs:        backend/.server.log, frontend/.server.log"
+Write-Host "Logs:        backend/{.server.log, .server.log.err}, frontend/{.server.log, .server.log.err}"
 exit 0

--- a/dal-web/scripts/stop.ps1
+++ b/dal-web/scripts/stop.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 7.0
+# Stop the DAL web UI (FastAPI backend + React/Vite frontend) on Windows.
+#
+# Usage:
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1 [-Force]
+#
+# What it does:
+#   1. Reads the backend port from dal-web/frontend/vite.config.ts.
+#   2. Kills each service by PID (from the .server.pid files written by
+#      start.ps1), walking the process tree so child workers (uvicorn reload
+#      worker, node/vite children) are also terminated. Falls back to a
+#      port-based kill if a child still holds the socket.
+#   3. Removes the PID files.
+#   4. Verifies that both ports are free.
+#
+# With -Force, escalates to Stop-Process -Force (SIGKILL-equivalent) if a
+# process refuses to die within 5 seconds.
+#
+# Exit codes:
+#   0  services stopped successfully (or were already stopped)
+#   1  a service could not be stopped even with -Force
+
+[CmdletBinding()]
+param([switch]$Force)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Resolve paths (this script lives in dal-web/scripts/)
+# ---------------------------------------------------------------------------
+$ScriptDir    = $PSScriptRoot
+$WebRoot      = Split-Path -Parent $ScriptDir        # dal-web
+$BackendDir   = Join-Path $WebRoot 'backend'
+$FrontendDir  = Join-Path $WebRoot 'frontend'
+$FrontendPort = 5173
+
+$BackendPidFile  = Join-Path $BackendDir  '.server.pid'
+$FrontendPidFile = Join-Path $FrontendDir '.server.pid'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Info  { param([string]$Msg) Write-Host "[info]  $Msg" -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Host "[warn]  $Msg" -ForegroundColor Yellow }
+function Write-ErrLn { param([string]$Msg) Write-Host "[error] $Msg" -ForegroundColor Red }
+
+function Test-PortFree {
+    param([int]$Port)
+    $c = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    $null -eq $c -or $c.Count -eq 0
+}
+
+function Read-BackendPort {
+    param([string]$ViteConfigPath, [int]$Default = 8001)
+    if (-not (Test-Path $ViteConfigPath)) { return $Default }
+    $content = Get-Content -Raw $ViteConfigPath
+    if ($content -match 'target\s*:\s*"http://127\.0\.0\.1:(\d+)"') {
+        return [int]$Matches[1]
+    }
+    $Default
+}
+
+# Collect a PID and all of its descendants (recursively) via the CIM process
+# tree. Returns the full set including the root, so callers can terminate the
+# whole subtree in one pass -- necessary because uvicorn --reload and vite both
+# spawn child workers that inherit the listening socket but have a different PID
+# than the parent we recorded.
+function Get-DescendantPids {
+    param([int]$RootPid)
+    $result = [System.Collections.Generic.List[int]]::new()
+    $result.Add($RootPid)
+    $stack = [System.Collections.Generic.Stack[int]]::new()
+    $stack.Push($RootPid)
+    while ($stack.Count -gt 0) {
+        $parent = $stack.Pop()
+        $children = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.ParentProcessId -eq $parent } |
+            Select-Object -ExpandProperty ProcessId
+        foreach ($cpid in $children) {
+            if ($cpid -and -not $result.Contains($cpid)) {
+                $result.Add($cpid)
+                $stack.Push($cpid)
+            }
+        }
+    }
+    ,$result
+}
+
+function Test-ProcessAlive {
+    param([int]$Pid_)
+    $null -ne (Get-Process -Id $Pid_ -ErrorAction SilentlyContinue)
+}
+
+# Terminate a process tree. SIGTERM-equivalent first, then escalate to -Force
+# (SIGKILL-equivalent) after a grace window when $Force is set.
+function Stop-ProcessTree {
+    param(
+        [int]    $RootPid,
+        [string] $Name,
+        [switch] $Force
+    )
+    if (-not (Test-ProcessAlive $RootPid)) { return $true }
+
+    $pids = Get-DescendantPids -RootPid $RootPid
+    Write-Info "Stopping $Name tree (PIDs: $($pids -join ', '))..."
+    foreach ($p in $pids) {
+        if (Test-ProcessAlive $p) {
+            Stop-Process -Id $p -ErrorAction SilentlyContinue
+        }
+    }
+
+    for ($i = 0; $i -lt 10; $i++) {
+        Start-Sleep -Milliseconds 500
+        $alive = $false
+        foreach ($p in $pids) { if (Test-ProcessAlive $p) { $alive = $true; break } }
+        if (-not $alive) { return $true }
+    }
+
+    if ($Force) {
+        Write-Warn "Escalating to force kill for $Name tree..."
+        foreach ($p in $pids) {
+            if (Test-ProcessAlive $p) {
+                Stop-Process -Id $p -Force -ErrorAction SilentlyContinue
+            }
+        }
+        Start-Sleep -Seconds 1
+        foreach ($p in $pids) { if (Test-ProcessAlive $p) { return $false } }
+        return $true
+    }
+    return $false
+}
+
+# Defense in depth: after the tracked PID is gone, a child it spawned may still
+# hold the port (e.g. npm-spawned wrappers that inherit the socket). Kill
+# whatever owns the listening socket.
+function Stop-ByPort {
+    param([int]$Port, [string]$Name, [switch]$Force)
+    $conns = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    if ($null -eq $conns -or $conns.Count -eq 0) { return $true }
+    $owners = $conns | Select-Object -ExpandProperty OwningProcess -Unique
+    Write-Warn "Port $Port still held by $Name (PIDs: $($owners -join ', ')); killing by port..."
+    foreach ($opid in $owners) {
+        Stop-Process -Id $opid -Force:$Force -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Seconds 1
+    (Test-PortFree $Port)
+}
+
+function Stop-Service {
+    param([int]$Port, [string]$Name, [string]$PidFile, [switch]$Force)
+
+    if (Test-Path $PidFile) {
+        $pidVal = [int](Get-Content $PidFile -Raw).Trim()
+        if (-not (Stop-ProcessTree -RootPid $pidVal -Name $Name -Force:$Force)) {
+            if ($Force) {
+                Write-ErrLn "$Name PID $pidVal could not be killed."
+            } else {
+                Write-Warn "$Name (PID $pidVal) did not stop within 5s. Re-run with -Force to escalate."
+            }
+        }
+        Remove-Item $PidFile -ErrorAction SilentlyContinue
+    } else {
+        Write-Warn "No $Name PID file found."
+    }
+
+    # Defense in depth: the tracked tree may be gone while a child it spawned
+    # still holds the port. Always verify the port and fall back if needed.
+    if (-not (Test-PortFree $Port)) {
+        Write-Warn "$Name port $Port still busy after PID kill; falling back to port-based kill..."
+        $null = Stop-ByPort -Port $Port -Name $Name -Force:$Force
+    }
+}
+
+# Read backend port from vite.config.ts proxy target.
+$BackendPort = Read-BackendPort -ViteConfigPath (Join-Path $FrontendDir 'vite.config.ts')
+
+# ---------------------------------------------------------------------------
+# 1. Check current state
+# ---------------------------------------------------------------------------
+$backendRunning  = -not (Test-PortFree $BackendPort)
+$frontendRunning = -not (Test-PortFree $FrontendPort)
+
+if (-not $backendRunning -and -not $frontendRunning) {
+    Write-Info "No DAL web UI services are running (ports $BackendPort and $FrontendPort are both free)."
+    Remove-Item $BackendPidFile, $FrontendPidFile -ErrorAction SilentlyContinue
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# 2. Stop backend
+# ---------------------------------------------------------------------------
+if ($backendRunning) {
+    Stop-Service -Port $BackendPort -Name 'backend' -PidFile $BackendPidFile -Force:$Force
+}
+
+# ---------------------------------------------------------------------------
+# 3. Stop frontend
+# ---------------------------------------------------------------------------
+if ($frontendRunning) {
+    Stop-Service -Port $FrontendPort -Name 'frontend' -PidFile $FrontendPidFile -Force:$Force
+}
+
+# ---------------------------------------------------------------------------
+# 4. Final verification
+# ---------------------------------------------------------------------------
+Start-Sleep -Seconds 1
+$remaining = 0
+if (-not (Test-PortFree $BackendPort)) {
+    Write-ErrLn "Backend is still listening on port $BackendPort."
+    $remaining = 1
+}
+if (-not (Test-PortFree $FrontendPort)) {
+    Write-ErrLn "Frontend is still listening on port $FrontendPort."
+    $remaining = 1
+}
+
+if ($remaining -eq 0) {
+    Write-Host "[ok] DAL web UI stopped. Ports $BackendPort and $FrontendPort are free." -ForegroundColor Green
+    exit 0
+} else {
+    Write-ErrLn "Some services could not be stopped. Try: pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1 -Force"
+    Write-ErrLn "Or manually: Get-NetTCPConnection -LocalPort $BackendPort -State Listen | %{ Stop-Process -Id `$_.OwningProcess -Force }; Get-NetTCPConnection -LocalPort $FrontendPort -State Listen | %{ Stop-Process -Id `$_.OwningProcess -Force }"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- Add `dal-web/scripts/start.ps1` and `stop.ps1` — PowerShell 7 equivalents of the existing `start.sh`/`stop.sh`, so the web UI can be launched/stopped on Windows without Git Bash.
- Mirror bash behavior: prereq checks (Python 3.13+, uv, node, npm), backend port parsed from `vite.config.ts` (default 8001), frontend on 5173, `uv sync` + uvicorn `--reload`, direct vite launch (avoids the npm-wrapper orphan-on-stop problem), health-check sequencing, `/api/health` smoke test, PID/log file layout, and matching exit codes (start 0/1/2/3, stop 0/1).
- `stop.ps1` walks the process tree recursively via `Get-CimInstance Win32_Process` before falling back to port-based kill; supports `-Force` to escalate.
- Update docs to reference the Windows variants: `dal-web/README.md`, the `CLAUDE.md` web-UI section, and `.claude/skills/dal-web-setup/SKILL.md` (now dispatches `.ps1` on Windows, `.sh` elsewhere).

## Test plan
These are launch scripts with no automated test suite, so they were validated by direct dry-runs:
- [x] Both scripts parse clean (`[System.Management.Automation.Language.Parser]::ParseFile` → 0 errors); `#Requires -Version 7.0` present on both.
- [x] Port parser dry-run against `vite.config.ts` → 8001 (matches the bash grep).
- [x] `Test-PortFree` helper verified against bound/free/released ports; process-tree kill helpers verified against a real `cmd → cmd → ping` tree.
- [x] `stop.ps1` with no services running → exit 0 with the correct message.
- [ ] (Manual) From a clean Windows checkout: `.\dal-web\scripts\start.ps1`, confirm frontend/backend/docs URLs come up, then `.\dal-web\scripts\stop.ps1` and confirm both ports are freed.