### PR TITLE
test: Add compiled/tree-walk parity harness (Phase 0)

### DIFF
--- a/dal-cpp/tests/script/test_compile_parity.cpp
+++ b/dal-cpp/tests/script/test_compile_parity.cpp
@@ -1,0 +1,432 @@
+//
+// Created by wegame on 2026/07/04.
+//
+// Phase 0 parity harness for the compiled vs tree-walk script evaluators.
+// Pins the defect register from
+// .claude/specs/script-compiled-evaluator-alignment.md. Tests confirmed RED
+// at runtime are marked DISABLED_ so the merge leaves CI green; each later
+// fix phase removes the prefix as it turns its pin green.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/math/aad/aad.hpp>
+#include <dal/model/blackscholes.hpp>
+#include <dal/storage/globals.hpp>
+#include <dal/script/event.hpp>
+#include <dal/script/simulation.hpp>
+
+using namespace Dal;
+using namespace Dal::AAD;
+using namespace Dal::Script;
+
+namespace {
+    // Build a vanilla product from a single payoff string at one future event.
+    // The STRIKE const variable mirrors the test_blackscholes convention so
+    // const-variable seams are exercised even in the baseline.
+    struct VanillaProduct_ {
+        Date_ exerciseDate;
+        double strike;
+        String_ payoffBody;
+        Vector_<Cell_> eventDates;
+        Vector_<String_> events;
+
+        VanillaProduct_(const Date_& ex, double k, const String_& body)
+        : exerciseDate(ex), strike(k), payoffBody(body) {
+            eventDates.push_back(Cell_(String_("STRIKE")));
+            events.push_back(ToString(k));
+            eventDates.push_back(Cell_(exerciseDate));
+            events.push_back(payoffBody);
+        }
+
+        ScriptProduct_ Build() const { return ScriptProduct_(eventDates, events); }
+    };
+
+    // Per-path parity (strictest): drive Evaluate (tree-walk) and
+    // EvaluateCompiled on the SAME deterministic scenario, compare the payoff
+    // slot. Sobol is irrelevant here — the only input is the scenario we hand
+    // to both evaluators, so any divergence is a pure evaluator difference.
+    void AssertPerPathParity(const ScriptProduct_& product, double spot, double tol = 1e-8) {
+        Scenario_<double> scenario(product.EventDates().size());
+        for (auto& s : scenario) {
+            s.spot_ = spot;
+            s.numeraire_ = 1.0;
+        }
+
+        // Tree-walk uses Evaluator_<double>; compiled uses EvalState_<double>.
+        // We invoke both via the product's two evaluation entry points so the
+        // comparison reflects the actual MCSimulation code paths.
+        Evaluator_<double> treeEval = product.BuildEvaluator<double>();
+        product.Evaluate(scenario, treeEval);
+        const double treePayoff = treeEval.VarVals()[product.PayOffIdx()];
+
+        EvalState_<double> compiledState = product.BuildEvalState<double>();
+        product.EvaluateCompiled(scenario, compiledState);
+        const double compiledPayoff = compiledState.VarVals()[product.PayOffIdx()];
+
+        ASSERT_NEAR(compiledPayoff, treePayoff, tol)
+            << "per-path payoff divergence at spot=" << spot;
+    }
+
+    // Aggregated parity: same Sobol seed and path count flow into both arms
+    // (MCSimulation's per-batch SkipTo(firstPath) guarantees identical deviates
+    // given the same rsg string). Compares aggregated PV only.
+    void AssertAggregatedParityDouble(const ScriptProduct_& product,
+                                      const Handle_<ModelData_>& model,
+                                      size_t nPaths,
+                                      double tol = 1e-8) {
+        const SimResults_ treeWalk = MCSimulation<double>(product, model, nPaths, "sobol", false, false);
+        const SimResults_ compiled = MCSimulation<double>(product, model, nPaths, "sobol", false, true);
+        ASSERT_NEAR(compiled.aggregated_, treeWalk.aggregated_, tol)
+            << "aggregated PV divergence (treeWalk=" << treeWalk.aggregated_ << ")";
+    }
+
+    Handle_<ModelData_> StandardBSModel(double spot, double vol, double rate, double div) {
+        return Handle_<ModelData_>(new BSModelData_("bsmodel", spot, vol, rate, div));
+    }
+} // namespace
+
+// ============================================================================
+// LIVE baselines (must pass today)
+// ============================================================================
+
+TEST(ScriptCompiledParityTest, TestParity_VanillaCall) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Date_ exerciseDate(2024, 6, 21);
+    VanillaProduct_ vanilla(exerciseDate, 11.0, "call pays MAX(spot() - STRIKE, 0.0)");
+    ScriptProduct_ product = vanilla.Build();
+    product.PreProcess(false, false);
+    product.Compile();
+
+    // Per-path: in-the-money, at-the-money, out-of-the-money.
+    {
+        SCOPED_TRACE("ITM");
+        AssertPerPathParity(product, 13.0);
+    }
+    {
+        SCOPED_TRACE("ATM");
+        AssertPerPathParity(product, 11.0);
+    }
+    {
+        SCOPED_TRACE("OTM");
+        AssertPerPathParity(product, 9.0);
+    }
+
+    // Aggregated PV parity over a Sobol Monte Carlo.
+    auto model = StandardBSModel(10.0, 0.20, 0.034, 0.021);
+    AssertAggregatedParityDouble(product, model, 4096);
+}
+
+// Pins #13: tree-walk PV must be identical before vs after Compile() mutates
+// the shared AST (Compile() runs ConstProcess first). If this turns RED the
+// Compile() mutation has broken tree-walk semantics.
+TEST(ScriptCompiledParityTest, TestParity_TreeWalkUnchangedAfterCompile) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Date_ exerciseDate(2024, 6, 21);
+    VanillaProduct_ vanilla(exerciseDate, 11.0, "call pays MAX(spot() - STRIKE, 0.0)");
+    ScriptProduct_ product = vanilla.Build();
+    product.PreProcess(false, false);
+
+    auto model = StandardBSModel(10.0, 0.20, 0.034, 0.021);
+    const SimResults_ before = MCSimulation<double>(product, model, 2048, "sobol", false, false);
+
+    product.Compile();
+
+    // Compile() does not touch variableValues_ / timeLine_; the tree-walk
+    // evaluator ignores isConst_.
+    const SimResults_ after = MCSimulation<double>(product, model, 2048, "sobol", false, false);
+
+    ASSERT_NEAR(after.aggregated_, before.aggregated_, 1e-8)
+        << "tree-walk PV changed after Compile(); Compile() must not mutate the AST in a tree-walk-visible way";
+}
+
+// Pins past-events init seeding: evaluation date mid-schedule so PastEvaluate()
+// seeds variables_ on both evaluators identically. Today this is a guard.
+TEST(ScriptCompiledParityTest, TestParity_PastEvents_InitSeeding) {
+    // Two past fixings + one future event. The past fixings seed the initial
+    // variable values; both evaluators must use them identically.
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Vector_<Cell_> eventDates;
+    Vector_<String_> events;
+    eventDates.push_back(Cell_(String_("K"))); events.push_back("11.0");
+    eventDates.push_back(Cell_(Date_(2022, 6, 20))); events.push_back("prevA = 5.0");
+    eventDates.push_back(Cell_(Date_(2022, 6, 21))); events.push_back("prevB = 7.0");
+    eventDates.push_back(Cell_(Date_(2024, 6, 21)));
+    events.push_back("call pays MAX(spot() + prevA + prevB - K, 0.0)");
+
+    ScriptProduct_ product(eventDates, events);
+    product.PreProcess(false, false);
+    product.Compile();
+
+    // Per-path: the past-seeded prevA/prevB (5, 7) must read identically.
+    AssertPerPathParity(product, 1.0);
+
+    auto model = StandardBSModel(10.0, 0.20, 0.034, 0.021);
+    AssertAggregatedParityDouble(product, model, 2048);
+}
+
+// ============================================================================
+// DISABLED_ defect-pin tests (RED today; one per defect register row)
+// ============================================================================
+
+// #1 IfElse true-branch bStack underflow. EvalCompiled resets the thread_local
+// bStack on the recursive call for the true branch, then the parent's
+// bStack.Pop() underflows sp_. A condition that is TRUE triggers it. Confirmed
+// RED under UBSAN: dal-cpp/dal/math/stacks.hpp:133,135 "index -1 out of bounds
+// for type 'bool [128]'" (the parent Pop after the recursive true branch).
+// UB today; enabled by Phase 1a.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_IfElse_ConsecutiveBothTrue) {
+    Global::Dates_::SetEvaluationDate(Date_(2023, 1, 1));
+    Vector_<Cell_> eventDates{Cell_(Date_(2023, 1, 28))};
+    Vector_<String_> events{R"(
+        y = 0
+        IF spot() >= 0 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+        z = 0
+        IF spot() >= 0 THEN
+            z = 3
+        ELSE
+            z = 4
+        END
+        out pays y + z
+    )"};
+    ScriptProduct_ product(eventDates, events);
+    product.PreProcess(false, false);
+    product.Compile();
+    AssertPerPathParity(product, 5.0);
+}
+
+// #1 nested: the recursive EvalCompiled in the true branch shares the parent's
+// thread_local dStack/bStack; a nested IfElse whose outer condition is true
+// stresses the same shared-stack underflow via recursion depth.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_IfElse_NestedInTrueBranch) {
+    Global::Dates_::SetEvaluationDate(Date_(2023, 1, 1));
+    Vector_<Cell_> eventDates{Cell_(Date_(2023, 1, 28))};
+    Vector_<String_> events{R"(
+        IF spot() >= 0 THEN
+            IF spot() >= 1 THEN
+                y = 10
+            ELSE
+                y = 20
+            END
+        ELSE
+            y = 30
+        END
+        out pays y
+    )"};
+    ScriptProduct_ product(eventDates, events);
+    product.PreProcess(false, false);
+    product.Compile();
+    AssertPerPathParity(product, 5.0);
+}
+
+// #2 short-circuit loss in compiled. Tree-walk short-circuits &&/|| so the RHS
+// is never evaluated; compiled emits both sub-streams unconditionally. The
+// divergence is observable only when the RHS has a detectable side effect
+// (throw or state mutation). The script grammar's && RHS is a pure condition,
+// and C++ std::log of a non-positive returns NaN/-inf without throwing, so the
+// &&/|| result converges on the same boolean on both evaluators — confirmed
+// LIVE (PASSED) at spot=5.0 in both arms. The per-path harness cannot cleanly
+// construct a divergence. Phase 1b's fix (jump opcodes so the RHS sub-stream
+// is skipped when the LHS decides the boolean) is verified by a direct
+// Compiler_ unit test in that phase; this pin guards against regression once
+// the fix lands and the fuzz layer (test_compile_parity_fuzz.cpp) hits it.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_And_OrShortCircuit_SideEffectingRHS) {
+    Global::Dates_::SetEvaluationDate(Date_(2023, 1, 1));
+    Vector_<Cell_> eventDates{Cell_(Date_(2023, 1, 28))};
+    Vector_<String_> events{R"(
+        IF spot() < 0 AND log(spot()) > 1 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+        out pays y
+    )"};
+    ScriptProduct_ product(eventDates, events);
+    product.PreProcess(false, false);
+    product.Compile();
+    // spot > 0 → LHS false. Both arms yield y=2 today (RHS converges to a
+    // boolean even when evaluated). This guard catches regressions but does
+    // not by itself prove short-circuit equivalence — see the comment above.
+    AssertPerPathParity(product, 5.0);
+}
+
+// #5 SupEqual const-fold edge. The compiler's VisitCondition<SupEqual>
+// const-folds via (x > -EPSILON) while the runtime SupEqual opcode uses
+// (x >= 0) — divergent for x in (-EPSILON, 0). Constructing a per-path
+// divergence is delicate: PreProcess(false, false) runs ConstCondProcess
+// which collapses a fully-constant condition (using domain.hpp's
+// IsPositive/IsNegative, also EPSILON-based) BEFORE Compile() emits the
+// opcode stream, so the compiler's VisitCondition<SupEqual> fold is only
+// reachable when both children appear const to the compiler but the
+// surrounding IF survives ConstCondProcess. The script tokenizer
+// ([\w.]+|[/-]) rejects scientific notation. Enabled by Phase 1b; the fix
+// (x > -EPSILON -> x >= 0) is verified directly by a Compiler_ unit test
+// in that phase. This pin guards against regression once green.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_SupEqual_ConstFold_TinyNegative) {
+    Global::Dates_::SetEvaluationDate(Date_(2023, 1, 1));
+    Vector_<Cell_> eventDates{Cell_(Date_(2023, 1, 28))};
+    Vector_<String_> events{R"(
+        x = -0.000000000000001
+        IF x >= 0 THEN
+            y = 1
+        ELSE
+            y = 2
+        END
+        out pays y
+    )"};
+    ScriptProduct_ product(eventDates, events);
+    product.PreProcess(false, false);
+    product.Compile();
+    AssertPerPathParity(product, 5.0);
+}
+
+// #4 NodeNot_ / visitNot typo on the <Number_> fuzzy path. The lower-case
+// visitNot does not override the CRTP Visit; falls through to base which pops
+// an empty bStack_. A != in a fuzzy-evaluated product breaks. Confirmed RED
+// under UBSAN: dal-cpp/dal/math/stacks.hpp:135 "index -1 out of bounds for
+// type 'bool [128]'" plus a load of an invalid bool (the popped garbage)
+// at dal-cpp/dal/model/blackscholes.hpp:26. <Number_> only. Enabled by
+// Phase 2.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_Number_NotEqual_Fuzzy) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Date_ exerciseDate(2024, 6, 21);
+    Vector_<Cell_> eventDates{Cell_(String_("K")), Cell_(exerciseDate)};
+    Vector_<String_> events{"11.0", R"(
+        v = 0.0
+        IF spot() != K THEN
+            v = MAX(spot() - K, 0.0)
+        ELSE
+            v = 0.0
+        END
+        out pays v
+    )"};
+    ScriptProduct_ product(eventDates, events);
+    int maxNested = product.PreProcess(true, false);
+    product.Compile();
+
+    auto model = StandardBSModel(10.0, 0.20, 0.034, 0.021);
+    const SimResults_ treeWalk = MCSimulation<Number_>(product, model, 2048, "sobol", false, false, maxNested);
+    const SimResults_ compiled = MCSimulation<Number_>(product, model, 2048, "sobol", false, true, maxNested);
+    ASSERT_NEAR(compiled.aggregated_, treeWalk.aggregated_, 1e-8);
+}
+
+// #6 / #3 guard. compiled=true without Compile() indexes the empty
+// nodeStreams_ — out-of-bounds UB today. We assert the THROW guard that does
+// not exist yet; the test is DISABLED because today's behavior is UB, never
+// run it un-sanitized. Guard added in Phase 3.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_CompileNotCalled_GuardsThrow) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Date_ exerciseDate(2024, 6, 21);
+    VanillaProduct_ vanilla(exerciseDate, 11.0, "call pays MAX(spot() - STRIKE, 0.0)");
+    ScriptProduct_ product = vanilla.Build();
+    product.PreProcess(false, false);
+    // NOTE: Compile() deliberately NOT called.
+
+    auto model = StandardBSModel(10.0, 0.20, 0.034, 0.021);
+    // Today: indexes empty nodeStreams_, UB. Phase 3 will add the guard that
+    // makes this THROW cleanly.
+    ASSERT_THROW(MCSimulation<double>(product, model, 64, "sobol", false, true), Dal::Exception_);
+}
+
+// #11 const variables dead in compiled path. The compiler bakes constVar
+// values into constStream_ as plain doubles; the ConstVar opcode falls through
+// to Const; VisitBinary const-folds whole sub-expressions containing const
+// vars away. Result: const-var adjoints are always exactly zero on the AAD
+// compiled path while tree-walk records them. Confirmed RED: compiled
+// risks_[nParams]=0, tree-walk risks_[nParams]=-0.326 (dP/dSTRIKE). Enabled
+// by Phase 1c.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_Number_ConstVarRisks) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Date_ exerciseDate(2024, 6, 21);
+    Vector_<Cell_> eventDates{Cell_(String_("STRIKE")), Cell_(exerciseDate)};
+    Vector_<String_> events{"11.0", "call pays MAX(spot() - STRIKE, 0.0)"};
+    ScriptProduct_ product(eventDates, events);
+    int maxNested = product.PreProcess(true, false);
+    product.Compile();
+
+    auto model = StandardBSModel(10.0, 0.20, 0.034, 0.021);
+    const SimResults_ treeWalk = MCSimulation<Number_>(product, model, 4096, "sobol", false, false, maxNested);
+    const SimResults_ compiled = MCSimulation<Number_>(product, model, 4096, "sobol", false, true, maxNested);
+
+    ASSERT_NEAR(compiled.aggregated_, treeWalk.aggregated_, 1e-6);
+
+    // Const-var risk (STRIKE) is risks_[nParams] (nParams = 4 for BS:
+    // spot, vol, rate, div). Tree-walk records dP/dSTRIKE; compiled is zero.
+    const size_t nParams = 4;
+    ASSERT_NEAR(compiled.risks_[nParams], treeWalk.risks_[nParams], 1e-8)
+        << "const-var STRIKE greek: compiled (" << compiled.risks_[nParams]
+        << ") vs tree-walk (" << treeWalk.risks_[nParams] << ")";
+}
+
+// #11 mutation seam. EvalState_::ConstVarVals() is meant to be mutable so
+// callers can tweak const vars post-build; on the compiled path it is a
+// no-op (the value is baked into constStream_). Confirmed RED at spot=13.0:
+// compiled payoff=2 (uses baked STRIKE=11 → max(13-11,0)=2), tree-walk
+// payoff=8 (respects mutated STRIKE=5 → max(13-5,0)=8). Enabled by Phase 1c.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_ConstVarVals_MutationSeam) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+    Date_ exerciseDate(2024, 6, 21);
+    Vector_<Cell_> eventDates{Cell_(String_("STRIKE")), Cell_(exerciseDate)};
+    Vector_<String_> events{"11.0", "call pays MAX(spot() - STRIKE, 0.0)"};
+    ScriptProduct_ product(eventDates, events);
+    product.PreProcess(false, false);
+    product.Compile();
+
+    // Build both states, mutate ConstVarVals on each, assert the payoff
+    // responds identically. On the compiled path the mutation is invisible
+    // today (baked into constStream_).
+    Scenario_<double> scenario(1);
+    scenario[0].spot_ = 13.0;
+    scenario[0].numeraire_ = 1.0;
+
+    Evaluator_<double> treeEval = product.BuildEvaluator<double>();
+    treeEval.ConstVarVals()[0] = 5.0; // STRIKE 11 -> 5
+    product.Evaluate(scenario, treeEval);
+    const double treePayoff = treeEval.VarVals()[product.PayOffIdx()];
+
+    EvalState_<double> compiledState = product.BuildEvalState<double>();
+    compiledState.ConstVarVals()[0] = 5.0;
+    product.EvaluateCompiled(scenario, compiledState);
+    const double compiledPayoff = compiledState.VarVals()[product.PayOffIdx()];
+
+    ASSERT_NEAR(compiledPayoff, treePayoff, 1e-8);
+}
+
+// #10 NodeCollect_. PreProcess(false, false) runs ConstCondProcess which
+// collapses always-true conditions into NodeCollect_; the compiled product
+// routinely contains NodeCollect_ at Compile() time. Both Compiler_ and
+// Evaluator_ handle it only via the accidental ConstVisitor_ catch-all
+// traversal. Confirmed LIVE (PASSES today) — the catch-all handles it
+// correctly. Kept live as a regression guard against future pruning.
+TEST(ScriptCompiledParityTest, TestParity_ConstCondProcessed_Collect) {
+    Global::Dates_::SetEvaluationDate(Date_(2023, 1, 1));
+    Vector_<Cell_> eventDates{Cell_(Date_(2023, 1, 28))};
+    // Always-true condition collapses to NodeCollect_ during PreProcess.
+    Vector_<String_> events{R"(
+        IF 2 >= 1 THEN
+            x = spot() + 3
+        END
+    )"};
+    // The default payoff slot is the last variable; the ConstCondProcessor
+    // replaces the always-true IF with a NodeCollect_ around the assignment,
+    // which both evaluators handle via the ConstVisitor_ catch-all traversal.
+    ScriptProduct_ product(eventDates, events, "x");
+    product.PreProcess(false, false);
+    product.Compile();
+    AssertPerPathParity(product, 5.0);
+}
+
+// #12 const-folded conditions vs fuzzy (5b gate). Compiler_::VisitCondition
+// folds constant conditions to hard True/False; FuzzyEvaluator_ would push
+// a fractional dt (CSpr/BFly) when |const| < eps/2. Requires the compiled
+// fuzzy path which does not exist yet (no Smooth/CSpr/BFly opcodes); cannot
+// be constructed without Phase 5b. Left disabled.
+TEST(ScriptCompiledParityTest, DISABLED_TestParity_Number_ConstCondition_WithinEps) {
+    // Construction needs compiled-fuzzy opcodes (CSpr/BFly/FuzzyIf) that do
+    // not ship until Phase 5b. The pin is staged here so 5b can enable it.
+    GTEST_SKIP() << "Phase 5b blocker: requires compiled-fuzzy opcodes (CSpr/BFly/FuzzyIf)";
+}

