### PR TITLE
fix: address PR #221 review findings across code, gate, and docs

### DIFF
--- a/.claude/agents/dal-implementer.md
+++ b/.claude/agents/dal-implementer.md
@@ -129,10 +129,9 @@ You may need to declare a minimal header/signature so the test compiles, but wri
 (leave it unimplemented, throwing, or returning a placeholder). Build and run the new test, and **confirm it fails
 for the right reason** — the assertion fails or the symbol is unimplemented, not a typo or unrelated breakage:
 ```bash
-mkdir -p build && cd build
-cmake --preset=Release-linux .. && make -j$(nproc) dal_cpp_tests && make install
-cd ..
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_cpp_tests -j$(nproc)
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
 ```
 A test that passes before you write the implementation is not testing the new behavior — fix the test, don't move on.
 
@@ -160,8 +159,9 @@ Commit the generated files together with your markup source.
 
 Rebuild and re-run the target test until it is **green**:
 ```bash
-cd build && cmake --preset=Release-linux .. && make -j$(nproc) dal_cpp_tests && make install && cd ..
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_cpp_tests -j$(nproc)
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
 ```
 If the test fails, fix the *implementation* — never weaken the test unless its expectation is genuinely wrong.
 
@@ -178,7 +178,7 @@ covered by a test that drove its implementation.
 
 **4.1 Run the full test suite** to check for regressions:
 ```bash
-bin/dal_cpp_tests
+./build/Release-linux/dal-cpp/dal_cpp_tests
 ```
 If existing tests fail, fix the regression before proceeding.
 

--- a/.claude/agents/dal-performancer.md
+++ b/.claude/agents/dal-performancer.md
@@ -64,11 +64,12 @@ This is a C++17 quantitative finance library with AAD support. Relevant context 
 - `.claude/specs/perf-enhancement-candidates.md` — codebase-wide perf candidate ranking (the inverse problem: where gains live, which tells you which paths are hot)
 - `.claude/specs/perf-safe-wins-plan.md` — example of a perf-change plan gated on byte-identity + best-of-N
 - `dal-cpp/benchmarks/<name>_perf/` — each benchmark is its own standalone executable, NOT a single binary and NOT registered with CTest
-- `dal-cpp/CMakeLists.txt` — defines `DAL_CPP_BUILD_BENCHMARKS` (default `ON`); the `base` preset in `CMakePresets.json` also sets it `on`
-- `build_linux.sh` — explicitly sets `-DDAL_CPP_BUILD_BENCHMARKS=ON`, builds, and `make install`s, but does NOT execute benchmarks (they are not in CTest)
-- `.github/workflows/cmake-linux.yml` — the CI **Benchmarks** job runs the 8 `*_perf` targets once per push on shared GitHub-hosted Azure runners
+- `dal-cpp/CMakeLists.txt` — defines `DAL_CPP_BUILD_BENCHMARKS` (option default `ON`); the `base` preset in `CMakePresets.json` overrides it to `off`, so preset-driven builds — including `build_linux.sh` without `--benchmarks`/`--full` — disable benchmarks unless the flag is passed explicitly
+- `build_linux.sh` — defaults `-DDAL_CPP_BUILD_BENCHMARKS=OFF`; pass `--benchmarks` (or `--full`) to enable. Builds and `cmake --install`s into `build/stage/Release-linux`, but does NOT execute benchmarks (they are not in CTest)
+- `.github/workflows/cmake-linux.yml` — the CI **Benchmarks** job builds all 15 `*_perf` targets (`DAL_ENABLE_NATIVE_ARCH=ON`, gcc-14, native AADet, Release) and runs them; on pull requests it additionally runs the paired base-vs-head regression gate via `.github/scripts/check_benchmark_regressions.py`
+- `.github/scripts/check_benchmark_regressions.py` — the paired base-vs-head regression gate CI runs on PRs. It enforces a 4% threshold over 2 confirmation rounds of 10 interleaved process-level samples (failure requires **every** round to exceed +4%), reduces each round on `min`, plus a separate Sobol `precise opt-in / fast` ratio ceiling (default 10x) and a one-time informational migration row. Reproduce locally with `--samples 10 --confirmation-rounds 2 --threshold-percent 4`
 
-After build, binaries are at `bin/<name>_perf` after `make install`, or `./dal-cpp/benchmarks/<name>/<name>_perf` in the build tree. **Prefer the build-tree path during iteration** — `bin/` only updates on `make install` and goes stale (this is a known trap).
+After build, binaries are at `build/stage/Release-linux/bin/<name>_perf` after `cmake --install`, or `./build/Release-linux/dal-cpp/benchmarks/<name>/<name>_perf` in the build tree. **Prefer the build-tree path during iteration** — the stage directory only updates on `cmake --install` and goes stale (this is a known trap).
 
 ## Your Process
 
@@ -97,12 +98,12 @@ Build **both** the branch-under-test and the baseline, in Release configuration,
 
 1. For the branch-under-test (current checkout):
    ```bash
-   mkdir -p build && cd build
-   cmake --preset=Release-linux .. && make -j$(nproc) && make install && cd ..
+   cmake --preset=Release-linux -S . -B build/Release-linux -DDAL_CPP_BUILD_BENCHMARKS=ON
+   cmake --build build/Release-linux -j$(nproc)
    ```
 2. For the baseline: check out the merge-base into a separate build directory (or a separate worktree) and build it the same way. Keep the two build trees isolated so their binaries do not overwrite each other.
-3. Confirm `DAL_CPP_BUILD_BENCHMARKS=ON` in both builds — without it the `*_perf` targets do not exist.
-4. Run the binaries from the **build-tree path** (`./dal-cpp/benchmarks/<name>/<name>_perf`), not `bin/`. The `bin/` directory only updates on `make install` and goes stale between rebuilds — this is a known trap and a frequent source of bogus "regressions" that are actually stale-binary comparisons.
+3. Confirm `DAL_CPP_BUILD_BENCHMARKS=ON` in both builds — the `base` preset defaults it `off`, so the explicit flag is required or the `*_perf` targets will not exist.
+4. Run the binaries from the **build-tree path** (`./build/Release-linux/dal-cpp/benchmarks/<name>/<name>_perf`), not the stage directory. The stage directory only updates on `cmake --install` and goes stale between rebuilds — this is a known trap and a frequent source of bogus "regressions" that are actually stale-binary comparisons.
 
 ### Phase 3: Paired best-of-N measurement
 
