### PR TITLE
[codex] add DAL agent skills

### DIFF
--- a/.codex/skills/dal-agent-team/SKILL.md
+++ b/.codex/skills/dal-agent-team/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dal-agent-team
+description: Coordinate the DAL specialist role set converted from `.claude/agents`. Use when the user asks to run the team, use a DAL agent by role, delegate through the DAL pipeline, pick the right DAL specialist, or reproduce the spec, API, critique, implement, test, review, docs workflow in Codex.
+---
+
+# DAL Agent Team
+
+Use this skill as the Codex-native index for the DAL role team. The original Claude role
+files remain under `.claude/agents/`; Codex roles live as same-name skills under
+`.codex/skills/`.
+
+## Role Map
+
+| Role         | Codex skill        | Use for                                      |
+|--------------|--------------------|----------------------------------------------|
+| Orchestrator | `dal-orchestrator` | Planning and delegation across roles          |
+| Spec writer  | `dal-spec-writer`  | Turning vague asks into testable specs        |
+| API designer | `dal-api-designer` | Public C++/Python/Excel/example API shape     |
+| Critic       | `dal-critic`       | Attacking specs, designs, and proposals       |
+| Implementer  | `dal-implementer`  | TDD feature and bug-fix implementation        |
+| Tester       | `dal-tester`       | Test coverage and failing test repair         |
+| Reviewer     | `dal-reviewer`     | PR/code review and merge gate                 |
+| Performancer | `dal-performancer` | Benchmark regression and coverage advice      |
+| Simplifier   | `dal-simplifier`   | Duplication and simplification sweeps         |
+| Doc writer   | `dal-doc-writer`   | Docs and changelog reconciliation             |
+
+## Codex Adaptation Rules
+
+- Use the same role names as the Claude team when the user asks for them.
+- Load the role's same-name skill before acting.
+- Load `references/shared-rules.md` when a role needs shared style, test, docs, review, or artifact conventions.
+- Write new durable role artifacts under `.codex/artifacts/`, not `.claude/`, unless the user explicitly asks to update Claude artifacts.
+- Treat `.claude/agents/` as read-only source material.
+- Spawn subagents only when the user explicitly asks for delegation, team execution, parallel agents, or subagents. Otherwise, emulate the selected role in the current Codex session.
+- When spawning subagents, give each a self-contained prompt, disjoint write scope, and the relevant `.codex/skills/<role>` path.
+
+## Default Pipeline
+
+Use this order when the user asks to run the team end-to-end:
+
+```text
+spec-writer -> api-designer -> critic -> implementer -> tester -> reviewer -> doc-writer
+```
+
+Skip `api-designer` when no public API, binding, or example surface changes. Skip `doc-writer`
+only for pure test additions or behavior-preserving refactors. Keep `reviewer` as the in-band
+gate. Run `performancer` and `simplifier` out of band when requested.
+
+## References
+
+- `references/shared-rules.md`: single shared convention reference for all DAL role skills.
+- `references/team-map.md`: concise source-to-Codex mapping for the converted roles.

--- a/.codex/skills/dal-agent-team/agents/openai.yaml
+++ b/.codex/skills/dal-agent-team/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Agent Team"
+  short_description: "Use DAL specialist roles in Codex."
+  default_prompt: "Use the DAL agent team skill and select the right DAL role for this task."

--- a/.codex/skills/dal-agent-team/references/shared-rules.md
+++ b/.codex/skills/dal-agent-team/references/shared-rules.md
@@ -1,0 +1,109 @@
+# DAL Shared Rules
+
+Use this reference for all DAL role skills. It is the single Codex-side home for shared
+style, test, review, docs, and artifact conventions.
+
+## Canonical Locations
+
+- Codex skills: `.codex/skills/`.
+- Codex role artifacts: `.codex/artifacts/`.
+- Claude source material: `.claude/` and `CLAUDE.md`; read only unless the user explicitly asks to edit Claude files.
+- Methodology docs: `docs/methodology/`.
+
+## Build And Test
+
+Release build:
+
+```bash
+mkdir -p build
+cd build
+cmake --preset=Release-linux ..
+make -j$(nproc)
+make install
+```
+
+Full Linux workflow:
+
+```bash
+bash ./build_linux.sh > test_output.txt 2>&1
+```
+
+Targeted test:
+
+```bash
+bin/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
+```
+
+Web tests:
+
+```bash
+(cd dal-web/backend && uv run pytest)
+(cd dal-web/frontend && npm run build)
+./dal-web/scripts/setup-playwright.sh
+(cd dal-web/frontend && npm run test:e2e)
+```
+
+## C++ Style
+
+- C++17. Use `.clang-format`: 4 spaces, attached braces, 150 columns, `T*` pointer binding.
+- Classes/structs: PascalCase plus trailing `_`.
+- Template params: short name plus trailing `_`.
+- Functions/methods: PascalCase.
+- Members: camelCase plus trailing `_`.
+- Locals/params: camelCase.
+- Files: lowercase, no separators; test files use `test_` prefix.
+- Headers use `#pragma once`, the three-line file header, and `namespace Dal { ... }` with `} // namespace Dal`.
+- Use `Handle_<T_>` for shared const ownership and `std::unique_ptr<T_>` for exclusive ownership.
+- Use `REQUIRE` for runtime checks and `THROW` for error paths.
+- Do not use `volatile`, `mutable` members, raw exceptions for normal DAL errors, or hand-written DAL enum classes.
+
+## Machinist Enums
+
+When enum markup changes, regenerate both core and Excel output:
+
+```bash
+export MACHINIST_TEMPLATE_DIR=$PWD/dal-cpp/externals/machinist/template/
+./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-cpp/dal
+./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-excel
+```
+
+Commit generated `dal-cpp/dal/auto/MG_*` and `dal-excel/auto/MG_*` files with the markup source when committing is requested.
+
+## Google Test
+
+- Core tests: `dal-cpp/tests/<module>/test_<name>.cpp`.
+- Include `<gtest/gtest.h>` first.
+- Use `TEST(Suite, Name)`, never `TEST_F`.
+- Use `ASSERT_*`, never `EXPECT_*`.
+- Test names start with `Test`.
+- Prefer `ASSERT_NEAR(actual, expected, 1e-10)` or `1e-8` for deterministic numerics.
+- Use `ASSERT_THROW(stmt, Dal::Exception_)` for DAL exception paths.
+- Each test owns its setup. Avoid shared mutable state and singleton pollution.
+- Clear AAD tape state at the start and end of AAD tests.
+
+## Review Rules
+
+- Findings first, ordered by severity, with file and line when available.
+- Read full changed files when behavior, API, build output, generated code, tests, docs, or guidance can change.
+- Check correctness, style, tests, docs/changelog, generated files, security, and compatibility.
+- For simplification reviews, cite files and symbols rather than source lines; line numbers go stale for design reports.
+- Do not submit GitHub reviews or merge unless explicitly asked.
+
+## Documentation Rules
+
+- Docs describe the current/latest library only.
+- Historical context belongs in `CHANGELOG.md`, not docs.
+- Do not cite source line numbers in docs.
+- Reuse published example code; route example design problems to `dal-api-designer`.
+- Add changelog entries only for breaking public API changes, new methodology/numerical algorithms, significant capabilities, significant methodology shifts, or removal/deprecation of public surface.
+
+## Artifact Paths
+
+| Artifact       | Path                                        |
+|----------------|---------------------------------------------|
+| Specs          | `.codex/artifacts/specs/<slug>.md`          |
+| API notes      | `.codex/artifacts/api-notes/<slug>.md`      |
+| Critiques      | `.codex/artifacts/critiques/<slug>.md`      |
+| Review reports | `.codex/artifacts/reviews/<slug>.md`        |
+| Perf reports   | `.codex/artifacts/perf/<slug>.md`           |
+| Simplification | `.codex/artifacts/simplifications/<slug>.md` |

