### PR TITLE
perf: benchmark yield curve instrument pricing

### DIFF
--- a/.codex/artifacts/perf/ycinstrument-pricing-performance.md
+++ b/.codex/artifacts/perf/ycinstrument-pricing-performance.md
@@ -1,0 +1,222 @@
+# Yield-Curve Instrument Pricing Performance Review
+
+## Findings
+
+### Blocking
+
+None.
+
+### Significant
+
+None.
+
+### Low / Advisory
+
+1. **The ten-run artifact is too noisy for a threshold or regression verdict.** The 20 rows span
+   3.59%-46.42% between the best and worst executable-level medians, with 18 of 20 rows above 4%;
+   the 3M projection basket and its derived per-instrument row are the 46% outliers
+   (`.superpowers/sdd/task-3-verification-report.md:64-91`). This does not require a code change:
+   the executable is deliberately report-only and is absent from the calibrated regression set
+   (`.github/scripts/check_benchmark_regressions.py:20-29`). A single CI run must not be used to
+   claim a speedup or regression.
+
+2. **Integer nanosecond normalization quantizes the cheapest rows.** `Normalize` divides the raw
+   `int64_t` fields before printing (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:180-183`),
+   while the cheap PRECOMPUTE rows are only 23-25 ns/operation
+   (`.superpowers/sdd/task-3-verification-report.md:66-73`). One printed nanosecond is therefore
+   about 4% of those rows, so their reported spread is partly output granularity rather than solely
+   runtime variation. The underlying 250,000-operation batches are long enough to measure, so this
+   is an interpretation caveat rather than a merge blocker. Future regression tooling should use
+   raw batch samples or higher-precision normalization.
+
+3. **The fixture is calibration-shaped, not a production-calendar latency model.** It deliberately
+   uses zero lags, `Holidays::None()`, `Unadjusted`, and `ACT_365F`
+   (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:62-85`). This improves determinism but
+   understates calendar and settlement work in PRECOMPUTE relative to some real USD books. The
+   benchmark still exercises the intended pricing topology: an eight-knot OIS curve, base-layered
+   3M/6M forwards, map-backed routing, and realistic long-leg frequencies
+   (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:88-125`). Treat the absolute numbers
+   as stable fixture observations, not production SLAs.
+
+## Verdict
+
+**Approve.** No blocking or significant performance-methodology finding remains. The benchmark is
+fit for report-only coverage and future like-for-like comparisons once a base revision also
+contains the target.
+
+## Reviewed Scope
+
+- Diff: `401d5b7a..2b849146`
+- Reviewed head: `2b849146` (`docs: clarify benchmark plan and noise evidence`)
+- New target: `ycinstrument_perf`
+- Implementation, target CMake, Linux/Windows reporting integration, design, implementation plan,
+  and Task 3 verification evidence were reviewed in full.
+- No production pricing, calibration, curve, AAD, or shared benchmark-harness implementation was
+  changed by the feature.
+
+## Resolved Review Items and Documentation Assessment
+
+The documentation-only follow-up changed no benchmark, CMake, workflow, harness, or production
+file. It resolves both prior documentation concerns:
+
+- The implementation plan now places a prominent **Historical snapshot - do not copy** warning
+  immediately before its embedded C++ draft. It directs readers to the final source and names the
+  two material differences: the required `ycimp.hpp` declaration include and the measured per-case
+  batch/pass counts
+  (`docs/superpowers/plans/2026-07-12-ycinstrument-pricing-performance.md:96`). The stale embedded
+  block can no longer reasonably be mistaken for authoritative implementation source.
+- The design now calls 2-4% only a nominal expectation for quiet paired runs, separately records
+  the actual unpinned-VM 3.59%-46.42% spread, links this performance artifact, and requires future
+  conclusions to use the run-specific measured noise floor
+  (`docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md:128-134`). This is
+  consistent with the evidence and with the report-only CI decision.
+
+The documentation-fix checkpoint reports a two-file-only commit, `git diff --check` and cached
+scope success, and documentation validation for 31 Markdown files
+(`.superpowers/sdd/task-4-doc-fix-report.md`). These resolved items do not alter the methodology
+findings or the Approve verdict.
+
+## Methodology Assessment
+
+### Fixture realism and routing
+
+The immutable fixture is constructed before measurement and contains:
+
+- eight knots from 3M through 40Y;
+- a 2% OIS discount curve;
+- base-layered 3M and 6M projection curves with distinct spreads;
+- a map-backed `CurveBlock_` containing discount and both projection entries
+  (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:88-105`).
+
+All seven concrete instrument identities are represented with the intended discount, projection,
+and multi-tenor paths (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:107-125`). The
+three baskets have realistic calibration shapes: 20 discount instruments, 20 3M-projection
+instruments, and ten passive 3M-vs-6M basis swaps
+(`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:214-254`). `BasisSwap_` labels include
+`PASSIVE`, so the output does not imply analytic-Jacobian eligibility.
+
+Untimed gates prove that projection does not silently fall back to discount, Future convexity is
+applied, STIR/OIS inheritance is preserved, and BasisSwap reads the 6M curve
+(`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:134-165`). Basket values are also
+required to be finite and non-zero before timing
+(`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:265-274`).
+
+### Timed-region boundaries and lifecycle separation
+
+The phase split is sound:
+
+- PRECOMPUTE repeatedly replaces a retained `RateHandle_`, so allocation, handle replacement, and
+  destruction of the prior object are measured as a lifecycle
+  (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:185-196`).
+- PRICE creates one rate handle before `Bench::Run` and reuses it throughout the timed body
+  (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:199-211`).
+- Basket instruments, rate handles, and correctness checks are all built before the timed basket
+  loops (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:293-318`).
+
+“Steady-state” correctly means reuse after `YCInstrument_::Precompute`; it does not promise that a
+production `Rate_::operator()` itself performs no internal schedule/context work. Curve,
+instrument, convention, and test-fixture construction do not leak into PRICE rows.
+
+### Batching and raw sample duration
+
+The benchmark uses three warmups and ten measured samples per timed call. Case-specific batch sizes
+are explicit at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:29-39`, and the shared
+harness times the whole batch before sorting ten samples into median/min/max
+(`dal-cpp/dal/benchmarks/bench.hpp:46-66`).
+
+Initial development batches produced approximately 2.2-118 ms samples, so only operation/pass
+counts were recalibrated. A post-calibration run placed all 17 independently timed calls in the
+5.438-17.700 ms target range (`.superpowers/sdd/task-1-implementer-report.md:84-107`). The 20 printed
+rows correspond to 17 timed calls because each of the three baskets prints both pass and
+per-instrument normalization from one raw result.
+
+Using the Task 3 best/worst normalized medians and the current divisors, the ten-run raw-median
+envelope is approximately 5.431-20.793 ms. The upper value is the noisy 3M projection basket; the
+other calibrated cases remain near the intended 5-20 ms window. This is long enough to prevent
+clock-call overhead from dominating and short enough for routine Linux/Windows reporting.
+
+### Normalization and output meaning
+
+`Normalize` applies the same positive divisor to median, min, and max while preserving the repeat
+count (`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:180-183`). Basket pass and
+per-instrument rows are produced from the same samples rather than timing the basket twice
+(`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:276-290`). The per-instrument basket
+number is therefore an average across a heterogeneous basket, not the latency of any one member;
+the individual rows provide attribution.
+
+Task 3 confirmed ten complete executable invocations, exactly 20 rows in every invocation, 20
+unique labels, and 28.289 seconds total wall time
+(`.superpowers/sdd/task-3-verification-report.md:36-62`). Representative best-to-worst ranges were:
+
+- cheap PRECOMPUTE: 23-25 ns/operation;
+- cheap PRICE: 213-249 ns/operation;
+- long PRECOMPUTE: 4.937-15.368 us/operation;
+- long PRICE: 3.128-18.745 us/operation;
+- baskets: 30.065-124.250 us/pass and 1.503-12.425 us/instrument
+  (`.superpowers/sdd/task-3-verification-report.md:66-85`).
+
+### Dead-code-elimination protection
+
+Every PRICE/basket iteration contributes to a data-dependent checksum
+(`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:199-210`,
+`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:276-287`). PRECOMPUTE retains a live
+rate handle. All sinks are passed through `Bench::DoNotOptimize`, whose GCC path uses an inline-asm
+input and memory clobber and whose MSVC path uses `_ReadWriteBarrier`
+(`dal-cpp/dal/benchmarks/bench.hpp:24-36`). Post-run REQUIRE checks also consume the sink/checksum.
+This is adequate for the current non-LTO cross-translation-unit build.
+
+## Noise Characterization and Regression Boundary
+
+The local artifact used:
+
+- Release, `-O3 -DNDEBUG`;
+- GCC 15.2.0;
+- AADet;
+- `DAL_ENABLE_NATIVE_ARCH=OFF`;
+- x86_64, Intel Core i9-13900HX, 32 logical processors under Microsoft full virtualization
+  (`.superpowers/sdd/task-3-verification-report.md:159-180`).
+
+The process was not pinned; turbo/governor state was uncontrolled; other host/VM activity could
+not be excluded; and the run was not paired with a baseline. The 3M projection outlier confirms
+that the artifact is descriptive, not a regression gate
+(`.superpowers/sdd/task-3-verification-report.md:182-187`). CI uses native tuning on both Linux and
+Windows (`.github/workflows/cmake-linux.yml:360-376`, `.github/workflows/cmake-windows.yml:230-255`),
+so local absolute values must not be compared directly with CI output.
+
+### No master baseline
+
+`master` at `401d5b7a` has no `ycinstrument_perf` entry in
+`dal-cpp/benchmarks/CMakeLists.txt` and no
+`dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp`; the reviewed head is `2b849146`.
+Consequently, **master has no `ycinstrument_perf` baseline, so no branch-vs-baseline regression
+conclusion is possible for this new executable**. The ten runs characterize only current-head
+repeatability.
+
+Once the target exists on both sides of a future change, performance conclusions should use paired,
+interleaved Release runs with at least ten complete invocations per side and best-of-N minima. A
+single invocation or a delta within the run-specific measured noise floor is inconclusive.
+
+## CI Placement
+
+The target is registered immediately before `curve_calibration_perf` in CMake
+(`dal-cpp/benchmarks/CMakeLists.txt:16-17`) and in both reporting arrays
+(`.github/workflows/cmake-linux.yml:399-420`, `.github/workflows/cmake-windows.yml:237-257`). Linux
+runs the head executable from its build-tree path; Windows runs the installed executable. Both
+capture and publish normal benchmark output.
+
+The calibrated regression script still contains only the established eight-target set
+(`.github/scripts/check_benchmark_regressions.py:20-29`), and Task 3 independently confirmed the new
+name is absent (`.superpowers/sdd/task-3-verification-report.md:143-157`). Thus executable failures
+remain visible, but timing values do not create a brittle merge gate.
+
+## Verification Evidence
+
+- Build: `ycinstrument_perf` and `dal_cpp_tests` resolved successfully
+  (`.superpowers/sdd/task-3-verification-report.md:12-34`).
+- Focused tests: 11/11 passed (`.superpowers/sdd/task-3-verification-report.md:93-106`).
+- Full core tests: 876/876 across 79 suites passed
+  (`.superpowers/sdd/task-3-verification-report.md:108-121`).
+- Documentation integrity: 31 Markdown files passed; working tree diff/status/stat were clean
+  (`.superpowers/sdd/task-3-verification-report.md:123-149`).
+- Registration and regression-boundary checks passed
+  (`.superpowers/sdd/task-3-verification-report.md:143-157`).

--- a/.codex/artifacts/reviews/ycinstrument-pricing-performance.md
+++ b/.codex/artifacts/reviews/ycinstrument-pricing-performance.md
@@ -1,0 +1,66 @@
+# Yield-Curve Instrument Pricing Performance - Whole-Branch Code Review
+
+- Date: 2026-07-12
+- Range reviewed: `401d5b7a..2b849146`
+- Head reviewed: `2b849146`
+- Mode: read-only re-review of the supplied updated whole-feature diff and prior review fixes
+
+## Findings
+
+### Critical
+
+None.
+
+### Important
+
+None.
+
+### Minor
+
+None.
+
+## Resolved Findings
+
+1. **Resolved - the implementation plan now clearly marks its embedded source as historical and non-copyable.**
+   - A prominent warning immediately before the stale source block states that it is a historical pre-calibration snapshot, is neither authoritative nor copyable, and directs readers to the final benchmark source at `docs/superpowers/plans/2026-07-12-ycinstrument-pricing-performance.md:92-98`.
+   - The warning explicitly identifies the required `dal/curve/ycimp.hpp` include and measured per-case operation and basket-pass counts, which are present in the authoritative source at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:13-39,276-318`.
+
+2. **Resolved - the design now distinguishes nominal noise guidance from current measured evidence.**
+   - `docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md:127-133` now says 2-4% is only a nominal expectation for quiet paired runs, records the current 3.59%-46.42% unpinned-VM spread, links the performance artifact, and requires conclusions to use the run-specific measured noise floor.
+   - The stated range matches the ten-run evidence at `.superpowers/sdd/task-3-verification-report.md:64-91` and the performance review at `.codex/artifacts/perf/ycinstrument-pricing-performance.md:13-30`.
+
+## Strengths
+
+- **Pricing and routing fixture:** the benchmark builds a map-backed `CurveBlock_` with an OIS discount curve and base-layered 3M/6M forwards before timing at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:88-105`. The seven representative contracts exercise discount, projection, alias, convexity, and two-tenor basis pricing at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:107-126`.
+- **Untimed correctness gates:** finite values, projection-vs-discount routing, Future convexity, STIR/FRA inheritance, OISSwap/Swap inheritance, and BasisSwap 6M sensitivity are checked before measurement at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:129-166`.
+- **Timing isolation:** PRECOMPUTE deliberately measures rate-handle lifecycle replacement, while PRICE constructs one rate before `Bench::Run` and measures only repeated `Rate_::operator()` calls at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:185-212`. Basket instruments and rates are likewise built before timing at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:257-263,293-309`.
+- **Normalization and stable output:** normalized median/min/max preserve the ten-sample count at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:180-183`. Seven phase pairs plus three basket/per-instrument pairs produce exactly 20 stable labels at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:168-177,288-318`; BasisSwap labels explicitly contain `PASSIVE`.
+- **Dead-code protection:** every PRICE and basket measurement accumulates a checked data-dependent checksum and calls `Bench::DoNotOptimize`; PRECOMPUTE retains and validates the final handle at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:185-212,276-290`.
+- **Cross-platform integration:** the standard optional AAD libraries, non-MSVC pthread linkage, and install rule are present at `dal-cpp/benchmarks/ycinstrument_perf/CMakeLists.txt:1-23`. The target is registered immediately before `curve_calibration_perf` in CMake, Linux, and Windows at `dal-cpp/benchmarks/CMakeLists.txt:16-17`, `.github/workflows/cmake-linux.yml:418-419`, and `.github/workflows/cmake-windows.yml:255-256`.
+- **Report-only boundary:** the workflows run and publish the executable, while `.github/scripts/check_benchmark_regressions.py` remains unchanged and contains no `ycinstrument_perf` entry.
+- **Scope discipline:** the feature range changes only the benchmark target/source, the two reporting arrays, and its design/implementation-plan documents. No production pricing, calibration, shared benchmark-harness, or test source changed.
+
+## Verification
+
+Fresh re-review checks on `2b849146`:
+
+- `python3 .github/scripts/check_docs.py` - 31 Markdown files passed.
+- Direct assertions for the historical/non-copyable warning, `ycimp.hpp` and calibrated-count guidance, nominal-noise wording, measured 3.59%-46.42% range, and run-specific conclusion rule - passed.
+- `git diff --name-status ff258a70..2b849146` - exactly the implementation-plan and design documents changed.
+- `git diff --check 401d5b7a..2b849146` - passed.
+
+The immediately preceding whole-branch gate remains valid because the review-fix commit is documentation-only:
+
+- `ycinstrument_perf` and `dal_cpp_tests` built successfully.
+- One executable run produced 20 unique measured labels, all reporting 10 repetitions.
+- Focused `YCInstrumentTest.*` passed 11/11; full core tests passed 876/876.
+- `clang-format --dry-run --Werror -sort-includes=0` passed on the new source; `platform.hpp` remains first at `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp:5`.
+- Occurrence checks found exactly one target entry in CMake and each workflow, and zero entries in the calibrated regression script.
+
+Residual risk: Windows and alternate-AAD-backend compilation were not reproduced locally during this review; the CMake pattern matches existing benchmark targets and the workflow additions provide those cross-platform gates. The executable is new on this branch, so there is no master baseline from which to make a branch-vs-baseline performance conclusion.
+
+## Verdict
+
+Approve
+
+No Critical, Important, or Minor findings remain. Both prior Minor findings are resolved in `2b849146`.

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -415,6 +415,7 @@ jobs:
             black_perf
             iv_brent_perf
             script_mc_perf
