### PR TITLE
fix: guard script result lookup

### DIFF
--- a/dal-cpp/dal/script/simulation.hpp
+++ b/dal-cpp/dal/script/simulation.hpp
@@ -30,8 +30,10 @@ namespace Dal::Script {
         Vector_<String_> names_;
         std::map<String_, const double*> results_;
 
-        FORCE_INLINE double operator[](const String_& name) {
-            return *results_[name];
+        [[nodiscard]] FORCE_INLINE double operator[](const String_& name) const {
+            const auto it = results_.find(name);
+            REQUIRE2(it != results_.end(), "simulation result '" + name + "' is not available", ScriptError_);
+            return *it->second;
         }
     };
 

--- a/dal-cpp/tests/script/test_compile_parity.cpp
+++ b/dal-cpp/tests/script/test_compile_parity.cpp
@@ -323,6 +323,16 @@ TEST(ScriptCompiledParityTest, TestParity_CompileNotCalled_GuardsThrow) {
     ASSERT_THROW(MCSimulation<double>(product, model, 64, "sobol", false, true), Dal::Exception_);
 }
 
+TEST(ScriptCompiledParityTest, TestSimResultsLookupRejectsUnknownName) {
+    Vector_<String_> names;
+    names.push_back(String_("delta"));
+    SimResults_ results(names);
+    results.risks_[0] = 1.25;
+
+    ASSERT_NEAR(results[String_("delta")], 1.25, 1e-10);
+    ASSERT_THROW(static_cast<void>(results[String_("missing")]), Dal::Exception_);
+}
+
 TEST(ScriptCompiledParityTest, TestParity_Number_ConstVarRisks) {
     Global::Dates_::SetEvaluationDate(Date_(2022, 6, 22));
     Date_ exerciseDate(2024, 6, 21);


### PR DESCRIPTION
## Summary
- Guard SimResults_ lookup so unknown result names throw a DAL exception instead of inserting a null pointer
- Add regression coverage for known and missing simulation result lookups

## Test plan
- [x] MSBuild.exe build\\dal-cpp\\dal_cpp_tests.vcxproj /p:Configuration=Release /m:1 /v:minimal /p:BuildInParallel=false
- [x] .\\build\\dal-cpp\\Release\\dal_cpp_tests.exe --gtest_filter=ScriptCompiledParityTest.TestSimResultsLookupRejectsUnknownName:ScriptTest.TestFuzzyNotEqualContinuous:ScriptCompiledParityTest.TestParity_Number_ConstVarRisks:ScriptCompiledParityTest.TestParity_ConstVarVals_MutationSeam:ScriptCompiledParityTest.TestParity_Number_NotEqual_Fuzzy
- [x] .\\build\\dal-cpp\\Release\\dal_cpp_tests.exe --gtest_filter=ScriptCompiledParityTest.*