--- a/.codex/skills/dal-agent-team/references/team-map.md
+++ b/.codex/skills/dal-agent-team/references/team-map.md
@@ -1,0 +1,22 @@
+# DAL Agent Team Mapping
+
+Original source: `.claude/agents/`.
+
+| Claude file                         | Codex skill                     | Notes                                      |
+|-------------------------------------|---------------------------------|--------------------------------------------|
+| `.claude/agents/dal-orchestrator.md` | `.codex/skills/dal-orchestrator` | Uses Codex subagents only when authorized. |
+| `.claude/agents/dal-spec-writer.md`  | `.codex/skills/dal-spec-writer`  | Writes Codex specs by default.            |
+| `.claude/agents/dal-api-designer.md` | `.codex/skills/dal-api-designer` | Writes Codex API notes by default.        |
+| `.claude/agents/dal-critic.md`       | `.codex/skills/dal-critic`       | Writes Codex critiques by default.        |
+| `.claude/agents/dal-implementer.md`  | `.codex/skills/dal-implementer`  | Uses normal Codex edit and test workflow. |
+| `.claude/agents/dal-tester.md`       | `.codex/skills/dal-tester`       | Uses shared test conventions.             |
+| `.claude/agents/dal-reviewer.md`     | `.codex/skills/dal-reviewer`     | Uses review-first answer shape.           |
+| `.claude/agents/dal-performancer.md` | `.codex/skills/dal-performancer` | Best-of-N benchmark gate.                 |
+| `.claude/agents/dal-simplifier.md`   | `.codex/skills/dal-simplifier`   | Read-only unless apply mode is requested. |
+| `.claude/agents/dal-doc-writer.md`   | `.codex/skills/dal-doc-writer`   | Uses current-state docs rule.             |
+
+The Claude-specific tool names `Agent`, `EnterWorktree`, `TaskCreate`, and `SendMessage`
+do not appear in the Codex role files. Codex uses available tools directly and follows the
+session's subagent policy.
+
+Shared role conventions live in `.codex/skills/dal-agent-team/references/shared-rules.md`.

--- a/.codex/skills/dal-api-designer/SKILL.md
+++ b/.codex/skills/dal-api-designer/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: dal-api-designer
+description: Design and critique developer-facing DAL API surfaces. Use for public C++ headers, factory signatures, Python bindings, Excel bindings, example programs, error messages, argument ordering, defaults, naming, and ergonomics before implementation or when an existing API is awkward.
+---
+
+# DAL API Designer
+
+Design the surface a quant, Python user, or Excel author actually sees. Do not implement the
+feature while operating in this role.
+
+## Read First
+
+- Relevant `dal-public/src/` headers.
+- Analogous `dal-cpp/examples/` programs.
+- Excel binding files if Excel-callable.
+- Python binding files if Python-callable.
+- Relevant `docs/methodology/` vocabulary.
+- Existing spec in `.codex/artifacts/specs/` or `.claude/specs/` if referenced.
+
+## Evaluate
+
+- Required arguments first, optional defaults last.
+- More than roughly six positional arguments is a smell; prefer a config struct.
+- Names must match methodology vocabulary.
+- Error messages should name the offending input and constraint.
+- The C++ shape should project cleanly into Python and Excel.
+- Example code should teach the happy path in about 20-50 lines.
+
+## Artifact Path
+
+Write new Codex API notes to:
+
+```text
+.codex/artifacts/api-notes/<feature-slug>.md
+```
+
+## API Note Shape
+
+```markdown
+# <Feature Name> - API Note
+
+## Audiences
+- C++ quants:
+- Excel users:
+- Python users:
+
+## Surface Today
+<signature or n/a>
+
+## Proposed Surface
+~~~cpp
+namespace Dal {
+    Handle_<Type_> NewThing(...);
+}
+~~~
+
+## Why This Shape
+- <decision and alternative>
+
+## Error Cases
+| Input violation | Message text |
+|-----------------|--------------|
+
+## Example
+<10-30 lines of typical use>
+
+## Open Questions
+- <if any>
+```

--- a/.codex/skills/dal-api-designer/agents/openai.yaml
+++ b/.codex/skills/dal-api-designer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL API Designer"
+  short_description: "Design public DAL API surfaces."
+  default_prompt: "Use dal-api-designer to shape this DAL API."

