### PR TITLE
docs: expose Windows CI and refresh coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # DAL - Derivatives Algorithms Library
 
 [![CMake Linux CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-linux.yml/badge.svg?branch=master)](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-linux.yml)
+[![CMake Windows CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-windows.yml/badge.svg?branch=master)](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-windows.yml)
 [![Codacy Grade](https://app.codacy.com/project/badge/Grade/9c84afd2bb534c6c87584e5d6e4cc420)](https://app.codacy.com/app/wegamekinglc/Derivatives-Algorithms-Lib)
-[![Coverage Status](https://coveralls.io/repos/wegamekinglc/Derivatives-Algorithms-Lib/badge.svg?branch=master)](https://coveralls.io/github/wegamekinglc/Derivatives-Algorithms-Lib?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/wegamekinglc/Derivatives-Algorithms-Lib/badge.svg?branch=master)](https://coveralls.io/github/wegamekinglc/Derivatives-Algorithms-Lib?branch=master)
 
 A C++17 quantitative finance library with built-in Automatic Adjoint Differentiation (AAD). Features include yield curve construction, Monte Carlo simulation, finite difference PDE solvers, a scripting engine for exotic payoffs with tree-walk and compiled evaluators, and parallel model evaluation.
 


### PR DESCRIPTION
## Summary
- add the live Windows CI status badge alongside the Linux badge
- switch the Coveralls image to its canonical GitHub repository path so coverage status stays current

## Why
The README did not expose Windows CI status, and its coverage badge used Coveralls' legacy repository path. This keeps both quality signals visible and live for readers.

## Test plan
- [x] `python3 .github/scripts/check_docs.py`
- [x] `git diff --check`
- [x] verified the Windows badge resolves to passing and Coveralls resolves to the latest `master` report
- [x] no C++ build run; this is a documentation-only change
