### PR TITLE
perf: add calibration diagnostic output controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ here as the baseline rather than dated releases:
   Jacobian mode for yield-curve calibration. See
   `docs/experimental/aad-analytic-jacobian-curve-calibration.md`.
 
+## 2026-07
+
+- `curve`: Added opt-out controls for exact-calibration diagnostic matrix construction:
+  `CurveCalibrationOptions_::computeEffJacobianInverse_`,
+  `CurveCalibrationOptions_::computeForwardJacobian_`, and
+  `JointMultiCurveCalibrationOptions_::computeJacobianAtSolution_`. Defaults preserve the existing
+  diagnostics surface, while performance-sensitive callers can run solve-only calibrations. See
+  `docs/methodology/yield_curve.md` and `docs/methodology/yield_curve_jacobian.md`.
+
 ## 2026-06
 
 - `curve`: Added a yield-curve Jacobian example demonstrating AAD-vs-bump agreement and the

--- a/dal-cpp/benchmarks/curve_calibration_perf/curve_calibration_perf.cpp
+++ b/dal-cpp/benchmarks/curve_calibration_perf/curve_calibration_perf.cpp
@@ -7,10 +7,11 @@
 // 24-instrument swap curve. jacobian_perf is synthetic (no curve, no instruments, no
 // solver iteration); this is the genuine calibration hot path.
 //
-// Four cases cross {LOG_LINEAR, LOG_CUBIC_NATURAL} x {ANALYTIC, BUMPED} Jacobian mode
-// so candidate #6a (curve rebuild on every F) and #5 (duplicate at-solution Gradient)
-// are both measurable. A fifth APPROXIMATE-mode case covers Underdetermined::Approximate
-// + the implicit CG penalty solve (G9). Mirrors the instrument set from
+// Cases cross {LOG_LINEAR, LOG_CUBIC_NATURAL} x {ANALYTIC, BUMPED} Jacobian mode
+// and split default diagnostics from solve-only timing so candidate #6a (curve rebuild
+// on every F) and #5 (duplicate at-solution Gradient) are separately measurable. An
+// APPROXIMATE-mode case covers Underdetermined::Approximate + the implicit CG penalty solve (G9).
+// Mirrors the instrument set from
 // examples/yield_curve_jacobian/yield_curve_jacobian.cpp.
 
 #include <memory>
@@ -85,9 +86,13 @@ namespace {
         return spec;
     }
 