--- a/.codex/skills/dal-critic/SKILL.md
+++ b/.codex/skills/dal-critic/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: dal-critic
+description: Adversarially review DAL specs, API notes, designs, and proposals before implementation. Use to find hidden assumptions, missing edge cases, incorrect methodology, weak acceptance criteria, performance risk, compatibility problems, or quietly bad tradeoffs in plans, not already-implemented code.
+---
+
+# DAL Critic
+
+Attack plans before they harden into code. Do not implement fixes while operating as critic.
+
+## Read First
+
+- Target spec, API note, design, or proposal.
+- Relevant methodology docs.
+- Closest existing analogue in source.
+- Tests for the analogue.
+
+## Axes
+
+- Correctness: methodology, units, day-count, compounding, AAD differentiability.
+- Hidden assumptions: sorted input, non-empty input, thread/tape/currency assumptions.
+- Edge cases: empty, single element, boundaries, duplicate dates, zero/negative, NaN/Inf.
+- Compatibility: callers, tests, serialization, bindings.
+- Performance: complexity, allocation, hot loops, serialized paths.
+- Surface: naming, argument order, defaults, error messages.
+- Test plan: whether tests are real and fail against stubs.
+- Scope: whether the smallest useful version is smaller than the proposal.
+
+## Artifact Path
+
+Write new Codex critiques to:
+
+```text
+.codex/artifacts/critiques/<feature-slug>.md
+```
+
+## Verdicts
+
+Use one: `Block`, `Revise`, `Proceed with caveats`, `Looks fine`.
+
+## Output Shape
+
+```markdown
+# <Feature Name> - Critique
+
+## Target
+- Spec:
+- API note:
+
+## Verdict
+**Block / Revise / Proceed with caveats / Looks fine**
+
+## Findings
+
+### Blocking Issues
+- **<title>** - <problem, evidence, impact>
+  - **Suggested fix:** <concrete change>
+
+### Significant Concerns
+- **<title>** - <problem and fix>
+
+### Minor / Style Notes
+- <note>
+
+## Counter-Proposals
+<brief alternatives>
+
+## Questions for the Author
+- <question>
+```

--- a/.codex/skills/dal-critic/agents/openai.yaml
+++ b/.codex/skills/dal-critic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Critic"
+  short_description: "Stress-test DAL plans."
+  default_prompt: "Use dal-critic to critique this DAL plan."

--- a/.codex/skills/dal-doc-writer/SKILL.md
+++ b/.codex/skills/dal-doc-writer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: dal-doc-writer
+description: Reconcile DAL documentation and changelog with current source. Use when `docs/`, methodology notes, `docs/README.md`, `CLAUDE.md` methodology lists, examples, API listings, or `CHANGELOG.md` need updates after a code change or new capability.
+---
+
+# DAL Doc Writer
+
+Keep docs true against current source. Load
+`.codex/skills/dal-agent-team/references/shared-rules.md` for current-state docs and changelog rules.
+
+## Workflow
+
+1. Establish ground truth from current source, public headers, bindings, examples, and relevant artifacts.
+2. Read target docs in full before editing.
+3. Report discrepancies before rewriting when scope is non-trivial.
+4. Edit docs in place with current-state language.
+5. Update `docs/README.md` and `CLAUDE.md` methodology lists when docs are added, removed, or renamed.
+6. Add `CHANGELOG.md` entries only for fundamental changes.
+7. Check markdown tables, links, trailing whitespace, and final newlines.
+
+Use the shared reference for current-state docs, changelog qualification, and markdown conventions.
+Do not edit C++ source or generated files in this role.

--- a/.codex/skills/dal-doc-writer/agents/openai.yaml
+++ b/.codex/skills/dal-doc-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Doc Writer"
+  short_description: "Reconcile DAL docs."
+  default_prompt: "Use dal-doc-writer to update DAL documentation."

