### PR TITLE
fix: scope dal gitignore rule to repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ build-*
 build2/
 CMakeUserPresets.json
 # Installed Python bindings (build artifact)
-dal/
+/dal/
 .claude/scheduled_tasks.lock
 /cmake/
 /pyproject.toml


### PR DESCRIPTION
## Summary
- Anchor the installed `dal/` build artifact ignore rule to the repository root.
- Allow nested directories named `dal`, such as `public/python/dal`, to be tracked by Git.

## Test plan
- [x] `git check-ignore -v dal/example.tmp`
- [x] `git check-ignore -v public/python/dal/example.tmp`