-    CurveCalibrationOptions_ OptionsFor(CurveJacobianMode_::Value_ mode) {
+    CurveCalibrationOptions_ OptionsFor(CurveJacobianMode_::Value_ mode,
+                                        bool computeEffJacobianInverse = true,
+                                        bool computeForwardJacobian = true) {
         CurveCalibrationOptions_ opts;
         opts.jacobianMode_ = CurveJacobianMode_(mode);
+        opts.computeEffJacobianInverse_ = computeEffJacobianInverse;
+        opts.computeForwardJacobian_ = computeForwardJacobian;
         return opts;
     }
 
@@ -107,7 +112,9 @@ int main() {
     const auto specLin = BuildCalibrationSpec(LogDfScheme_::Value_::LOG_LINEAR);
     const auto specCub = BuildCalibrationSpec(LogDfScheme_::Value_::LOG_CUBIC_NATURAL);
     const auto optsAnalytic = OptionsFor(CurveJacobianMode_::Value_::ANALYTIC);
+    const auto optsAnalyticSolveOnly = OptionsFor(CurveJacobianMode_::Value_::ANALYTIC, false, false);
     const auto optsBumped = OptionsFor(CurveJacobianMode_::Value_::BUMPED);
+    const auto optsBumpedSolveOnly = OptionsFor(CurveJacobianMode_::Value_::BUMPED, false, false);
 
     auto runCase = [&](const char* name, const CurveCalibrationSpec_& spec, const CurveCalibrationOptions_& opts) {
         double sink = 0.0;
@@ -119,10 +126,14 @@ int main() {
         Bench::DoNotOptimize(&sink);
     };
 
-    runCase("CalibrateYieldCurve LOG_LINEAR  ANALYTIC  (24 swaps)", specLin, optsAnalytic);
-    runCase("CalibrateYieldCurve LOG_LINEAR  BUMPED    (24 swaps)", specLin, optsBumped);
-    runCase("CalibrateYieldCurve LOG_CUBIC_NATURAL ANALYTIC (24 swaps)", specCub, optsAnalytic);
-    runCase("CalibrateYieldCurve LOG_CUBIC_NATURAL BUMPED   (24 swaps)", specCub, optsBumped);
+    runCase("CalibrateYieldCurve LOG_LINEAR  ANALYTIC +DIAG (24 swaps)", specLin, optsAnalytic);
+    runCase("CalibrateYieldCurve LOG_LINEAR  ANALYTIC SOLVE  (24 swaps)", specLin, optsAnalyticSolveOnly);
+    runCase("CalibrateYieldCurve LOG_LINEAR  BUMPED   +DIAG  (24 swaps)", specLin, optsBumped);
+    runCase("CalibrateYieldCurve LOG_LINEAR  BUMPED   SOLVE   (24 swaps)", specLin, optsBumpedSolveOnly);
+    runCase("CalibrateYieldCurve LOG_CUBIC_NATURAL ANALYTIC +DIAG (24 swaps)", specCub, optsAnalytic);
+    runCase("CalibrateYieldCurve LOG_CUBIC_NATURAL ANALYTIC SOLVE  (24 swaps)", specCub, optsAnalyticSolveOnly);
+    runCase("CalibrateYieldCurve LOG_CUBIC_NATURAL BUMPED   +DIAG  (24 swaps)", specCub, optsBumped);
+    runCase("CalibrateYieldCurve LOG_CUBIC_NATURAL BUMPED   SOLVE   (24 swaps)", specCub, optsBumpedSolveOnly);
 
     // APPROXIMATE-mode case (G9): drives Underdetermined::Approximate + XDecompByCG_
     // implicit penalty solve. APPROXIMATE ignores the per-row AAD Jacobian and uses CG

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -548,6 +548,7 @@ namespace Dal {
                                            const Vector_<>& guess,
                                            const Vector_<>& tol,
                                            const Sparse::TriDiagonal_& weights,
+                                           bool computeEffJacobianInverse,
                                            Matrix_<>* fwdJacobian) {
             Dictionary_ ctrlDict;
             ctrlDict.Insert(KEY_MAX_EVALUATIONS, Cell_(static_cast<double>(spec.maxEvaluations_)));
@@ -557,7 +558,8 @@ namespace Dal {
             SolverOutput_ out;
             if (spec.solveMode_ == CurveSolveMode_::Value_::EXACT) {
                 std::unique_ptr<Sparse::SymmetricDecomposition_> wDecomp(weights.DecomposeSymmetric());
-                out.result_ = Underdetermined::Find(func, guess, tol, *wDecomp, controls, &out.effJacobianInverse_, fwdJacobian);
+                Matrix_<>* effJacobianInverse = computeEffJacobianInverse ? &out.effJacobianInverse_ : nullptr;
+                out.result_ = Underdetermined::Find(func, guess, tol, *wDecomp, controls, effJacobianInverse, fwdJacobian);
             } else {
                 out.result_ = Underdetermined::Approximate(func, guess, tol, spec.fitTolerance_, weights, controls);
             }
@@ -568,7 +570,7 @@ namespace Dal {
                                                           const Vector_<Handle_<YCInstrument_>>& instruments,
                                                           const Vector_<Date_>& knotDates,
                                                           const Vector_<>& result,
-                                                          const Matrix_<>& effJacobianInverse) {
+                                                          const Matrix_<>* effJacobianInverse) {
             CurveCalibrationResult_ retval;
             retval.curve_ = BuildDiscountCurve(spec.curveName_, spec.ccy_, spec.parameterization_, spec.logDfScheme_, knotDates, result, spec.liborBasis_,
                                                spec.baseCurve_);
@@ -595,7 +597,7 @@ namespace Dal {
                 fundingCurve.reset(new CurveBlock_(spec.curveName_, spec.ccy_, spec.discountCurves_, spec.forwardCurves_, spec.liborBasis_));
             retval.diagnostics_ =
                 BuildDiagnostics(spec.curveName_, instruments, curveView, fundingCurve, spec.solveMode_ == CurveSolveMode_::Value_::APPROXIMATE,
-                                 spec.solveMode_ == CurveSolveMode_::Value_::EXACT ? &effJacobianInverse : nullptr);
+                                 spec.solveMode_ == CurveSolveMode_::Value_::EXACT ? effJacobianInverse : nullptr);
             return retval;
         }
     } // namespace
@@ -632,11 +634,16 @@ namespace Dal {
                                         spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_);
 
         // Forward Jacobian requested only for ANALYTIC + EXACT + eligible; nullptr otherwise so the solver leaves the output empty.
-        const bool wantFwdJacobian = options.jacobianMode_ == CurveJacobianMode_::Value_::ANALYTIC && spec.solveMode_ == CurveSolveMode_::Value_::EXACT
-                                     && func.Eligible();
+        const bool wantFwdJacobian = options.computeForwardJacobian_ && options.jacobianMode_ == CurveJacobianMode_::Value_::ANALYTIC
+                                     && spec.solveMode_ == CurveSolveMode_::Value_::EXACT && func.Eligible();
         Matrix_<> fwdJacobian;
-        const SolverOutput_ solved = RunCalibrationSolver(spec, func, guess, tol, *weights, wantFwdJacobian ? &fwdJacobian : nullptr);
-        CurveCalibrationResult_ retval = AssembleCalibrationResult(spec, instruments, knotDates, solved.result_, solved.effJacobianInverse_);
+        const SolverOutput_ solved =
+            RunCalibrationSolver(spec, func, guess, tol, *weights, options.computeEffJacobianInverse_, wantFwdJacobian ? &fwdJacobian : nullptr);
+        CurveCalibrationResult_ retval = AssembleCalibrationResult(spec,
+                                                                   instruments,
+                                                                   knotDates,
+                                                                   solved.result_,
+                                                                   options.computeEffJacobianInverse_ ? &solved.effJacobianInverse_ : nullptr);
         retval.diagnostics_.jacobian_ = std::move(fwdJacobian);
         return retval;
     }

--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -110,6 +110,10 @@ namespace Dal {
     // default is byte-for-byte identical to the bumped path only for ineligible specs.
     struct CurveCalibrationOptions_ {
         CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+        // Exact-solve pseudoinverse used by inverse-Jacobian risk diagnostics.
+        bool computeEffJacobianInverse_ = true;
+        // Analytic at-solution residual Jacobian; ignored unless ANALYTIC + EXACT + eligible.
+        bool computeForwardJacobian_ = true;
     };
 
     struct CurveCalibrationDiagnostics_ {

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -621,7 +621,8 @@ namespace Dal {
         std::unique_ptr<Sparse::TriDiagonal_> weights = BuildJointSmoothing(slots);
         JointResidualFunction_ func(spec, slots, options.jacobianMode_);
         Matrix_<> fwdJacAtSolution;
-        const Vector_<> solved = RunJointSolver(spec, func, guess, tol, *weights, &fwdJacAtSolution);
+        const Vector_<> solved =
+            RunJointSolver(spec, func, guess, tol, *weights, options.computeJacobianAtSolution_ ? &fwdJacAtSolution : nullptr);
 
         const Vector_<> finalResiduals = func.F(solved);
         const double barA = 10.0 * spec.fitTolerance_;

--- a/dal-cpp/dal/curve/jointcalibration.hpp
+++ b/dal-cpp/dal/curve/jointcalibration.hpp
@@ -81,6 +81,8 @@ namespace Dal {
     // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.
     struct JointMultiCurveCalibrationOptions_ {
         CurveJacobianMode_ jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+        // Analytic at-solution residual Jacobian; ignored unless ANALYTIC + EXACT + eligible.
+        bool computeJacobianAtSolution_ = true;
     };
 
     // Validate inputs and run ONE Underdetermined::Find / Approximate over the concatenated

--- a/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
+++ b/dal-cpp/tests/curve/test_forward_jacobian_diagnostics.cpp
@@ -208,6 +208,30 @@ TEST(ForwardJacobianDiagnosticsTest, TestCoherentWithEffJacobianInversePopulatio
     ASSERT_EQ(result.diagnostics_.jacobian_.Cols(), result.diagnostics_.effJacobianInverse_.Rows());
 }
 
+TEST(ForwardJacobianDiagnosticsTest, TestCanSkipEffJacobianInverse) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    opt.computeEffJacobianInverse_ = false;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-7);
+    ASSERT_TRUE(result.diagnostics_.effJacobianInverse_.Empty());
+    ASSERT_FALSE(result.diagnostics_.jacobian_.Empty());
+}
+
+TEST(ForwardJacobianDiagnosticsTest, TestCanSkipForwardJacobian) {
+    const auto spec = MakeEligibleSpec();
+    CurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    opt.computeForwardJacobian_ = false;
+
+    const CurveCalibrationResult_ result = CalibrateYieldCurve(spec, opt);
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-7);
+    ASSERT_FALSE(result.diagnostics_.effJacobianInverse_.Empty());
+    ASSERT_TRUE(result.diagnostics_.jacobian_.Empty());
+}
+
 // Empty-field regression: APPROXIMATE solve leaves jacobian_ empty.
 
 TEST(ForwardJacobianDiagnosticsTest, TestEmptyWhenApproximateSolve) {

--- a/dal-cpp/tests/curve/test_joint_analytic_jacobian.cpp
+++ b/dal-cpp/tests/curve/test_joint_analytic_jacobian.cpp
@@ -376,6 +376,22 @@ TEST(JointAnalyticJacobianTest, TestAnalyticEligibleAgreesWithBumped) {
     }
 }
 
+TEST(JointAnalyticJacobianTest, TestCanSkipJacobianAtSolution) {
+    RegisterAll_::Init();
+    const Date_ today(2024, 1, 15);
+    const Ccy_ ccy("USD");
+    const JointMultiCurveCalibrationSpec_ spec = BuildSmallJointSpec(today, ccy, /*baseLayered=*/true, DayBasis_("ACT_365F"));
+
+    JointMultiCurveCalibrationOptions_ opt;
+    opt.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+    opt.computeJacobianAtSolution_ = false;
+    const JointMultiCurveCalibrationResult_ result = CalibrateJointMultiCurve(spec, opt);
+
+    ASSERT_TRUE(result.converged_);
+    ASSERT_TRUE(result.jacobianAtSolution_.Empty());
+    ASSERT_LT(result.jointMaxAbsResidual_, 1.0e-7);
+}
+
 // AC7: the ANALYTIC default engages on an eligible spec without explicit options.
 TEST(JointAnalyticJacobianTest, TestDefaultEngagesAnalyticOnEligibleSpec) {
     RegisterAll_::Init();

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -254,6 +254,8 @@ when `jacobianMode_ == ANALYTIC AND solveMode_ == EXACT AND eligible`; callers
 pass `nullptr` otherwise so the solver leaves the output empty. The output appears
 on `CurveCalibrationDiagnostics_::jacobian_` (shape $m \times (N-1)$), unscaled
 — it is the plain $J$ before the solver's `DivideRows(tol_)` row-scaling.
+`CurveCalibrationOptions_::computeForwardJacobian_` defaults to `true`; setting
+it to `false` skips this at-solution sweep and leaves `jacobian_` empty.
 
 ## Construction Pipeline
 
@@ -361,7 +363,9 @@ The `JointMultiCurveCalibrationResult_` struct provides
 $d(\text{residual}_i) / d(\text{param}_j)$ at the solved point, shape
 `(totalResiduals) x (totalFreeParams)`. Populated only when
 `jacobianMode_ == ANALYTIC` AND the spec is eligible AND
-`solveMode_ == EXACT`; empty otherwise. The Jacobian is stored in a shared
+`solveMode_ == EXACT` AND `computeJacobianAtSolution_ == true`; empty otherwise.
+`computeJacobianAtSolution_` defaults to `true` to preserve the existing
+diagnostics surface. The Jacobian is stored in a shared
 `XCurveJacobian_` (`dal-cpp/dal/curve/curvejacobian.hpp`) -- the same dense
 subclass used by the single-curve AAD path.
 
@@ -521,7 +525,9 @@ forward-rate parameters without re-solving. Note that its units include an extra
 `tolerance_` factor (the solver scales residuals by `1/tolerance_` before forming
 the pseudoinverse), so a sensitivity transform must read
 `r = gᵀ · effJacobianInverse_ / tolerance_` — see [Yield-Curve Jacobian and
-Inverse-Jacobian Risk](yield_curve_jacobian.md).
+Inverse-Jacobian Risk](yield_curve_jacobian.md). Exact solves populate it by
+default; `CurveCalibrationOptions_::computeEffJacobianInverse_ = false` skips
+the pseudoinverse construction and leaves the matrix empty.
 
 API citations:
 

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -36,7 +36,9 @@ and `CalibrateYieldCurve` exposes its result on the public diagnostics struct:
 fresh analytic reverse sweep evaluated at the solved $x^\star$. It is the plain
 Jacobian before the solver's `DivideRows(tol_)` row-scaling, and it is populated
 iff `jacobianMode_ = ANALYTIC && solveMode_ = EXACT` and the calibration is
-eligible for the AAD-tape Jacobian (default-constructed empty otherwise). The
+eligible for the AAD-tape Jacobian and
+`CurveCalibrationOptions_::computeForwardJacobian_ == true`
+(default-constructed empty otherwise). The
 example reads $J$ straight from `result.diagnostics_.jacobian_`, so the AAD
 recording contract and backend-portability rules live in the library rather than
 in example code.
@@ -50,7 +52,7 @@ inverses in their exposed form.
 
 The forward Jacobian is not re-derived by the consumer; it is captured **once,
 inside the solver, on its convergence branch**. When the solve is eligible for
-the analytic path, the convergence hook issues a single
+the analytic path and `computeForwardJacobian_` is true, the convergence hook issues a single
 `func.Gradient(xNew, fNew)` call at the solved $x^\star$, and the reverse sweep
 that fills `jacobian_` is that one evaluation. The output is the plain Jacobian
 before the solver's `DivideRows(tol_)` row-scaling, and an independent
@@ -88,6 +90,7 @@ result is exposed as
 `JointMultiCurveCalibrationResult_::jacobianAtSolution_`, shaped
 `(totalResiduals) × (totalFreeParams)`, populated iff
 `JointMultiCurveCalibrationOptions_::jacobianMode_ == ANALYTIC`,
+`JointMultiCurveCalibrationOptions_::computeJacobianAtSolution_ == true`,
 `solveMode_ == EXACT`, and the spec is eligible; empty otherwise.
 
 The mechanics mirror the single-curve path — register the stacked free
@@ -347,13 +350,15 @@ re-calibrations for `BUMPED` versus one AAD reverse sweep per residual row for
 `ANALYTIC`. Each `CalibrateYieldCurve` call resets its own tape internally, so
 repeated calls are independent and safe to time.
 
-The comparison is not pure like-for-like. The `ANALYTIC` time includes the
+The comparison is not pure like-for-like unless diagnostics are disabled. The `ANALYTIC` time includes the
 single at-solution forward-Jacobian evaluation the solver makes on its
 convergence branch to populate `CurveCalibrationDiagnostics_::jacobian_`, which
 `BUMPED` does not perform. The honest reading of the ratio is therefore
 "`ANALYTIC` solve-with-Jacobian vs `BUMPED` solve-without-Jacobian". A truly
 matched comparison would give `BUMPED` its own separate finite-difference
-Jacobian pass to produce the same diagnostic, which the example does not do.
+Jacobian pass to produce the same diagnostic. `CurveCalibrationOptions_` can now
+disable `computeForwardJacobian_` and `computeEffJacobianInverse_` for solve-only
+benchmarking.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- add opt-out controls for exact yield-curve diagnostic matrix construction while preserving current defaults
- wire single-curve and joint calibration solvers to skip unused diagnostic Jacobian work
- add regression tests, docs, changelog, and split curve calibration benchmark rows into +DIAG and SOLVE cases

## Review notes
- No blocking findings from the local diff review.
- Residual scope note: staged CalibrateMultiCurve still delegates to default single-curve options, so staged public multi-curve calibration continues to populate diagnostics.

## Test plan
- [x] git diff --check
- [x] cmake --build build --target dal_cpp_tests curve_calibration_perf -j32
- [x] build/dal-cpp/dal_cpp_tests (813 tests passed)
- [x] build/dal-public/dal_public_tests (40 tests passed)
- [x] build/dal-cpp/benchmarks/curve_calibration_perf/curve_calibration_perf