--- a/.codex/skills/dal-git-pr/SKILL.md
+++ b/.codex/skills/dal-git-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: dal-git-pr
+description: Package DAL repository changes into commits and pull requests. Use when the user says to commit, push, open a PR, update a PR, ship it, send for review, or wrap up current work.
+---
+
+# DAL Git PR
+
+## Overview
+
+Use this skill to turn completed work into focused commits and a PR. Preserve unrelated
+user changes and never stage dirty submodule contents or generated build artifacts.
+
+## Workflow
+
+1. Inspect state:
+
+```bash
+git status --short
+git diff --stat
+git diff --staged --stat
+git log --oneline -5
+```
+
+2. Determine the branch. Use an existing feature/fix branch when appropriate; create a new branch from `master` if currently on `master`.
+3. Review the diff carefully. Stage only files that belong to this logical change.
+4. Commit with an imperative summary under 72 characters and a body explaining why.
+5. Push the branch.
+6. Create or update the PR with a concise title under 70 characters.
+
+## Commit Message
+
+Use one logical change per commit:
+
+```text
+Add log-linear interpolation
+
+Explain why the change is needed and what behavior it enables.
+```
+
+Do not append co-author trailers unless the user explicitly asks.
+
+## PR Body
+
+Use this shape:
+
+```markdown
+## Summary
+- <key change>
+- <key change>
+
+## Test plan
+- [x] <targeted test or build>
+- [x] <full suite or rationale if not run>
+```
+
+Allowed PR title prefixes: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`,
+`style:`, `perf:`, `ci:`. Use draft PRs for unfinished work.
+
+## Submodules
+
+Stage submodule pointer updates only when intentional. Do not stage dirty submodule
+working tree contents.

--- a/.codex/skills/dal-git-pr/agents/openai.yaml
+++ b/.codex/skills/dal-git-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Git PR"
+  short_description: "Package DAL changes into commits and PRs."
+  default_prompt: "Use the DAL git PR skill to commit, push, or open a pull request."

--- a/.codex/skills/dal-implementer/SKILL.md
+++ b/.codex/skills/dal-implementer/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: dal-implementer
+description: Implement DAL C++ features and bug fixes with test-driven development. Use when executing a specification, adding a module or class, changing production behavior, wiring generated enums, or iterating from failing tests to passing code in the Derivatives Algorithms Library.
+---
+
+# DAL Implementer
+
+Implement features end to end with TDD. Load
+`.codex/skills/dal-agent-team/references/shared-rules.md` for shared conventions before editing.
+
+## Requirements
+
+- Read the spec, API note, critique, methodology docs, and relevant source/tests before coding.
+- For non-trivial or public changes, state a concise design before editing.
+- Work red -> green -> refactor for each behavior.
+- Never weaken tests to pass.
+- Use the shared reference for build, test, style, and Machinist commands.
+
+## TDD Cycle
+
+1. Red: add one focused failing test and run it.
+2. Green: write the minimum production code to pass.
+3. Refactor: clean up while keeping the test green.
+4. Repeat for edge cases and error cases.
+
+## Wrap-Up
+
+Report files changed, behavior implemented, tests run, and any design deviations.

--- a/.codex/skills/dal-implementer/agents/openai.yaml
+++ b/.codex/skills/dal-implementer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Implementer"
+  short_description: "Implement DAL changes with TDD."
+  default_prompt: "Use dal-implementer to implement this DAL change."

--- a/.codex/skills/dal-orchestrator/SKILL.md
+++ b/.codex/skills/dal-orchestrator/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: dal-orchestrator
+description: Plan and coordinate DAL specialist work. Use when the user says to run the DAL team, pick up an issue end-to-end, delegate across roles, decide which DAL agent should handle a task, or route work through spec, API design, critique, implementation, testing, review, and docs.
+---
+
+# DAL Orchestrator
+
+Act as the dispatcher for the DAL role team. Do not implement code directly while operating
+as orchestrator unless the user changes scope. Analyze, plan, delegate when authorized, and report.
+
+## Inputs To Gather
+
+- User request, issue number, or PR number.
+- Current branch and relevant local state.
+- Existing upstream artifacts in `.codex/artifacts/` or `.claude/` if referenced.
+- Whether the user explicitly authorized subagents or team delegation.
+
+## Routing
+
+- New feature with unclear scope: `dal-spec-writer` -> `dal-critic` -> `dal-implementer` -> `dal-tester` -> `dal-reviewer` -> `dal-doc-writer`.
+- Public API, binding, or example change: `dal-spec-writer` -> `dal-api-designer` -> `dal-critic` -> `dal-implementer` -> `dal-tester` -> `dal-reviewer` -> `dal-doc-writer`.
+- Clear bug fix: `dal-implementer` -> `dal-tester` -> `dal-reviewer` -> `dal-doc-writer`.
+- Test coverage gap: `dal-tester` -> `dal-reviewer`.
+- Post-implementation quality sweeps: `dal-performancer` and/or `dal-simplifier` out of band.
+
+Never skip `dal-reviewer` for code changes. Let `dal-doc-writer` decide if docs or `CHANGELOG.md`
+are needed, except for pure tests or behavior-preserving refactors.
+
+## Delegation Rules
+
+- Spawn subagents only when the user explicitly asks for agents, delegation, team execution, or parallel work.
+- If subagents are not authorized, perform the selected role locally after loading its skill.
+- Give delegated agents self-contained prompts with issue title, paths, acceptance criteria, and write scope.
+- Use sequential delegation when later stages depend on earlier artifacts.
+- Use parallel delegation only for independent sidecar work.
+
+## Report
+
+Summarize:
+
+- Selected route and skipped stages.
+- Which role is active or delegated.
+- Expected artifacts under `.codex/artifacts/`.
+- Blockers or open questions.

--- a/.codex/skills/dal-orchestrator/agents/openai.yaml
+++ b/.codex/skills/dal-orchestrator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Orchestrator"
+  short_description: "Route work across DAL roles."
+  default_prompt: "Use dal-orchestrator to plan and route this DAL task."

--- a/.codex/skills/dal-performancer/SKILL.md
+++ b/.codex/skills/dal-performancer/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dal-performancer
+description: Run or advise on DAL benchmark regression checks and benchmark coverage. Use after implementation and passing tests when the user asks about performance, benchmark regressions, CI benchmark noise, hot paths, or where to add `*_perf` coverage.
+---
+
+# DAL Performancer
+
+Treat benchmark noise as the dominant risk. Do not flag regressions from single runs.
+
+## Regression Set
+
+Gate on these eight benchmarks:
+
+- `tape_perf`
+- `jacobian_perf`
+- `pde_perf`
+- `rng_perf`
+- `interp_perf`
+- `krylov_perf`
+- `banded_perf`
+- `cholesky_perf`
+
+Do not gate on `matrix_perf` or `script_perf`; report them only if asked.
+
+## Measurement Workflow
+
+1. Identify baseline: merge-base against `master` unless the user names a ref.
+2. Build branch and baseline in Release with benchmarks enabled.
+3. Run each benchmark from the build tree path, not stale `bin/`.
+4. Use paired, interleaved runs with N at least 10 for each binary.
+5. Reduce to best-of-N min.
+6. Flag regression only when branch min exceeds baseline min by more than the calibrated noise floor, roughly 2-4 percent.
+
+Build:
+
+```bash
+mkdir -p build
+cd build
+cmake --preset=Release-linux ..
+make -j$(nproc)
+```
+
+## Report Table
+
+| Benchmark | Baseline min (ms) | Branch min (ms) | Delta | Verdict | Notes |
+|-----------|-------------------|-----------------|-------|---------|-------|
+
+Include sample count, environment quietness, and whether the result is inconclusive.
+
+## Coverage Advisory
+
+Map changed hot paths to existing benchmarks. Suggest a new target or extension only when no benchmark covers the path.

--- a/.codex/skills/dal-performancer/agents/openai.yaml
+++ b/.codex/skills/dal-performancer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Performancer"
+  short_description: "Check DAL benchmark risk."
+  default_prompt: "Use dal-performancer to evaluate DAL performance risk."

--- a/.codex/skills/dal-reviewer/SKILL.md
+++ b/.codex/skills/dal-reviewer/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: dal-reviewer
+description: Review DAL code, diffs, and GitHub PRs for correctness, style, tests, docs, generated files, security, and merge readiness. Use when the user asks for a code review, PR review, style gate, safety check, or merge decision.
+---
+
+# DAL Reviewer
+
+Review from a bug-finding stance. Findings come first, ordered by severity.
+
+## PR Intake
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,body,state,headRefName,baseRefName,author,files,statusCheckRollup,reviews
+gh pr diff <PR_NUMBER>
+```
+
+Review the PR head, not the current branch by accident. Prefer a separate worktree when checkout
+is needed and local changes exist.
+
+## Checklist
+
+- Load `.codex/skills/dal-agent-team/references/shared-rules.md`.
+- Cross-check specs, API notes, and critiques when present.
+- Apply the shared review rules and run verification when review scope requires it.
+
+## Output
+
+Use this structure:
+
+```markdown
+## Findings
+- **<file>:<line>** - <issue, impact, suggested fix>
+
+## Open Questions
+- <question>
+
+## Tests
+- <commands run or not run>
+
+## Summary
+<brief>
+
+## Verdict
+Approve / Request Changes / Comment Only
+```
+
+If no findings, say so clearly and mention residual test risk.
+
+Do not submit a GitHub review or merge unless explicitly asked.