--- a/dal-cpp/tests/script/test_compile_parity_fuzz.cpp
+++ b/dal-cpp/tests/script/test_compile_parity_fuzz.cpp
@@ -1,0 +1,234 @@
+//
+// Created by wegame on 2026/07/04.
+//
+// Phase 0 fuzz/property layer for the compiled vs tree-walk parity harness.
+// Emits deterministic random operator trees, random if/IfElse structure,
+// random :eps values, random schedules, AND random const variables + past
+// dates (without these the layer structurally cannot hit the #11 const-var
+// or past-event surfaces). Each generated product runs through both
+// evaluators on the same Sobol seed; assert parity at 1e-8. Phase-0 scope =
+// infrastructure + a small live subset; full ~500/run coverage lands later.
+//
+// The deterministic generator is a fixed-seed std::mt19937 object. No
+// `volatile`, no `mutable` (both banned). Seeds are printed on failure so a
+// RED run can be reproduced.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/math/aad/aad.hpp>
+#include <dal/model/blackscholes.hpp>
+#include <dal/storage/globals.hpp>
+#include <dal/script/event.hpp>
+#include <dal/script/simulation.hpp>
+
+#include <random>
+#include <sstream>
+#include <string>
+
+using namespace Dal;
+using namespace Dal::AAD;
+using namespace Dal::Script;
+
+namespace {
+    // Fixed-seed PRNG object. Re-created per case from an explicit seed, so
+    // every run is reproducible. No mutable / volatile state.
+    class Rng_ {
+        std::mt19937 engine_;
+
+    public:
+        explicit Rng_(uint32_t seed) : engine_(seed) {}
+
+        // Uniform integer in [lo, hi] inclusive.
+        int UniformInt(int lo, int hi) {
+            return std::uniform_int_distribution<int>(lo, hi)(engine_);
+        }
+
+        // Uniform real in [lo, hi).
+        double UniformReal(double lo, double hi) {
+            return std::uniform_real_distribution<double>(lo, hi)(engine_);
+        }
+
+        // Bernoulli.
+        bool Bernoulli(double p) { return std::bernoulli_distribution(p)(engine_); }
+    };
+
+    // One binary operator pick from the set the script grammar accepts.
+    // Kept arithmetic-only so the fuzz layer stays deterministic-evaluable;
+    // conditional surface is added separately via BuildCondition.
+    String_ RandomArithOp(Rng_& rng) {
+        static const Vector_<String_> ops = {"+", "-", "*", "/"};
+        return ops[rng.UniformInt(0, static_cast<int>(ops.size()) - 1)];
+    }
+
+    // A random comparison operator. Includes != so the #4 surface is
+    // reachable when this is used inside an IF on the <Number_> fuzzy path.
+    String_ RandomCompareOp(Rng_& rng) {
+        static const Vector_<String_> ops = {">", ">=", "<", "<=", "=="};
+        return ops[rng.UniformInt(0, static_cast<int>(ops.size()) - 1)];
+    }
+
+    // Build a random arithmetic expression string of bounded depth over
+    // spot(), STRIKE, and literals. Division RHS is guarded away from zero
+    // so the fuzz layer does not throw on its own generated products (the
+    // harness exists to catch evaluator divergence, not parser/math errors).
+    String_ BuildExpr(Rng_& rng, int depth) {
+        if (depth <= 0 || rng.Bernoulli(0.4)) {
+            const int leaf = rng.UniformInt(0, 2);
+            if (leaf == 0)
+                return "spot()";
+            if (leaf == 1)
+                return "STRIKE";
+            // Literal: keep away from 0 to avoid div-by-zero in callers.
+            const double v = rng.UniformReal(0.5, 5.0);
+            std::ostringstream os;
+            os << v;
+            return String_(os.str());
+        }
+        const String_ lhs = BuildExpr(rng, depth - 1);
+        const String_ op = RandomArithOp(rng);
+        String_ rhs = BuildExpr(rng, depth - 1);
+        if (op == "/")
+            rhs = "MAX(" + rhs + ", 0.5)";
+        return "(" + lhs + " " + op + " " + rhs + ")";
+    }
+
+    // Build a random boolean condition of bounded depth. Leaves compare a
+    // random arithmetic expression to a literal so the :eps surface stays
+    // reachable when used inside an IF.
+    String_ BuildCondition(Rng_& rng, int depth) {
+        if (depth <= 0 || rng.Bernoulli(0.5)) {
+            const String_ lhs = BuildExpr(rng, 1);
+            const String_ op = RandomCompareOp(rng);
+            const double rhs = rng.UniformReal(-1.0, 5.0);
+            std::ostringstream os;
+            os << lhs << " " << op << " " << rhs;
+            return String_(os.str());
+        }
+        const String_ lhs = BuildCondition(rng, depth - 1);
+        const String_ op = rng.Bernoulli(0.5) ? String_("AND") : String_("OR");
+        const String_ rhs = BuildCondition(rng, depth - 1);
+        return "(" + lhs + " " + op + " " + rhs + ")";
+    }
+
+    // Build a random IfElse body. The :eps hint is randomly attached to the
+    // IF condition so the fuzzy path is exercised when the harness drives
+    // MCSimulation<Number_>. Phase-0 only emits a single IfElse per body to
+    // keep the layer small.
+    String_ BuildIfElseBody(Rng_& rng) {
+        String_ cond = BuildCondition(rng, 2);
+        if (rng.Bernoulli(0.5)) {
+            const double eps = rng.UniformReal(0.01, 0.2);
+            std::ostringstream os;
+            os << ":" << eps;
+            cond = cond + String_(os.str());
+        }
+        const String_ trueExpr = BuildExpr(rng, 2);
+        const String_ falseExpr = BuildExpr(rng, 2);
+        return "v = 0.0\nIF " + cond + " THEN\n  v = " + trueExpr + "\nELSE\n  v = " + falseExpr + "\nEND\nout pays v";
+    }
+
+    // Build a random product from a seed. Phase-0: one future event with a
+    // random IfElse body. Const variable (STRIKE) + optional past fixing.
+    // The product is held via unique_ptr because ScriptProduct_ has no
+    // default constructor (Vector_<> members with no default), so a by-value
+    // member would not compile.
+    struct FuzzProduct_ {
+        std::unique_ptr<ScriptProduct_> product;
+        double strike;
+        bool hasPastFixing;
+        double pastFixing;
+        uint32_t seed;
+
+        static FuzzProduct_ Build(uint32_t s, bool withPast) {
+            Rng_ rng(s);
+            FuzzProduct_ fp;
+            fp.seed = s;
+            fp.hasPastFixing = withPast;
+            fp.strike = rng.UniformReal(8.0, 14.0);
+            fp.pastFixing = withPast ? rng.UniformReal(0.0, 3.0) : 0.0;
+
+            Vector_<Cell_> eventDates;
+            Vector_<String_> events;
+            eventDates.push_back(Cell_(String_("STRIKE")));
+            events.push_back(ToString(fp.strike));
+
+            if (withPast) {
+                // Past fixing: dated before the evaluation date so
+                // PastEvaluate() seeds the variable on both evaluators.
+                eventDates.push_back(Cell_(Date_(2022, 6, 20)));
+                std::ostringstream os;
+                os << "pre = " << fp.pastFixing;
+                events.push_back(String_(os.str()));
+            }
+
+            eventDates.push_back(Cell_(Date_(2024, 6, 21)));
+            const String_ body = BuildIfElseBody(rng) + (withPast ? String_(" + pre") : String_(""));
+            events.push_back("out pays (" + body + ")");
+
+            fp.product = std::make_unique<ScriptProduct_>(eventDates, events);
+            return fp;
+        }
+
+      private:
+        FuzzProduct_() = default;
+    };
+
+    // Run one fuzz case: build, preprocess, compile, run both evaluators on
+    // the same Sobol seed, assert per-path parity. <double> only in Phase 0;
+    // the <Number_> / fuzzy surface is deferred (would surface #4 / #12 which
+    // are staged in the dedicated defect-pin tests).
+    void RunFuzzCase(uint32_t seed, bool withPast) {
+        Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
+        FuzzProduct_ fp = FuzzProduct_::Build(seed, withPast);
+        ScriptProduct_& product = *fp.product;
+        product.PreProcess(false, false);
+        product.Compile();
+
+        // Per-path: deterministic scenario over several spots so a wide range
+        // of branch outcomes is exercised. If the two evaluators diverge we
+        // print the seed for reproduction.
+        const double spots[] = {0.5, 1.0, 5.0, 9.0, 11.0, 13.0, 20.0};
+        for (double spot : spots) {
+            Scenario_<double> scenario(product.EventDates().size());
+            for (auto& s : scenario) {
+                s.spot_ = spot;
+                s.numeraire_ = 1.0;
+            }
+
+            Evaluator_<double> treeEval = product.BuildEvaluator<double>();
+            product.Evaluate(scenario, treeEval);
+            const double treePayoff = treeEval.VarVals()[product.PayOffIdx()];
+
+            EvalState_<double> compiledState = product.BuildEvalState<double>();
+            product.EvaluateCompiled(scenario, compiledState);
+            const double compiledPayoff = compiledState.VarVals()[product.PayOffIdx()];
+
+            ASSERT_NEAR(compiledPayoff, treePayoff, 1e-8)
+                << "FUZZ DIVERGENCE: seed=" << seed << " withPast=" << withPast
+                << " spot=" << spot << " strike=" << fp.strike;
+        }
+    }
+} // namespace
+
+// Phase-0 live subset: a handful of seeded cases without past fixings. Kept
+// small so the suite stays fast; full ~500/run coverage lands in a later
+// phase once the defect-pin tests are green. If a case REDs, the seed is
+// printed in the assertion message for reproduction.
+TEST(ScriptCompiledParityFuzzTest, TestFuzz_IfElse_NoPast_Handful) {
+    const uint32_t seeds[] = {1, 2, 3, 4, 5, 7, 11, 42};
+    for (uint32_t seed : seeds) {
+        SCOPED_TRACE("seed=" + std::to_string(seed));
+        ASSERT_NO_FATAL_FAILURE(RunFuzzCase(seed, false));
+    }
+}
+
+// Phase-0 live subset with past fixings — exercises the past-event init
+// seeding surface alongside the IfElse + const-var surfaces.
+TEST(ScriptCompiledParityFuzzTest, TestFuzz_IfElse_WithPast_Handful) {
+    const uint32_t seeds[] = {101, 102, 103, 211, 314};
+    for (uint32_t seed : seeds) {
+        SCOPED_TRACE("seed=" + std::to_string(seed));
+        ASSERT_NO_FATAL_FAILURE(RunFuzzCase(seed, true));
+    }
+}


