### PR TITLE
perf: flatten compiled script dispatch

### DIFF
--- a/dal-cpp/dal/script/visitor/compiler.hpp
+++ b/dal-cpp/dal/script/visitor/compiler.hpp
@@ -368,493 +368,6 @@ namespace Dal::Script {
                              bool reset = true);
 
     template <class T_>
-    inline bool EvalBasicArithmeticOp(int op, size_t& i, StaticStack_<T_>& dStack) {
-        switch (op) {
-        case Add:
-            dStack[1] += dStack.Top();
-            dStack.Pop();
-            ++i;
-            return true;
-        case Sub:
-            dStack[1] -= dStack.Top();
-            dStack.Pop();
-            ++i;
-            return true;
-        case Multi:
-            dStack[1] *= dStack.Top();
-            dStack.Pop();
-            ++i;
-            return true;
-        case Div:
-            dStack[1] /= dStack.Top();
-            dStack.Pop();
-            ++i;
-            return true;
-        case Pow:
-            dStack[1] = pow(dStack[1], dStack.Top());
-            dStack.Pop();
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalExtremaOp(int op, size_t& i, StaticStack_<T_>& dStack) {
-        switch (op) {
-        case Max2: {
-            const T_ y = dStack.TopAndPop();
-            if (y > dStack[0])
-                dStack[0] = y;
-            ++i;
-            return true;
-        }
-        case Min2: {
-            const T_ y = dStack.TopAndPop();
-            if (y < dStack[0])
-                dStack[0] = y;
-            ++i;
-            return true;
-        }
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalConstArithmeticOp(int op,
-                                      const Vector_<int>& nodeStream,
-                                      const Vector_<double>& constStream,
-                                      size_t& i,
-                                      StaticStack_<T_>& dStack) {
-        switch (op) {
-        case AddConst:
-            dStack.Top() += constStream[nodeStream[++i]];
-            ++i;
-            return true;
-        case SubConst:
-            dStack.Top() -= constStream[nodeStream[++i]];
-            ++i;
-            return true;
-        case ConstSub:
-            dStack.Top() = constStream[nodeStream[++i]] - dStack.Top();
-            ++i;
-            return true;
-        case MultiConst:
-            dStack.Top() *= constStream[nodeStream[++i]];
-            ++i;
-            return true;
-        case DivConst:
-            dStack.Top() /= constStream[nodeStream[++i]];
-            ++i;
-            return true;
-        case ConstDiv:
-            dStack.Top() = constStream[nodeStream[++i]] / dStack.Top();
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalConstPowOp(int op,
-                               const Vector_<int>& nodeStream,
-                               const Vector_<double>& constStream,
-                               size_t& i,
-                               StaticStack_<T_>& dStack) {
-        switch (op) {
-        case PowConst:
-            dStack.Top() = pow(dStack.Top(), constStream[nodeStream[++i]]);
-            ++i;
-            return true;
-        case ConstPow:
-            dStack.Top() = pow(constStream[nodeStream[++i]], dStack.Top());
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalConstExtremaOp(int op,
-                                   const Vector_<int>& nodeStream,
-                                   const Vector_<double>& constStream,
-                                   size_t& i,
-                                   StaticStack_<T_>& dStack) {
-        switch (op) {
-        case Max2Const: {
-            const T_ y(constStream[nodeStream[++i]]);
-            if (y > dStack.Top())
-                dStack.Top() = y;
-            ++i;
-            return true;
-        }
-        case Min2Const: {
-            const T_ y(constStream[nodeStream[++i]]);
-            if (y < dStack.Top())
-                dStack.Top() = y;
-            ++i;
-            return true;
-        }
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalUnaryMathOp(int op, size_t& i, StaticStack_<T_>& dStack) {
-        switch (op) {
-        case Sqrt:
-            dStack.Top() = sqrt(dStack.Top());
-            ++i;
-            return true;
-        case Log:
-            dStack.Top() = log(dStack.Top());
-            ++i;
-            return true;
-        case Exp:
-            dStack.Top() = exp(dStack.Top());
-            ++i;
-            return true;
-        case UMinus:
-            dStack.Top() = -dStack.Top();
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalLoadOp(int op,
-                           const Vector_<int>& nodeStream,
-                           const Vector_<double>& constStream,
-                           const AAD::Sample_<T_>& scenario,
-                           EvalState_<T_>& state,
-                           size_t& i,
-                           StaticStack_<T_>& dStack) {
-        switch (op) {
-        case Spot:
-            dStack.Push(scenario.spot_);
-            ++i;
-            return true;
-        case Var:
-            dStack.Push(state.variables_[nodeStream[++i]]);
-            ++i;
-            return true;
-        case ConstVar:
-            dStack.Push(state.constVariables_[nodeStream[++i]]);
-            ++i;
-            return true;
-        case Const:
-            dStack.Push(constStream[nodeStream[++i]]);
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalStoreOp(int op,
-                            const Vector_<int>& nodeStream,
-                            const Vector_<double>& constStream,
-                            const AAD::Sample_<T_>& scenario,
-                            EvalState_<T_>& state,
-                            size_t& i,
-                            StaticStack_<T_>& dStack) {
-        switch (op) {
-        case Assign: {
-            const size_t idx = nodeStream[++i];
-            state.variables_[idx] = dStack.TopAndPop();
-            ++i;
-            return true;
-        }
-        case AssignConst: {
-            const double val = constStream[nodeStream[++i]];
-            const size_t idx = nodeStream[++i];
-            state.variables_[idx] = T_(val);
-            ++i;
-            return true;
-        }
-        case Pays: {
-            const size_t idx = nodeStream[++i];
-            state.variables_[idx] += dStack.TopAndPop() / scenario.numeraire_;
-            ++i;
-            return true;
-        }
-        case PaysConst: {
-            const double val = constStream[nodeStream[++i]];
-            const size_t idx = nodeStream[++i];
-            state.variables_[idx] += T_(val) / scenario.numeraire_;
-            ++i;
-            return true;
-        }
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalBranchOp(int op,
-                             const Vector_<int>& nodeStream,
-                             const Vector_<double>& constStream,
-                             const AAD::Sample_<T_>& scenario,
-                             EvalState_<T_>& state,
-                             size_t& i,
-                             StaticStack_<bool>& bStack) {
-        switch (op) {
-        case If:
-            if (bStack.Top()) {
-                i += 2;
-            } else {
-                i = nodeStream[++i];
-            }
-            bStack.Pop();
-            return true;
-        case IfElse:
-            if (!bStack.Top()) {
-                i = nodeStream[++i];
-            } else {
-                //  Preserve parent stacks while running the true branch.
-                EvalCompiled(nodeStream, constStream, scenario, state, i + 3, nodeStream[i + 1], false);
-                i = nodeStream[i + 2];
-            }
-            bStack.Pop();
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalComparisonOp(int op, size_t& i, StaticStack_<T_>& dStack, StaticStack_<bool>& bStack) {
-        switch (op) {
-        case Equal:
-            bStack.Push(dStack.TopAndPop() == 0);
-            ++i;
-            return true;
-        case Sup:
-            bStack.Push(dStack.TopAndPop() > 0);
-            ++i;
-            return true;
-        case SupEqual:
-            bStack.Push(dStack.TopAndPop() >= 0);
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    inline bool EvalLogicalOp(int op, size_t& i, StaticStack_<bool>& bStack) {
-        switch (op) {
-        case And:
-            if (bStack[1])
-                bStack[1] = bStack.Top();
-            bStack.Pop();
-            ++i;
-            return true;
-        case Or:
-            if (!bStack[1])
-                bStack[1] = bStack.Top();
-            bStack.Pop();
-            ++i;
-            return true;
-        case Not:
-            bStack.Top() = !bStack.Top();
-            ++i;
-            return true;
-        case True:
-            bStack.Push(true);
-            ++i;
-            return true;
-        case False:
-            bStack.Push(false);
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalFuzzyConditionOp(int op,
-                                     const Vector_<int>& nodeStream,
-                                     const Vector_<double>& constStream,
-                                     EvalState_<T_>& state,
-                                     size_t& i,
-                                     StaticStack_<T_>& dStack) {
-        switch (op) {
-        case FuzzyEqual: {
-            const double eps = constStream[nodeStream[++i]];
-            dStack.Top() = BFly(dStack.Top(), eps < 0 ? state.defEps_ : eps);
-            ++i;
-            return true;
-        }
-        case FuzzyEqualDiscrete: {
-            const double lb = constStream[nodeStream[++i]];
-            const double rb = constStream[nodeStream[++i]];
-            dStack.Top() = BFly(dStack.Top(), lb, rb);
-            ++i;
-            return true;
-        }
-        case FuzzyComp: {
-            const double eps = constStream[nodeStream[++i]];
-            dStack.Top() = CSpr(dStack.Top(), eps < 0 ? state.defEps_ : eps);
-            ++i;
-            return true;
-        }
-        case FuzzyCompDiscrete: {
-            const double lb = constStream[nodeStream[++i]];
-            const double rb = constStream[nodeStream[++i]];
-            dStack.Top() = CSpr(dStack.Top(), lb, rb);
-            ++i;
-            return true;
-        }
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalFuzzyLogicOp(int op, size_t& i, StaticStack_<T_>& dStack) {
-        switch (op) {
-        case FuzzyAnd: {
-            const T_ x = dStack.TopAndPop();
-            dStack.Top() *= x;
-            ++i;
-            return true;
-        }
-        case FuzzyOr: {
-            const T_ x = dStack.TopAndPop();
-            const T_ y = dStack.TopAndPop();
-            dStack.Push(x + y - x * y);
-            ++i;
-            return true;
-        }
-        case FuzzyNot:
-            dStack.Top() = 1.0 - dStack.Top();
-            ++i;
-            return true;
-        case FuzzyTrue:
-            dStack.Push(T_(1.0));
-            ++i;
-            return true;
-        case FuzzyFalse:
-            dStack.Push(T_(0.0));
-            ++i;
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    template <class T_>
-    inline bool EvalFuzzyIfOp(int op,
-                              const Vector_<int>& nodeStream,
-                              const Vector_<double>& constStream,
-                              const AAD::Sample_<T_>& scenario,
-                              EvalState_<T_>& state,
-                              size_t& i,
-                              StaticStack_<T_>& dStack) {
-        if (op != FuzzyIf)
-            return false;
-
-        //  Layout: FuzzyIf lastTrue lastFalse nAff aff... [true][false]
-        const size_t lastTrue = nodeStream[i + 1];
-        const size_t lastFalse = nodeStream[i + 2];
-        const int nAff = nodeStream[i + 3];
-        const size_t firstAff = i + 4;
-        const size_t firstTrue = firstAff + nAff;
-
-        const T_ t = dStack.TopAndPop();
-        if (t > 1.0 - EPSILON) {
-            EvalCompiled(nodeStream, constStream, scenario, state, firstTrue, lastTrue, false);
-            i = lastFalse;
-        } else if (t < EPSILON) {
-            i = lastTrue;
-        } else {
-            const size_t lvl = state.nestedIfLvl_++;
-            for (int k = 0; k < nAff; ++k) {
-                const size_t idx = nodeStream[firstAff + k];
-                state.varStore0_[lvl][idx] = state.variables_[idx];
-            }
-            EvalCompiled(nodeStream, constStream, scenario, state, firstTrue, lastTrue, false);
-            for (int k = 0; k < nAff; ++k) {
-                const size_t idx = nodeStream[firstAff + k];
-                state.varStore1_[lvl][idx] = state.variables_[idx];
-                state.variables_[idx] = state.varStore0_[lvl][idx];
-            }
-            EvalCompiled(nodeStream, constStream, scenario, state, lastTrue, lastFalse, false);
-            for (int k = 0; k < nAff; ++k) {
-                const size_t idx = nodeStream[firstAff + k];
-                state.variables_[idx] = t * state.varStore1_[lvl][idx] + (1.0 - t) * state.variables_[idx];
-            }
-            --state.nestedIfLvl_;
-            i = lastFalse;
-        }
-        return true;
-    }
-
-    template <class T_>
-    inline bool EvalLowOpcode(int op,
-                              const Vector_<int>& nodeStream,
-                              const Vector_<double>& constStream,
-                              size_t& i,
-                              StaticStack_<T_>& dStack) {
-        if (EvalBasicArithmeticOp(op, i, dStack))
-            return true;
-        if (EvalExtremaOp(op, i, dStack))
-            return true;
-        if (EvalConstArithmeticOp(op, nodeStream, constStream, i, dStack))
-            return true;
-        if (EvalConstPowOp(op, nodeStream, constStream, i, dStack))
-            return true;
-        return EvalConstExtremaOp(op, nodeStream, constStream, i, dStack);
-    }
-
-    template <class T_>
-    inline bool EvalMidOpcode(int op,
-                              const Vector_<int>& nodeStream,
-                              const Vector_<double>& constStream,
-                              const AAD::Sample_<T_>& scenario,
-                              EvalState_<T_>& state,
-                              size_t& i,
-                              StaticStack_<T_>& dStack,
-                              StaticStack_<bool>& bStack) {
-        if (EvalUnaryMathOp(op, i, dStack))
-            return true;
-        if (EvalLoadOp(op, nodeStream, constStream, scenario, state, i, dStack))
-            return true;
-        if (EvalStoreOp(op, nodeStream, constStream, scenario, state, i, dStack))
-            return true;
-        if (EvalBranchOp(op, nodeStream, constStream, scenario, state, i, bStack))
-            return true;
-        if (EvalComparisonOp(op, i, dStack, bStack))
-            return true;
-        return EvalLogicalOp(op, i, bStack);
-    }
-
-    template <class T_>
-    inline bool EvalFuzzyOpcode(int op,
-                                const Vector_<int>& nodeStream,
-                                const Vector_<double>& constStream,
-                                const AAD::Sample_<T_>& scenario,
-                                EvalState_<T_>& state,
-                                size_t& i,
-                                StaticStack_<T_>& dStack) {
-        if (EvalFuzzyConditionOp(op, nodeStream, constStream, state, i, dStack))
-            return true;
-        if (EvalFuzzyLogicOp(op, i, dStack))
-            return true;
-        return EvalFuzzyIfOp(op, nodeStream, constStream, scenario, state, i, dStack);
-    }
-
-    template <class T_>
     inline void EvalCompiled(const Vector_<int>& nodeStream,
                              const Vector_<double>& constStream,
                              const AAD::Sample_<T_>& scenario,
@@ -874,13 +387,294 @@ namespace Dal::Script {
 
         while (i < n) {
             const int op = nodeStream[i];
-            if (EvalLowOpcode(op, nodeStream, constStream, i, dStack))
-                continue;
-            if (EvalMidOpcode(op, nodeStream, constStream, scenario, state, i, dStack, bStack))
-                continue;
-            if (EvalFuzzyOpcode(op, nodeStream, constStream, scenario, state, i, dStack))
-                continue;
-            THROW("unknown compiled script opcode: " + std::to_string(op));
+            switch (op) {
+            case Add:
+                dStack[1] += dStack.Top();
+                dStack.Pop();
+                ++i;
+                break;
+            case AddConst:
+                dStack.Top() += constStream[nodeStream[++i]];
+                ++i;
+                break;
+            case Sub:
+                dStack[1] -= dStack.Top();
+                dStack.Pop();
+                ++i;
+                break;
+            case SubConst:
+                dStack.Top() -= constStream[nodeStream[++i]];
+                ++i;
+                break;
+            case ConstSub:
+                dStack.Top() = constStream[nodeStream[++i]] - dStack.Top();
+                ++i;
+                break;
+            case Multi:
+                dStack[1] *= dStack.Top();
+                dStack.Pop();
+                ++i;
+                break;
+            case MultiConst:
+                dStack.Top() *= constStream[nodeStream[++i]];
+                ++i;
+                break;
+            case Div:
+                dStack[1] /= dStack.Top();
+                dStack.Pop();
+                ++i;
+                break;
+            case DivConst:
+                dStack.Top() /= constStream[nodeStream[++i]];
+                ++i;
+                break;
+            case ConstDiv:
+                dStack.Top() = constStream[nodeStream[++i]] / dStack.Top();
+                ++i;
+                break;
+            case Pow:
+                dStack[1] = pow(dStack[1], dStack.Top());
+                dStack.Pop();
+                ++i;
+                break;
+            case PowConst:
+                dStack.Top() = pow(dStack.Top(), constStream[nodeStream[++i]]);
+                ++i;
+                break;
+            case ConstPow:
+                dStack.Top() = pow(constStream[nodeStream[++i]], dStack.Top());
+                ++i;
+                break;
+            case Max2: {
+                const T_ y = dStack.TopAndPop();
+                if (y > dStack[0])
+                    dStack[0] = y;
+                ++i;
+                break;
+            }
+            case Max2Const: {
+                const T_ y(constStream[nodeStream[++i]]);
+                if (y > dStack.Top())
+                    dStack.Top() = y;
+                ++i;
+                break;
+            }
+            case Min2: {
+                const T_ y = dStack.TopAndPop();
+                if (y < dStack[0])
+                    dStack[0] = y;
+                ++i;
+                break;
+            }
+            case Min2Const: {
+                const T_ y(constStream[nodeStream[++i]]);
+                if (y < dStack.Top())
+                    dStack.Top() = y;
+                ++i;
+                break;
+            }
+            case Spot:
+                dStack.Push(scenario.spot_);
+                ++i;
+                break;
+            case Var:
+                dStack.Push(state.variables_[nodeStream[++i]]);
+                ++i;
+                break;
+            case ConstVar:
+                dStack.Push(state.constVariables_[nodeStream[++i]]);
+                ++i;
+                break;
+            case Const:
+                dStack.Push(constStream[nodeStream[++i]]);
+                ++i;
+                break;
+            case Assign: {
+                const size_t idx = nodeStream[++i];
+                state.variables_[idx] = dStack.TopAndPop();
+                ++i;
+                break;
+            }
+            case AssignConst: {
+                const double val = constStream[nodeStream[++i]];
+                const size_t idx = nodeStream[++i];
+                state.variables_[idx] = T_(val);
+                ++i;
+                break;
+            }
+            case Pays: {
+                const size_t idx = nodeStream[++i];
+                state.variables_[idx] += dStack.TopAndPop() / scenario.numeraire_;
+                ++i;
+                break;
+            }
+            case PaysConst: {
+                const double val = constStream[nodeStream[++i]];
+                const size_t idx = nodeStream[++i];
+                state.variables_[idx] += T_(val) / scenario.numeraire_;
+                ++i;
+                break;
+            }
+            case If:
+                if (bStack.Top()) {
+                    i += 2;
+                } else {
+                    i = nodeStream[++i];
+                }
+                bStack.Pop();
+                break;
+            case IfElse:
+                if (!bStack.Top()) {
+                    i = nodeStream[++i];
+                } else {
+                    //  Preserve parent stacks while running the true branch.
+                    EvalCompiled(nodeStream, constStream, scenario, state, i + 3, nodeStream[i + 1], false);
+                    i = nodeStream[i + 2];
+                }
+                bStack.Pop();
+                break;
+            case Equal:
+                bStack.Push(dStack.TopAndPop() == 0);
+                ++i;
+                break;
+            case Sup:
+                bStack.Push(dStack.TopAndPop() > 0);
+                ++i;
+                break;
+            case SupEqual:
+                bStack.Push(dStack.TopAndPop() >= 0);
+                ++i;
+                break;
+            case And:
+                if (bStack[1])
+                    bStack[1] = bStack.Top();
+                bStack.Pop();
+                ++i;
+                break;
+            case Or:
+                if (!bStack[1])
+                    bStack[1] = bStack.Top();
+                bStack.Pop();
+                ++i;
+                break;
+            case Sqrt:
+                dStack.Top() = sqrt(dStack.Top());
+                ++i;
+                break;
+            case Log:
+                dStack.Top() = log(dStack.Top());
+                ++i;
+                break;
+            case Exp:
+                dStack.Top() = exp(dStack.Top());
+                ++i;
+                break;
+            case Not:
+                bStack.Top() = !bStack.Top();
+                ++i;
+                break;
+            case UMinus:
+                dStack.Top() = -dStack.Top();
+                ++i;
+                break;
+            case True:
+                bStack.Push(true);
+                ++i;
+                break;
+            case False:
+                bStack.Push(false);
+                ++i;
+                break;
+            case FuzzyEqual: {
+                const double eps = constStream[nodeStream[++i]];
+                dStack.Top() = BFly(dStack.Top(), eps < 0 ? state.defEps_ : eps);
+                ++i;
+                break;
+            }
+            case FuzzyEqualDiscrete: {
+                const double lb = constStream[nodeStream[++i]];
+                const double rb = constStream[nodeStream[++i]];
+                dStack.Top() = BFly(dStack.Top(), lb, rb);
+                ++i;
+                break;
+            }
+            case FuzzyComp: {
+                const double eps = constStream[nodeStream[++i]];
+                dStack.Top() = CSpr(dStack.Top(), eps < 0 ? state.defEps_ : eps);
+                ++i;
+                break;
+            }
+            case FuzzyCompDiscrete: {
+                const double lb = constStream[nodeStream[++i]];
+                const double rb = constStream[nodeStream[++i]];
+                dStack.Top() = CSpr(dStack.Top(), lb, rb);
+                ++i;
+                break;
+            }
+            case FuzzyAnd: {
+                const T_ x = dStack.TopAndPop();
+                dStack.Top() *= x;
+                ++i;
+                break;
+            }
+            case FuzzyOr: {
+                const T_ x = dStack.TopAndPop();
+                const T_ y = dStack.TopAndPop();
+                dStack.Push(x + y - x * y);
+                ++i;
+                break;
+            }
+            case FuzzyNot:
+                dStack.Top() = 1.0 - dStack.Top();
+                ++i;
+                break;
+            case FuzzyTrue:
+                dStack.Push(T_(1.0));
+                ++i;
+                break;
+            case FuzzyFalse:
+                dStack.Push(T_(0.0));
+                ++i;
+                break;
+            case FuzzyIf: {
+                //  Layout: FuzzyIf lastTrue lastFalse nAff aff... [true][false]
+                const size_t lastTrue = nodeStream[i + 1];
+                const size_t lastFalse = nodeStream[i + 2];
+                const int nAff = nodeStream[i + 3];
+                const size_t firstAff = i + 4;
+                const size_t firstTrue = firstAff + nAff;
+
+                const T_ t = dStack.TopAndPop();
+                if (t > 1.0 - EPSILON) {
+                    EvalCompiled(nodeStream, constStream, scenario, state, firstTrue, lastTrue, false);
+                    i = lastFalse;
+                } else if (t < EPSILON) {
+                    i = lastTrue;
+                } else {
+                    const size_t lvl = state.nestedIfLvl_++;
+                    for (int k = 0; k < nAff; ++k) {
+                        const size_t idx = nodeStream[firstAff + k];
+                        state.varStore0_[lvl][idx] = state.variables_[idx];
+                    }
+                    EvalCompiled(nodeStream, constStream, scenario, state, firstTrue, lastTrue, false);
+                    for (int k = 0; k < nAff; ++k) {
+                        const size_t idx = nodeStream[firstAff + k];
+                        state.varStore1_[lvl][idx] = state.variables_[idx];
+                        state.variables_[idx] = state.varStore0_[lvl][idx];
+                    }
+                    EvalCompiled(nodeStream, constStream, scenario, state, lastTrue, lastFalse, false);
+                    for (int k = 0; k < nAff; ++k) {
+                        const size_t idx = nodeStream[firstAff + k];
+                        state.variables_[idx] = t * state.varStore1_[lvl][idx] + (1.0 - t) * state.variables_[idx];
+                    }
+                    --state.nestedIfLvl_;
+                    i = lastFalse;
+                }
+                break;
+            }
+            default:
+                THROW("unknown compiled script opcode: " + std::to_string(op));
+            }
         }
     }
 } // namespace Dal::Script


### PR DESCRIPTION
## Summary
- Replace compiled script evaluator's layered opcode category dispatch with one flat opcode switch in `EvalCompiled`.
- Remove the now-dead helper evaluator functions so opcode execution has a single implementation path.
- Keeps the compiled bytecode format and public API unchanged.

## Review
- [x] In-band DAL reviewer pass found dead duplicated opcode helpers after the initial flat-switch change.
- [x] Addressed the review finding by removing the stale helper evaluator path before publishing.

## Test plan
- [x] `cmake --build build --target script_mc_perf dal_cpp_tests -j$(nproc)`
- [x] `build/dal-cpp/dal_cpp_tests '--gtest_filter=Script*'` - 201/201 passed
- [x] `build/dal-cpp/benchmarks/script_mc_perf/script_mc_perf`
- [x] Temporary `script_mc_perf` run with `kRepeats = 30` on this branch:
  - weekly barrier double compiled=false min: `13.833 ms`
  - weekly barrier double compiled=true min: `8.801 ms`
  - weekly barrier Number_ compiled=false min: `3.313 ms`
  - weekly barrier Number_ compiled=true min: `2.966 ms`