--- a/.codex/skills/dal-reviewer/agents/openai.yaml
+++ b/.codex/skills/dal-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Reviewer"
+  short_description: "Review DAL PRs and diffs."
+  default_prompt: "Use dal-reviewer to review this DAL change."

--- a/.codex/skills/dal-simplifier/SKILL.md
+++ b/.codex/skills/dal-simplifier/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: dal-simplifier
+description: Find simplification opportunities in implemented DAL code. Use after implementation or on a named module/diff to detect duplicated logic, near-duplicate types, dead code, verbose constructs, duplicated test setup, and oversized source comments that belong in methodology docs.
+---
+
+# DAL Simplifier
+
+Read implemented code and recommend simplifications. Default mode is report-only. Edit only when
+the user explicitly asks for apply/fix mode.
+
+## Read
+
+- Full changed files or named module files.
+- Closest existing analogue.
+- Relevant tests.
+- `.codex/skills/dal-agent-team/references/shared-rules.md` conventions for no duplication and comment style.
+
+## Look For
+
+- Duplicated functions, branches, switch cases, or setup blocks.
+- Near-duplicate templated and non-templated types.
+- Dead, unreachable, or redundant code.
+- Work computed and discarded.
+- Hand-rolled loops with clearer standard-library or existing-helper forms.
+- Large explanatory comments that should move to `docs/methodology/`.
+
+## Report Shape
+
+```markdown
+## Simplification Report: <target>
+
+### Summary
+<dominant pattern or clean result>
+
+### Findings
+
+#### 1. <short title>
+- **Sites:** <files and symbols>
+- **Pattern:** duplicated logic / near-duplicate type / dead code / verbose construct / oversized comment
+- **Rule:** <project rule>
+- **Why it matters:** <impact>
+- **Recommended fix:** <helper/template/lambda/table/delete/doc migration>
+- **Risk:** low / medium / high
+
+### Not Findings
+- <axis checked and clean>
+```
+
+Do not cite source line numbers in simplification reports; cite symbols and files.

--- a/.codex/skills/dal-simplifier/agents/openai.yaml
+++ b/.codex/skills/dal-simplifier/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Simplifier"
+  short_description: "Find DAL simplifications."
+  default_prompt: "Use dal-simplifier to sweep this DAL code."

--- a/.codex/skills/dal-spec-writer/SKILL.md
+++ b/.codex/skills/dal-spec-writer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: dal-spec-writer
+description: Convert fuzzy DAL requests, thin GitHub issues, performance asks, or one-line feature ideas into precise, testable requirement specifications. Use when scope, inputs, outputs, acceptance criteria, edge cases, AAD behavior, performance targets, or compatibility constraints are unclear before implementation.
+---
+
+# DAL Spec Writer
+
+Turn vague asks into a testable requirement spec. Do not write implementation code.
+
+## Workflow
+
+1. Gather source material: user prompt, GitHub issue body/comments when provided, relevant headers, existing tests, methodology docs, and existing artifacts.
+2. Ask only targeted questions when the answer cannot be inferred safely.
+3. Define goals, non-goals, functional requirements, non-functional requirements, inputs/outputs, and acceptance criteria.
+4. Write a durable spec only when requested or when the team workflow needs one.
+
+## Artifact Path
+
+Write new Codex specs to:
+
+```text
+.codex/artifacts/specs/<feature-slug>.md
+```
+
+Do not write `.claude/specs/` unless explicitly asked.
+
+## Spec Template
+
+```markdown
+# <Feature Name> - Specification
+
+## Source
+- Issue: #<N> or user request on <date>
+- Related methodology: <docs/methodology/*.md>
+
+## Problem Statement
+<2-4 sentences>
+
+## Goals
+- <testable outcome>
+
+## Non-Goals
+- <explicit out-of-scope item>
+
+## Functional Requirements
+- **FR1** - <verifiable behavior>
+
+## Non-Functional Requirements
+- **Performance** - <target, workload, measurement>
+- **Differentiability** - <AAD requirements, if any>
+- **Compatibility** - <what must not break>
+
+## Inputs and Outputs
+| Name | Type | Units | Range / Constraints |
+|------|------|-------|---------------------|
+
+## Acceptance Criteria
+- [ ] Given <state>, when <action>, then <observable result>
+- [ ] Relevant tests pass
+- [ ] Documentation updated where applicable
+
+## Open Questions
+- <unresolved item>
+```
+
+Acceptance criteria must be executable as tests, build checks, or measurable observations.

--- a/.codex/skills/dal-spec-writer/agents/openai.yaml
+++ b/.codex/skills/dal-spec-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Spec Writer"
+  short_description: "Turn DAL asks into testable specs."
+  default_prompt: "Use dal-spec-writer to write a precise DAL specification."

--- a/.codex/skills/dal-tester/SKILL.md
+++ b/.codex/skills/dal-tester/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: dal-tester
+description: Write DAL tests, improve coverage, and repair failing test suites. Use for Google Test coverage in `dal-cpp` or `dal-public`, Playwright e2e smoke tests for `dal-web`, test coverage gap analysis, failing suite triage, or adding tests for new C++ or web behavior.
+---
+
+# DAL Tester
+
+Write focused tests that follow project conventions. Load
+`.codex/skills/dal-agent-team/references/shared-rules.md` for Google Test and web test rules.
+
+## Coverage Workflow
+
+When no module is specified:
+
+1. List subdirectories under `dal-cpp/dal/`, excluding `auto/`.
+2. Count `.cpp` files per module.
+3. Cross-reference tests under `dal-cpp/tests/`.
+4. Rank weakest coverage, prioritizing core modules such as `curve`, `math`, and `script`.
+5. Report the table and start with one self-contained module.
+
+When a module is specified, skip coverage ranking and read that module's headers, sources,
+and existing tests first.
+
+Use the shared reference for test file layout, assertions, singleton/AAD cautions, and commands.
+
+## Report
+
+Summarize tests added, coverage targeted, commands run, and pass/fail status.

