### PR TITLE
feat: flip RNG precise default to true on Sobol and PseudoRandom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ here as the baseline rather than dated releases:
 
 ## 2026-07
 
+- `random`: Sobol and PseudoRandom normal draws now default to the precise
+  inverse-normal-CDF routine (`precise=true`) on `NewSobol`, `SobolRSG_`,
+  `PseudoRandom_::New`, and `PseudoRSG_` (`dal-cpp/dal/math/random/{sobol,pseudorandom}.hpp`),
+  restoring ~1e-15 Acklam+Newton accuracy in the default path (previously the
+  faster ~1e-9 Acklam-only routine was the default). This shifts default
+  Sobol/PseudoRandom normal variates; opt back into the fast path with
+  `precise=false`. See `docs/methodology/random.md`. Non-breaking (default-argument
+  reproducibility change only; the precise routine was already available).
 - `random`: Sobol normal draws now skip the Newton polish on `InverseNCDF` by default
   (`SobolRSG_(..., polish=false)`, `dal-cpp/dal/math/random/sobol.hpp`), halving the per-deviate
   cost at the cost of ~1e-9 Acklam accuracy instead of ~1e-15 (Acklam+Newton) — below QMC sampling

--- a/dal-cpp/benchmarks/matrix_perf/matrix_perf.cpp
+++ b/dal-cpp/benchmarks/matrix_perf/matrix_perf.cpp
@@ -142,7 +142,7 @@ void MultiV5(const Matrix_& a, const Matrix_& b, Matrix_& c) {
 
 int main() {
     const int n = 1000;
-    std::unique_ptr<Dal::Random_> random(Dal::NewSobol(n, 1000));
+    std::unique_ptr<Dal::Random_> random(Dal::NewSobol(n, 1000, /*precise=*/false));
     Matrix_ a(n, n, random);
     Matrix_ b(n, n, random);
     Matrix_ c(n, n, nullptr);

--- a/dal-cpp/benchmarks/rng_perf/rng_perf.cpp
+++ b/dal-cpp/benchmarks/rng_perf/rng_perf.cpp
@@ -3,7 +3,10 @@
 //
 // Sobol random-number-generator micro-benchmark.
 // Builds a SobolRSG_ (dimension 10) and measures FillNormal and FillUniform
-// over a 100K-path batch, the dominant MC inner loop.
+// over a 100K-path batch, the dominant MC inner loop. Both the fast path
+// (precise=false, Acklam-only ~1e-9) and the precise path (precise=true,
+// Acklam+Newton ~1e-15, the library default since 2026-07) are measured so
+// the per-deviate inverse-CDF cost difference is a tracked quantity.
 
 #include <dal/platform/platform.hpp>
 #include <dal/math/random/sobol.hpp>
@@ -23,8 +26,22 @@ int main() {
 
     {
         double sink = 0.0;
-        auto r = Bench::Run("Sobol FillNormal (100K x 10D)", [&]() {
-            std::unique_ptr<SequenceSet_> rsg(NewSobol(kDim, 0));
+        auto r = Bench::Run("Sobol FillNormal fast (100K x 10D)", [&]() {
+            std::unique_ptr<SequenceSet_> rsg(NewSobol(kDim, 0, /*precise=*/false));
+            Vector_<> dst(kDim);
+            for (int i = 0; i < kNumPaths; ++i) {
+                rsg->FillNormal(&dst);
+                sink += dst[0];
+            }
+        }, 2, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+    }
+
+    {
+        double sink = 0.0;
+        auto r = Bench::Run("Sobol FillNormal precise (100K x 10D)", [&]() {
+            std::unique_ptr<SequenceSet_> rsg(NewSobol(kDim, 0, /*precise=*/true));
             Vector_<> dst(kDim);
             for (int i = 0; i < kNumPaths; ++i) {
                 rsg->FillNormal(&dst);
@@ -38,7 +55,7 @@ int main() {
     {
         double sink = 0.0;
         auto r = Bench::Run("Sobol FillUniform (100K x 10D)", [&]() {
-            std::unique_ptr<SequenceSet_> rsg(NewSobol(kDim, 0));
+            std::unique_ptr<SequenceSet_> rsg(NewSobol(kDim, 0, /*precise=*/false));
             Vector_<> dst(kDim);
             for (int i = 0; i < kNumPaths; ++i) {
                 rsg->FillUniform(&dst);

--- a/dal-cpp/dal/math/random/pseudorandom.hpp
+++ b/dal-cpp/dal/math/random/pseudorandom.hpp
@@ -36,7 +36,7 @@ namespace Dal {
         Vector_<> cache_;
 
     public:
-        explicit PseudoRandom_(size_t nDim, bool precise = false) : cache_(nDim), precise_(precise) {}
+        explicit PseudoRandom_(size_t nDim, bool precise = true) : cache_(nDim), precise_(precise) {}
         ~PseudoRandom_() override = default;
         virtual double NextUniform() = 0;
         void FillUniform(Vector_<>* deviates) override;
@@ -48,7 +48,7 @@ namespace Dal {
     };
 
 #include <dal/auto/MG_RNGType_enum.hpp>
-    PseudoRandom_* New(const RNGType_& type, int seed, size_t nDim = 1, bool precise = false);
+    PseudoRandom_* New(const RNGType_& type, int seed, size_t nDim = 1, bool precise = true);
 
     class BASE_EXPORT PseudoRSG_: public Storable_ {
         std::unique_ptr<PseudoRandom_> rsg_;
@@ -56,7 +56,7 @@ namespace Dal {
         double ndim_;
         bool precise_;
     public:
-        PseudoRSG_(const String_& name, double seed, double ndim = 1, bool precise = false)
+        PseudoRSG_(const String_& name, double seed, double ndim = 1, bool precise = true)
         : Storable_("PseudoRSG", name), seed_(seed), ndim_(ndim), precise_(precise) {
             rsg_.reset(New(RNGType_(name), static_cast<int>(seed), static_cast<size_t>(ndim), precise));
         }

--- a/dal-cpp/dal/math/random/sobol.hpp
+++ b/dal-cpp/dal/math/random/sobol.hpp
@@ -20,7 +20,7 @@ polish is boolean
 -IF-------------------------------------------------------------------------*/
 
 namespace Dal {
-    SequenceSet_* NewSobol(int size, size_t iPath, bool precise = false, bool polish = false);
+    SequenceSet_* NewSobol(int size, size_t iPath, bool precise = true, bool polish = false);
 
     class BASE_EXPORT SobolRSG_: public Storable_ {
         std::unique_ptr<SequenceSet_> rsg_;
@@ -29,7 +29,7 @@ namespace Dal {
         bool precise_;
         bool polish_;
     public:
-        SobolRSG_(const String_& name, double iPath, double nDim = 1, bool precise = false, bool polish = false)
+        SobolRSG_(const String_& name, double iPath, double nDim = 1, bool precise = true, bool polish = false)
             : Storable_("SobolRSG", name), i_path_(iPath), ndim_(nDim), precise_(precise), polish_(polish) {
             rsg_.reset(NewSobol(static_cast<int>(ndim_), static_cast<size_t>(i_path_), precise, polish));
         }

--- a/docs/methodology/random.md
+++ b/docs/methodology/random.md
@@ -190,8 +190,11 @@ inverse-CDF evaluation, both defaulted on construction and stored on the
 storable wrapper `SobolRSG_` (`dal-cpp/dal/math/random/sobol.hpp`) and on
 `SobolSet_`:
 
-- `precise_` selects a higher-accuracy inverse-normal-CDF routine, mirroring the
-  pseudo-random family.
+- `precise_` selects the higher-accuracy inverse-normal-CDF routine (Acklam's
+  rational approximation refined by a Newton step, ~1e-15 accuracy), mirroring
+  the pseudo-random family. It defaults to **`true`** so default Sobol normal
+  variates are full-precision; pass `precise = false` to opt back into the
+  faster Acklam-only routine (~1e-9), which is still below QMC sampling noise.
 - `polish_` toggles the Newton polish step in `InverseNCDF`. The Acklam rational
   approximation without polish is already accurate to roughly $10^{-9}$, well
   below quasi-Monte-Carlo sampling noise, so polish defaults to **`false`** and
@@ -199,10 +202,12 @@ storable wrapper `SobolRSG_` (`dal-cpp/dal/math/random/sobol.hpp`) and on
   halves the per-deviate cost of `FillNormal` without measurably moving QMC
   convergence.
 
-The constructor surface is therefore `NewSobol(size, iPath, precise = false,
+The constructor surface is therefore `NewSobol(size, iPath, precise = true,
 polish = false)` and the storable `SobolRSG_(name, iPath, nDim = 1, precise =
-false, polish = false)`; both flags are persisted by the storable markup so a
-serialised generator round-trips with its precision settings intact.
+true, polish = false)`; `precise = true` is the public default, and a caller
+passes `precise = false` to opt back into the fast Acklam-only path. Both flags
+are persisted by the storable markup so a serialised generator round-trips with
+its precision settings intact.
 
 ### Path Seeking
 


### PR DESCRIPTION
## Summary
- Flip the public-surface default of `precise` from `false` to `true` on `PseudoRandom_`, `PseudoRandom_::New`, `PseudoRSG_` (`dal-cpp/dal/math/random/pseudorandom.hpp`) and `NewSobol`, `SobolRSG_` (`dal-cpp/dal/math/random/sobol.hpp`), restoring ~1e-15 Acklam+Newton accuracy in the default path (previously the faster ~1e-9 Acklam-only routine was the default). Opt back into the fast path with `precise=false`.
- Pin `precise=false` on the two benchmark seeding calls (`dal-cpp/benchmarks/matrix_perf/matrix_perf.cpp`, `dal-cpp/benchmarks/rng_perf/rng_perf.cpp`) so existing fast-path timings are not silently re-baselined; add a new `precise=true` row to `rng_perf` so the cost delta is tracked.
- Update `docs/methodology/random.md` to reflect the new default.
- Add a `2026-07` `random` entry to `CHANGELOG.md` (default behavior change visible to downstream callers).

## Test plan
- [x] Local Release-linux build of `dal_cpp` (gcc 15.2, `-O3 -march=native -ffp-contract=fast`).
- [x] Full `dal_cpp_tests`: 774/774 pass (70 suites).
- [x] `RandomTest.*` 8/8, `ScriptTest.*` 159/159, `ModelTest.*` 5/5 — all pass with the new default.
- [x] `ScriptTest.TestBlackScholesAAD` (the 1e-6 risk assertion at `dal-cpp/tests/script/test_blackscholes.cpp:64`) holds under precise-mode — measured drift ~3e-7, well inside the 1e-6 tolerance; no test constants were changed.
- [x] `rng_perf` and `matrix_perf` benchmark targets build clean and run.
- The CI full matrix (clang/gcc/msvc × adept/xad/codipack) is the real gate.

## Notes
- Internal subclass ctors (`ShuffledIRN_`, `MRG32k32a_`, `SobolSet_`) and the `Branch`/`Clone` reproduction paths intentionally retain `precise=false` to preserve pre-existing reproduction semantics. Surfacing `precise`/`polish` through `dal-public`/`dal-python`/`dal-excel` bindings, and the latent `Branch`/`Clone` precision-drop, are deliberately out of scope for this PR — separate follow-ups.