### PR TITLE
fix: avoid shared double accumulation in script MC

### DIFF
--- a/dal-cpp/dal/script/simulation.hpp
+++ b/dal-cpp/dal/script/simulation.hpp
@@ -138,13 +138,14 @@ namespace Dal::Script {
                 Scenario_<>& path = paths[threadNum];
                 auto& random = rngVector[threadNum];
                 random->SkipTo(firstPath);
+                double sumValue = 0.0;
                 if (useCompiled) {
                     EvalState_<double>& evalState = evalStateVector[threadNum];
                     for (size_t i = 0; i < pathsInTask; ++i) {
                         random->FillNormal(&gaussVec);
                         mdl->GeneratePath(gaussVec, &path);
                         compiledProduct->Evaluate(path, evalState);
-                        simResult += evalState.VarVals()[payoffIndex];
+                        sumValue += evalState.VarVals()[payoffIndex];
                     }
                 } else {
                     Evaluator_<double>& eval = evalVector[threadNum];
@@ -152,9 +153,10 @@ namespace Dal::Script {
                         random->FillNormal(&gaussVec);
                         mdl->GeneratePath(gaussVec, &path);
                         product.Evaluate(path, eval);
-                        simResult += eval.VarVals()[payoffIndex];
+                        sumValue += eval.VarVals()[payoffIndex];
                     }
                 }
+                simResult = sumValue;
                 return true;
             }));
             pathsLeft -= pathsInTask;


### PR DESCRIPTION
## Summary
- Accumulate double-path script MC payoffs in a local per-task variable before writing the task result slot.
- Align the double path with the existing `Number_` accumulation pattern to avoid repeated writes to shared result storage in the inner loop.

## Test plan
- [x] `cmake --build build --target script_mc_perf -j$(nproc)`
- [x] `build/dal-cpp/benchmarks/script_mc_perf/script_mc_perf`