--- a/.codex/skills/dal-tester/agents/openai.yaml
+++ b/.codex/skills/dal-tester/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Tester"
+  short_description: "Write and repair DAL tests."
+  default_prompt: "Use dal-tester to add or fix DAL tests."

--- a/.codex/skills/dal-web/SKILL.md
+++ b/.codex/skills/dal-web/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: dal-web
+description: Work on the DAL web UI and backend. Use when starting or stopping the FastAPI/React app, changing `dal-web/`, running backend/frontend/e2e tests, applying the industrial terminal UI style, or enforcing async backend rules.
+---
+
+# DAL Web
+
+## Overview
+
+Use this skill for `dal-web/` tasks: service startup/shutdown, backend FastAPI changes,
+frontend React/Vite work, Playwright smoke tests, persistence configuration, and the
+project's financial terminal UI style.
+
+## Start And Stop
+
+Linux, macOS, WSL, or git-bash:
+
+```bash
+./dal-web/scripts/start.sh
+./dal-web/scripts/stop.sh
+./dal-web/scripts/stop.sh --force
+```
+
+Windows PowerShell 7:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/start.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File dal-web/scripts/stop.ps1 -Force
+```
+
+The frontend is normally at `http://localhost:5173`; backend docs are at
+`http://127.0.0.1:8001/docs`.
+
+## Tests
+
+```bash
+(cd dal-web/backend && uv run pytest)
+(cd dal-web/frontend && npm run build)
+./dal-web/scripts/setup-playwright.sh
+(cd dal-web/frontend && npm run test:e2e)
+```
+
+Run Playwright when frontend/backend contract or user-facing flows change.
+
+## Backend Rules
+
+- New request handlers are `async def`.
+- Offload blocking DAL extension calls from async paths with `await asyncio.to_thread(...)`.
+- The SQLAlchemy `Store`/`DbStore` seam is intentionally synchronous and may be called directly from handlers.
+- Do not change route names, JSON shapes, status codes, or `running -> completed | failed` polling semantics unless explicitly requested.
+
+## Frontend Style
+
+Load `references/web-standards.md` before changing UI. The style is data-dense, technical,
+dark, financial, and restrained.
+
+## References
+
+- `references/web-standards.md`: design palette, layout, component rules, backend async rules, and persistence variables.

--- a/.codex/skills/dal-web/agents/openai.yaml
+++ b/.codex/skills/dal-web/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DAL Web"
+  short_description: "Run and style the DAL web app."
+  default_prompt: "Use the DAL web skill for this web UI task."

--- a/.codex/skills/dal-web/references/web-standards.md
+++ b/.codex/skills/dal-web/references/web-standards.md
@@ -1,0 +1,72 @@
+# DAL Web Standards
+
+## Architecture
+
+- `dal-web/backend/`: FastAPI app using the compiled `dal` Python package.
+- `dal-web/frontend/`: React, TypeScript, Vite.
+- Start/stop scripts live under `dal-web/scripts/`.
+- Default frontend URL: `http://localhost:5173`.
+- Default backend docs URL: `http://127.0.0.1:8001/docs`.
+
+## Backend Rules
+
+- New request handlers are `async def`.
+- Request-path dependencies and helpers should be async.
+- Inside async code, offload blocking DAL extension calls with `await asyncio.to_thread(...)`.
+- The SQLAlchemy `Store`/`DbStore` seam is deliberately synchronous and may be called directly from handlers.
+- Do not rewrite the store to async without an explicit decision.
+- External HTTP contract is immutable unless requested: routes, JSON shapes, status codes, and `running -> completed | failed` polling stay stable.
+- Use type hints on public signatures.
+- Format Python with `ruff format`.
+
+## Persistence
+
+| Variable               | Default                               | Meaning                                      |
+|------------------------|---------------------------------------|----------------------------------------------|
+| `DAL_WEB_DB_URL`       | local SQLite under backend `.data/`   | SQLAlchemy URL for persistence               |
+| `DAL_WEB_STORE`        | unset                                 | `memory` uses the legacy in-memory store     |
+| `DAL_WEB_AUTO_MIGRATE` | unset                                 | `1` runs Alembic upgrade on startup          |
+
+## Tests
+
+```bash
+(cd dal-web/backend && uv run pytest)
+(cd dal-web/frontend && npm run build)
+./dal-web/scripts/setup-playwright.sh
+(cd dal-web/frontend && npm run test:e2e)
+```
+
+## Frontend Design
+
+Use an industrial terminal style inspired by trading desks:
+
+- Dark layered backgrounds.
+- Gold/amber accents for active or important controls.
+- Green for positive/success, red for negative/error, amber for running/warning.
+- Data-dense layouts, restrained decoration, high contrast.
+- Top navigation, not sidebar navigation.
+- Full-width content; avoid unnecessary `max-width`.
+- Spacing follows an 8px grid.
+- Border radius is 6px or less for cards and 4px for controls.
+- No glow effects, grid backgrounds, purple gradients, bounce, or rotation animations.
+- Numbers use JetBrains Mono and tabular numerals.
+- Labels are uppercase, small, and bold.
+
+Core palette:
+
+```css
+--bg: #0f1419;
+--bg-2: #161b22;
+--bg-3: #21262d;
+--bg-elevated: #2d333b;
+--border: #30363d;
+--text: #c9d1d9;
+--text-dim: #8b949e;
+--accent: #d4a017;
+--accent-2: #b8860b;
+--green: #2ea043;
+--red: #da3633;
+--amber: #d29922;
+```
+
+Styles are centralized in `dal-web/frontend/src/styles.css`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,26 @@
 # AGENTS.md
 
+Last updated: 2026-07-04
+
 Codex-native guidance for working in this repository. This file is intentionally separate from
 `CLAUDE.md` and `.claude/`; do not edit the Claude originals unless the user explicitly asks.
 
 ## Codex Artifacts
 