+            ycinstrument_perf
             curve_calibration_perf
           )
 

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -252,6 +252,7 @@ jobs:
             black_perf
             iv_brent_perf
             script_mc_perf
+            ycinstrument_perf
             curve_calibration_perf
           )
 

--- a/dal-cpp/benchmarks/CMakeLists.txt
+++ b/dal-cpp/benchmarks/CMakeLists.txt
@@ -13,6 +13,7 @@ set(DAL_BENCHMARK_TARGETS
     black_perf
     iv_brent_perf
     script_mc_perf
+    ycinstrument_perf
     curve_calibration_perf
     threadpool_perf
     stacks_perf)

--- a/dal-cpp/benchmarks/ycinstrument_perf/CMakeLists.txt
+++ b/dal-cpp/benchmarks/ycinstrument_perf/CMakeLists.txt
@@ -1,0 +1,23 @@
+file(GLOB_RECURSE YCINSTRUMENT_PERF_FILES CONFIGURE_DEPENDS "*.hpp" "*.cpp")
+
+add_executable(ycinstrument_perf ${YCINSTRUMENT_PERF_FILES})
+
+target_link_libraries(ycinstrument_perf dal_library)
+
+if(DAL_USE_XAD_AAD)
+    target_link_libraries(ycinstrument_perf XAD::xad)
+elseif(DAL_USE_CODIPACK_AAD)
+    target_link_libraries(ycinstrument_perf CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(ycinstrument_perf adept)
+endif ()
+
+if(MSVC)
+else()
+    target_link_libraries(ycinstrument_perf pthread)
+endif()
+
+install(TARGETS ycinstrument_perf
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )

--- a/dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp
+++ b/dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp
@@ -1,0 +1,320 @@
+//
+// Created by dal-implementer on 2026/7/12.
+//
+
+#include <dal/platform/platform.hpp>
+#include <dal/platform/strict.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <dal/benchmarks/bench.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/ycimp.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/curve/ycpwlf.hpp>
+#include <dal/platform/initall.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+
+using namespace Dal;
+
+namespace {
+    constexpr int kWarmups = 3;
+    constexpr int kRepeats = 10;
+    constexpr int kCheapPrecomputeBatch = 250000;
+    constexpr int kCheapPriceBatch = 75000;
+    constexpr int kLongPrecomputeBatch = 1100;
+    constexpr int kSwapPriceBatch = 1000;
+    constexpr int kOisSwapPriceBatch = 5000;
+    constexpr int kBasisSwapPriceBatch = 750;
+    constexpr int kDiscountBasketPasses = 500;
+    constexpr int kProjectionBasketPasses = 200;
+    constexpr int kBasisBasketPasses = 100;
+    constexpr double kFutureConvexity = 0.0015;
+
+    using InstrumentHandle_ = Handle_<YCInstrument_>;
+    using RateHandle_ = Handle_<YCInstrument_::Rate_>;
+
+    struct InstrumentSet_ {
+        InstrumentHandle_ deposit_;
+        InstrumentHandle_ fra_;
+        InstrumentHandle_ future_;
+        InstrumentHandle_ stir_;
+        InstrumentHandle_ swap_;
+        InstrumentHandle_ oisSwap_;
+        InstrumentHandle_ basisSwap_;
+    };
+
+    struct InstrumentCase_ {
+        std::string label_;
+        InstrumentHandle_ instrument_;
+        int precomputeBatch_;
+        int priceBatch_;
+    };
+
+    RateLegConvention_ MakeLeg(const char* frequency, const DayBasis_& basis) {
+        RateLegConvention_ result;
+        result.paymentLag_ = 0;
+        result.paymentFrequency_ = PeriodLength_(frequency);
+        result.dayBasis_ = basis;
+        result.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        result.paymentConvention_ = BizDayConvention_("Unadjusted");
+        result.accrualHolidays_ = Holidays::None();
+        result.paymentHolidays_ = Holidays::None();
+        return result;
+    }
+
+    RateIndexConvention_ MakeIndex(const char* tenor, const DayBasis_& basis, bool useProjection) {
+        RateIndexConvention_ result;
+        result.spotLag_ = 0;
+        result.fixingLag_ = 0;
+        result.useProjectionCurve_ = useProjection;
+        result.forecastTenor_ = PeriodLength_(tenor);
+        result.dayBasis_ = basis;
+        result.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        result.fixingHolidays_ = Holidays::None();
+        result.accrualHolidays_ = Holidays::None();
+        result.collateral_ = CollateralType_(CollateralType_::Value_::OIS);
+        return result;
+    }
+
+    Handle_<YieldCurve_> BuildMarket(const Date_& today, const DayBasis_& basis, double sixMonthSpread = 0.01) {
+        const Vector_<Date_> knots = {
+            Date::AddMonths(today, 3),  Date::AddMonths(today, 6),   Date::AddMonths(today, 12),  Date::AddMonths(today, 24),
+            Date::AddMonths(today, 60), Date::AddMonths(today, 120), Date::AddMonths(today, 240), Date::AddMonths(today, 480),
+        };
+        const Vector_<> oisValues(knots.size(), 0.02);
+        const Vector_<> threeMonthSpread(knots.size(), 0.005);
+        const Vector_<> sixMonthSpreadValues(knots.size(), sixMonthSpread);
+
+        const Handle_<DiscountCurve_> ois(NewDiscountPWLF("pricing_ois", "USD", PiecewiseLinear_(knots, oisValues, oisValues)));
+        const Handle_<DiscountCurve_> threeMonth(
+            NewDiscountPWLF("pricing_3m", "USD", PiecewiseLinear_(knots, threeMonthSpread, threeMonthSpread), ois));
+        const Handle_<DiscountCurve_> sixMonth(
+            NewDiscountPWLF("pricing_6m", "USD", PiecewiseLinear_(knots, sixMonthSpreadValues, sixMonthSpreadValues), ois));
+
+        return Handle_<YieldCurve_>(new CurveBlock_("pricing_market", "USD", {{CollateralType_(CollateralType_::Value_::OIS), ois}},
+                                                    {{PeriodLength_("3M"), threeMonth}, {PeriodLength_("6M"), sixMonth}}, basis));
+    }
+
+    InstrumentSet_ BuildInstrumentSet(const Date_& today, const DayBasis_& basis) {
+        const Date_ threeMonths = Date::AddMonths(today, 3);
+        const Date_ sixMonths = Date::AddMonths(today, 6);
+        const Date_ tenYears = Date::AddMonths(today, 120);
+        const RateIndexConvention_ discountIndex = MakeIndex("3M", basis, false);
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateIndexConvention_ projected6m = MakeIndex("6M", basis, true);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+        const RateLegConvention_ quarterlyLeg = MakeLeg("3M", basis);
+        const RateLegConvention_ semiannualLeg = MakeLeg("6M", basis);
+
+        InstrumentSet_ result;
+        result.deposit_.reset(new Deposit_(today, today, sixMonths, 0.0, discountIndex));
+        result.fra_.reset(new FRA_(today, threeMonths, sixMonths, 0.0, projected3m));
+        result.future_.reset(new Future_(today, threeMonths, sixMonths, 0.0, projected3m, kFutureConvexity));
+        result.stir_.reset(new STIR_(today, threeMonths, sixMonths, 0.0, discountIndex));
+        result.swap_.reset(new Swap_(today, today, tenYears, 0.0, annualLeg, projected3m, quarterlyLeg));
+        result.oisSwap_.reset(new OISSwap_(today, today, tenYears, 0.0, annualLeg, discountIndex, annualLeg));
+        result.basisSwap_.reset(new BasisSwap_(today, today, tenYears, 0.0, projected3m, quarterlyLeg, projected6m, semiannualLeg));
+        return result;
+    }
+
+    double Price(const InstrumentHandle_& instrument, const YieldCurve_& market) {
+        const RateHandle_ rate = instrument->Precompute(Handle_<YieldCurve_>());
+        return (*rate)(market);
+    }
+
+    void ValidateInstrumentSet(const InstrumentSet_& instruments, const Date_& today, const DayBasis_& basis, const YieldCurve_& market) {
+        const std::vector<InstrumentHandle_> all = {
+            instruments.deposit_, instruments.fra_,     instruments.future_,    instruments.stir_,
+            instruments.swap_,    instruments.oisSwap_, instruments.basisSwap_,
+        };
+        for (const auto& instrument : all)
+            REQUIRE(std::isfinite(Price(instrument, market)), "Instrument pricing benchmark requires finite model rates");
+
+        const Date_ threeMonths = Date::AddMonths(today, 3);
+        const Date_ sixMonths = Date::AddMonths(today, 6);
+        const Date_ tenYears = Date::AddMonths(today, 120);
+        const RateIndexConvention_ discountIndex = MakeIndex("3M", basis, false);
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+
+        const InstrumentHandle_ discountFra(new FRA_(today, threeMonths, sixMonths, 0.0, discountIndex));
+        const InstrumentHandle_ projectedFra(new FRA_(today, threeMonths, sixMonths, 0.0, projected3m));
+        const InstrumentHandle_ discountFraForStir(new FRA_(today, threeMonths, sixMonths, 0.0, discountIndex));
+        const InstrumentHandle_ discountSwap(new Swap_(today, today, tenYears, 0.0, annualLeg, discountIndex, annualLeg));
+
+        REQUIRE(std::fabs(Price(projectedFra, market) - Price(discountFra, market)) > 1.0e-8,
+                "Projection benchmark must not silently fall back to discount pricing");
+        REQUIRE(std::fabs(Price(instruments.future_, market) - (Price(projectedFra, market) - kFutureConvexity)) < 1.0e-12,
+                "Future benchmark must apply its convexity adjustment");
+        REQUIRE(std::fabs(Price(instruments.stir_, market) - Price(discountFraForStir, market)) < 1.0e-12,
+                "STIR benchmark must retain inherited FRA pricing");
+        REQUIRE(std::fabs(Price(instruments.oisSwap_, market) - Price(discountSwap, market)) < 1.0e-12,
+                "OIS benchmark must retain inherited discount-only swap pricing");
+
+        const Handle_<YieldCurve_> alternateMarket = BuildMarket(today, basis, 0.015);
+        REQUIRE(std::fabs(Price(instruments.basisSwap_, market) - Price(instruments.basisSwap_, *alternateMarket)) > 1.0e-8,
+                "Basis-swap benchmark must read the 6M projection curve");
+    }
+
+    std::vector<InstrumentCase_> IndividualCases(const InstrumentSet_& instruments) {
+        return {
+            {"Deposit_ 6M", instruments.deposit_, kCheapPrecomputeBatch, kCheapPriceBatch},
+            {"FRA_ 3x6 3M projection", instruments.fra_, kCheapPrecomputeBatch, kCheapPriceBatch},
+            {"Future_ 3x6 3M projection", instruments.future_, kCheapPrecomputeBatch, kCheapPriceBatch},
+            {"STIR_ 3x6", instruments.stir_, kCheapPrecomputeBatch, kCheapPriceBatch},
+            {"Swap_ 10Y annual-vs-3M", instruments.swap_, kLongPrecomputeBatch, kSwapPriceBatch},
+            {"OISSwap_ 10Y annual", instruments.oisSwap_, kLongPrecomputeBatch, kOisSwapPriceBatch},
+            {"BasisSwap_ 10Y 3M-vs-6M PASSIVE", instruments.basisSwap_, kLongPrecomputeBatch, kBasisSwapPriceBatch},
+        };
+    }
+
+    Bench::Result_ Normalize(const Bench::Result_& raw, const std::string& name, int64_t divisor) {
+        REQUIRE(divisor > 0, "Benchmark normalization divisor must be positive");
+        return Bench::Result_{name, raw.medianNs / divisor, raw.minNs / divisor, raw.maxNs / divisor, raw.repeats};
+    }
+
+    void RunPrecompute(const InstrumentCase_& instrumentCase) {
+        RateHandle_ sink = instrumentCase.instrument_->Precompute(Handle_<YieldCurve_>());
+        const Bench::Result_ raw = Bench::Run(
+            instrumentCase.label_,
+            [&]() {
+                for (int i = 0; i < instrumentCase.precomputeBatch_; ++i)
+                    sink = instrumentCase.instrument_->Precompute(Handle_<YieldCurve_>());
+            },
+            kWarmups, kRepeats);
+        Bench::DoNotOptimize(sink.get());
+        REQUIRE(sink, "Instrument PRECOMPUTE sink must retain a rate handle");
+        Bench::Print(Normalize(raw, instrumentCase.label_ + " PRECOMPUTE lifecycle / operation", instrumentCase.precomputeBatch_));
+    }
+
+    void RunPrice(const InstrumentCase_& instrumentCase, const YieldCurve_& market) {
+        const RateHandle_ rate = instrumentCase.instrument_->Precompute(Handle_<YieldCurve_>());
+        double checksum = 0.0;
+        const Bench::Result_ raw = Bench::Run(
+            instrumentCase.label_,
+            [&]() {
+                for (int i = 0; i < instrumentCase.priceBatch_; ++i)
+                    checksum += (*rate)(market);
+            },
+            kWarmups, kRepeats);
+        Bench::DoNotOptimize(&checksum);
+        REQUIRE(std::isfinite(checksum) && std::fabs(checksum) > 0.0, "Instrument PRICE checksum must be finite and non-zero");
+        Bench::Print(Normalize(raw, instrumentCase.label_ + " PRICE / operation", instrumentCase.priceBatch_));
+    }
+
+    std::vector<InstrumentHandle_> DiscountBasket(const Date_& today, const DayBasis_& basis) {
+        const RateIndexConvention_ discountIndex = MakeIndex("3M", basis, false);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+        std::vector<InstrumentHandle_> result;
+        result.reserve(20);
+        for (int month = 1; month <= 5; ++month)
+            result.emplace_back(new Deposit_(today, today, Date::AddMonths(today, month), 0.0, discountIndex));
+        for (int startMonth : {6, 9, 12})
+            result.emplace_back(new STIR_(today, Date::AddMonths(today, startMonth), Date::AddMonths(today, startMonth + 3), 0.0, discountIndex));
+        for (int year = 2; year <= 13; ++year)
+            result.emplace_back(new OISSwap_(today, today, Date::AddMonths(today, 12 * year), 0.0, annualLeg, discountIndex, annualLeg));
+        return result;
+    }
+
+    std::vector<InstrumentHandle_> ProjectionBasket(const Date_& today, const DayBasis_& basis) {
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+        const RateLegConvention_ quarterlyLeg = MakeLeg("3M", basis);
+        std::vector<InstrumentHandle_> result;
+        result.reserve(20);
+        for (int startMonth = 1; startMonth <= 8; ++startMonth)
+            result.emplace_back(new FRA_(today, Date::AddMonths(today, startMonth), Date::AddMonths(today, startMonth + 3), 0.0, projected3m));
+        for (int startMonth = 9; startMonth <= 12; ++startMonth)
+            result.emplace_back(
+                new Future_(today, Date::AddMonths(today, startMonth), Date::AddMonths(today, startMonth + 3), 0.0, projected3m, kFutureConvexity));
+        for (int year = 3; year <= 10; ++year)
+            result.emplace_back(new Swap_(today, today, Date::AddMonths(today, 12 * year), 0.0, annualLeg, projected3m, quarterlyLeg));
+        return result;
+    }
+
+    std::vector<InstrumentHandle_> BasisBasket(const Date_& today, const DayBasis_& basis) {
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateIndexConvention_ projected6m = MakeIndex("6M", basis, true);
+        const RateLegConvention_ quarterlyLeg = MakeLeg("3M", basis);
+        const RateLegConvention_ semiannualLeg = MakeLeg("6M", basis);
+        std::vector<InstrumentHandle_> result;
+        result.reserve(10);
+        for (int year = 2; year <= 11; ++year)
+            result.emplace_back(
+                new BasisSwap_(today, today, Date::AddMonths(today, 12 * year), 0.0, projected3m, quarterlyLeg, projected6m, semiannualLeg));
+        return result;
+    }
+
+    std::vector<RateHandle_> PrecomputeAll(const std::vector<InstrumentHandle_>& instruments) {
+        std::vector<RateHandle_> result;
+        result.reserve(instruments.size());
+        for (const auto& instrument : instruments)
+            result.push_back(instrument->Precompute(Handle_<YieldCurve_>()));
+        return result;
+    }
+
+    void ValidateBasket(const std::vector<RateHandle_>& rates, const YieldCurve_& market) {
+        REQUIRE(!rates.empty(), "Pricing basket must not be empty");
+        double checksum = 0.0;
+        for (const auto& rate : rates) {
+            const double value = (*rate)(market);
+            REQUIRE(std::isfinite(value), "Pricing basket requires finite model rates");
+            checksum += value;
+        }
+        REQUIRE(std::isfinite(checksum) && std::fabs(checksum) > 0.0, "Pricing basket checksum must be finite and non-zero");
+    }
+
+    void RunBasket(const std::string& label, const std::vector<RateHandle_>& rates, const YieldCurve_& market, int passes) {
+        double checksum = 0.0;
+        const Bench::Result_ raw = Bench::Run(
+            label,
+            [&]() {
+                for (int pass = 0; pass < passes; ++pass)
+                    for (const auto& rate : rates)
+                        checksum += (*rate)(market);
+            },
+            kWarmups, kRepeats);
+        Bench::DoNotOptimize(&checksum);
+        REQUIRE(std::isfinite(checksum) && std::fabs(checksum) > 0.0, "Pricing BASKET checksum must be finite and non-zero");
+        Bench::Print(Normalize(raw, label + " BASKET / pass", passes));
+        Bench::Print(Normalize(raw, label + " PER-INSTRUMENT", passes * static_cast<int64_t>(rates.size())));
+    }
+} // namespace
+
+int main() {
+    RegisterAll_::Init();
+    const Date_ today(2024, 1, 15);
+    const DayBasis_ basis("ACT_365F");
+    const Handle_<YieldCurve_> market = BuildMarket(today, basis);
+    const InstrumentSet_ instruments = BuildInstrumentSet(today, basis);
+    ValidateInstrumentSet(instruments, today, basis, *market);
+
+    const std::vector<InstrumentHandle_> discountInstruments = DiscountBasket(today, basis);
+    const std::vector<InstrumentHandle_> projectionInstruments = ProjectionBasket(today, basis);
+    const std::vector<InstrumentHandle_> basisInstruments = BasisBasket(today, basis);
+    const std::vector<RateHandle_> discountRates = PrecomputeAll(discountInstruments);
+    const std::vector<RateHandle_> projectionRates = PrecomputeAll(projectionInstruments);
+    const std::vector<RateHandle_> basisRates = PrecomputeAll(basisInstruments);
+    ValidateBasket(discountRates, *market);
+    ValidateBasket(projectionRates, *market);
+    ValidateBasket(basisRates, *market);
+
+    Bench::PrintHeader();
+    for (const auto& instrumentCase : IndividualCases(instruments)) {
+        RunPrecompute(instrumentCase);
+        RunPrice(instrumentCase, *market);
+    }
+    RunBasket("Discount 20-instrument", discountRates, *market, kDiscountBasketPasses);
+    RunBasket("3M projection 20-instrument", projectionRates, *market, kProjectionBasketPasses);
+    RunBasket("3M-vs-6M PASSIVE 10-instrument", basisRates, *market, kBasisBasketPasses);
+    return 0;
+}

--- a/docs/superpowers/plans/2026-07-12-ycinstrument-pricing-performance.md
+++ b/docs/superpowers/plans/2026-07-12-ycinstrument-pricing-performance.md
@@ -93,6 +93,8 @@ install(TARGETS ycinstrument_perf
 
 Create `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp` with the following implementation:
 
+> **Historical snapshot - do not copy:** The embedded C++ below records the pre-calibration implementation draft and is neither authoritative nor copyable as the final benchmark source. Use `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp` instead; the final source includes the required `dal/curve/ycimp.hpp` factory declaration and the measured per-case operation and basket-pass counts.
+
 ```cpp
 //
 // Created by dal-implementer on 2026/7/12.

--- a/docs/superpowers/plans/2026-07-12-ycinstrument-pricing-performance.md
+++ b/docs/superpowers/plans/2026-07-12-ycinstrument-pricing-performance.md
@@ -1,0 +1,716 @@
+# Yield-Curve Instrument Pricing Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a cross-platform `ycinstrument_perf` executable that separately measures precompute lifecycle and steady-state pricing for all seven concrete yield-curve instruments, plus three calibration-shaped pricing baskets.
+
+**Architecture:** Build one immutable map-backed OIS/3M/6M market fixture, construct every instrument and precomputed rate outside steady-state timed regions, and use the shared `Dal::Bench` harness for batched measurements. Keep correctness gates untimed, normalize samples without modifying the shared harness, and report the new executable in Linux and Windows CI without adding a noisy regression threshold.
+
+**Tech Stack:** C++17, DAL curve and instrument APIs, CMake, `Dal::Bench`, GitHub Actions YAML, Google Test.
+
+## Global Constraints
+
+- Benchmark all seven concrete types: `Deposit_`, `FRA_`, `Future_`, `STIR_`, `Swap_`, `OISSwap_`, and `BasisSwap_`.
+- Print separate `PRECOMPUTE` and steady-state `PRICE` rows for each concrete type.
+- Print discount, 3M projection, and 3M-vs-6M baskets as both `BASKET` and `PER-INSTRUMENT` rows.
+- Use a map-backed `CurveBlock_` with OIS discounting and base-layered 3M/6M forward curves.
+- Construct curves and instruments outside timed regions; construct precomputed `Rate_` handles outside `PRICE` rows.
+- Use three warmups and ten measured samples; batch work so samples target 5-20ms.
+- Add no absolute timing assertion and do not add `ycinstrument_perf` to the calibrated eight-target regression gate.
+- Label `BasisSwap_` rows `PASSIVE`; do not imply analytical-Jacobian support.
+- Preserve `dal-cpp/dal/benchmarks/bench.hpp` and all production pricing/calibration code unchanged.
+- Keep `dal/platform/platform.hpp` first and format the new translation unit with `clang-format -sort-includes=0`.
+- The original checkout rejects `.git/index.lock` writes. Execute in the writable isolated feature checkout, create task-scoped commits there, and leave the original checkout untouched.
+
+---
+
+### Task 1: Add the instrument-pricing benchmark executable
+
+**Files:**
+- Modify: `dal-cpp/benchmarks/CMakeLists.txt`
+- Create: `dal-cpp/benchmarks/ycinstrument_perf/CMakeLists.txt`
+- Create: `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp`
+- Test: `dal-cpp/tests/curve/test_ycinstrument.cpp`
+
+**Interfaces:**
+- Consumes: `Dal::Bench::Run`, `Dal::Bench::Print`, `Dal::Bench::DoNotOptimize`, `YCInstrument_::Precompute`, `YCInstrument_::Rate_::operator()`, `CurveBlock_`, and `NewDiscountPWLF`.
+- Produces: CMake target and installed executable `ycinstrument_perf`, with exactly 20 result rows.
+
+- [ ] **Step 1: Register the missing target to establish the red build gate**
+
+Edit `dal-cpp/benchmarks/CMakeLists.txt` so the tail of `DAL_BENCHMARK_TARGETS` reads:
+
+```cmake
+    iv_brent_perf
+    script_mc_perf
+    ycinstrument_perf
+    curve_calibration_perf
+    threadpool_perf
+    stacks_perf)
+```
+
+- [ ] **Step 2: Run the red gate and confirm the target is genuinely missing**
+
+Run:
+
+```bash
+cmake --build build --target ycinstrument_perf -j2
+```
+
+Expected: CMake regeneration fails because `dal-cpp/benchmarks/ycinstrument_perf` does not exist. A compiler error or an unrelated configuration error is not the expected red result and must be diagnosed before proceeding.
+
+- [ ] **Step 3: Add the standard target definition**
+
+Create `dal-cpp/benchmarks/ycinstrument_perf/CMakeLists.txt` with exactly:
+
+```cmake
+file(GLOB_RECURSE YCINSTRUMENT_PERF_FILES CONFIGURE_DEPENDS "*.hpp" "*.cpp")
+
+add_executable(ycinstrument_perf ${YCINSTRUMENT_PERF_FILES})
+
+target_link_libraries(ycinstrument_perf dal_library)
+
+if(DAL_USE_XAD_AAD)
+    target_link_libraries(ycinstrument_perf XAD::xad)
+elseif(DAL_USE_CODIPACK_AAD)
+    target_link_libraries(ycinstrument_perf CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(ycinstrument_perf adept)
+endif ()
+
+if(MSVC)
+else()
+    target_link_libraries(ycinstrument_perf pthread)
+endif()
+
+install(TARGETS ycinstrument_perf
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )
+```
+
+- [ ] **Step 4: Implement the complete benchmark**
+
+Create `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp` with the following implementation:
+
+```cpp
+//
+// Created by dal-implementer on 2026/7/12.
+//
+
+#include <dal/platform/platform.hpp>
+#include <dal/platform/strict.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <dal/benchmarks/bench.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/ycinstrument.hpp>
+#include <dal/curve/ycpwlf.hpp>
+#include <dal/platform/initall.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/periodlength.hpp>
+
+using namespace Dal;
+
+namespace {
+    constexpr int kWarmups = 3;
+    constexpr int kRepeats = 10;
+    constexpr int kCheapBatch = 100000;
+    constexpr int kLongPrecomputeBatch = 1000;
+    constexpr int kLongPriceBatch = 5000;
+    constexpr int kBasketPasses = 1000;
+    constexpr double kFutureConvexity = 0.0015;
+
+    using InstrumentHandle_ = Handle_<YCInstrument_>;
+    using RateHandle_ = Handle_<YCInstrument_::Rate_>;
+
+    struct InstrumentSet_ {
+        InstrumentHandle_ deposit_;
+        InstrumentHandle_ fra_;
+        InstrumentHandle_ future_;
+        InstrumentHandle_ stir_;
+        InstrumentHandle_ swap_;
+        InstrumentHandle_ oisSwap_;
+        InstrumentHandle_ basisSwap_;
+    };
+
+    struct InstrumentCase_ {
+        std::string label_;
+        InstrumentHandle_ instrument_;
+        int precomputeBatch_;
+        int priceBatch_;
+    };
+
+    RateLegConvention_ MakeLeg(const char* frequency, const DayBasis_& basis) {
+        RateLegConvention_ result;
+        result.paymentLag_ = 0;
+        result.paymentFrequency_ = PeriodLength_(frequency);
+        result.dayBasis_ = basis;
+        result.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        result.paymentConvention_ = BizDayConvention_("Unadjusted");
+        result.accrualHolidays_ = Holidays::None();
+        result.paymentHolidays_ = Holidays::None();
+        return result;
+    }
+
+    RateIndexConvention_ MakeIndex(const char* tenor, const DayBasis_& basis, bool useProjection) {
+        RateIndexConvention_ result;
+        result.spotLag_ = 0;
+        result.fixingLag_ = 0;
+        result.useProjectionCurve_ = useProjection;
+        result.forecastTenor_ = PeriodLength_(tenor);
+        result.dayBasis_ = basis;
+        result.businessDayConvention_ = BizDayConvention_("Unadjusted");
+        result.fixingHolidays_ = Holidays::None();
+        result.accrualHolidays_ = Holidays::None();
+        result.collateral_ = CollateralType_(CollateralType_::Value_::OIS);
+        return result;
+    }
+
+    Handle_<YieldCurve_> BuildMarket(const Date_& today, const DayBasis_& basis, double sixMonthSpread = 0.01) {
+        const Vector_<Date_> knots = {
+            Date::AddMonths(today, 3),   Date::AddMonths(today, 6),   Date::AddMonths(today, 12),  Date::AddMonths(today, 24),
+            Date::AddMonths(today, 60),  Date::AddMonths(today, 120), Date::AddMonths(today, 240), Date::AddMonths(today, 480),
+        };
+        const Vector_<> oisValues(knots.size(), 0.02);
+        const Vector_<> threeMonthSpread(knots.size(), 0.005);
+        const Vector_<> sixMonthSpreadValues(knots.size(), sixMonthSpread);
+
+        const Handle_<DiscountCurve_> ois(NewDiscountPWLF("pricing_ois", "USD", PiecewiseLinear_(knots, oisValues, oisValues)));
+        const Handle_<DiscountCurve_> threeMonth(
+            NewDiscountPWLF("pricing_3m", "USD", PiecewiseLinear_(knots, threeMonthSpread, threeMonthSpread), ois));
+        const Handle_<DiscountCurve_> sixMonth(
+            NewDiscountPWLF("pricing_6m", "USD", PiecewiseLinear_(knots, sixMonthSpreadValues, sixMonthSpreadValues), ois));
+
+        return Handle_<YieldCurve_>(new CurveBlock_("pricing_market",
+                                                     "USD",
+                                                     {{CollateralType_(CollateralType_::Value_::OIS), ois}},
+                                                     {{PeriodLength_("3M"), threeMonth}, {PeriodLength_("6M"), sixMonth}},
+                                                     basis));
+    }
+
+    InstrumentSet_ BuildInstrumentSet(const Date_& today, const DayBasis_& basis) {
+        const Date_ threeMonths = Date::AddMonths(today, 3);
+        const Date_ sixMonths = Date::AddMonths(today, 6);
+        const Date_ tenYears = Date::AddMonths(today, 120);
+        const RateIndexConvention_ discountIndex = MakeIndex("3M", basis, false);
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateIndexConvention_ projected6m = MakeIndex("6M", basis, true);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+        const RateLegConvention_ quarterlyLeg = MakeLeg("3M", basis);
+        const RateLegConvention_ semiannualLeg = MakeLeg("6M", basis);
+
+        InstrumentSet_ result;
+        result.deposit_.reset(new Deposit_(today, today, sixMonths, 0.0, discountIndex));
+        result.fra_.reset(new FRA_(today, threeMonths, sixMonths, 0.0, projected3m));
+        result.future_.reset(new Future_(today, threeMonths, sixMonths, 0.0, projected3m, kFutureConvexity));
+        result.stir_.reset(new STIR_(today, threeMonths, sixMonths, 0.0, discountIndex));
+        result.swap_.reset(new Swap_(today, today, tenYears, 0.0, annualLeg, projected3m, quarterlyLeg));
+        result.oisSwap_.reset(new OISSwap_(today, today, tenYears, 0.0, annualLeg, discountIndex, annualLeg));
+        result.basisSwap_.reset(new BasisSwap_(today, today, tenYears, 0.0, projected3m, quarterlyLeg, projected6m, semiannualLeg));
+        return result;
+    }
+
+    double Price(const InstrumentHandle_& instrument, const YieldCurve_& market) {
+        const RateHandle_ rate = instrument->Precompute(Handle_<YieldCurve_>());
+        return (*rate)(market);
+    }
+
+    void ValidateInstrumentSet(const InstrumentSet_& instruments, const Date_& today, const DayBasis_& basis, const YieldCurve_& market) {
+        const std::vector<InstrumentHandle_> all = {
+            instruments.deposit_, instruments.fra_, instruments.future_, instruments.stir_,
+            instruments.swap_, instruments.oisSwap_, instruments.basisSwap_,
+        };
+        for (const auto& instrument : all)
+            REQUIRE(std::isfinite(Price(instrument, market)), "Instrument pricing benchmark requires finite model rates");
+
+        const Date_ threeMonths = Date::AddMonths(today, 3);
+        const Date_ sixMonths = Date::AddMonths(today, 6);
+        const Date_ tenYears = Date::AddMonths(today, 120);
+        const RateIndexConvention_ discountIndex = MakeIndex("3M", basis, false);
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+
+        const InstrumentHandle_ discountFra(new FRA_(today, threeMonths, sixMonths, 0.0, discountIndex));
+        const InstrumentHandle_ projectedFra(new FRA_(today, threeMonths, sixMonths, 0.0, projected3m));
+        const InstrumentHandle_ discountFraForStir(new FRA_(today, threeMonths, sixMonths, 0.0, discountIndex));
+        const InstrumentHandle_ discountSwap(new Swap_(today, today, tenYears, 0.0, annualLeg, discountIndex, annualLeg));
+
+        REQUIRE(std::fabs(Price(projectedFra, market) - Price(discountFra, market)) > 1.0e-8,
+                "Projection benchmark must not silently fall back to discount pricing");
+        REQUIRE(std::fabs(Price(instruments.future_, market) - (Price(projectedFra, market) - kFutureConvexity)) < 1.0e-12,
+                "Future benchmark must apply its convexity adjustment");
+        REQUIRE(std::fabs(Price(instruments.stir_, market) - Price(discountFraForStir, market)) < 1.0e-12,
+                "STIR benchmark must retain inherited FRA pricing");
+        REQUIRE(std::fabs(Price(instruments.oisSwap_, market) - Price(discountSwap, market)) < 1.0e-12,
+                "OIS benchmark must retain inherited discount-only swap pricing");
+
+        const Handle_<YieldCurve_> alternateMarket = BuildMarket(today, basis, 0.015);
+        REQUIRE(std::fabs(Price(instruments.basisSwap_, market) - Price(instruments.basisSwap_, *alternateMarket)) > 1.0e-8,
+                "Basis-swap benchmark must read the 6M projection curve");
+    }
+
+    std::vector<InstrumentCase_> IndividualCases(const InstrumentSet_& instruments) {
+        return {
+            {"Deposit_ 6M", instruments.deposit_, kCheapBatch, kCheapBatch},
+            {"FRA_ 3x6 3M projection", instruments.fra_, kCheapBatch, kCheapBatch},
+            {"Future_ 3x6 3M projection", instruments.future_, kCheapBatch, kCheapBatch},
+            {"STIR_ 3x6", instruments.stir_, kCheapBatch, kCheapBatch},
+            {"Swap_ 10Y annual-vs-3M", instruments.swap_, kLongPrecomputeBatch, kLongPriceBatch},
+            {"OISSwap_ 10Y annual", instruments.oisSwap_, kLongPrecomputeBatch, kLongPriceBatch},
+            {"BasisSwap_ 10Y 3M-vs-6M PASSIVE", instruments.basisSwap_, kLongPrecomputeBatch, kLongPriceBatch},
+        };
+    }
+
+    Bench::Result_ Normalize(const Bench::Result_& raw, const std::string& name, int64_t divisor) {
+        REQUIRE(divisor > 0, "Benchmark normalization divisor must be positive");
+        return Bench::Result_{name, raw.medianNs / divisor, raw.minNs / divisor, raw.maxNs / divisor, raw.repeats};
+    }
+
+    void RunPrecompute(const InstrumentCase_& instrumentCase) {
+        RateHandle_ sink = instrumentCase.instrument_->Precompute(Handle_<YieldCurve_>());
+        const Bench::Result_ raw = Bench::Run(
+            instrumentCase.label_,
+            [&]() {
+                for (int i = 0; i < instrumentCase.precomputeBatch_; ++i)
+                    sink = instrumentCase.instrument_->Precompute(Handle_<YieldCurve_>());
+            },
+            kWarmups,
+            kRepeats);
+        Bench::DoNotOptimize(sink.get());
+        REQUIRE(sink, "Instrument PRECOMPUTE sink must retain a rate handle");
+        Bench::Print(Normalize(raw, instrumentCase.label_ + " PRECOMPUTE lifecycle / operation", instrumentCase.precomputeBatch_));
+    }
+
+    void RunPrice(const InstrumentCase_& instrumentCase, const YieldCurve_& market) {
+        const RateHandle_ rate = instrumentCase.instrument_->Precompute(Handle_<YieldCurve_>());
+        double checksum = 0.0;
+        const Bench::Result_ raw = Bench::Run(
+            instrumentCase.label_,
+            [&]() {
+                for (int i = 0; i < instrumentCase.priceBatch_; ++i)
+                    checksum += (*rate)(market);
+            },
+            kWarmups,
+            kRepeats);
+        Bench::DoNotOptimize(&checksum);
+        REQUIRE(std::isfinite(checksum) && std::fabs(checksum) > 0.0, "Instrument PRICE checksum must be finite and non-zero");
+        Bench::Print(Normalize(raw, instrumentCase.label_ + " PRICE / operation", instrumentCase.priceBatch_));
+    }
+
+    std::vector<InstrumentHandle_> DiscountBasket(const Date_& today, const DayBasis_& basis) {
+        const RateIndexConvention_ discountIndex = MakeIndex("3M", basis, false);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+        std::vector<InstrumentHandle_> result;
+        result.reserve(20);
+        for (int month = 1; month <= 5; ++month)
+            result.emplace_back(new Deposit_(today, today, Date::AddMonths(today, month), 0.0, discountIndex));
+        for (int startMonth : {6, 9, 12})
+            result.emplace_back(new STIR_(today, Date::AddMonths(today, startMonth), Date::AddMonths(today, startMonth + 3), 0.0, discountIndex));
+        for (int year = 2; year <= 13; ++year)
+            result.emplace_back(new OISSwap_(today, today, Date::AddMonths(today, 12 * year), 0.0, annualLeg, discountIndex, annualLeg));
+        return result;
+    }
+
+    std::vector<InstrumentHandle_> ProjectionBasket(const Date_& today, const DayBasis_& basis) {
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateLegConvention_ annualLeg = MakeLeg("12M", basis);
+        const RateLegConvention_ quarterlyLeg = MakeLeg("3M", basis);
+        std::vector<InstrumentHandle_> result;
+        result.reserve(20);
+        for (int startMonth = 1; startMonth <= 8; ++startMonth)
+            result.emplace_back(
+                new FRA_(today, Date::AddMonths(today, startMonth), Date::AddMonths(today, startMonth + 3), 0.0, projected3m));
+        for (int startMonth = 9; startMonth <= 12; ++startMonth)
+            result.emplace_back(
+                new Future_(today, Date::AddMonths(today, startMonth), Date::AddMonths(today, startMonth + 3), 0.0, projected3m, kFutureConvexity));
+        for (int year = 3; year <= 10; ++year)
+            result.emplace_back(new Swap_(today, today, Date::AddMonths(today, 12 * year), 0.0, annualLeg, projected3m, quarterlyLeg));
+        return result;
+    }
+
+    std::vector<InstrumentHandle_> BasisBasket(const Date_& today, const DayBasis_& basis) {
+        const RateIndexConvention_ projected3m = MakeIndex("3M", basis, true);
+        const RateIndexConvention_ projected6m = MakeIndex("6M", basis, true);
+        const RateLegConvention_ quarterlyLeg = MakeLeg("3M", basis);
+        const RateLegConvention_ semiannualLeg = MakeLeg("6M", basis);
+        std::vector<InstrumentHandle_> result;
+        result.reserve(10);
+        for (int year = 2; year <= 11; ++year)
+            result.emplace_back(new BasisSwap_(today,
+                                               today,
+                                               Date::AddMonths(today, 12 * year),
+                                               0.0,
+                                               projected3m,
+                                               quarterlyLeg,
+                                               projected6m,
+                                               semiannualLeg));
+        return result;
+    }
+
+    std::vector<RateHandle_> PrecomputeAll(const std::vector<InstrumentHandle_>& instruments) {
+        std::vector<RateHandle_> result;
+        result.reserve(instruments.size());
+        for (const auto& instrument : instruments)
+            result.push_back(instrument->Precompute(Handle_<YieldCurve_>()));
+        return result;
+    }
+
+    void ValidateBasket(const std::vector<RateHandle_>& rates, const YieldCurve_& market) {
+        REQUIRE(!rates.empty(), "Pricing basket must not be empty");
+        double checksum = 0.0;
+        for (const auto& rate : rates) {
+            const double value = (*rate)(market);
+            REQUIRE(std::isfinite(value), "Pricing basket requires finite model rates");
+            checksum += value;
+        }
+        REQUIRE(std::isfinite(checksum) && std::fabs(checksum) > 0.0, "Pricing basket checksum must be finite and non-zero");
+    }
+
+    void RunBasket(const std::string& label, const std::vector<RateHandle_>& rates, const YieldCurve_& market) {
+        double checksum = 0.0;
+        const Bench::Result_ raw = Bench::Run(
+            label,
+            [&]() {
+                for (int pass = 0; pass < kBasketPasses; ++pass)
+                    for (const auto& rate : rates)
+                        checksum += (*rate)(market);
+            },
+            kWarmups,
+            kRepeats);
+        Bench::DoNotOptimize(&checksum);
+        REQUIRE(std::isfinite(checksum) && std::fabs(checksum) > 0.0, "Pricing BASKET checksum must be finite and non-zero");
+        Bench::Print(Normalize(raw, label + " BASKET / pass", kBasketPasses));
+        Bench::Print(Normalize(raw, label + " PER-INSTRUMENT", kBasketPasses * static_cast<int64_t>(rates.size())));
+    }
+} // namespace
+
+int main() {
+    RegisterAll_::Init();
+    const Date_ today(2024, 1, 15);
+    const DayBasis_ basis("ACT_365F");
+    const Handle_<YieldCurve_> market = BuildMarket(today, basis);
+    const InstrumentSet_ instruments = BuildInstrumentSet(today, basis);
+    ValidateInstrumentSet(instruments, today, basis, *market);
+
+    const std::vector<InstrumentHandle_> discountInstruments = DiscountBasket(today, basis);
+    const std::vector<InstrumentHandle_> projectionInstruments = ProjectionBasket(today, basis);
+    const std::vector<InstrumentHandle_> basisInstruments = BasisBasket(today, basis);
+    const std::vector<RateHandle_> discountRates = PrecomputeAll(discountInstruments);
+    const std::vector<RateHandle_> projectionRates = PrecomputeAll(projectionInstruments);
+    const std::vector<RateHandle_> basisRates = PrecomputeAll(basisInstruments);
+    ValidateBasket(discountRates, *market);
+    ValidateBasket(projectionRates, *market);
+    ValidateBasket(basisRates, *market);
+
+    Bench::PrintHeader();
+    for (const auto& instrumentCase : IndividualCases(instruments)) {
+        RunPrecompute(instrumentCase);
+        RunPrice(instrumentCase, *market);
+    }
+    RunBasket("Discount 20-instrument", discountRates, *market);
+    RunBasket("3M projection 20-instrument", projectionRates, *market);
+    RunBasket("3M-vs-6M PASSIVE 10-instrument", basisRates, *market);
+    return 0;
+}
+```
+
+- [ ] **Step 5: Format the new source without reordering platform headers**
+
+Run:
+
+```bash
+clang-format -i -sort-includes=0 dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp
+git diff --check
+```
+
+Expected: both commands exit zero; `dal/platform/platform.hpp` remains the first include.
+
+- [ ] **Step 6: Build the green target**
+
+Run:
+
+```bash
+cmake --build build --target ycinstrument_perf -j2
+```
+
+Expected: exit zero and `build/dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf` exists.
+
+- [ ] **Step 7: Run the executable and verify its output contract**
+
+Run:
+
+```bash
+output=$(./build/dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf)
+print -- "$output"
+printf '%s\n' "$output" | rg -c 'PRECOMPUTE| PRICE | BASKET |PER-INSTRUMENT'
+for instrument in Deposit_ FRA_ Future_ STIR_ Swap_ OISSwap_ BasisSwap_; do
+    printf '%s\n' "$output" | rg -q "$instrument"
+done
+printf '%s\n' "$output" | rg -q 'BasisSwap_.*PASSIVE'
+```
+
+Expected: the count command prints `20`; all searches exit zero; the executable prints no warning or exception.
+
+- [ ] **Step 8: Run the focused correctness suite**
+
+Run:
+
+```bash
+cmake --build build --target dal_cpp_tests -j2
+./build/dal-cpp/dal_cpp_tests --gtest_filter='YCInstrumentTest.*' --gtest_brief=1
+```
+
+Expected: build exits zero and every `YCInstrumentTest` passes.
+
+- [ ] **Step 9: Record the task checkpoint**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+```
+
+Expected: only the design/plan plus the three Task 1 benchmark paths are changed; no build artifacts are tracked. Commit the verified Task 1 implementation in the isolated feature checkout.
+
+---
+
+### Task 2: Publish the benchmark in Linux and Windows CI reports
+
+**Files:**
+- Modify: `.github/workflows/cmake-linux.yml`
+- Modify: `.github/workflows/cmake-windows.yml`
+- Test: `.github/workflows/cmake-linux.yml`
+- Test: `.github/workflows/cmake-windows.yml`
+
+**Interfaces:**
+- Consumes: installed CMake target `ycinstrument_perf` from Task 1.
+- Produces: CI execution and summary output for `ycinstrument_perf` on both supported platforms.
+
+- [ ] **Step 1: Run the red inventory check**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+for name in ("cmake-linux.yml", "cmake-windows.yml"):
+    text = Path(".github/workflows", name).read_text()
+    assert "ycinstrument_perf" in text, f"{name} does not report ycinstrument_perf"
+PY
+```
+
+Expected: `AssertionError: cmake-linux.yml does not report ycinstrument_perf`.
+
+- [ ] **Step 2: Add the Linux reporting entry**
+
+In `.github/workflows/cmake-linux.yml`, change the benchmark array tail to:
+
+```yaml
+            iv_brent_perf
+            script_mc_perf
+            ycinstrument_perf
+            curve_calibration_perf
+          )
+```
+
+- [ ] **Step 3: Add the Windows reporting entry**
+
+In `.github/workflows/cmake-windows.yml`, change the benchmark array tail to:
+
+```yaml
+            iv_brent_perf
+            script_mc_perf
+            ycinstrument_perf
+            curve_calibration_perf
+          )
+```
+
+- [ ] **Step 4: Run the green inventory check and protect the regression gate boundary**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+for name in ("cmake-linux.yml", "cmake-windows.yml"):
+    text = Path(".github/workflows", name).read_text()
+    assert text.count("ycinstrument_perf") == 1, f"{name} must report ycinstrument_perf exactly once"
+
+gate = Path(".github/scripts/check_benchmark_regressions.py").read_text()
+assert "ycinstrument_perf" not in gate, "new pricing timings must remain report-only"
+PY
+```
+
+Expected: exit zero with no output.
+
+- [ ] **Step 5: Run documentation/workflow integrity and record the task checkpoint**
+
+Run:
+
+```bash
+python3 .github/scripts/check_docs.py
+git diff --check
+git status --short
+```
+
+Expected: documentation checks pass, diff check exits zero, and only intended feature files are listed. Do not alter the pre-existing `threadpool_perf`/`stacks_perf` workflow-list drift in this task.
+
+---
+
+### Task 3: Verify runtime behavior and characterize benchmark noise
+
+**Files:**
+- Verify: `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp`
+- Verify: `dal-cpp/tests/curve/test_ycinstrument.cpp`
+- Verify: `dal-cpp/benchmarks/CMakeLists.txt`
+- Verify: `.github/workflows/cmake-linux.yml`
+- Verify: `.github/workflows/cmake-windows.yml`
+
+**Interfaces:**
+- Consumes: completed benchmark executable and CI registration from Tasks 1-2.
+- Produces: fresh build/test evidence and a ten-run noise report for every benchmark row.
+
+- [ ] **Step 1: Rebuild the exact final sources**
+
+Run:
+
+```bash
+cmake --build build --target ycinstrument_perf dal_cpp_tests -j2
+```
+
+Expected: exit zero with both targets freshly linked.
+
+- [ ] **Step 2: Run the benchmark ten times and summarize observed spread in memory**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import re
+import subprocess
+
+binary = "./build/dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf"
+rows = {}
+for run in range(10):
+    output = subprocess.check_output([binary], text=True)
+    measured = [line for line in output.splitlines() if re.search(r"PRECOMPUTE| PRICE | BASKET |PER-INSTRUMENT", line)]
+    assert len(measured) == 20, f"run {run + 1}: expected 20 rows, got {len(measured)}"
+    for line in measured:
+        name = line[:75].rstrip()
+        match = re.search(r"([0-9.]+)\s+(ns|us|ms)\s+([0-9.]+)\s+(ns|us|ms)\s+([0-9.]+)\s+(ns|us|ms)", line[75:])
+        assert match, f"cannot parse benchmark row: {line}"
+        scale = {"ns": 1.0, "us": 1.0e3, "ms": 1.0e6}
+        median_ns = float(match.group(1)) * scale[match.group(2)]
+        rows.setdefault(name, []).append(median_ns)
+
+for name, values in rows.items():
+    best = min(values)
+    worst = max(values)
+    spread = 100.0 * (worst - best) / best
+    print(f"{name}: best={best:.3f}ns worst={worst:.3f}ns spread={spread:.2f}%")
+PY
+```
+
+Expected: ten successful invocations, 20 parsed rows per invocation, and a printed best/worst/spread line for every row. Report the observed spread; do not fail the task because a noisy shared runner exceeds 4%.
+
+- [ ] **Step 3: Run focused and full core tests**
+
+Run:
+
+```bash
+./build/dal-cpp/dal_cpp_tests --gtest_filter='YCInstrumentTest.*' --gtest_brief=1
+./build/dal-cpp/dal_cpp_tests --gtest_brief=1
+```
+
+Expected: both commands exit zero; the first reports only `YCInstrumentTest`, and the second reports zero failed tests.
+
+- [ ] **Step 4: Run final static and scope checks**
+
+Run:
+
+```bash
+python3 .github/scripts/check_docs.py
+git diff --check
+git status --short
+git diff --stat
+rg -n "ycinstrument_perf" dal-cpp/benchmarks/CMakeLists.txt .github/workflows/cmake-linux.yml .github/workflows/cmake-windows.yml
+rg -n "ycinstrument_perf" .github/scripts/check_benchmark_regressions.py && exit 1 || true
+```
+
+Expected: documentation and diff checks pass; the target appears once in CMake and once per workflow; it does not appear in the regression-gate script.
+
+---
+
+### Task 4: Complete DAL performance and code review gates
+
+**Files:**
+- Review: all files changed from `master` for this feature.
+- Artifact: `.codex/artifacts/perf/ycinstrument-pricing-performance.md`
+- Artifact: `.codex/artifacts/reviews/ycinstrument-pricing-performance.md`
+
+**Interfaces:**
+- Consumes: final diff and verification evidence from Tasks 1-3.
+- Produces: a performance assessment and merge-readiness verdict with no open blocking findings.
+
+- [ ] **Step 1: Run the DAL performance review**
+
+Use `dal-performancer` to inspect the fixture, timed-region boundaries, batch duration, output normalization, repeated-run noise, and CI gate placement. Write the evidence and verdict to:
+
+```text
+.codex/artifacts/perf/ycinstrument-pricing-performance.md
+```
+
+The report must include the ten-run sample count, environment/build configuration, observed spread, and a statement that there is no baseline target on `master`, so no branch-vs-baseline regression conclusion is possible for this new executable.
+
+- [ ] **Step 2: Run the DAL code review**
+
+Use `dal-reviewer` to review the complete feature diff for pricing correctness, routing, cross-platform CMake/YAML integration, stable labels, dead-code-elimination protection, test evidence, and unintended production changes. Write findings-first output and an `Approve` or `Request Changes` verdict to:
+
+```text
+.codex/artifacts/reviews/ycinstrument-pricing-performance.md
+```
+
+- [ ] **Step 3: Resolve every blocking review finding and re-run its covering gate**
+
+For each blocking finding, add or tighten an untimed benchmark correctness requirement before changing benchmark behavior, verify that the requirement fails for the reported defect, implement the smallest fix, and re-run:
+
+```bash
+cmake --build build --target ycinstrument_perf -j2
+./build/dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf
+./build/dal-cpp/dal_cpp_tests --gtest_filter='YCInstrumentTest.*' --gtest_brief=1
+```
+
+Append the fix evidence to both review artifacts and repeat review until neither report contains a blocking finding.
+
+- [ ] **Step 4: Produce the final handoff**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+```
+
+Report:
+
+- exact files changed;
+- 20 benchmark labels and representative timing ranges;
+- focused/full test counts;
+- documentation and scope-check results;
+- performance-review and code-review verdicts;
+- the isolated-checkout workaround for the original checkout's `.git/index.lock` restriction;
+- the dedicated branch and PR URL requested by the user.

