### PR TITLE
fix: out-of-bounds write in dense SymmetricDecomposition::QForm

### DIFF
--- a/dal-cpp/dal/math/matrix/sparse.cpp
+++ b/dal-cpp/dal/math/matrix/sparse.cpp
@@ -11,9 +11,10 @@
 namespace Dal::Sparse {
     // brute-force implementation
     void SymmetricDecomposition_::QForm(const Matrix_<>& j_mat, SquareMatrix_<>* dst) const {
+        REQUIRE(j_mat.Cols() == Size(), "j_mat size should match with this matrix's size");
         dst->Resize(j_mat.Rows());
 
-        Vector_<> wij;
+        Vector_<> wij(Size());
         Vector_<> row(j_mat.Cols());
 
         for (int ii = 0; ii < j_mat.Rows(); ++ii) {

--- a/dal-cpp/tests/math/matrix/test_sparse_qform.cpp
+++ b/dal-cpp/tests/math/matrix/test_sparse_qform.cpp
@@ -1,0 +1,60 @@
+//
+// Created by wegam on 2026/07/04.
+//
+
+#include <gtest/gtest.h>
+#include <dal/math/matrix/cholesky.hpp>
+#include <dal/math/matrix/sparse.hpp>
+#include <dal/math/matrix/squarematrix.hpp>
+#include <dal/utilities/numerics.hpp>
+
+using namespace Dal;
+using namespace Dal::Sparse;
+
+TEST(SparseQFormTest, TestDenseSymmetricDecompositionQForm) {
+    const int n = 4;
+    double tmpW[n][n] = {
+        {4.0, 1.0, 0.5, 0.2},
+        {1.0, 5.0, 0.3, 0.7},
+        {0.5, 0.3, 6.0, 1.1},
+        {0.2, 0.7, 1.1, 7.0}};
+    SquareMatrix_<> w(n);
+    for (int i = 0; i < n; ++i)
+        for (int j = 0; j < n; ++j)
+            w(i, j) = tmpW[i][j];
+
+    std::unique_ptr<SymmetricDecomposition_> deComp(CholeskyDecomposition(w));
+
+    const int jRows = 3;
+    Matrix_<> j_mat(jRows, n, 0.0);
+    double tmpJ[jRows][n] = {
+        {1.0, 2.0, -1.0, 0.5},
+        {0.5, -1.0, 2.0, 1.0},
+        {1.5, 0.25, 0.75, -0.5}};
+    for (int i = 0; i < jRows; ++i)
+        for (int k = 0; k < n; ++k)
+            j_mat(i, k) = tmpJ[i][k];
+
+    SquareMatrix_<> dst;
+    deComp->QForm(j_mat, &dst);
+
+    // Reference: dst_ref[i][k] = sum_r (W^{-1} J^T)[r][i] * J[k][r] via per-row solves.
+    // Solve W x_i = J_i for each J row; then dst_ref[i][k] = InnerProduct(x_i, J_k).
+    Vector_<Vector_<>> solvedRows(jRows);
+    for (int i = 0; i < jRows; ++i) {
+        Vector_<> rowJ(n);
+        for (int k = 0; k < n; ++k)
+            rowJ[k] = j_mat(i, k);
+        solvedRows[i].Resize(n);
+        deComp->Solve(rowJ, &solvedRows[i]);
+    }
+
+    ASSERT_EQ(dst.Rows(), jRows);
+    ASSERT_EQ(dst.Cols(), jRows);
+    for (int i = 0; i < jRows; ++i)
+        for (int k = 0; k < jRows; ++k) {
+            const double expected = InnerProduct(solvedRows[i], j_mat.Row(k));
+            ASSERT_NEAR(dst(i, k), expected, 1e-9);
+            ASSERT_NEAR(dst(k, i), expected, 1e-9);
+        }
+}

--- a/dal-cpp/tests/math/matrix/test_sparse_qform.cpp
+++ b/dal-cpp/tests/math/matrix/test_sparse_qform.cpp
@@ -11,6 +11,22 @@
 using namespace Dal;
 using namespace Dal::Sparse;
 
+namespace {
+    Vector_<Vector_<>> SolveEachRow(SymmetricDecomposition_& deComp, const Matrix_<>& j_mat) {
+        const int jRows = j_mat.Rows();
+        const int n = j_mat.Cols();
+        Vector_<Vector_<>> solvedRows(jRows);
+        for (int i = 0; i < jRows; ++i) {
+            Vector_<> rowJ(n);
+            for (int k = 0; k < n; ++k)
+                rowJ[k] = j_mat(i, k);
+            solvedRows[i].Resize(n);
+            deComp.Solve(rowJ, &solvedRows[i]);
+        }
+        return solvedRows;
+    }
+} // namespace
+
 TEST(SparseQFormTest, TestDenseSymmetricDecompositionQForm) {
     const int n = 4;
     double tmpW[n][n] = {
@@ -40,14 +56,7 @@ TEST(SparseQFormTest, TestDenseSymmetricDecompositionQForm) {
 
     // Reference: dst_ref[i][k] = sum_r (W^{-1} J^T)[r][i] * J[k][r] via per-row solves.
     // Solve W x_i = J_i for each J row; then dst_ref[i][k] = InnerProduct(x_i, J_k).
-    Vector_<Vector_<>> solvedRows(jRows);
-    for (int i = 0; i < jRows; ++i) {
-        Vector_<> rowJ(n);
-        for (int k = 0; k < n; ++k)
-            rowJ[k] = j_mat(i, k);
-        solvedRows[i].Resize(n);
-        deComp->Solve(rowJ, &solvedRows[i]);
-    }
+    const Vector_<Vector_<>> solvedRows = SolveEachRow(*deComp, j_mat);
 
     ASSERT_EQ(dst.Rows(), jRows);
     ASSERT_EQ(dst.Cols(), jRows);


### PR DESCRIPTION
## Summary
- Fix an out-of-bounds write in the dense `Sparse::SymmetricDecomposition_::QForm` (`dal-cpp/dal/math/matrix/sparse.cpp`). The work vector `wij` was declared **empty** and then passed to `Solve`, whose dense Cholesky `XSolve_af` (`dal-cpp/dal/math/matrix/cholesky.cpp`) writes `(*x)[ii]` for `ii` in `[0, Size())` without resizing. Any non-trivial dense `QForm` call therefore wrote off the end of `wij`, corrupting memory. The bug was latent because production calibration goes through the **banded** override (which pre-sizes), but the dense path is a public virtual and a live landmine.
- The fix mirrors the banded `QForm` override (`dal-cpp/dal/math/matrix/banded.cpp`): add `REQUIRE(j_mat.Cols() == Size(), ...)` and pre-size `Vector_<> wij(Size());`. `XSolve_af` and the caller-side pre-size convention are left untouched (matching the existing banded idiom).
- Adds a regression test `dal-cpp/tests/math/matrix/test_sparse_qform.cpp` exercising the **dense** path end-to-end via `CholeskyDecomposition(W)` (which returns a `Cholesky_` that does NOT override `QForm`) and asserting `dst == J W^{-1} J^T` against an independent per-row `Solve` reference (`ASSERT_NEAR(..., 1e-9)`). Before the fix the test aborts (OOB); after, it passes.

## Reachability (reviewer context)
- The dense `QForm` is reachable via the public factory `CholeskyDecomposition(W)` (`dal-cpp/dal/math/matrix/cholesky.hpp`), whose `Cholesky_` does not override `QForm` and so falls through to the buggy base.
- Production call sites of `QForm` — `dal-cpp/dal/curve/curvejacobian.hpp`, `dal-cpp/dal/math/optimization/underdetermined.cpp`, and the curve calibration paths (`calibration.cpp`, `xccycalibration.cpp`, `jointcalibration.cpp`) — all reach it through `weights->DecomposeSymmetric()` where `weights` is a **banded** matrix, so they hit the banded override (safe) and never tripped this bug. No current production caller exercises the dense path, which is why it survived; `dal-cpp/benchmarks/matrix_perf/matrix_perf.cpp` explicitly notes it cannot exercise `QForm` for exactly this reason.

## Test plan
- [x] New regression test `SparseQFormTest.TestDenseSymmetricDecompositionQForm` passes (aborts before the fix, passes after).
- [x] Full matrix suite (`MatrixTest.*` + `SparseQFormTest.*`, 51 tests) green.
- [x] Full `dal_cpp_tests` suite (775 tests) green — no regressions.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>