-- Project-local Codex skills are stored under `.codex/skills/`.
-- To make these skills globally discoverable outside this repo, copy or sync each folder under `.codex/skills/` into `~/.codex/skills/`.
-- Prefer the new Codex skills over the Claude agent files when a user asks for implementation, tests, reviews, docs, web work, or PR packaging.
-- The individual Claude roles from `.claude/agents/` have same-name Codex skill equivalents under `.codex/skills/dal-*`.
+- **Reference:** Project-local Codex skills are stored under `.codex/skills/`.
+- **Optional:** To make these skills globally discoverable outside this repo, copy or sync each folder under `.codex/skills/` into `~/.codex/skills/`.
+- **Default:** Prefer the new Codex skills over the Claude agent files when a user asks for implementation, tests, reviews, docs, web work, or PR packaging.
+- **Reference:** The individual Claude roles from `.claude/agents/` have same-name Codex skill equivalents under `.codex/skills/dal-*`.
 
 ## Repository Shape
 
-This is a C++17 quantitative finance workspace with AAD support.
+This is a C++17 quantitative finance workspace with Automatic Adjoint Differentiation (AAD) support.
 
-- `dal-cpp/` is the core library and always builds.
-- `dal-public/` wraps the core C++ API.
-- `dal-python/` contains pybind11 bindings and the Python package.
-- `dal-excel/` contains the Windows Excel add-in.
-- `dal-web/` is a FastAPI backend plus React/Vite frontend and is not built by CMake.
+- **Reference:** `dal-cpp/` is the core library and is enabled in the normal CMake workspace.
+- **Reference:** `dal-public/` wraps the core C++ API.
+- **Reference:** `dal-python/` contains pybind11 bindings and the Python package.
+- **Reference:** `dal-excel/` contains the Windows Excel add-in.
+- **Reference:** `dal-web/` is a FastAPI backend plus React/Vite frontend and is not built by CMake.
 
 The dependency direction is `dal-cpp <- dal-public <- {dal-python, dal-excel}`.
 
@@ -51,16 +53,16 @@ If enum Machinist markup changes, regenerate both core and Excel auto files befo
 
 ## Work Style
 
-- Preserve user changes. Inspect the working tree before edits and never revert unrelated work.
-- Prefer small, test-driven changes for C++ behavior: red, green, refactor.
-- Use `apply_patch` for manual edits.
-- Follow `.clang-format` and the conventions captured in `.codex/skills/dal-agent-team/references/shared-rules.md`.
-- For reviews, lead with findings and file/line references.
-- Keep docs current-state only. Put historical context only in `CHANGELOG.md`.
+- **Mandatory:** Preserve user changes unless the user explicitly requests a revert; inspect the working tree before edits and leave unrelated work alone.
+- **Default:** Prefer small, test-driven changes for C++ behavior: red, green, refactor.
+- **Default:** Use `apply_patch` for manual edits.
+- **Mandatory:** Follow `.clang-format` and the conventions captured in `.codex/skills/dal-agent-team/references/shared-rules.md`.
+- **Mandatory:** For reviews, lead with findings and file/line references.
+- **Mandatory:** Keep docs current-state only. Put historical context only in `CHANGELOG.md`.
 
 ## Skill Routing
 
-- Use `dal-agent-team` for role routing or end-to-end team flow.
-- Use same-name role skills for Claude-agent equivalents: `dal-orchestrator`, `dal-spec-writer`, `dal-api-designer`, `dal-critic`, `dal-implementer`, `dal-tester`, `dal-reviewer`, `dal-performancer`, `dal-simplifier`, and `dal-doc-writer`.
-- Use `dal-web` for starting/stopping the web app, backend async rules, frontend e2e, and web UI design.
-- Use `dal-git-pr` for committing, pushing, and opening or updating PRs.
+- **Default:** Use `dal-agent-team` for role routing or end-to-end team flow.
+- **Default:** Use same-name role skills for Claude-agent equivalents: `dal-orchestrator`, `dal-spec-writer`, `dal-api-designer`, `dal-critic`, `dal-implementer`, `dal-tester`, `dal-reviewer`, `dal-performancer`, `dal-simplifier`, and `dal-doc-writer`.
+- **Default:** Use `dal-web` for starting/stopping the web app, backend async rules, frontend e2e, and web UI design.
+- **Default:** Use `dal-git-pr` for committing, pushing, and opening or updating PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+Codex-native guidance for working in this repository. This file is intentionally separate from
+`CLAUDE.md` and `.claude/`; do not edit the Claude originals unless the user explicitly asks.
+
+## Codex Artifacts
+
+- Project-local Codex skills are stored under `.codex/skills/`.
+- To make these skills globally discoverable outside this repo, copy or sync each folder under `.codex/skills/` into `~/.codex/skills/`.
+- Prefer the new Codex skills over the Claude agent files when a user asks for implementation, tests, reviews, docs, web work, or PR packaging.
+- The individual Claude roles from `.claude/agents/` have same-name Codex skill equivalents under `.codex/skills/dal-*`.
+
+## Repository Shape
+
+This is a C++17 quantitative finance workspace with AAD support.
+
+- `dal-cpp/` is the core library and always builds.
+- `dal-public/` wraps the core C++ API.
+- `dal-python/` contains pybind11 bindings and the Python package.
+- `dal-excel/` contains the Windows Excel add-in.
+- `dal-web/` is a FastAPI backend plus React/Vite frontend and is not built by CMake.
+
+The dependency direction is `dal-cpp <- dal-public <- {dal-python, dal-excel}`.
+
+## Build And Test
+
+Use the existing project scripts and presets:
+
+```bash
+bash ./build_linux.sh
+```
+
+```bash
+mkdir -p build
+cd build
+cmake --preset=Release-linux ..
+make -j$(nproc)
+make install
+```
+
+Run tests from the installed binaries or CTest:
+
+```bash
+(cd build && ctest --output-on-failure)
+bin/dal_cpp_tests
+bin/dal_public_tests
+bin/dal_cpp_tests --gtest_filter=<SuiteName>.*
+```
+
+If enum Machinist markup changes, regenerate both core and Excel auto files before building.
+
+## Work Style
+
+- Preserve user changes. Inspect the working tree before edits and never revert unrelated work.
+- Prefer small, test-driven changes for C++ behavior: red, green, refactor.
+- Use `apply_patch` for manual edits.
+- Follow `.clang-format` and the conventions captured in `.codex/skills/dal-agent-team/references/shared-rules.md`.
+- For reviews, lead with findings and file/line references.
+- Keep docs current-state only. Put historical context only in `CHANGELOG.md`.
+
+## Skill Routing
+
+- Use `dal-agent-team` for role routing or end-to-end team flow.
+- Use same-name role skills for Claude-agent equivalents: `dal-orchestrator`, `dal-spec-writer`, `dal-api-designer`, `dal-critic`, `dal-implementer`, `dal-tester`, `dal-reviewer`, `dal-performancer`, `dal-simplifier`, and `dal-doc-writer`.
+- Use `dal-web` for starting/stopping the web app, backend async rules, frontend e2e, and web UI design.
+- Use `dal-git-pr` for committing, pushing, and opening or updating PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,20 +7,24 @@ Codex-native guidance for working in this repository. This file is intentionally
 
 ## Codex Artifacts
 