--- a/docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md
+++ b/docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md
@@ -125,8 +125,12 @@ calibration residual evaluation.
   adjust only that case's batch count while preserving all measurement and labeling rules.
 
 The executable reports observations only. Cross-branch performance conclusions require paired,
-interleaved Release runs with at least ten complete invocations and best-of-N minima. Changes
-inside the observed 2-4% environment noise floor are inconclusive.
+interleaved Release runs with at least ten complete invocations and best-of-N minima. A 2-4%
+noise floor is only a nominal expectation for quiet paired runs, not an observed property of every
+environment. The current ten-run evidence on an unpinned VM measured 3.59%-46.42% best-to-worst
+spread, as recorded in `.codex/artifacts/perf/ycinstrument-pricing-performance.md`. Performance
+conclusions must use the run-specific measured noise floor; changes at or below that floor are
+inconclusive.
 
 ## Untimed Correctness Gates
 

--- a/docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md
+++ b/docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md
@@ -1,0 +1,211 @@
+# Yield-Curve Instrument Pricing Performance Benchmark Design
+
+## Source
+
+- User request: add runtime benchmarks for every instrument priced by the yield-curve calibration framework.
+- Approved scope: all seven concrete `YCInstrument_` types.
+- Approved measurement split: precompute lifecycle and steady-state pricing.
+- Approved structure: per-instrument microbenchmarks plus calibration-shaped pricing baskets.
+
+## Problem Statement
+
+DAL has end-to-end curve-calibration timing, but that timing combines curve construction,
+solver iterations, Jacobians, diagnostics, and instrument pricing. It cannot attribute a
+runtime change to one instrument or distinguish one-time `Precompute` work from the repeated
+`Rate_::operator()` calls made by a calibration residual evaluation.
+
+A dedicated benchmark must expose those costs without changing pricing behavior or turning
+noisy wall-clock results into brittle test thresholds.
+
+## Goals
+
+- Benchmark every concrete built-in yield-curve instrument:
+  `Deposit_`, `FRA_`, `Future_`, `STIR_`, `Swap_`, `OISSwap_`, and `BasisSwap_`.
+- Measure `Precompute` lifecycle cost separately from steady-state pricing cost.
+- Measure realistic discount, projection, and multi-tenor residual-style baskets.
+- Use the same map-backed curve routing used by calibration.
+- Produce stable, self-describing median/min/max rows on Linux and Windows CI.
+- Prevent dead-code elimination and validate the untimed fixture before measuring it.
+
+## Non-Goals
+
+- No production pricing, calibration, curve, AAD, or public API changes.
+- No end-to-end solve timing; `curve_calibration_perf` remains responsible for that surface.
+- No curve-construction timing inside an instrument row.
+- No absolute runtime assertions or new merge-blocking regression threshold.
+- No claim that `BasisSwap_` supports the analytical-Jacobian visitor. Its rows are passive
+  pricing coverage and correspond to bumped calibration behavior.
+- No documentation or changelog update outside this design and implementation plan.
+
+## Benchmark Target
+
+Create one executable named `ycinstrument_perf`:
+
+- `dal-cpp/benchmarks/ycinstrument_perf/ycinstrument_perf.cpp`
+- `dal-cpp/benchmarks/ycinstrument_perf/CMakeLists.txt`
+
+Register it in `dal-cpp/benchmarks/CMakeLists.txt` and in both CI benchmark-reporting arrays.
+Use the existing `Dal::Bench` harness and the standard optional AAD-backend and platform link
+rules used by other DAL benchmark targets. Do not add the target to the calibrated eight-target
+regression gate.
+
+## Deterministic Market Fixture
+
+The benchmark owns one immutable pricing fixture:
+
+- anchor date: `2024-01-15`;
+- currency: `USD`;
+- day basis: `ACT_365F`;
+- holidays: `Holidays::None()`;
+- business-day and payment conventions: `Unadjusted`;
+- OIS discount curve: multi-knot piecewise-linear forward curve at 2.00%;
+- 3M projection curve: the OIS curve as typed base plus a 0.50% forward spread;
+- 6M projection curve: the OIS curve as typed base plus a 1.00% forward spread;
+- curve knots: 3M, 6M, 1Y, 2Y, 5Y, 10Y, 20Y, and 40Y after the anchor;
+- context: map-backed `CurveBlock_` containing OIS discounting and both 3M and 6M
+  projection entries.
+
+The fixture must be built before any timed region. The forward curves remain base-layered so
+the benchmark includes the same discount-plus-spread evaluation used by multi-curve calibration.
+
+## Individual Instrument Matrix
+
+| Instrument | Representative contract | Pricing route | Analytical-Jacobian note |
+|------------|-------------------------|---------------|--------------------------|
+| `Deposit_` | 6M | OIS discount | Direct visitor family |
+| `FRA_` | 3x6 | 3M projection | Direct visitor family |
+| `Future_` | 3x6 with 15bp convexity adjustment | 3M projection | Direct visitor family |
+| `STIR_` | 3x6 | OIS discount | Inherits FRA pricing |
+| `Swap_` | 10Y, annual fixed and quarterly floating | OIS discount plus 3M projection | Direct visitor family |
+| `OISSwap_` | 10Y, annual fixed and annual overnight | OIS discount | Inherits swap pricing |
+| `BasisSwap_` | 10Y, quarterly 3M versus semiannual 6M | OIS discount plus two projections | Passive/BUMPED only |
+
+Every matrix entry produces two rows:
+
+1. `PRECOMPUTE lifecycle`: call `YCInstrument_::Precompute`, retain the returned pointer as
+   the sink, and include replacement/destruction of the prior handle in the measured lifecycle.
+2. `PRICE`: reuse one precomputed `Rate_` and call it against the immutable `CurveBlock_`.
+
+The label must include instrument identity, representative maturity/frequencies, timing phase,
+and the fact that the displayed time is normalized per operation.
+
+## Calibration-Shaped Baskets
+
+Build three baskets from distinct instruments and precompute their rates before timing:
+
+1. **Discount basket, 20 instruments:** five deposits, three STIRs, and twelve OIS swaps.
+2. **3M projection basket, 20 instruments:** eight FRAs, four futures, and eight vanilla swaps.
+3. **Multi-tenor basket, 10 instruments:** ten 3M-versus-6M basis swaps.
+
+A timed basket pass invokes every precomputed rate once and accumulates the model rates. The
+same samples produce two printed results:
+
+- elapsed time normalized to one complete basket pass;
+- elapsed time normalized to one priced instrument.
+
+This preserves attribution in the individual rows while exposing the loop shape used by
+calibration residual evaluation.
+
+## Measurement Semantics
+
+- Use `Bench::Run` with three warmups and ten measured samples.
+- Batch cheap individual operations 100,000 times per timed sample.
+- Batch swap, OIS-swap, and basis-swap operations 5,000 times per pricing sample and 1,000
+  times per precompute-lifecycle sample.
+- Repeat each basket pass 1,000 times per timed sample.
+- Normalize `medianNs`, `minNs`, and `maxNs` by the operation count before printing a
+  per-operation row. Preserve the original repetition count.
+- Print basket time once per pass and once per instrument from the same underlying samples;
+  do not time the basket twice.
+- Accumulate computed rates into a `double` checksum and pass its address to
+  `Bench::DoNotOptimize` after each case.
+- Keep case construction, curve construction, convention construction, and correctness checks
+  outside timed regions.
+- If an initial development run falls outside the 5-20ms target duration for a timed sample,
+  adjust only that case's batch count while preserving all measurement and labeling rules.
+
+The executable reports observations only. Cross-branch performance conclusions require paired,
+interleaved Release runs with at least ten complete invocations and best-of-N minima. Changes
+inside the observed 2-4% environment noise floor are inconclusive.
+
+## Untimed Correctness Gates
+
+Before printing timings, the executable must require that:
+
+- every individual and basket model rate is finite;
+- the 3M projected FRA rate differs from the OIS discount-only forward rate;
+- the future price equals its corresponding forward rate less the configured convexity
+  adjustment within `1.0e-12`;
+- an STIR and an FRA with identical dates and discount-only conventions agree within
+  `1.0e-12`;
+- an OIS swap and a vanilla swap with identical discount-only conventions agree within
+  `1.0e-12`;
+- changing the 6M projection input changes the untimed basis-swap result;
+- each timed pricing checksum is finite and non-zero, and each precompute sink retains a
+  non-empty rate handle.
+
+These checks protect the benchmark from silently measuring discount fallback under a
+projection label or from optimizing away the pricing result. They are not runtime thresholds.
+
+## Output Contract
+
+The executable prints the shared benchmark header followed by exactly 20 result rows:
+
+- 14 individual rows: seven instruments times two phases;
+- six basket rows: three baskets times two normalizations.
+
+Labels must remain within the shared 75-character name column and must use these phase tokens:
+`PRECOMPUTE`, `PRICE`, `BASKET`, and `PER-INSTRUMENT`. `BasisSwap_` pricing labels must include
+`PASSIVE` so the output cannot be mistaken for analytical-Jacobian coverage.
+
+## Build And CI Integration
+
+- Add `ycinstrument_perf` to `DAL_BENCHMARK_TARGETS` immediately before
+  `curve_calibration_perf`.
+- Add the same target immediately before `curve_calibration_perf` in Linux and Windows benchmark
+  reporting arrays.
+- Leave unrelated benchmark-list drift unchanged.
+- Do not add the target to `.github/scripts/check_benchmark_regressions.py`.
+- Install the executable to `bin` using the standard benchmark target permissions.
+
+## Verification
+
+1. Establish a red build by registering the target before its directory/source exists and
+   confirm CMake fails because `ycinstrument_perf` is missing.
+2. Build the target in the existing Release build tree.
+3. Run the executable and confirm its 20 labels, finite checksums, and zero exit status.
+4. Run the executable ten complete times and report the observed best/min/max spread without
+   treating it as a gate.
+5. Run `YCInstrumentTest.*`.
+6. Run the full `dal_cpp_tests` suite.
+7. Run `git diff --check` and inspect the exact CMake and workflow target lists.
+8. Complete independent DAL performance and code reviews.
+
+## Acceptance Criteria
+
+- [ ] `ycinstrument_perf` builds in Release on the repository's supported CMake configuration.
+- [ ] All seven concrete instrument types have separate precompute and steady-state pricing rows.
+- [ ] Discount, 3M projection, and multi-tenor baskets print both basket and per-instrument time.
+- [ ] All pricing construction is outside steady-state timed regions.
+- [ ] Untimed correctness gates detect routing or fixture mistakes before measurement.
+- [ ] The executable prints exactly 20 stable benchmark rows and exits successfully.
+- [ ] Linux and Windows CI build, run, and publish the new benchmark output.
+- [ ] No absolute timing threshold or new regression gate is introduced.
+- [ ] Targeted and full DAL tests pass.
+- [ ] Independent performance and code reviews report no blocking findings.
+
+## Risks And Mitigations
+
+- **Clock noise on cheap rates:** batch 100,000 calls and normalize after measurement.
+- **Compiler elimination:** use virtual rate handles, a data-dependent checksum, and
+  `Bench::DoNotOptimize`.
+- **Projection silently falling back to discount:** require a route-sensitive FRA result before
+  timing.
+- **Coupon count dominating comparisons:** keep maturity and leg frequencies in every long-rate
+  label; compare a row only with the same row across revisions.
+- **Setup mixed into price timing:** create curves, instruments, and rate handles before every
+  steady-state row.
+- **Alias coverage misrepresented:** label STIR/OIS inheritance in source comments and retain
+  distinct concrete timing rows.
+- **Basis swap overstated as analytical support:** label it `PASSIVE` and keep it outside analytic
+  claims and regression gates.