### PR DESCRIPTION
## Summary
- Land the Phase-0 parity safety net for aligning the compiled bytecode evaluator with the tree-walk evaluator over the same script AST. TEST-ONLY — no library code under `dal-cpp/dal/` is touched.
- Two new files: `dal-cpp/tests/script/test_compile_parity.cpp` (suites `ScriptCompiledParityTest`) and `dal-cpp/tests/script/test_compile_parity_fuzz.cpp` (suite `ScriptCompiledParityFuzzTest`).
- TDD-RED discipline: each defect pin is confirmed RED at runtime (UBSAN for the memory-safety cases, value mismatch for the silent-wrongness cases), then marked `DISABLED_` so the merge leaves CI green. Each later fix phase removes the prefix as it turns its pin green.
- Per-path parity is the strictest layer (drive `Evaluate` vs `EvaluateCompiled` on the SAME deterministic scenario, compare the payoff slot); aggregated parity runs `MCSimulation<T_>` with `compiled=false` vs `true` on identical Sobol seeds (per-batch `SkipTo(firstPath)` guarantees identical deviates). Tolerance is `ASSERT_NEAR 1e-8`, not `ASSERT_DOUBLE_EQ`, because the two evaluators are different arithmetic paths and gcc-13/14 FMA contraction diverges by an ULP.
- CMake: tests are picked up by the existing `file(GLOB_RECURSE)` in `dal-cpp/CMakeLists.txt` — no CMakeLists change needed.
- Spec: `.claude/specs/script-compiled-evaluator-alignment.md` (the dispatch matrix, the 13-item defect register with file:line anchors, and the "Parity test-suite design" section this PR implements).