-- **Reference:** Project-local Codex skills are stored under `.codex/skills/`.
-- **Optional:** To make these skills globally discoverable outside this repo, copy or sync each folder under `.codex/skills/` into `~/.codex/skills/`.
-- **Default:** Prefer the new Codex skills over the Claude agent files when a user asks for implementation, tests, reviews, docs, web work, or PR packaging.
-- **Reference:** The individual Claude roles from `.claude/agents/` have same-name Codex skill equivalents under `.codex/skills/dal-*`.
+| Priority  | Guidance                                                                                                                                     |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| Reference | Project-local Codex skills are stored under `.codex/skills/`.                                                                                |
+| Optional  | To make these skills globally discoverable outside this repo, copy or sync each folder under `.codex/skills/` into `~/.codex/skills/`.       |
+| Default   | Prefer the new Codex skills over the Claude agent files when a user asks for implementation, tests, reviews, docs, web work, or PR packaging. |
+| Reference | The individual Claude roles from `.claude/agents/` have same-name Codex skill equivalents under `.codex/skills/dal-*`.                       |
 
 ## Repository Shape
 
 This is a C++17 quantitative finance workspace with Automatic Adjoint Differentiation (AAD) support.
 
-- **Reference:** `dal-cpp/` is the core library and is enabled in the normal CMake workspace.
-- **Reference:** `dal-public/` wraps the core C++ API.
-- **Reference:** `dal-python/` contains pybind11 bindings and the Python package.
-- **Reference:** `dal-excel/` contains the Windows Excel add-in.
-- **Reference:** `dal-web/` is a FastAPI backend plus React/Vite frontend and is not built by CMake.
+| Priority  | Path           | Role                                                                            |
+|-----------|----------------|---------------------------------------------------------------------------------|
+| Reference | `dal-cpp/`     | Core library, enabled in the normal CMake workspace.                            |
+| Reference | `dal-public/`  | C++ API wrapper around the core library.                                        |
+| Reference | `dal-python/`  | pybind11 bindings and Python package.                                           |
+| Reference | `dal-excel/`   | Windows Excel add-in.                                                           |
+| Reference | `dal-web/`     | FastAPI backend plus React/Vite frontend; not built by CMake.                   |
 
 The dependency direction is `dal-cpp <- dal-public <- {dal-python, dal-excel}`.
 
@@ -53,16 +57,20 @@ If enum Machinist markup changes, regenerate both core and Excel auto files befo
 
 ## Work Style
 
-- **Mandatory:** Preserve user changes unless the user explicitly requests a revert; inspect the working tree before edits and leave unrelated work alone.
-- **Default:** Prefer small, test-driven changes for C++ behavior: red, green, refactor.
-- **Default:** Use `apply_patch` for manual edits.
-- **Mandatory:** Follow `.clang-format` and the conventions captured in `.codex/skills/dal-agent-team/references/shared-rules.md`.
-- **Mandatory:** For reviews, lead with findings and file/line references.
-- **Mandatory:** Keep docs current-state only. Put historical context only in `CHANGELOG.md`.
+| Priority  | Guidance                                                                                                                                       |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| Mandatory | Preserve user changes unless the user explicitly requests a revert; inspect the working tree before edits and leave unrelated work alone.       |
+| Default   | Prefer small, test-driven changes for C++ behavior: red, green, refactor.                                                                      |
+| Default   | Use `apply_patch` for manual edits.                                                                                                            |
+| Mandatory | Follow `.clang-format` and the conventions captured in `.codex/skills/dal-agent-team/references/shared-rules.md`.                              |
+| Mandatory | For reviews, lead with findings and file/line references.                                                                                      |
+| Mandatory | Keep docs current-state only. Put historical context only in `CHANGELOG.md`.                                                                   |
 
 ## Skill Routing
 
-- **Default:** Use `dal-agent-team` for role routing or end-to-end team flow.
-- **Default:** Use same-name role skills for Claude-agent equivalents: `dal-orchestrator`, `dal-spec-writer`, `dal-api-designer`, `dal-critic`, `dal-implementer`, `dal-tester`, `dal-reviewer`, `dal-performancer`, `dal-simplifier`, and `dal-doc-writer`.
-- **Default:** Use `dal-web` for starting/stopping the web app, backend async rules, frontend e2e, and web UI design.
-- **Default:** Use `dal-git-pr` for committing, pushing, and opening or updating PRs.
+| Priority | Skill or group             | Use for                                                                                                                                                                   |
+|----------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Default  | `dal-agent-team`           | Role routing or end-to-end team flow.                                                                                                                                     |
+| Default  | Same-name role skills      | Claude-agent equivalents: `dal-orchestrator`, `dal-spec-writer`, `dal-api-designer`, `dal-critic`, `dal-implementer`, `dal-tester`, `dal-reviewer`, `dal-performancer`, `dal-simplifier`, and `dal-doc-writer`. |
+| Default  | `dal-web`                  | Starting/stopping the web app, backend async rules, frontend e2e, and web UI design.                                                                                      |
+| Default  | `dal-git-pr`               | Committing, pushing, and opening or updating PRs.                                                                                                                         |


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` for Codex-native repository routing.
- Add a simplified `.codex/skills/` DAL agent team converted from `.claude/agents/`.
- Centralize shared DAL conventions in `dal-agent-team/references/shared-rules.md` and keep only non-duplicative utility skills for web and PR work.

## Test plan
- [x] Ran `quick_validate.py` for each `.codex/skills/*` skill.
- [x] Ran `git diff --cached --check` before commit.