--- a/docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md
+++ b/docs/superpowers/specs/2026-07-12-ycinstrument-pricing-performance-design.md
@@ -70,15 +70,15 @@ the benchmark includes the same discount-plus-spread evaluation used by multi-cu
 
 ## Individual Instrument Matrix
 
-| Instrument | Representative contract | Pricing route | Analytical-Jacobian note |
-|------------|-------------------------|---------------|--------------------------|
-| `Deposit_` | 6M | OIS discount | Direct visitor family |
-| `FRA_` | 3x6 | 3M projection | Direct visitor family |
-| `Future_` | 3x6 with 15bp convexity adjustment | 3M projection | Direct visitor family |
-| `STIR_` | 3x6 | OIS discount | Inherits FRA pricing |
-| `Swap_` | 10Y, annual fixed and quarterly floating | OIS discount plus 3M projection | Direct visitor family |
-| `OISSwap_` | 10Y, annual fixed and annual overnight | OIS discount | Inherits swap pricing |
-| `BasisSwap_` | 10Y, quarterly 3M versus semiannual 6M | OIS discount plus two projections | Passive/BUMPED only |
+| Instrument   | Representative contract                  | Pricing route                     | Analytical-Jacobian note |
+|--------------|------------------------------------------|-----------------------------------|--------------------------|
+| `Deposit_`   | 6M                                       | OIS discount                      | Direct visitor family    |
+| `FRA_`       | 3x6                                      | 3M projection                     | Direct visitor family    |
+| `Future_`    | 3x6 with 15bp convexity adjustment       | 3M projection                     | Direct visitor family    |
+| `STIR_`      | 3x6                                      | OIS discount                      | Inherits FRA pricing     |
+| `Swap_`      | 10Y, annual fixed and quarterly floating | OIS discount plus 3M projection   | Direct visitor family    |
+| `OISSwap_`   | 10Y, annual fixed and annual overnight   | OIS discount                      | Inherits swap pricing    |
+| `BasisSwap_` | 10Y, quarterly 3M versus semiannual 6M   | OIS discount plus two projections | Passive/BUMPED only      |
 
 Every matrix entry produces two rows:
 


### PR DESCRIPTION
## Summary

- add ycinstrument_perf with separate PRECOMPUTE lifecycle and steady-state PRICE rows for all seven yield-curve instrument types
- add discount, 3M projection, and passive 3M-vs-6M basket/per-instrument rows using a map-backed OIS/3M/6M market
- report the benchmark in Linux and Windows CI while keeping timings out of the calibrated regression gate
- include design, implementation plan, ten-run methodology evidence, and approved DAL performance/code reviews

## Verification

- Release target build: ycinstrument_perf and dal_cpp_tests
- benchmark contract: 20 rows, 10 samples per row, all seven types, BasisSwap labeled PASSIVE
- focused tests: 11/11 YCInstrumentTest
- full core tests: 876/876 across 79 suites
- ten-run sweep: 10/10 invocations parsed 20 rows; observed spread 3.59%-46.42% on an unpinned VM
- documentation, clang-format, diff, registration, and regression-boundary checks passed

## Notes

The benchmark is report-only. Master has no matching target, so this PR makes no branch-vs-baseline performance claim and adds no absolute timing threshold.