@@ -126,7 +127,7 @@ Therefore:
 
 - **Never** trust a single-run CI benchmark comparison. Do not cry wolf.
 - **Gate on best-of-N (min)**, not mean or median.
-- Only flag a **regression** if the branch's best-of-N min exceeds the baseline min by more than **2× the ~1% gold-standard noise floor** — i.e. a sustained delta clearly above ~2-4%, not a single-digit noisy blip.
+- Only flag a **regression** if the branch's best-of-N min exceeds the baseline min by more than **2× the ~1% gold-standard noise floor** — i.e. a sustained delta clearly above ~2-4%, not a single-digit noisy blip. The CI paired gate (`.github/scripts/check_benchmark_regressions.py`) operationalizes this as a 4% threshold where failure requires every confirmation round (2 rounds of 10 interleaved samples) to exceed +4%; mirror that when reproducing locally.
 - Classify each benchmark as one of: **regression**, **no-change**, or **improvement**. "no-change" is the expected and honorable outcome; do not invent a regression to justify the run.
 
 Produce a short report table:
@@ -164,8 +165,8 @@ Do **not** merge the PR. Merging is the user's action (and `dal-reviewer`'s to g
 |------------------------|-------------------------------------------------------------------------------------|
 | Regression set         | `tape_perf`, `jacobian_perf`, `pde_perf`, `rng_perf`, `interp_perf`, `krylov_perf`, `banded_perf`, `cholesky_perf` (8) |
 | Excluded from gate     | `matrix_perf`, `script_perf` (informational only)                                   |
-| Build config           | Release (`cmake --preset=Release-linux`), `DAL_CPP_BUILD_BENCHMARKS=ON`             |
-| Binary path            | `./dal-cpp/benchmarks/<name>/<name>_perf` during iteration; `bin/<name>_perf` only after `make install` (stale trap) |
+| Build config           | Release (`cmake --preset=Release-linux -S . -B build/Release-linux -DDAL_CPP_BUILD_BENCHMARKS=ON` — the `base` preset defaults benchmarks OFF) |
+| Binary path            | `./build/Release-linux/dal-cpp/benchmarks/<name>/<name>_perf` during iteration; `build/stage/Release-linux/bin/<name>_perf` only after `cmake --install` (stale trap) |
 | Sample count           | N ≥ 10 per benchmark, per binary, interleaved                                       |
 | Reduction              | best-of-N (**min**), never mean/median                                              |
 | Regression threshold   | branch min exceeds baseline min by > 2× the ~1% gold-standard noise floor (~2-4%)   |

--- a/.claude/agents/dal-reviewer.md
+++ b/.claude/agents/dal-reviewer.md
@@ -150,8 +150,8 @@ Check the exit code and `test_output.txt` for failures. If the build itself fail
 Then run targeted tests for the changed modules and the full suite:
 
 ```bash
-bin/dal_cpp_tests --gtest_filter=<ChangedSuite1>.*:<ChangedSuite2>.*
-bin/dal_cpp_tests
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<ChangedSuite1>.*:<ChangedSuite2>.*
+./build/Release-linux/dal-cpp/dal_cpp_tests
 ```
 
 Capture:

