### PR TITLE
perf: add PDE scheme benchmark coverage

### DIFF
--- a/dal-cpp/benchmarks/pde_perf/pde_perf.cpp
+++ b/dal-cpp/benchmarks/pde_perf/pde_perf.cpp
@@ -2,15 +2,20 @@
 // Created by dal-implementer on 2026-6-28.
 //
 // PDE time-stepping micro-benchmark.
-// Prices a European call via ThetaScheme_ with Crank-Nicolson (theta = 0.5),
-// 200 space steps and 200 time steps. Each timed iteration rebuilds the grid,
-// prepares the operator, and runs the full rollback loop.
+// Prices a European call via ThetaScheme_ with explicit, Crank-Nicolson, and
+// implicit schemes. Each timed iteration rebuilds the grid, prepares the
+// operator, and runs the full rollback loop.
 
 #include <dal/platform/platform.hpp>
+
 #include <dal/benchmarks/bench.hpp>
 #include <dal/math/pde/pdegrid.hpp>
 #include <dal/math/pde/thetascheme.hpp>
 #include <dal/math/vectors.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
 
 using namespace Dal;
 using namespace Dal::PDE;
@@ -18,13 +23,52 @@ using namespace Dal::PDE;
 namespace {
     constexpr int kSpaceSteps = 200;
     constexpr int kTimeSteps = 200;
-    constexpr double kSpot = 100.0;
+    constexpr int kExplicitTimeSteps = 2000;
     constexpr double kStrike = 120.0;
     constexpr double kRate = 0.05;
     constexpr double kDiv = 0.03;
     constexpr double kVol = 0.15;
     constexpr double kT = 3.0;
-    constexpr double kTheta = 0.5;
+
+    struct SchemeCase_ {
+        const char* name;
+        double theta;
+        int timeSteps;
+    };
+
+    const SchemeCase_ kSchemeCases[] = {
+        {"ThetaScheme rollback (200x2000 explicit)", 0.0, kExplicitTimeSteps},
+        {"ThetaScheme rollback (200x200 CN)", 0.5, kTimeSteps},
+        {"ThetaScheme rollback (200x200 implicit)", 1.0, kTimeSteps},
+    };
+
+    double PriceEuropeanCall(double theta, int timeSteps) {
+        const double minX = 0.0;
+        const double maxX = 500.0;
+        const int numX = kSpaceSteps + 1;
+        const CoordinateVector_ x = MakeUniformGrid(minX, maxX, numX);
+        const Vector_<CoordinateVector_> grids(1, x);
+        const Vector_<> loc = GridLocations(x);
+
+        Vector_<std::shared_ptr<Cube_<>>> vals(1, std::make_shared<Cube_<>>(1, 1, numX));
+        for (int k = 0; k < numX; ++k)
+            (*vals[0])(0, 0, k) = std::max(loc[k] - kStrike, 0.0);
+        Vector_<std::shared_ptr<Cube_<>>> next(1, std::make_shared<Cube_<>>(1, 1, numX));
+
+        const Handle_<ScalarCoeff_> disc(NewConstCoeff(kRate));
+        const Handle_<VectorCoeff_> mu(NewVectorCoeff([](double s) { return (kRate - kDiv) * s; }));
+        const Handle_<MatrixCoeff_> var(NewMatrixCoeff([](double s) { return kVol * kVol * s * s; }));
+        ThetaScheme_ scheme(theta);
+        const double dt = kT / timeSteps;
+        scheme.Prepare(dt, grids, *disc, *mu, *var);
+        for (int n = 0; n < timeSteps; ++n) {
+            (*next[0])(0, 0, 0) = 0.0;
+            (*next[0])(0, 0, numX - 1) = maxX * std::exp(-kDiv * (n + 1) * dt) - std::exp(-kRate * (n + 1) * dt) * kStrike;
+            scheme(dt, grids, vals, *disc, *mu, *var, &next);
+            vals.Swap(&next);
+        }
+        return (*vals[0])(0, 0, numX / 2);
+    }
 } // namespace
 
 int main() {
@@ -32,38 +76,9 @@ int main() {
     constexpr int kRepeats = 10;
     Bench::PrintHeader();
 
-    {
+    for (const SchemeCase_& schemeCase : kSchemeCases) {
         double sink = 0.0;
-        auto r = Bench::Run(
-            "ThetaScheme rollback (200x200 CN)",
-            [&]() {
-                const double minX = 0.0;
-                const double maxX = 500.0;
-                const int numX = kSpaceSteps + 1;
-                const CoordinateVector_ x = MakeUniformGrid(minX, maxX, numX);
-                const Vector_<CoordinateVector_> grids(1, x);
-                const Vector_<> loc = GridLocations(x);
-
-                Vector_<std::shared_ptr<Cube_<>>> vals(1, std::make_shared<Cube_<>>(1, 1, numX));
-                for (int k = 0; k < numX; ++k)
-                    (*vals[0])(0, 0, k) = std::max(loc[k] - kStrike, 0.0);
-                Vector_<std::shared_ptr<Cube_<>>> next(1, std::make_shared<Cube_<>>(1, 1, numX));
-
-                const Handle_<ScalarCoeff_> disc(NewConstCoeff(kRate));
-                const Handle_<VectorCoeff_> mu(NewVectorCoeff([](double s) { return (kRate - kDiv) * s; }));
-                const Handle_<MatrixCoeff_> var(NewMatrixCoeff([](double s) { return kVol * kVol * s * s; }));
-                ThetaScheme_ scheme(kTheta);
-                const double dt = kT / kTimeSteps;
-                scheme.Prepare(dt, grids, *disc, *mu, *var);
-                for (int n = 0; n < kTimeSteps; ++n) {
-                    (*next[0])(0, 0, 0) = 0.0;
-                    (*next[0])(0, 0, numX - 1) = maxX * std::exp(-kDiv * (n + 1) * dt) - std::exp(-kRate * (n + 1) * dt) * kStrike;
-                    scheme(dt, grids, vals, *disc, *mu, *var, &next);
-                    vals.Swap(&next);
-                }
-                sink += (*vals[0])(0, 0, numX / 2);
-            },
-            2, kRepeats);
+        auto r = Bench::Run(schemeCase.name, [&]() { sink += PriceEuropeanCall(schemeCase.theta, schemeCase.timeSteps); }, 2, kRepeats);
         Bench::Print(r);
         Bench::DoNotOptimize(&sink);
     }

--- a/dal-cpp/examples/european_fd/european_fd.cpp
+++ b/dal-cpp/examples/european_fd/european_fd.cpp
@@ -3,65 +3,71 @@
 //
 
 #include <dal/platform/platform.hpp>
+
 #include <dal/math/distribution/black.hpp>
 #include <dal/math/interp/interpcubic.hpp>
 #include <dal/math/operators.hpp>
 #include <dal/math/pde/pdegrid.hpp>
 #include <dal/math/pde/thetascheme.hpp>
 #include <dal/utilities/timer.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <iomanip>
+#include <memory>
+#include <string>
 
 using namespace Dal;
 
-int main() {
-    Dal::RegisterAll_::Init();
+namespace {
+    constexpr double kMinX = 0.0;
+    constexpr double kMaxX = 500.0;
+    constexpr double kT = 3.0;
+    constexpr double kRate = 0.05;
+    constexpr double kDiv = 0.03;
+    constexpr double kVol = 0.15;
+    constexpr double kStrike = 120.0;
+    constexpr double kSpot = 100.0;
+    constexpr int kBaseSteps = 250;
+    constexpr int kRounds = 20;
+    constexpr int kExplicitTimeSteps = 5000;
 
-    double minX = 0.00;
-    double maxX = 500.00;
-    int steps = 250;
-    int nRound = 20;
+    struct SchemeRun_ {
+        const char* name;
+        double theta;
+        int spaceSteps;
+        int timeSteps;
+    };
 
-    double t = 3.00;
-    double rate = 0.05;
-    double div = 0.03;
-    double vol = 0.15;
-    double strike = 120.0;
-    double spot = 100.0;
-    double theta = 0.5;
+    struct PriceResult_ {
+        double value;
+        int64_t elapsedMs;
+    };
 
-    Vector_<int> widths = {20, 14, 14, 14, 14, 14};
-    double discounts = std::exp(-rate * t);
-    double fwd = std::exp((rate - div) * t) * spot;
-    double volStd = std::sqrt(t) * vol;
-    const auto benchmark = discounts * Distribution::BlackOpt(fwd, volStd, strike, OptionType_::Value_::CALL);
-
-    std::cout << std::setw(widths[0]) << std::right << "# of grids (x/t)" << std::setw(widths[1]) << std::right << "spot" << std::setw(widths[2])
-              << std::right << "price" << std::setw(widths[3]) << std::right << "benchmark" << std::setw(widths[4]) << std::right << "Diff (bps)"
-              << std::setw(widths[5]) << std::right << "Elapsed (ms)" << std::endl;
-
-    for (int i = 1; i <= nRound; ++i) {
-        int numX = steps * i + 1;
-        int numT = steps * i;
-
+    PriceResult_ PriceEuropeanCall(const SchemeRun_& run) {
         Timer_ timer;
-        const PDE::CoordinateVector_ x = PDE::MakeUniformGrid(minX, maxX, numX);
+        const int numX = run.spaceSteps + 1;
+        const int numT = run.timeSteps;
+
+        const PDE::CoordinateVector_ x = PDE::MakeUniformGrid(kMinX, kMaxX, numX);
         const Vector_<PDE::CoordinateVector_> grids(1, x);
         const Vector_<> loc = PDE::GridLocations(x);
 
         Vector_<std::shared_ptr<Cube_<>>> vals(1, std::make_shared<Cube_<>>(1, 1, numX));
         for (int k = 0; k < numX; ++k)
-            (*vals[0])(0, 0, k) = std::max(loc[k] - strike, 0.0);
+            (*vals[0])(0, 0, k) = std::max(loc[k] - kStrike, 0.0);
         Vector_<std::shared_ptr<Cube_<>>> next(1, std::make_shared<Cube_<>>(1, 1, numX));
 
-        const Handle_<PDE::ScalarCoeff_> disc(PDE::NewConstCoeff(rate));
-        const Handle_<PDE::VectorCoeff_> mu(PDE::NewVectorCoeff([=](double s) { return (rate - div) * s; }));
-        const Handle_<PDE::MatrixCoeff_> var(PDE::NewMatrixCoeff([=](double s) { return vol * vol * s * s; }));
-        PDE::ThetaScheme_ scheme(theta);
-        double dt = t / numT;
+        const Handle_<PDE::ScalarCoeff_> disc(PDE::NewConstCoeff(kRate));
+        const Handle_<PDE::VectorCoeff_> mu(PDE::NewVectorCoeff([](double s) { return (kRate - kDiv) * s; }));
+        const Handle_<PDE::MatrixCoeff_> var(PDE::NewMatrixCoeff([](double s) { return kVol * kVol * s * s; }));
+        PDE::ThetaScheme_ scheme(run.theta);
+        const double dt = kT / numT;
         scheme.Prepare(dt, grids, *disc, *mu, *var);
         for (int n = 0; n < numT; ++n) {
             (*next[0])(0, 0, 0) = 0.0;
-            (*next[0])(0, 0, numX - 1) = maxX * exp(-div * (n + 1) * dt) - std::exp(-rate * (n + 1) * dt) * strike;
+            (*next[0])(0, 0, numX - 1) = kMaxX * std::exp(-kDiv * (n + 1) * dt) - std::exp(-kRate * (n + 1) * dt) * kStrike;
             scheme(dt, grids, vals, *disc, *mu, *var, &next);
             vals.Swap(&next);
         }
@@ -71,11 +77,45 @@ int main() {
         Interp::Boundary_ lhs(2, 0.);
         Interp::Boundary_ rhs(2, 0);
         std::unique_ptr<Interp1_> interp(Interp::NewCubic("cubic", loc, res, lhs, rhs));
-        double calculated = (*interp)(spot);
-        std::cout << std::setw(widths[0]) << std::right << numT << std::fixed << std::setw(widths[1]) << std::right << spot << std::setprecision(6)
-                  << std::setw(widths[2]) << std::right << calculated << std::setw(widths[3]) << std::right << benchmark << std::setw(widths[4])
-                  << std::right << (calculated - benchmark) / benchmark * 10000 << std::setw(widths[5]) << std::right
-                  << int(timer.Elapsed<milliseconds>()) << std::endl;
+        return {(*interp)(kSpot), timer.Elapsed<milliseconds>()};
+    }
+} // namespace
+
+int main() {
+    Dal::RegisterAll_::Init();
+
+    const SchemeRun_ schemeRuns[] = {
+        {"Explicit", 0.0, kBaseSteps, kExplicitTimeSteps},
+        {"Crank-Nicolson", 0.5, kBaseSteps, kBaseSteps},
+        {"Implicit", 1.0, kBaseSteps, kBaseSteps},
+    };
+
+    Vector_<int> widths = {18, 20, 14, 14, 14, 14, 14};
+    double discounts = std::exp(-kRate * kT);
+    double fwd = std::exp((kRate - kDiv) * kT) * kSpot;
+    double volStd = std::sqrt(kT) * kVol;
+    const auto benchmark = discounts * Distribution::BlackOpt(fwd, volStd, kStrike, OptionType_::Value_::CALL);
+
+    std::cout << std::setw(widths[0]) << std::right << "scheme" << std::setw(widths[1]) << std::right << "grids (x/t)" << std::setw(widths[2])
+              << std::right << "spot" << std::setw(widths[3]) << std::right << "price" << std::setw(widths[4]) << std::right << "benchmark"
+              << std::setw(widths[5]) << std::right << "Diff (bps)" << std::setw(widths[6]) << std::right << "Elapsed (ms)" << std::endl;
+
+    const auto printRun = [&](const SchemeRun_& run) {
+        const PriceResult_ result = PriceEuropeanCall(run);
+        const std::string gridLabel = std::to_string(run.spaceSteps + 1) + "/" + std::to_string(run.timeSteps);
+        std::cout << std::setw(widths[0]) << std::right << run.name << std::setw(widths[1]) << std::right << gridLabel << std::fixed
+                  << std::setw(widths[2]) << std::right << std::setprecision(2) << kSpot << std::setprecision(6) << std::setw(widths[3]) << std::right
+                  << result.value << std::setw(widths[4]) << std::right << benchmark << std::setw(widths[5]) << std::right
+                  << (result.value - benchmark) / benchmark * 10000 << std::setw(widths[6]) << std::right << result.elapsedMs << std::endl;
+    };
+
+    for (const SchemeRun_& run : schemeRuns) {
+        printRun(run);
+    }
+
+    for (int i = 2; i <= kRounds; ++i) {
+        const SchemeRun_ run{"Crank-Nicolson", 0.5, kBaseSteps * i, kBaseSteps * i};
+        printRun(run);
     }
 
     return 0;

--- a/docs/methodology/pde.md
+++ b/docs/methodology/pde.md
@@ -291,10 +291,22 @@ fresh `Cube_<>(1, 1, n)`; the implementation does not resize cubes in place.
 
 ## Example Roll Loop
 
-The European finite-difference example in `dal-cpp/examples/european_fd/` uses the
-framework as follows:
+The European finite-difference example in `dal-cpp/examples/european_fd/` runs explicit,
+Crank-Nicolson, and fully implicit scheme configurations through the same rollback helper.
+The explicit configuration uses a finer time grid because explicit rollback is
+conditionally stable. After the base scheme comparison, the example continues the
+Crank-Nicolson convergence sweep by increasing `spaceSteps` and `timeSteps` together. For
+each selected run, the helper uses:
 
 ```cpp
+const SchemeRun_ schemeRuns[] = {
+    {"Explicit", 0.0, kBaseSteps, kExplicitTimeSteps},
+    {"Crank-Nicolson", 0.5, kBaseSteps, kBaseSteps},
+    {"Implicit", 1.0, kBaseSteps, kBaseSteps},
+};
+
+const int numX = run.spaceSteps + 1;
+const int numT = run.timeSteps;
 const CoordinateVector_ x = MakeUniformGrid(0.0, 500.0, numX);
 const Vector_<CoordinateVector_> grids(1, x);
 const Vector_<> loc = GridLocations(x);
@@ -308,7 +320,7 @@ for (int k = 0; k < numX; ++k)
     (*vals[0])(0, 0, k) = std::max(loc[k] - strike, 0.0);
 Vector_<std::shared_ptr<Cube_<>>> next(1, std::make_shared<Cube_<>>(1, 1, numX));
 
-ThetaScheme_ scheme(0.5);
+ThetaScheme_ scheme(run.theta);
 const double dt = t / numT;
 scheme.Prepare(dt, grids, *disc, *mu, *var);
 for (int n = 0; n < numT; ++n) {


### PR DESCRIPTION
## Summary
- Extend `pde_perf` to benchmark explicit, Crank-Nicolson, and implicit theta-scheme rollbacks.
- Update `european_fd` to print explicit, Crank-Nicolson, and implicit runs before the CN convergence sweep.
- Refresh the PDE methodology note to describe the shared rollback helper and explicit-scheme time grid.

## Test plan
- [x] `cmake --build build --target pde_perf european_fd -j$(nproc)`
- [x] `build/dal-cpp/examples/european_fd/european_fd`
- [x] `build/dal-cpp/benchmarks/pde_perf/pde_perf`