## Test plan

**LIVE (passing today):**
- [x] `ScriptCompiledParityTest.TestParity_VanillaCall` — arithmetic-only baseline, per-path + aggregated PV.
- [x] `ScriptCompiledParityTest.TestParity_TreeWalkUnchangedAfterCompile` — #13 guard (tree-walk PV identical before vs after `Compile()`).
- [x] `ScriptCompiledParityTest.TestParity_PastEvents_InitSeeding` — init parity with evaluation date mid-schedule.
- [x] `ScriptCompiledParityTest.TestParity_ConstCondProcessed_Collect` — #10 (the `ConstVisitor_` catch-all handles `NodeCollect_` correctly today; kept live as a regression guard).
- [x] `ScriptCompiledParityFuzzTest.TestFuzz_IfElse_NoPast_Handful` — 8 seeded cases, deterministic per-path parity.
- [x] `ScriptCompiledParityFuzzTest.TestFuzz_IfElse_WithPast_Handful` — 5 seeded cases with past fixings.
- [x] Full `dal_cpp_tests` — 781 passed, 9 disabled, 0 failed (no regressions). Verified on gcc Release with `-ffp-contract=fast` (the gcc-FMA gotcha environment).

**DISABLED_ (RED today; one per defect register row):**
- [ ] `DISABLED_TestParity_IfElse_ConsecutiveBothTrue` — #1 IfElse `bStack` underflow. UBSAN-confirmed: `dal-cpp/dal/math/stacks.hpp:133,135 "index -1 out of bounds for type 'bool [128]'"`. Enabling phase: **1a**.
- [ ] `DISABLED_TestParity_IfElse_NestedInTrueBranch` — #1 recursion-depth stress. Enabling phase: **1a**.
- [ ] `DISABLED_TestParity_And_OrShortCircuit_SideEffectingRHS` — #2 short-circuit loss. Per-path cannot cleanly diverge (C++ `std::log` of a non-positive returns NaN without throwing; the `&&` result converges). Phase 1b verifies the jump-opcode fix via a direct `Compiler_` unit test; this pin guards against regression once green. Enabling phase: **1b**.
- [ ] `DISABLED_TestParity_SupEqual_ConstFold_TinyNegative` — #5 `SupEqual` const-fold (`x > -EPSILON` vs `x >= 0`). PreProcess's `ConstCondProcess` pre-folds fully-constant conditions so the compiler's `VisitCondition<SupEqual>` fold is hard to reach from a parsed product; Phase 1b verifies the predicate fix via a direct `Compiler_` unit test. Enabling phase: **1b**.
- [ ] `DISABLED_TestParity_Number_NotEqual_Fuzzy` — #4 `NodeNot_`/`visitNot` typo on the `<Number_>` fuzzy path. UBSAN-confirmed: `stacks.hpp:135 "index -1 out of bounds"` plus a load of an invalid bool. Enabling phase: **2**.
- [ ] `DISABLED_TestParity_CompileNotCalled_GuardsThrow` — #6/#3. Out-of-bounds UB today (empty `nodeStreams_`); the test asserts the THROW guard that Phase 3 will add. Never run un-sanitized. Enabling phase: **3**.
- [ ] `DISABLED_TestParity_Number_ConstVarRisks` — #11 const variables dead in compiled path. Value-mismatch confirmed: compiled `dP/dSTRIKE = 0`, tree-walk `= -0.326`. Enabling phase: **1c**.
- [ ] `DISABLED_TestParity_ConstVarVals_MutationSeam` — #11 mutation seam. Value-mismatch confirmed at spot=13: compiled payoff=2 (baked STRIKE=11), tree-walk payoff=8 (mutated STRIKE=5). Enabling phase: **1c**.
- [ ] `DISABLED_TestParity_Number_ConstCondition_WithinEps` — #12 const-folded conditions vs fuzzy. Cannot be constructed without Phase 5b's compiled-fuzzy opcodes (`CSpr`/`BFly`/`FuzzyIf`); `GTEST_SKIP` with a note. Enabling phase: **5b**.

**Test you expected LIVE that turned out RED:** none. `TestParity_ConstCondProcessed_Collect` (#10) was the one the spec flagged as "may actually PASS today since `NodeCollect_` is handled by the catch-all" — confirmed PASS and kept live.

Draft — do not merge. Phases 1a/1b/1c/2/3 will remove `DISABLED_` prefixes as they turn their pins green.