### PR TITLE
docs: add functional-style and input-mutation rules

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -33,6 +33,15 @@
 | Test files        | `test_` prefix, snake_case | `test_vectors.cpp`, `test_date.cpp`               |
 | Namespaces        | PascalCase or lowercase    | `Dal`, `Dal::AAD`, `namespace exception`          |
 
+## Functional Style and Parameter Mutation
+
+- Prefer a **functional style wherever it is proper to do so**: pure functions, return-new-state, no side effects. This continues the const-correctness theme above — if a result can be computed without mutating shared state, do it that way.
+- **Avoid mutating the state of an input parameter** unless performance genuinely matters. Return new state instead.
+- When in-place mutation is genuinely needed, **pass by pointer, not by reference**, so the mutation is visible at the call site:
+  - Good: `Foo(&x);` — the `&` signals that `x` may be modified.
+  - Bad: `Foo(x);` where the signature is `void Foo(T_& x)` — the call site hides the mutation and is indistinguishable from a by-value call.
+- **Exception — calibration:** mutating inputs / out-parameters is acceptable inside calibration routines (large, performance-sensitive Jacobian and curve assembly, e.g. the joint and cross-currency calibration code under `dal-cpp/dal/curve/`). Keep this carve-out confined to calibration code and leave a one-line comment at the function noting why mutation is used.
+
 ## No Duplication
 
 - Don't repeat logic — if two code paths do the same thing, extract a shared function/template/helper.

--- a/.claude/rules/dal-web-code-style.md
+++ b/.claude/rules/dal-web-code-style.md
@@ -52,6 +52,12 @@ to `.claude/rules/code-style.md` (which covers the DAL C++ library) and to
 - A function named `*_async` that is neither `await`ed by callers nor schedules a
   task is a real smell: drop the suffix or make it a genuine coroutine.
 
+## No Input Mutation (Functional Style)
+
+- **Functional style is the default.** Prefer pure functions, return new state, and treat inputs as immutable wherever proper. This composes with the async-first model: pure functions are cheap to reason about across `await` boundaries and `asyncio.to_thread(...)` offloads.
+- **It is forbidden for a function to mutate its input parameters' state.** Inputs must be treated as immutable; construct and return new state instead. This covers in-place edits of passed-in `dict` / `list` / Pydantic models, reassigning attributes on an argument, and mutable default arguments.
+- Why: input mutation creates aliased, hidden state changes that are hard to trace in a concurrent, async codebase, and it breaks the assumption callers rely on when they pass the same object to multiple services or re-use it after the call. The immutability invariant is what makes the rest of the async design safe to read.
+
 ## External HTTP Contract Is Immutable
 
 - Async conversion MUST NOT change routes, request/response JSON shapes, HTTP


### PR DESCRIPTION
## Summary
- Add **"Functional Style and Parameter Mutation"** section to `.claude/rules/code-style.md`: prefer a functional style wherever proper; avoid mutating input parameters unless performance genuinely matters; when in-place mutation is needed, pass by **pointer** (not reference) so the mutation is visible at the call site (`Foo(&x)` vs `Foo(x)`); **calibration** called out as the explicit exception.
- Add **"No Input Mutation (Functional Style)"** section to `.claude/rules/dal-web-code-style.md`: functional style as the default (composes with the async model); mutating input parameter state is **forbidden**, with rationale covering `dict` / `list` / Pydantic models, attribute reassignment, and mutable defaults.
- Extends the existing const-correctness theme in the C++ guide (alongside the `mutable` ban and pure-const-evaluator rule) and the async-safety invariants in the Python guide.

## Test plan
- [x] Guidance-only change to `.claude/rules/*.md` — no C++ build, Python, or tests affected.
- [x] `git diff --stat` confirms only the two intended files changed (+9 / +6 lines, 15 insertions total).