--- a/.claude/agents/dal-simplifier.md
+++ b/.claude/agents/dal-simplifier.md
@@ -181,10 +181,10 @@ If the user has explicitly asked you to apply the fixes ("apply the duplication 
 2. Apply the agreed findings one at a time, building and re-running the affected suite after each change to
    prove behavior is unchanged:
    ```bash
-   mkdir -p build && cd build
-   cmake --preset=Release-linux .. && make -j$(nproc) dal_cpp_tests && make install && cd ..
-   bin/dal_cpp_tests --gtest_filter=<AffectedSuite>.*
-   bin/dal_cpp_tests
+   cmake --preset=Release-linux -S . -B build/Release-linux
+   cmake --build build/Release-linux --target dal_cpp_tests -j$(nproc)
+   ./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<AffectedSuite>.*
+   ./build/Release-linux/dal-cpp/dal_cpp_tests
    ```
 3. Style-self-review the changed files against `.claude/rules/code-style.md`.
 4. Report what changed, the test result, and offer to commit/PR - do not commit or push yourself.

--- a/.claude/agents/dal-spec-writer.md
+++ b/.claude/agents/dal-spec-writer.md
@@ -115,7 +115,7 @@ Write the spec to `.claude/specs/<feature-slug>.md` using this template:
 
 ## Acceptance Criteria
 - [ ] <test-shaped statement: given X, when Y, then Z>
-- [ ] <build passes, full `bin/dal_cpp_tests` green>
+- [ ] <build passes, full `./build/Release-linux/dal-cpp/dal_cpp_tests` green>
 - [ ] <documentation updated where applicable>
 
 ## Open Questions

--- a/.claude/rules/git-commit-pr.md
+++ b/.claude/rules/git-commit-pr.md
@@ -45,7 +45,7 @@ and reorder includes in test files to follow project convention (gtest first).
 
 ## Test plan
 - [x] Run specific test filters to verify new/changed functionality
-- [x] Full `bin/dal_cpp_tests` (and other CTest targets) to confirm no regressions
+- [x] Full `./build/Release-linux/dal-cpp/dal_cpp_tests` (and other CTest targets) to confirm no regressions
 ```
 
 - All tests must pass before merging

--- a/.claude/skills/dal-commit-and-pr/SKILL.md
+++ b/.claude/skills/dal-commit-and-pr/SKILL.md
@@ -94,8 +94,8 @@ gh pr create --title "<short title under 70 chars>" --body "$(cat <<'EOF'
 - <bullet points covering all key changes>
 
 ## Test plan
-- [ ] Run `bin/dal_cpp_tests --gtest_filter=<RelevantSuite>.*` to verify changes
-- [ ] Full `bin/dal_cpp_tests` to confirm no regressions
+- [ ] Run `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<RelevantSuite>.*` to verify changes
+- [ ] Full `./build/Release-linux/dal-cpp/dal_cpp_tests` to confirm no regressions
 EOF
 )"
 ```

--- a/.claude/skills/dal-unit-test-write/SKILL.md
+++ b/.claude/skills/dal-unit-test-write/SKILL.md
@@ -110,15 +110,14 @@ For helper classes, define them at file scope before the tests. Use anonymous `n
 ### 4. Build and verify
 
 ```bash
-mkdir -p build && cd build
-cmake --preset=Release-linux .. && make -j$(nproc) dal_cpp_tests && make install
-cd ..
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_cpp_tests -j$(nproc)
 ```
 
 Then run the new tests:
 
 ```bash
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
 ```
 
 If the build fails, the most common causes are:

--- a/.github/scripts/check_benchmark_regressions.py
+++ b/.github/scripts/check_benchmark_regressions.py
@@ -8,10 +8,14 @@ import json
 import os
 from pathlib import Path
 import re
-import statistics
 import subprocess
 import sys
 
+
+# Per-process wall-clock cap. The regression binaries finish in seconds; this
+# only exists to fail loudly on a deadlock (e.g. a thread-pool regression)
+# instead of stalling the job to the GitHub Actions 6h cap.
+BENCHMARK_TIMEOUT_SECONDS = 600
 
 BENCHMARKS = (
     "tape_perf",
@@ -69,14 +73,23 @@ def run_benchmark(build_root: Path, benchmark: str, output_file: Path) -> dict[s
     environment = os.environ.copy()
     environment.setdefault("DAL_NUM_THREADS", "4")
     # Running the validated, locally built executable is this tool's purpose; no shell parses the path.
-    completed = subprocess.run(  # nosemgrep
-        [str(binary)],  # nosemgrep
-        check=False,
-        capture_output=True,
-        text=True,
-        env=environment,
-        shell=False,
-    )
+    try:
+        completed = subprocess.run(  # nosemgrep
+            [str(binary)],  # nosemgrep
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+            shell=False,
+            timeout=BENCHMARK_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        output_file.write_text(
+            f"{binary.name} timed out after {BENCHMARK_TIMEOUT_SECONDS}s\n", encoding="utf-8"
+        )
+        raise RuntimeError(
+            f"{binary.name} exceeded the {BENCHMARK_TIMEOUT_SECONDS}s timeout; see {output_file}"
+        )
     output_file.write_text(completed.stdout + completed.stderr, encoding="utf-8")
     if completed.returncode:
         raise RuntimeError(f"{binary.name} exited with {completed.returncode}; see {output_file}")
@@ -120,8 +133,10 @@ def validate_sample_counts(
             raise RuntimeError(f"{benchmark} / {side}: incomplete samples {incomplete}")
 
 
-def median_samples(samples: dict[str, list[float]]) -> dict[str, float]:
-    return {case: statistics.median(values) for case, values in samples.items()}
+def min_samples(samples: dict[str, list[float]]) -> dict[str, float]:
+    # Gate on best-of-N (min): benchmark timings are right-skewed, so the minimum
+    # is the sample least contaminated by scheduler/cache/page-fault transients.
+    return {case: min(values) for case, values in samples.items()}
 
 
 def permitted_case_migration(base_cases: set[str], head_cases: set[str]) -> bool:
@@ -151,9 +166,9 @@ def round_deltas(
     for round_index in range(round_count):
         first = round_index * round_size
         last = first + round_size
-        base_median = statistics.median(base[first:last])
-        head_median = statistics.median(head[first:last])
-        deltas.append(100.0 * (head_median / base_median - 1.0))
+        base_min = min(base[first:last])
+        head_min = min(head[first:last])
+        deltas.append(100.0 * (head_min / base_min - 1.0))
     return deltas
 
 
@@ -165,8 +180,8 @@ def comparison_row(
     round_size: int,
     round_count: int,
 ) -> dict[str, object]:
-    base_value = statistics.median(base)
-    head_value = statistics.median(head)
+    base_value = min(base)
+    head_value = min(head)
     deltas = round_deltas(base, head, round_size, round_count)
     return {
         "case": case,
@@ -203,8 +218,8 @@ def compare_benchmark(
     round_size: int,
     round_count: int,
 ) -> tuple[list[dict[str, object]], list[str]]:
-    base = median_samples(samples["base"])
-    head = median_samples(samples["head"])
+    base = min_samples(samples["base"])
+    head = min_samples(samples["head"])
     migration_permitted, failures = benchmark_case_differences(benchmark, base, head)
     rows = []
     if migration_permitted:
@@ -366,7 +381,7 @@ def main() -> int:
         args.samples,
         args.confirmation_rounds,
     )
-    rng_head = median_samples(collected["rng_perf"]["head"]) if "rng_perf" in collected else {}
+    rng_head = min_samples(collected["rng_perf"]["head"]) if "rng_perf" in collected else {}
     precise_ratio = precise_sobol_ratio(rng_head)
     report = markdown_report(
         comparisons,

--- a/.github/scripts/tests/test_check_benchmark_regressions.py
+++ b/.github/scripts/tests/test_check_benchmark_regressions.py
@@ -3,6 +3,7 @@
 import importlib.util
 import os
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -55,6 +56,22 @@ Case in nanoseconds      120.000 ns  100.000 ns  130.000 ns    10
 
         self.assertAlmostEqual(rows[0]["round_delta_percent"][0], 4.1)
         self.assertEqual(rows[0]["round_delta_percent"][1], 0.0)
+        self.assertEqual(failures, [])
+
+    def test_compare_benchmark_reduces_each_round_on_minimum(self):
+        # Project policy (ci-benchmark-noise-floor) gates on best-of-N (min) because
+        # benchmark timings are right-skewed; verify the reducer is min, not median.
+        # head min is 100.0 but head median is 102.05, so this distinguishes them.
+        samples = {
+            "base": {"case": [100.0] * 20},
+            "head": {"case": [104.1, 100.0] * 10},
+        }
+
+        rows, failures = BENCHMARKS.compare_benchmark("pde_perf", samples, 4.0, 10.0, 10, 2)
+
+        self.assertAlmostEqual(rows[0]["base_ns"], 100.0)
+        self.assertAlmostEqual(rows[0]["head_ns"], 100.0)
+        self.assertEqual(rows[0]["round_delta_percent"], [0.0, 0.0])
         self.assertEqual(failures, [])
 
     def test_validate_sample_counts_rejects_partial_case(self):
@@ -115,6 +132,23 @@ Case in nanoseconds      120.000 ns  100.000 ns  130.000 ns    10
             run.assert_called_once()
             self.assertEqual(run.call_args.args[0], [str(binary.resolve())])
             self.assertFalse(run.call_args.kwargs["shell"])
+            self.assertEqual(run.call_args.kwargs["timeout"], BENCHMARKS.BENCHMARK_TIMEOUT_SECONDS)
+
+    def test_run_benchmark_raises_and_writes_marker_on_timeout(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            build_root = temporary_root / "build"
+            self._create_benchmark_binary(build_root)
+            output_file = temporary_root / "output.txt"
+            exc = subprocess.TimeoutExpired(
+                cmd=["x"], timeout=BENCHMARKS.BENCHMARK_TIMEOUT_SECONDS
+            )
+
+            with mock.patch.object(BENCHMARKS.subprocess, "run", side_effect=exc):
+                with self.assertRaisesRegex(RuntimeError, "exceeded"):
+                    BENCHMARKS.run_benchmark(build_root, "pde_perf", output_file)
+
+            self.assertIn("timed out", output_file.read_text(encoding="utf-8"))
 
     def test_rng_allows_precise_case_rename_and_checks_relative_cost(self):
         samples = {

--- a/.github/scripts/tests/test_check_benchmark_regressions.py
+++ b/.github/scripts/tests/test_check_benchmark_regressions.py
@@ -3,10 +3,10 @@
 import importlib.util
 import os
 from pathlib import Path
-import subprocess
 import tempfile
 import unittest
 from unittest import mock
+from subprocess import TimeoutExpired
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "check_benchmark_regressions.py"
@@ -140,7 +140,8 @@ Case in nanoseconds      120.000 ns  100.000 ns  130.000 ns    10
             build_root = temporary_root / "build"
             self._create_benchmark_binary(build_root)
             output_file = temporary_root / "output.txt"
-            exc = subprocess.TimeoutExpired(
+            # TimeoutExpired is an exception ctor raised via a mock, not a subprocess call.
+            exc = TimeoutExpired(  # nosemgrep
                 cmd=["x"], timeout=BENCHMARKS.BENCHMARK_TIMEOUT_SECONDS
             )
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,17 +5,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build Commands
 
 ```bash
-# Full Linux build (runs Machinist code generation, configures the workspace,
-# builds all enabled sub-projects, installs into the repo root, and runs CTest)
+# Default Linux build (configures core + public C++ + examples via the
+# Release-linux preset, installs into build/stage/Release-linux, and runs CTest).
+# Pass --full for Python plus benchmarks, --benchmarks for benchmarks only, or
+# --generate to regenerate Machinist sources.
 bash ./build_linux.sh
 
-# Manual build (top-level workspace)
-mkdir build && cd build
-cmake --preset=Release-linux .. && make -j32 && make install
+# Manual build (top-level workspace) -- Release-linux/Debug-linux do not declare a
+# binaryDir, so pass -S/-B explicitly (this is what build_linux.sh does) and use
+# cmake --build / cmake --install instead of raw make.
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux -j32
+cmake --install build/Release-linux
 
 # Debug build
-mkdir build && cd build
-cmake --preset=Debug-linux .. && make -j32 && make install
+cmake --preset=Debug-linux -S . -B build/Debug-linux
+cmake --build build/Debug-linux -j32
+cmake --install build/Debug-linux
 ```
 
 The top-level `CMakeLists.txt` is a thin workspace that selects sub-projects via options:
@@ -25,10 +31,10 @@ The top-level `CMakeLists.txt` is a thin workspace that selects sub-projects via
 - `DAL_BUILD_EXCEL` (default `OFF`) — build `dal-excel` (Windows-only)
 - `DAL_CPP_BUILD_TESTS` (default `ON`) — build the `dal-cpp` test suite
 - `DAL_CPP_BUILD_EXAMPLES` (default `ON`) — build the `dal-cpp` example programs
-- `DAL_CPP_BUILD_BENCHMARKS` (default `ON`) — build the `dal-cpp` benchmark programs
+- `DAL_CPP_BUILD_BENCHMARKS` (CMake option default `ON`, but the `base` preset in `CMakePresets.json` overrides it to `off`, so preset-driven builds — including `build_linux.sh` without `--benchmarks`/`--full` — disable benchmarks) — build the `dal-cpp` benchmark programs
 - `DAL_USE_ADEPT_AAD` / `DAL_USE_XAD_AAD` / `DAL_USE_CODIPACK_AAD` — pick the AAD backend (source default: Adept; CMake presets override all three to OFF unless explicitly enabled)
 
-CMake installs to the repo root (`CMAKE_INSTALL_PREFIX=${sourceDir}`), placing binaries in `bin/`, libraries in `lib/`, and headers in `include/`.
+CMake installs into a per-preset stage directory (`CMAKE_INSTALL_PREFIX=${sourceDir}/build/stage/${presetName}` in `CMakePresets.json`); `build_linux.sh` installs into `build/stage/Release-linux/`, placing binaries in `bin/`, libraries in `lib/`, and headers in `include/` under that stage directory.
 
 ## Running Tests
 
@@ -38,29 +44,32 @@ Tests are driven through CTest at the workspace level. Each sub-project register
 - `dal_public_tests` — public-API tests (built from `dal-public/tests/`)
 
 ```bash
-# Run all registered tests
-(cd build && ctest --output-on-failure)
+# Run all registered tests (build_linux.sh puts the build tree at build/Release-linux)
+ctest --test-dir build/Release-linux --output-on-failure
 
-# Run a single binary directly
-bin/dal_cpp_tests
-bin/dal_public_tests
+# Run a single binary directly (build tree)
+./build/Release-linux/dal-cpp/dal_cpp_tests
+./build/Release-linux/dal-public/dal_public_tests
 
 # Run a single test suite
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.*
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.*
 
 # Run a single test
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
 
 # Focused script tree-walk/compiled evaluator parity checks
-bin/dal_cpp_tests --gtest_filter='ScriptCompiledParityTest.*:ScriptCompiledParityFuzzTest.*'
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptCompiledParityTest.*:ScriptCompiledParityFuzzTest.*'
 ```
 
-For script engine performance changes, build and smoke-run the benchmark:
+For script engine performance changes, build and smoke-run the benchmark (benchmarks are off in the `base` preset, so enable them explicitly):
 
 ```bash
-cmake --build build --target script_mc_perf -j 4
-./build/dal-cpp/benchmarks/script_mc_perf/script_mc_perf
+cmake --preset=Release-linux -S . -B build/Release-linux -DDAL_CPP_BUILD_BENCHMARKS=ON
+cmake --build build/Release-linux --target script_mc_perf -j 4
+./build/Release-linux/dal-cpp/benchmarks/script_mc_perf/script_mc_perf
 ```
+
+The paired regression gate that CI runs on pull requests lives in `.github/scripts/check_benchmark_regressions.py`; see `.claude/agents/dal-performancer.md` for reproducing it locally.
 
 ## Code Style
 
@@ -97,7 +106,7 @@ The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Ea
 - `dal-cpp/dal/auto/` — auto-generated code (Machinist output, glob-included into the library)
 - `dal-cpp/tests/` — Google Test files compiled into the `dal_cpp_tests` binary
 - `dal-cpp/examples/` — standalone example programs (AAD, Monte Carlo, finite difference, scripting, concurrency, Sobol, underdetermined optimization)
-- `dal-cpp/benchmarks/` — standalone performance benchmark programs (matrix, script engine; `script_mc_perf` compares tree-walk and compiled script evaluation)
+- `dal-cpp/benchmarks/` — standalone performance benchmark programs, one executable per target (17 total: matrix, script, tape, jacobian, pde, rng, interp, krylov, banded, cholesky, specialfunctions, black, iv_brent, script_mc, curve_calibration, threadpool, stacks); an 8-target subset is gated by the paired regression script. `script_mc_perf` compares tree-walk and compiled script evaluation
 - `dal-cpp/externals/` — git submodules for AAD frameworks, gtest, rapidjson, machinist
 - `dal-cpp/config/` — Machinist input (`dal.ifc`, `dal.mgl`)
 - `dal-cpp/cmake/` — `Platform.cmake` and helpers

--- a/dal-cpp/CMakeLists.txt
+++ b/dal-cpp/CMakeLists.txt
@@ -259,6 +259,7 @@ if(DAL_CPP_BUILD_TESTS)
 
     add_executable(dal_cpp_tests ${TEST_FILES})
     target_link_libraries(dal_cpp_tests PRIVATE dal_cpp gtest gtest_main gmock gmock_main)
+    dal_apply_platform_options(dal_cpp_tests)
 
     gtest_discover_tests(dal_cpp_tests)
 

--- a/dal-cpp/benchmarks/CMakeLists.txt
+++ b/dal-cpp/benchmarks/CMakeLists.txt
@@ -13,7 +13,9 @@ set(DAL_BENCHMARK_TARGETS
     black_perf
     iv_brent_perf
     script_mc_perf
-    curve_calibration_perf)
+    curve_calibration_perf
+    threadpool_perf
+    stacks_perf)
 
 foreach(benchmark_target IN LISTS DAL_BENCHMARK_TARGETS)
     add_subdirectory(${benchmark_target})

--- a/dal-cpp/benchmarks/rng_perf/rng_perf.cpp
+++ b/dal-cpp/benchmarks/rng_perf/rng_perf.cpp
@@ -1,16 +1,9 @@
 //
 // Created by dal-implementer on 2026-6-28.
 //
-// Random-number-generator micro-benchmark.
-// Builds RNGs (dimension 10) and measures FillNormal / FillUniform over a 100K-path
-// batch, the dominant MC inner loop. Sobol is split into fast (precise=false,
-// polish=false, Acklam-only ~1e-9, the library default) and precise opt-in
-// (precise=true, polish=true, Acklam+Newton ~1e-15) so the per-deviate
-// inverse-CDF cost difference is tracked.
-// BrownianBridge (variance-reduction wrapper) and the PseudoRandom_ alternatives
-// MRG32k3a / ShuffledIRN are pinned to precise=false, isolating their generator-
-// specific overhead against the Sobol fast baseline rather than re-measuring the
-// common inverse-CDF cost (already covered by the Sobol fast/precise pair).
+// Random-number-generator micro-benchmark; see docs/methodology/random.md
+// (Benchmark Coverage) for the fast/precise Sobol case split and the
+// precise=false pinning of the BrownianBridge / pseudo-random cases.
 
 #include <dal/platform/platform.hpp>
 #include <dal/math/random/brownianbridge.hpp>

--- a/dal-cpp/benchmarks/stacks_perf/CMakeLists.txt
+++ b/dal-cpp/benchmarks/stacks_perf/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB_RECURSE STACKS_PERF_FILES CONFIGURE_DEPENDS "*.hpp" "*.cpp")
+
+add_executable(stacks_perf ${STACKS_PERF_FILES})
+
+target_link_libraries(stacks_perf dal_library)
+
+if(MSVC)
+else()
+    target_link_libraries(stacks_perf pthread)
+endif()
+
+install(TARGETS stacks_perf
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )

--- a/dal-cpp/benchmarks/stacks_perf/stacks_perf.cpp
+++ b/dal-cpp/benchmarks/stacks_perf/stacks_perf.cpp
@@ -1,0 +1,83 @@
+//
+// Created by wegam on 2026/7/11.
+//
+// Stack primitive micro-benchmarks.
+// Isolates the push / pop / grow / reset cost of the Stack_ and StaticStack_
+// templates that the AAD tape hits once per recorded node and once per sweep
+// node, so a regression in the low-level container is visible without going
+// through the full tape.
+
+#include <dal/platform/platform.hpp>
+#include <dal/benchmarks/bench.hpp>
+#include <dal/math/stacks.hpp>
+
+using namespace Dal;
+
+namespace {
+    constexpr int kPushCount = 100000;
+} // namespace
+
+int main() {
+    constexpr int kRepeats = 100;
+    Bench::PrintHeader();
+
+    // Push with doubling growth (Stack_::Grow path).
+    {
+        double sink = 0.0;
+        auto r = Bench::Run("Stack_ push 100K (grow)", [&]() {
+            Stack_<double, 128> s;
+            for (int i = 0; i < kPushCount; ++i)
+                s.Push(static_cast<double>(i));
+            sink += s.Top();
+        }, 3, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+    }
+
+    // Push then drain via TopAndPop.
+    {
+        double sink = 0.0;
+        auto r = Bench::Run("Stack_ push+pop 100K", [&]() {
+            Stack_<double, 128> s;
+            for (int i = 0; i < kPushCount; ++i)
+                s.Push(static_cast<double>(i));
+            for (int i = 0; i < kPushCount; ++i)
+                sink += s.TopAndPop();
+        }, 3, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+    }
+
+    // Push then Reset (rewind the stack pointer without popping element-by-element).
+    {
+        double sink = 0.0;
+        auto r = Bench::Run("Stack_ push+reset 100K", [&]() {
+            Stack_<double, 128> s;
+            for (int i = 0; i < kPushCount; ++i)
+                s.Push(static_cast<double>(i));
+            sink += s.Top();
+            s.Reset();
+        }, 3, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+    }
+
+    // StaticStack_ push+pop within fixed capacity (stack-allocated, no growth).
+    {
+        constexpr int kBatches = 1000;
+        double sink = 0.0;
+        auto r = Bench::Run("StaticStack_ push+pop x128 x1K", [&]() {
+            StaticStack_<double, 128> s;
+            for (int b = 0; b < kBatches; ++b) {
+                for (int i = 0; i < 128; ++i)
+                    s.Push(static_cast<double>(i));
+                for (int i = 0; i < 128; ++i)
+                    sink += s.TopAndPop();
+            }
+        }, 3, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+    }
+
+    return 0;
+}

--- a/dal-cpp/benchmarks/threadpool_perf/CMakeLists.txt
+++ b/dal-cpp/benchmarks/threadpool_perf/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB_RECURSE THREADPOOL_PERF_FILES CONFIGURE_DEPENDS "*.hpp" "*.cpp")
+
+add_executable(threadpool_perf ${THREADPOOL_PERF_FILES})
+
+target_link_libraries(threadpool_perf dal_library)
+
+if(MSVC)
+else()
+    target_link_libraries(threadpool_perf pthread)
+endif()
+
+install(TARGETS threadpool_perf
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )

--- a/dal-cpp/benchmarks/threadpool_perf/threadpool_perf.cpp
+++ b/dal-cpp/benchmarks/threadpool_perf/threadpool_perf.cpp
@@ -1,0 +1,63 @@
+//
+// Created by wegam on 2026/7/11.
+//
+// Thread-pool micro-benchmark.
+// Tracks dispatch/join throughput and Start/drain/Stop lifecycle cost so
+// regressions in the concurrent queue or worker management surface directly.
+
+#include <dal/platform/platform.hpp>
+#include <dal/benchmarks/bench.hpp>
+#include <dal/concurrency/threadpool.hpp>
+#include <vector>
+
+using namespace Dal;
+
+namespace {
+    constexpr int kNumTasks = 100000;
+    constexpr int kWorkers = 4;
+} // namespace
+
+int main() {
+    constexpr int kRepeats = 10;
+    Bench::PrintHeader();
+    ThreadPool_* pool = ThreadPool_::GetInstance();
+
+    // Throughput: spawn kNumTasks trivial tasks across kWorkers and join.
+    // The work is intentionally negligible so the measurement isolates queue
+    // push/pop, task dispatch, and future hand-off overhead.
+    {
+        long sink = 0;
+        pool->Start(kWorkers, true);
+        auto r = Bench::Run("Spawn+join 100K tasks (4 workers)", [&]() {
+            std::vector<TaskHandle_> handles;
+            handles.reserve(kNumTasks);
+            for (int i = 0; i < kNumTasks; ++i)
+                handles.emplace_back(pool->SpawnTask([]() -> bool { return true; }));
+            for (auto& handle : handles)
+                sink += handle.get() ? 1 : 0;
+        }, 3, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+        pool->Stop();
+    }
+
+    // Lifecycle: a full Start + drain + Stop round-trip per iteration. Covers
+    // thread creation, queue teardown, and join cost on top of the dispatch path.
+    {
+        long sink = 0;
+        auto r = Bench::Run("Start+drain+Stop round-trip (4 workers)", [&]() {
+            pool->Start(kWorkers, true);
+            std::vector<TaskHandle_> handles;
+            handles.reserve(kNumTasks);
+            for (int i = 0; i < kNumTasks; ++i)
+                handles.emplace_back(pool->SpawnTask([]() -> bool { return true; }));
+            for (auto& handle : handles)
+                sink += handle.get() ? 1 : 0;
+            pool->Stop();
+        }, 2, kRepeats);
+        Bench::Print(r);
+        Bench::DoNotOptimize(&sink);
+    }
+
+    return 0;
+}

--- a/dal-cpp/dal/concurrency/threadpool.cpp
+++ b/dal-cpp/dal/concurrency/threadpool.cpp
@@ -74,8 +74,8 @@ namespace Dal {
     }
 
     void ThreadPool_::StartLocked(std::unique_lock<std::mutex>& lock, size_t nThreads) {
-        ASSERT(lock.owns_lock(), "thread pool lifecycle lock must be held when starting");
-        ASSERT(activeCallers_ == 0, "a new thread pool generation cannot start while caller tasks are active");
+        REQUIRE(lock.owns_lock(), "thread pool lifecycle lock must be held when starting");
+        REQUIRE(activeCallers_ == 0, "a new thread pool generation cannot start while caller tasks are active");
         ++generation_;
         active_ = true;
         try {
@@ -83,26 +83,12 @@ namespace Dal {
             for (size_t i = 0; i < nThreads - 1; ++i)
                 threads_.emplace_back(&ThreadPool_::ThreadFunc, this, i + 1);
         } catch (...) {
-            active_ = false;
-            stopping_ = true;
-            std::vector<std::thread> threads;
-            threads.swap(threads_);
-            queue_.InterruptAndClear();
-            lock.unlock();
-            std::for_each(threads.begin(), threads.end(), std::mem_fn(&std::thread::join));
-            lock.lock();
-            queue_.ResetInterrupt();
-            stopping_ = false;
-            lifecycleCondition_.notify_all();
+            TearDownWorkersLocked(lock, false);
             throw;
         }
     }
 
-    void ThreadPool_::StopLocked(std::unique_lock<std::mutex>& lock) {
-        ASSERT(lock.owns_lock(), "thread pool lifecycle lock must be held when stopping");
-        if (!active_)
-            return;
-
+    void ThreadPool_::TearDownWorkersLocked(std::unique_lock<std::mutex>& lock, bool waitForCallers) {
         active_ = false;
         stopping_ = true;
         std::vector<std::thread> threads;
@@ -111,10 +97,19 @@ namespace Dal {
         lock.unlock();
         std::for_each(threads.begin(), threads.end(), std::mem_fn(&std::thread::join));
         lock.lock();
-        lifecycleCondition_.wait(lock, [this]() { return activeCallers_ == 0; });
+        if (waitForCallers)
+            lifecycleCondition_.wait(lock, [this]() { return activeCallers_ == 0; });
         queue_.ResetInterrupt();
         stopping_ = false;
         lifecycleCondition_.notify_all();
+    }
+
+    void ThreadPool_::StopLocked(std::unique_lock<std::mutex>& lock) {
+        REQUIRE(lock.owns_lock(), "thread pool lifecycle lock must be held when stopping");
+        if (!active_)
+            return;
+
+        TearDownWorkersLocked(lock, true);
     }
 
     void ThreadPool_::Start(size_t nThreads, bool restart) {
@@ -170,8 +165,8 @@ namespace Dal {
 
     void ThreadPool_::ReleaseActiveCaller(size_t generation) {
         std::lock_guard<std::mutex> lock(lifecycleMutex_);
-        ASSERT(generation == generation_, "caller task belongs to a stale thread pool generation");
-        ASSERT(activeCallers_ > 0, "thread pool caller task accounting underflow");
+        REQUIRE(generation == generation_, "caller task belongs to a stale thread pool generation");
+        REQUIRE(activeCallers_ > 0, "thread pool caller task accounting underflow");
         --activeCallers_;
         lifecycleCondition_.notify_all();
     }

--- a/dal-cpp/dal/concurrency/threadpool.hpp
+++ b/dal-cpp/dal/concurrency/threadpool.hpp
@@ -66,6 +66,7 @@ namespace Dal {
         static size_t DefaultThreadCount();
         void StartLocked(std::unique_lock<std::mutex>& lock, size_t nThreads);
         void StopLocked(std::unique_lock<std::mutex>& lock);
+        void TearDownWorkersLocked(std::unique_lock<std::mutex>& lock, bool waitForCallers);
         ThreadPool_();
 
     public:

--- a/dal-cpp/examples/CMakeLists.txt
+++ b/dal-cpp/examples/CMakeLists.txt
@@ -19,3 +19,32 @@ add_subdirectory(yield_curve_jacobian)
 if(DAL_HAS_EXCEL)
     add_subdirectory(excelwriter)
 endif()
+
+# Keep FP-contraction policy consistent with the library, tests, and benchmarks
+# (see dal_apply_platform_options in cmake/Platform.cmake).
+set(DAL_EXAMPLE_TARGETS
+    aad
+    digital
+    concurrency
+    curve_calibration
+    euribor3m_curve
+    interpolate_curve
+    joint_multi_curve_calibration
+    xccy_curve_calibration
+    european_mc
+    european_fd
+    snowball
+    sobol
+    script
+    underdetermined
+    uoc
+    vanilla
+    yield_curve_jacobian)
+
+if(DAL_HAS_EXCEL)
+    list(APPEND DAL_EXAMPLE_TARGETS excelwriter)
+endif()
+
+foreach(example_target IN LISTS DAL_EXAMPLE_TARGETS)
+    dal_apply_platform_options(${example_target})
+endforeach()

--- a/dal-cpp/tests/math/aad/models/flat_ivs.hpp
+++ b/dal-cpp/tests/math/aad/models/flat_ivs.hpp
@@ -1,0 +1,19 @@
+//
+// Created by wegam on 2026/7/11.
+//
+
+#pragma once
+
+#include <dal/model/ivs.hpp>
+
+namespace Dal::AAD {
+    // Constant-implied-vol IVS_ fixture shared by the IVS and Dupire tests.
+    class FlatIVS_ : public IVS_ {
+        double vol_;
+
+    public:
+        FlatIVS_(double spot, double rate, double repo, double vol) : IVS_(spot, rate, repo), vol_(vol) {}
+
+        [[nodiscard]] double ImpliedVol(double, double) const override { return vol_; }
+    };
+} // namespace Dal::AAD

--- a/dal-cpp/tests/math/aad/models/test_dupire.cpp
+++ b/dal-cpp/tests/math/aad/models/test_dupire.cpp
@@ -5,19 +5,10 @@
 #include <gtest/gtest.h>
 #include <dal/platform/platform.hpp>
 #include <dal/model/dupire.hpp>
+#include "flat_ivs.hpp"
 
+using namespace Dal;
 using namespace Dal::AAD;
-
-namespace {
-    class FlatIVS_ : public IVS_ {
-        double vol_;
-
-    public:
-        FlatIVS_(double spot, double rate, double repo, double vol) : IVS_(spot, rate, repo), vol_(vol) {}
-
-        [[nodiscard]] double ImpliedVol(double, double) const override { return vol_; }
-    };
-} // namespace
 
 TEST(AADTest, TestDupireCalib) {
     const auto spot = 100;

--- a/dal-cpp/tests/math/aad/models/test_ivs.cpp
+++ b/dal-cpp/tests/math/aad/models/test_ivs.cpp
@@ -9,20 +9,10 @@
 #include <dal/platform/platform.hpp>
 #include <dal/math/distribution/black.hpp>
 #include <dal/model/ivs.hpp>
+#include "flat_ivs.hpp"
 
 using namespace Dal;
 using namespace Dal::AAD;
-
-namespace {
-    class FlatIVS_ : public IVS_ {
-        double vol_;
-
-    public:
-        FlatIVS_(double spot, double rate, double repo, double vol) : IVS_(spot, rate, repo), vol_(vol) {}
-
-        [[nodiscard]] double ImpliedVol(double, double) const override { return vol_; }
-    };
-} // namespace
 
 TEST(AADTest, TestMertonIVS) {
     const auto T = 2.0;

--- a/dal-cpp/tests/math/matrix/test_banded.cpp
+++ b/dal-cpp/tests/math/matrix/test_banded.cpp
@@ -2,9 +2,10 @@
 // Created by wegam on 2021/2/24.
 //
 
+#include <gtest/gtest.h>
+
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/sparse.hpp>
-#include <gtest/gtest.h>
 
 using namespace Dal;
 

--- a/dal-cpp/tests/storage/test_globals.cpp
+++ b/dal-cpp/tests/storage/test_globals.cpp
@@ -72,7 +72,7 @@ TEST(StorageTest, TestEvaluationDateScopeOwnsBarrierButAllowsConcurrentRead) {
     bool setterCompletedInsideScope = false;
 
     {
-        auto override = XGLOBAL::SetEvaluationDateInScope(stable);
+        auto dateOverride = XGLOBAL::SetEvaluationDateInScope(stable);
         auto barrierProbe = std::async(std::launch::async, []() {
             XGLOBAL::ValuationMutationGuard_ probe(std::try_to_lock);
             return probe.OwnsLock();
@@ -145,7 +145,7 @@ TEST(StorageTest, TestEvaluationDateWorkersObserveOneStableDateWhileSetterWaits)
     bool allTasksSucceeded = true;
     bool allWorkersStable = false;
     {
-        auto override = XGLOBAL::SetEvaluationDateInScope(stable);
+        auto dateOverride = XGLOBAL::SetEvaluationDateInScope(stable);
         std::promise<void> setterStarted;
         setter = std::async(std::launch::async, [&]() {
             setterStarted.set_value();

--- a/docs/methodology/random.md
+++ b/docs/methodology/random.md
@@ -281,6 +281,23 @@ directly rather than iterating through every intermediate point.
   support for substream parallelism; `IRN` is retained as a lightweight
   Knuth-style alternative.
 
+## Benchmark Coverage
+
+The `rng_perf` benchmark (`dal-cpp/benchmarks/rng_perf/rng_perf.cpp`) isolates
+the per-deviate inverse-CDF cost and the generator-specific overhead. Each case
+builds the generator at dimension 10 and drives `FillNormal` / `FillUniform`
+over a 100K-path batch, the dominant Monte Carlo inner loop.
+
+- **Sobol fast** (`precise=false`, `polish=false`, Acklam-only) and **Sobol
+  precise opt-in** (`precise=true`, `polish=true`, Acklam plus the Newton step)
+  split the inverse-CDF cost difference, since Sobol forwards both flags to
+  `InverseNCDF` unchanged.
+- **BrownianBridge** (the variance-reduction wrapper) and the `PseudoRandom_`
+  alternatives `MRG32k3a` and `ShuffledIRN` are pinned to `precise=false`,
+  isolating their generator-specific overhead against the Sobol fast baseline
+  rather than re-measuring the common inverse-CDF cost already covered by the
+  Sobol fast/precise pair.
+
 ## See Also
 
 - [Script engine](script_engine.md) — the Monte Carlo driver that consumes these


### PR DESCRIPTION
## Summary
Follow-up to the PR #221 review. No blocking issues were found; this addresses the should-fix style/perf items, closes two benchmark-coverage gaps, and refreshes operational docs that went stale after PR #221's install-prefix flip. 8 focused commits.

**Benchmark gate (`.github/scripts/check_benchmark_regressions.py`)**
- Reduce each confirmation round on `min`, not `statistics.median` — matches the `ci-benchmark-noise-floor` policy and the report's existing "Base min / Head min" header (right-skewed timing distributions).
- Add a 600s `subprocess.run` timeout (writes a marker + raises) so a deadlocked benchmark fails loud instead of stalling CI to the 6h cap.
- Tests: +2 (min-reduction lock-in, timeout); all 12 gate tests pass.

**C++ style / correctness**
- Apply `dal_apply_platform_options` to `dal_cpp_tests` and every example target, so tests/examples inherit `-ffp-contract=fast` like the library and benchmarks (was a correctness risk near tight `1e-8`–`1e-10` assertions).
- Thread-pool: `ASSERT`→`REQUIRE` for release-relevant lifecycle invariants; factor the duplicated worker teardown (`StartLocked` catch vs `StopLocked`) into `TearDownWorkersLocked`.
- Dedup the byte-identical `FlatIVS_` test fixture into a shared header; rename the `override` keyword-shadowing local in `test_globals.cpp`; restore gtest-first include order in `test_banded.cpp`.

**Benchmark coverage**
- `threadpool_perf` (spawn+join throughput + Start/drain/Stop lifecycle) and `stacks_perf` (Stack_/StaticStack_ push/pop/grow/reset) for the PR #221 rewrites that previously had correctness coverage but no `*_perf`.

**Docs**
- `CLAUDE.md` + `.claude/agents/*` + unit-test skills + `git-commit-pr.md`: correct the default-build description, manual-build commands (`-S/-B` + `cmake --build`, since `Release-linux` has no `binaryDir`), the benchmark-default preset override, the CI benchmark job, and swap `bin/dal_cpp_tests` → build-tree paths throughout.
- Move the `rng_perf` case-design comment into `docs/methodology/random.md` (Benchmark Coverage), per the comment-style rule.

**Deliberately not done (flagged for awareness):**
- `NumThreads()`/`IsActive()` `const` restoration (review item S3): won't compile without `mutable` (banned) or atomifying the members (~12 sites in Savine-origin, TSan-covered code) — poor risk/reward for a cosmetic const. Left as-is with this note.
- MSVC-runtime verify-block dedup across `dal-public`/`dal-excel`/`dal-python`: MSVC-only code untestable on Linux; skipped to avoid a blind package-config refactor.
- `specs/`/`designs/` and `settings.local.json` still carry `bin/dal_cpp_tests` refs (historical acceptance criteria / machine-local allowlist); left out of this scope.

## Test plan
- [x] `python3 -m pytest .github/scripts/tests/test_check_benchmark_regressions.py` → 12 passed
- [x] `./build/Release-linux/dal-cpp/dal_cpp_tests` (full) → 853 passed
- [x] `./build/Release-linux/dal-public/dal_public_tests` (full) → 44 passed
- [x] `threadpool_perf` and `stacks_perf` smoke-run → produce sensible numbers
- [x] `grep` for stale `bin/dal_cpp_tests` / `make install` / `cmake --preset=Release-linux ..` across CLAUDE.md + `.claude/{agents,rules,skills}` → clean
