### PR TITLE
fix: submodule guards, excelwriter guard, agent docs, windows bat

### DIFF
--- a/.codex/skills/dal-agent-team/references/shared-rules.md
+++ b/.codex/skills/dal-agent-team/references/shared-rules.md
@@ -15,11 +15,9 @@ style, test, review, docs, and artifact conventions.
 Release build:
 
 ```bash
-mkdir -p build
-cd build
-cmake --preset=Release-linux ..
-make -j$(nproc)
-make install
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux -j$(nproc)
+cmake --install build/Release-linux
 ```
 
 Full Linux workflow:
@@ -31,13 +29,13 @@ bash ./build_linux.sh > test_output.txt 2>&1
 Targeted test:
 
 ```bash
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.<TestName>
 ```
 
 Web tests:
 
 ```bash
-(cd dal-web/backend && uv run pytest)
+(cd dal-web/backend && uv sync --locked --inexact && uv run --no-sync pytest)
 (cd dal-web/frontend && npm run build)
 ./dal-web/scripts/setup-playwright.sh
 (cd dal-web/frontend && npm run test:e2e)
@@ -59,12 +57,13 @@ Web tests:
 
 ## Machinist Enums
 
-When enum markup changes, regenerate both core and Excel output:
+When enum markup changes, regenerate both core and Excel output. The `Machinist`
+binary is a git-ignored build artifact, not checked in, so the reliable route is
+the CMake target, which builds Machinist first and runs it with the right inputs:
 
 ```bash
-export MACHINIST_TEMPLATE_DIR=$PWD/dal-cpp/externals/machinist/template/
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-cpp/dal
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-excel
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_generate
 ```
 
 Commit generated `dal-cpp/dal/auto/MG_*` and `dal-excel/auto/MG_*` files with the markup source when committing is requested.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,11 +59,13 @@ AST → simulation), `model/`, `curve/`, `indice/`, `risk/`, `concurrency/`, `st
 Enums are declared in Machinist markup `/*IF---- ... -IF----*/` blocks before `namespace Dal {`.
 Machinist generates `dal-cpp/dal/auto/MG_*_enum.{hpp,inc}`.
 
-**Regenerate only when markup changes:**
+**Regenerate only when markup changes.** The `Machinist` binary is a git-ignored build
+artifact, not checked in, so use the CMake target, which builds Machinist first and runs
+it with the right inputs:
+
 ```bash
-export MACHINIST_TEMPLATE_DIR=$PWD/dal-cpp/externals/machinist/template/
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-cpp/dal
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-excel
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_generate
 ```
 
 ## Conventions

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-gated, dependency-free checks for DAL's published Markdown."""
+"""Fail-gated, dependency-free checks for DAL's published and agent-facing Markdown."""
 
 from __future__ import annotations
 
@@ -24,6 +24,19 @@ DOCS = tuple(
         }
     )
 )
+# Agent-facing guides sit outside docs/ but carry the same build/test commands;
+# they get the standard checks plus referenced-path existence below.
+AGENT_DOCS = tuple(
+    sorted(
+        {
+            ROOT / "AGENTS.md",
+            ROOT / "CLAUDE.md",
+            ROOT / ".github/copilot-instructions.md",
+            ROOT / ".codex/skills/dal-agent-team/references/shared-rules.md",
+        }
+    )
+)
+ALL_DOCS = (*DOCS, *AGENT_DOCS)
 
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.+?)\s*$")
@@ -31,8 +44,49 @@ FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 TABLE_DELIMITER_RE = re.compile(r"^:?-{3,}:?$")
 TABLE_TOKEN_RE = re.compile(r"\\.|`+|.", flags=re.DOTALL)
 BUILD_OPTION_RE = re.compile(r"(?m)^\s*(--[a-z][a-z-]*)\)\s*")
+INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+AGENT_PATH_TOKEN_RE = re.compile(r"(?<![\w./~:-])(?:\./)?(?:[\w.+-]+/)+[\w.+-]+")
+AGENT_PLACEHOLDER_TAIL_RE = re.compile(r"/[^`\s]*[<>*${}~]")
+
+# Repo-root files agent docs name without a directory prefix.
+AGENT_ROOT_FILES = {
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CLAUDE.md",
+    "CMakeLists.txt",
+    "CMakePresets.json",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "build_linux.sh",
+    "build_windows.bat",
+}
+# Directory prefixes that mark a token as a repo-root-relative path claim.
+# build/ is deliberately absent: those paths name generated artifacts.
+AGENT_PATH_PREFIXES = (
+    ".claude/",
+    ".codex/",
+    ".github/",
+    "cmake/",
+    "dal-cpp/",
+    "dal-excel/",
+    "dal-public/",
+    "dal-python/",
+    "dal-web/",
+    "docs/",
+    "tests/",
+)
+# Referenced paths that exist only at runtime, not in a fresh checkout.
+AGENT_ALLOWED_MISSING = {"dal-web/backend/.data"}
+
+AGENT_ROOT_FILE_RE = re.compile(
+    r"(?<![\w./~:-])(?:"
+    + "|".join(re.escape(name) for name in sorted(AGENT_ROOT_FILES, key=len, reverse=True))
+    + r")(?![\w+-])"
+)
 
 STALE_DOCUMENTATION = {
+    "bin/dal_cpp_tests": "dal_cpp_tests is a build-tree target, not an installed binary",
     "bin/dal_public_tests": "dal_public_tests is a build-tree target, not an installed binary",
     "--gtest_filter=CurveTest.*": "the CurveTest suite does not exist",
     "dal_stub.py": "the web backend has no runtime stub module",
@@ -159,9 +213,9 @@ def check_link(
         )
 
 
-def check_links(errors: list[str]) -> None:
+def check_links(documents: tuple[Path, ...], errors: list[str]) -> None:
     anchor_cache: dict[Path, set[str]] = {}
-    for document in DOCS:
+    for document in documents:
         lines = document.read_text(encoding="utf-8").splitlines()
         for line_number, line in without_fenced_code(lines):
             for match in LINK_RE.finditer(line):
@@ -240,8 +294,8 @@ def check_table_body(
     return row_number
 
 
-def check_tables(errors: list[str]) -> None:
-    for document in DOCS:
+def check_tables(documents: tuple[Path, ...], errors: list[str]) -> None:
+    for document in documents:
         raw_lines = document.read_text(encoding="utf-8").splitlines()
         visible = dict(without_fenced_code(raw_lines))
         line_number = 1
@@ -262,8 +316,8 @@ def check_tables(errors: list[str]) -> None:
             line_number = max(line_number + 1, row_number)
 
 
-def check_whitespace(errors: list[str]) -> None:
-    for document in DOCS:
+def check_whitespace(documents: tuple[Path, ...], errors: list[str]) -> None:
+    for document in documents:
         for line_number, line in enumerate(
             document.read_text(encoding="utf-8").splitlines(keepends=True), start=1
         ):
@@ -293,8 +347,8 @@ def check_metadata(errors: list[str]) -> None:
             errors.append(f"{relative(document)}: stale BSD-3-Clause license metadata")
 
 
-def check_stale_commands(errors: list[str]) -> None:
-    for document in DOCS:
+def check_stale_commands(documents: tuple[Path, ...], errors: list[str]) -> None:
+    for document in documents:
         text = document.read_text(encoding="utf-8")
         for stale, explanation in STALE_DOCUMENTATION.items():
             for match in re.finditer(re.escape(stale), text):
@@ -318,10 +372,10 @@ def check_stale_commands(errors: list[str]) -> None:
         )
 
 
-def check_math_macros(errors: list[str]) -> None:
+def check_math_macros(documents: tuple[Path, ...], errors: list[str]) -> None:
     # Only scan visible (non-fenced) lines so a macro shown literally inside a
     # code fence is not flagged. Math lives in `$...$` / `$$...$$` on these lines.
-    for document in DOCS:
+    for document in documents:
         lines = document.read_text(encoding="utf-8").splitlines()
         for line_number, line in without_fenced_code(lines):
             for bad, good in FORBIDDEN_MATH_MACROS.items():
@@ -332,21 +386,77 @@ def check_math_macros(errors: list[str]) -> None:
                     )
 
 
+def code_regions(lines: list[str]) -> list[tuple[int, str]]:
+    # Path claims are checked only where conventions put them: fenced code and
+    # inline code spans. Prose (e.g. "docs/changelog") is not parsed.
+    regions: list[tuple[int, str]] = []
+    closing_marker: str | None = None
+    for line_number, line in enumerate(lines, start=1):
+        marker = FENCE_RE.match(line)
+        if marker:
+            token = marker.group(1)
+            if closing_marker is None:
+                closing_marker = token[0]
+            elif token[0] == closing_marker:
+                closing_marker = None
+            continue
+        if closing_marker is not None:
+            regions.append((line_number, line))
+        else:
+            for span in INLINE_CODE_RE.finditer(line):
+                regions.append((line_number, span.group(1)))
+    return regions
+
+
+def agent_referenced_paths(text: str) -> list[tuple[int, str]]:
+    referenced: list[tuple[int, str]] = []
+    for line_number, segment in code_regions(text.splitlines()):
+        found: list[tuple[int, str]] = [(m.start(), m.group(0)) for m in AGENT_ROOT_FILE_RE.finditer(segment)]
+        for match in AGENT_PATH_TOKEN_RE.finditer(segment):
+            token = match.group(0)
+            if token.startswith("./"):
+                token = token[2:]
+            token = token.rstrip(".,:;")
+            if any(marker in token for marker in "<>*${}~"):
+                continue
+            tail = segment[match.end() :]
+            if tail and (tail[0] in "<>*${}~" or AGENT_PLACEHOLDER_TAIL_RE.match(tail)):
+                continue
+            if token.startswith(AGENT_PATH_PREFIXES):
+                found.append((match.start(), token))
+        for _, token in sorted(found):
+            referenced.append((line_number, token))
+    return referenced
+
+
+def check_agent_paths(documents: tuple[Path, ...], root: Path, errors: list[str]) -> None:
+    for document in documents:
+        text = document.read_text(encoding="utf-8")
+        for line_number, token in agent_referenced_paths(text):
+            if token in AGENT_ALLOWED_MISSING or (root / token).exists():
+                continue
+            errors.append(
+                f"{document.relative_to(root).as_posix()}:{line_number}: "
+                f"referenced repository path does not exist: {token}"
+            )
+
+
 def main() -> int:
     errors: list[str] = []
-    check_links(errors)
-    check_tables(errors)
-    check_whitespace(errors)
+    check_links(ALL_DOCS, errors)
+    check_tables(ALL_DOCS, errors)
+    check_whitespace(ALL_DOCS, errors)
     check_metadata(errors)
-    check_stale_commands(errors)
-    check_math_macros(errors)
+    check_stale_commands(ALL_DOCS, errors)
+    check_math_macros(ALL_DOCS, errors)
+    check_agent_paths(AGENT_DOCS, ROOT, errors)
 
     if errors:
         print("Documentation checks failed:", file=sys.stderr)
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         return 1
-    print(f"Documentation checks passed for {len(DOCS)} Markdown files.")
+    print(f"Documentation checks passed for {len(ALL_DOCS)} Markdown files.")
     return 0
 
 

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -408,21 +408,26 @@ def code_regions(lines: list[str]) -> list[tuple[int, str]]:
     return regions
 
 
+def agent_path_claim(token: str, tail: str) -> str | None:
+    if token.startswith("./"):
+        token = token[2:]
+    token = token.rstrip(".,:;")
+    if any(marker in token for marker in "<>*${}~"):
+        return None
+    if tail and (tail[0] in "<>*${}~" or AGENT_PLACEHOLDER_TAIL_RE.match(tail)):
+        return None
+    if not token.startswith(AGENT_PATH_PREFIXES):
+        return None
+    return token
+
+
 def agent_referenced_paths(text: str) -> list[tuple[int, str]]:
     referenced: list[tuple[int, str]] = []
     for line_number, segment in code_regions(text.splitlines()):
         found: list[tuple[int, str]] = [(m.start(), m.group(0)) for m in AGENT_ROOT_FILE_RE.finditer(segment)]
         for match in AGENT_PATH_TOKEN_RE.finditer(segment):
-            token = match.group(0)
-            if token.startswith("./"):
-                token = token[2:]
-            token = token.rstrip(".,:;")
-            if any(marker in token for marker in "<>*${}~"):
-                continue
-            tail = segment[match.end() :]
-            if tail and (tail[0] in "<>*${}~" or AGENT_PLACEHOLDER_TAIL_RE.match(tail)):
-                continue
-            if token.startswith(AGENT_PATH_PREFIXES):
+            token = agent_path_claim(match.group(0), segment[match.end() :])
+            if token is not None:
                 found.append((match.start(), token))
         for _, token in sorted(found):
             referenced.append((line_number, token))

--- a/.github/scripts/tests/test_check_docs.py
+++ b/.github/scripts/tests/test_check_docs.py
@@ -1,0 +1,158 @@
+"""Tests for the DAL documentation checker."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_docs.py"
+SPEC = importlib.util.spec_from_file_location("check_docs", SCRIPT)
+CHECK_DOCS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK_DOCS)
+
+
+class AgentDocsTest(unittest.TestCase):
+    def test_agent_docs_cover_agent_facing_guides(self):
+        expected = {
+            "AGENTS.md",
+            "CLAUDE.md",
+            ".github/copilot-instructions.md",
+            ".codex/skills/dal-agent-team/references/shared-rules.md",
+        }
+
+        actual = {path.relative_to(CHECK_DOCS.ROOT).as_posix() for path in CHECK_DOCS.AGENT_DOCS}
+
+        self.assertEqual(actual, expected)
+
+    def test_agent_docs_exist(self):
+        for document in CHECK_DOCS.AGENT_DOCS:
+            self.assertTrue(document.is_file(), document)
+
+    def test_stale_table_flags_repo_root_test_binaries(self):
+        self.assertIn("bin/dal_cpp_tests", CHECK_DOCS.STALE_DOCUMENTATION)
+        self.assertIn("bin/dal_public_tests", CHECK_DOCS.STALE_DOCUMENTATION)
+
+
+class AgentReferencedPathsTest(unittest.TestCase):
+    def test_extracts_backticked_repo_path(self):
+        text = "Core numerics live in `dal-cpp/dal/math/` here."
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [(1, "dal-cpp/dal/math")])
+
+    def test_extracts_fenced_command_path(self):
+        text = "```bash\n./dal-web/scripts/setup-playwright.sh\n```"
+
+        self.assertEqual(
+            CHECK_DOCS.agent_referenced_paths(text), [(2, "dal-web/scripts/setup-playwright.sh")]
+        )
+
+    def test_ignores_prose_without_code_formatting(self):
+        text = "tests, docs/changelog, generated files, and dal-cpp/dal/math/ in prose"
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [])
+
+    def test_extracts_root_level_files(self):
+        text = "Edit `CMakePresets.json`, see `README.md`, and run `build_linux.sh`."
+
+        self.assertEqual(
+            CHECK_DOCS.agent_referenced_paths(text),
+            [(1, "CMakePresets.json"), (1, "README.md"), (1, "build_linux.sh")],
+        )
+
+    def test_reports_line_numbers(self):
+        text = "first line\nsecond `docs/methodology/aad.md` line"
+
+        self.assertEqual(
+            CHECK_DOCS.agent_referenced_paths(text), [(2, "docs/methodology/aad.md")]
+        )
+
+    def test_skips_build_tree_artifacts(self):
+        text = (
+            "run `./build/Release-linux/dal-cpp/dal_cpp_tests` "
+            "or `build/stage/Release-linux/bin` here"
+        )
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [])
+
+    def test_skips_placeholders_and_globs(self):
+        text = (
+            "`build/stage/<preset>/bin/`, `.codex/skills/dal-*`, "
+            "`dal-cpp/tests/<module>/test_<name>.cpp`, `${sourceDir}/build`, "
+            "`dal-cpp/dal/auto/MG_*_enum.{hpp,inc}`, `.codex/artifacts/specs/<slug>.md`"
+        )
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [])
+
+    def test_skips_home_and_url_paths(self):
+        text = "sync into `~/.codex/skills/` and see https://example.com/dal-cpp/x"
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [])
+
+    def test_skips_flags_and_plain_words(self):
+        text = "use `--gtest_filter=InterpTest.*`, `test_output.txt`, or `Makefile`"
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [])
+
+    def test_strips_trailing_sentence_punctuation(self):
+        text = "Presets live in `CMakePresets.json.`"
+
+        self.assertEqual(CHECK_DOCS.agent_referenced_paths(text), [(1, "CMakePresets.json")])
+
+
+class CheckAgentPathsTest(unittest.TestCase):
+    def _check(self, root: Path, text: str) -> list[str]:
+        document = root / "AGENTS.md"
+        document.write_text(text, encoding="utf-8")
+        errors: list[str] = []
+        CHECK_DOCS.check_agent_paths((document,), root, errors)
+        return errors
+
+    def test_existing_paths_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs" / "methodology").mkdir(parents=True)
+
+            errors = self._check(root, "see `docs/methodology/` here")
+
+            self.assertEqual(errors, [])
+
+    def test_missing_path_is_flagged_with_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir()
+
+            errors = self._check(root, "first\nsee `docs/missing.md` now")
+
+            self.assertEqual(len(errors), 1)
+            self.assertIn("AGENTS.md:2", errors[0])
+            self.assertIn("docs/missing.md", errors[0])
+
+    def test_runtime_created_paths_are_allowed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            errors = self._check(root, "SQLite file under `dal-web/backend/.data/` here")
+
+            self.assertEqual(errors, [])
+
+    def test_current_agent_docs_have_no_missing_referenced_paths(self):
+        errors: list[str] = []
+        CHECK_DOCS.check_agent_paths(CHECK_DOCS.AGENT_DOCS, CHECK_DOCS.ROOT, errors)
+        self.assertEqual(errors, [])
+
+
+class AgentDocsStandardChecksTest(unittest.TestCase):
+    def test_current_agent_docs_pass_standard_checks(self):
+        errors: list[str] = []
+        CHECK_DOCS.check_links(CHECK_DOCS.AGENT_DOCS, errors)
+        CHECK_DOCS.check_tables(CHECK_DOCS.AGENT_DOCS, errors)
+        CHECK_DOCS.check_whitespace(CHECK_DOCS.AGENT_DOCS, errors)
+        CHECK_DOCS.check_math_macros(CHECK_DOCS.AGENT_DOCS, errors)
+        CHECK_DOCS.check_stale_commands(CHECK_DOCS.AGENT_DOCS, errors)
+
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -165,6 +165,24 @@ jobs:
             -DDAL_PYTHON_BUILD_TESTS=OFF
           cmake --build $pythonBuild --target _dal --parallel
 
+  # Smoke-test the build_windows.bat entry point so it stops rotting. The
+  # --configure-only mode exercises everything the script owns -- vswhere
+  # discovery, the Machinist build plus code generation, and the CMake
+  # configure -- without paying for a second full build; the matrix above
+  # remains the proven direct-cmake path for compilation and tests.
+  build-script:
+    name: build_windows.bat (configure-only)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          submodules: recursive
+
+      - name: Run build_windows.bat --configure-only
+        shell: cmd
+        run: build_windows.bat --configure-only
+
   # Benchmark job: builds and runs all performance benchmarks on one
   # representative configuration (msvc, native/AADet backend).
   # Results appear in the CI logs and job summary; timings are not a pass/fail gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Last updated: 2026-07-04
+Last updated: 2026-07-18
 
 Codex-native guidance for working in this repository. This file is intentionally separate from
 `CLAUDE.md` and `.claude/`; do not edit the Claude originals unless the user explicitly asks.
@@ -37,20 +37,18 @@ bash ./build_linux.sh
 ```
 
 ```bash
-mkdir -p build
-cd build
-cmake --preset=Release-linux ..
-make -j$(nproc)
-make install
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux -j$(nproc)
+cmake --install build/Release-linux
 ```
 
-Run tests from the installed binaries or CTest:
+Run tests through CTest or the build-tree binaries:
 
 ```bash
-(cd build && ctest --output-on-failure)
-bin/dal_cpp_tests
-bin/dal_public_tests
-bin/dal_cpp_tests --gtest_filter=<SuiteName>.*
+ctest --test-dir build/Release-linux --output-on-failure
+./build/Release-linux/dal-cpp/dal_cpp_tests
+./build/Release-linux/dal-public/dal_public_tests
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.*
 ```
 
 If enum Machinist markup changes, regenerate both core and Excel auto files before building.

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,54 +1,126 @@
 @echo off
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -startdir=none -arch=x64 -host_arch=x64
+setlocal
 
-call :set_variable DAL_DIR "%CD%" %DAL_DIR%
-call :set_variable BUILD_TYPE "Release" %BUILD_TYPE%
+rem Optional first argument: --configure-only stops after the CMake configure
+rem (CI smoke-tests this script that way without paying for a full build).
+set "CONFIGURE_ONLY="
+if /i "%~1"=="--configure-only" set "CONFIGURE_ONLY=1"
+
+rem Discover Visual Studio with C++ build tools via vswhere -- the same query
+rem the Windows CI workflow uses -- so Community, Professional, Enterprise,
+rem and Build Tools editions all work.
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+    echo vswhere.exe was not found at "%VSWHERE%"
+    exit /b 1
+)
+set "VS_PATH="
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VS_PATH=%%i"
+if not defined VS_PATH (
+    echo Visual Studio with C++ build tools was not found
+    exit /b 1
+)
+set "VSDEVCMD=%VS_PATH%\Common7\Tools\VsDevCmd.bat"
+if not exist "%VSDEVCMD%" (
+    echo VsDevCmd.bat was not found at "%VSDEVCMD%"
+    exit /b 1
+)
+call "%VSDEVCMD%" -startdir=none -arch=x64 -host_arch=x64
+where cl >nul 2>&1
+if errorlevel 1 (
+    echo VsDevCmd.bat did not put the MSVC compiler on PATH
+    exit /b 1
+)
+
+call :set_variable DAL_DIR "%CD%" "%DAL_DIR%"
+call :set_variable BUILD_TYPE "Release" "%BUILD_TYPE%"
 
 echo BUILD_TYPE: %BUILD_TYPE%
 echo DAL_DIR: %DAL_DIR%
 
-rmdir /q /s bin
-rmdir /q /s lib
+if exist "%DAL_DIR%\bin" rmdir /q /s "%DAL_DIR%\bin"
+if exist "%DAL_DIR%\lib" rmdir /q /s "%DAL_DIR%\lib"
 
-cd dal-cpp\externals\machinist
-
-if exist build (
-  rem build folder already exists.
-) else (
-  mkdir build
+rem Build Machinist the same way the Windows CI workflow does -- cmake preset,
+rem build, install into the submodule's own bin\ -- then regenerate sources.
+pushd "%DAL_DIR%\dal-cpp\externals\machinist"
+if exist build rmdir /q /s build
+mkdir build
+pushd build
+cmake --preset %BUILD_TYPE%-windows ..
+if errorlevel 1 (
+    echo Machinist configure failed
+    popd
+    popd
+    exit /b 1
 )
+cmake --build .
+if errorlevel 1 (
+    echo Machinist build failed
+    popd
+    popd
+    exit /b 1
+)
+cmake --install .
+if errorlevel 1 (
+    echo Machinist install failed
+    popd
+    popd
+    exit /b 1
+)
+popd
 
-echo Starting build machinist2
-call ./build_windows.bat
-echo End build machinist2
-
-set MACHINIST_TEMPLATE_DIR=%CD%\template\
+set "MACHINIST_TEMPLATE_DIR=%CD%\template\"
 echo MACHINIST_TEMPLATE_DIR=%MACHINIST_TEMPLATE_DIR%
-bin\Machinist.exe -c %DAL_DIR%/dal-cpp/config/dal.ifc -l %DAL_DIR%/dal-cpp/config/dal.mgl -d %DAL_DIR%/dal-cpp/dal
-bin\Machinist.exe -c %DAL_DIR%/dal-cpp/config/dal.ifc -l %DAL_DIR%/dal-cpp/config/dal.mgl -d %DAL_DIR%/dal-excel
+bin\Machinist.exe -c "%DAL_DIR%\dal-cpp\config\dal.ifc" -l "%DAL_DIR%\dal-cpp\config\dal.mgl" -d "%DAL_DIR%\dal-cpp\dal"
+if errorlevel 1 (
+    echo Machinist code generation for dal-cpp failed
+    popd
+    exit /b 1
+)
+bin\Machinist.exe -c "%DAL_DIR%\dal-cpp\config\dal.ifc" -l "%DAL_DIR%\dal-cpp\config\dal.mgl" -d "%DAL_DIR%\dal-excel"
+if errorlevel 1 (
+    echo Machinist code generation for dal-excel failed
+    popd
+    exit /b 1
+)
+popd
 
-if %errorlevel% neq 0 exit /b 1
-
-
-cd %DAL_DIR%
+cd /d "%DAL_DIR%"
 
 cmake --preset %BUILD_TYPE%-windows -DDAL_BUILD_PUBLIC=ON -DDAL_CPP_BUILD_EXAMPLES=ON -DDAL_CPP_BUILD_BENCHMARKS=ON
+if errorlevel 1 (
+    echo CMake configure failed
+    exit /b 1
+)
 
-if %errorlevel% neq 0 exit /b 1
+if defined CONFIGURE_ONLY (
+    echo Configure-only mode: skipping build, install, and tests
+    exit /b 0
+)
 
-cmake --build build\%BUILD_TYPE%-windows --parallel %NUMBER_OF_PROCESSORS%
-cmake --install build\%BUILD_TYPE%-windows
+cmake --build "build\%BUILD_TYPE%-windows" --parallel %NUMBER_OF_PROCESSORS%
+if errorlevel 1 (
+    echo CMake build failed
+    exit /b 1
+)
 
-if %errorlevel% neq 0 exit /b 1
+cmake --install "build\%BUILD_TYPE%-windows"
+if errorlevel 1 (
+    echo CMake install failed
+    exit /b 1
+)
 
-echo "starting run unit tests suite via ctest"
-ctest --test-dir build\%BUILD_TYPE%-windows --output-on-failure -C %BUILD_TYPE%
+echo Starting unit test suite via ctest
+ctest --test-dir "build\%BUILD_TYPE%-windows" --output-on-failure -C %BUILD_TYPE%
+if errorlevel 1 (
+    echo ctest failed
+    exit /b 1
+)
 
-if %errorlevel% neq 0 exit /b 1
-
-@echo on
-
-EXIT /B 0
+endlocal
+exit /b 0
 
 :set_variable
-set %~1=%~2
+if "%~3"=="" (set "%~1=%~2") else (set "%~1=%~3")
+exit /b 0

--- a/dal-cpp/CMakeLists.txt
+++ b/dal-cpp/CMakeLists.txt
@@ -72,11 +72,15 @@ endif()
 # External dependencies
 # ---------------------------------------------------------------------------
 if(DAL_CPP_BUILD_TESTS)
+    dal_require_submodule("externals/googletest/CMakeLists.txt")
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
     set(INSTALL_GMOCK OFF CACHE BOOL "" FORCE)
     add_subdirectory(${PROJECT_SOURCE_DIR}/externals/googletest)
 endif()
 
+if(DAL_USE_XAD_AAD OR DAL_CPP_BUILD_EXAMPLES)
+    dal_require_submodule("externals/xad/CMakeLists.txt")
+endif()
 if(DAL_USE_XAD_AAD)
     add_subdirectory(${PROJECT_SOURCE_DIR}/externals/xad)
 elseif(DAL_CPP_BUILD_EXAMPLES)
@@ -86,13 +90,19 @@ elseif(DAL_CPP_BUILD_EXAMPLES)
 endif()
 
 if(DAL_USE_CODIPACK_AAD)
+    dal_require_submodule("externals/CodiPack/CMakeLists.txt")
     add_subdirectory(${PROJECT_SOURCE_DIR}/externals/CodiPack)
 elseif(DAL_USE_ADEPT_AAD)
+    dal_require_submodule("externals/adept/CMakeLists.txt")
     add_subdirectory(${PROJECT_SOURCE_DIR}/externals/adept)
 endif()
 
+# rapidjson headers are on the dal_cpp private include path.
+dal_require_submodule("externals/rapidjson/include/rapidjson/document.h")
+
 # Machinist is an explicit source-generation tool. It is built only when
 # dal_generate/dal_check_generated is requested and is never part of DAL installs.
+dal_require_submodule("externals/machinist/CMakeLists.txt")
 add_subdirectory(${PROJECT_SOURCE_DIR}/externals/machinist EXCLUDE_FROM_ALL)
 
 add_custom_target(dal_generate

--- a/dal-cpp/cmake/Platform.cmake
+++ b/dal-cpp/cmake/Platform.cmake
@@ -6,6 +6,17 @@ if(MSVC AND BUILD_SHARED_LIBS)
     message(FATAL_ERROR "Shared library (DLL) builds for DAL on MSVC are not supported")
 endif()
 
+# Fail fast with an actionable message when a required git submodule was not
+# initialized, instead of a bare "does not contain a CMakeLists.txt" error.
+function(dal_require_submodule sentinel)
+    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/${sentinel}")
+        message(FATAL_ERROR
+            "Required git submodule sources are missing: "
+            "${PROJECT_SOURCE_DIR}/${sentinel}\n"
+            "Initialize them with: git submodule update --init --recursive")
+    endif()
+endfunction()
+
 function(dal_apply_platform_options target)
     if(MSVC)
         target_compile_definitions(${target} PRIVATE

--- a/dal-cpp/examples/CMakeLists.txt
+++ b/dal-cpp/examples/CMakeLists.txt
@@ -18,6 +18,34 @@ add_subdirectory(uoc)
 add_subdirectory(vanilla)
 add_subdirectory(yield_curve_jacobian)
 
+# The excelwriter example needs MSVC's #import COM support plus the Microsoft
+# Office type libraries on the build machine (see excelimport.hpp). Detect
+# them; users may also pass the OFFICE_* paths explicitly as cache variables.
+set(DAL_HAS_EXCEL OFF)
+if(WIN32 AND MSVC)
+    set(_OFFICE_SEARCH_PATHS
+        "C:/Program Files/Microsoft Office/root/VFS/ProgramFilesCommonX86/Microsoft Shared/OFFICE16"
+        "C:/Program Files (x86)/Common Files/microsoft shared/OFFICE16"
+        "C:/Program Files/Common Files/Microsoft Shared/OFFICE16")
+    set(_VBA_SEARCH_PATHS
+        "C:/Program Files/Microsoft Office/root/VFS/ProgramFilesCommonX86/Microsoft Shared/VBA/VBA6"
+        "C:/Program Files (x86)/Common Files/microsoft shared/VBA/VBA6"
+        "C:/Program Files/Common Files/Microsoft Shared/VBA/VBA6")
+    set(_EXCEL_SEARCH_PATHS
+        "C:/Program Files/Microsoft Office/root/Office16"
+        "C:/Program Files (x86)/Microsoft Office/Office16"
+        "C:/Program Files/Microsoft Office/Office16")
+    find_file(OFFICE_MSO_DLL NAMES "MSO.DLL" PATHS ${_OFFICE_SEARCH_PATHS} NO_DEFAULT_PATH)
+    find_file(OFFICE_VBE_OLB NAMES "VBE6EXT.OLB" PATHS ${_VBA_SEARCH_PATHS} NO_DEFAULT_PATH)
+    find_file(OFFICE_EXCEL_EXE NAMES "EXCEL.EXE" PATHS ${_EXCEL_SEARCH_PATHS} NO_DEFAULT_PATH)
+    if(OFFICE_MSO_DLL AND OFFICE_VBE_OLB AND OFFICE_EXCEL_EXE)
+        set(DAL_HAS_EXCEL ON)
+        message(STATUS "Office found - excelwriter example enabled")
+    else()
+        message(STATUS "Office not found - excelwriter example skipped")
+    endif()
+endif()
+
 if(DAL_HAS_EXCEL)
     add_subdirectory(excelwriter)
 endif()


### PR DESCRIPTION
## Summary

Next tranche of the [2026-07-17 codebase review](.codex/artifacts/reviews/master-codebase-review-2026-07-17.md) — four items:

- **Submodule guards (plan item 10 tail).** Configuring without initialized submodules previously died with a bare `add_subdirectory ... does not contain a CMakeLists.txt file` and no remediation. New `dal_require_submodule()` (dal-cpp/cmake/Platform.cmake) checks a sentinel file per external before it is consumed — googletest, xad, CodiPack, adept, machinist, rapidjson — and fails with `Initialize them with: git submodule update --init --recursive`. pybind11 already had an equivalent guard in dal-python.
- **H11 — keep the `excelwriter` example; wire the dead `DAL_HAS_EXCEL` guard to a real detected condition.** Details below.
- **Agent-facing docs (plan item 11 tail).** Fixed stale `bin/dal_cpp_tests` / `bin/dal_public_tests` paths and the old `cd build && cmake --preset ..` flow in `AGENTS.md` and `.codex/skills/dal-agent-team/references/shared-rules.md`, added the missing `--no-sync` on web pytest, and replaced the direct Machinist binary invocation (a git-ignored build artifact) with the `dal_generate` target — in `shared-rules.md` and in `.github/copilot-instructions.md` (the latter caught by the new checker in CI). Extended `.github/scripts/check_docs.py` to the four agent-facing guides (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, shared-rules.md): links/tables/whitespace/math-macro/stale-command checks now apply to them, `bin/dal_cpp_tests` joined the stale table, and a new referenced-path existence check flags repo paths named in inline code or fenced blocks (prose like "docs/changelog" is not parsed; build-tree artifacts, placeholders, and globs are excluded by construction). New unittest coverage in `.github/scripts/tests/test_check_docs.py`.
- **H9 — `build_windows.bat` modernization.** Replaced the hard-coded VS2022 **Community** `VsDevCmd.bat` path with the same `vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64` discovery the Windows workflow uses (works on Professional/Enterprise/Build Tools), added `errorlevel` checks after every step, fixed `:set_variable` to honor the current-value argument (it previously always overwrote), and switched the Machinist build to the CI-proven `cmake --preset` route instead of the submodule's own legacy script. **CI shape:** a new `build-script` job runs `build_windows.bat --configure-only` — it genuinely executes everything the script owns (vswhere discovery, Machinist build + codegen, CMake configure) in a few minutes without a second full build; the direct-cmake matrix stays the authoritative compile/test path. Windows is not available locally, so the bat is validated by review and this CI leg.

### H11 — what excelwriter requires, and the wired condition

Evidence (from the sources and git history):

1. `excelwriter.cpp` is `#ifdef USE_EXCEL_REPORT` and drives `Dal::ExcelDriver_` (dal-cpp/dal/io/exceldriverlite.hpp), which uses COM (`Excel::_ApplicationPtr`, `_com_error`) via `dal-cpp/dal/io/excelimport.hpp`. `excelimport.hpp` `#error`s on any compiler without MSVC-style `#import` ("requires MSVC compiler (or clang-cl)").
2. The example's `CMakeLists.txt` compiles it with `USE_EXCEL_REPORT` and three `OFFICE_*_PATH` definitions drawn from `OFFICE_MSO_DLL` / `OFFICE_VBE_OLB` / `OFFICE_EXCEL_EXE` — i.e. it needs the Microsoft Office type libraries (`MSO.DLL`, `VBE6EXT.OLB`, `EXCEL.EXE`) on the build machine.
3. The example is interactive: it opens a visible Excel window (`MakeVisible(true)`) and builds a chart, so it can be *built* where Office is installed but not *run* headless in CI.
4. History: `99eb232c` introduced the example together with a `DAL_HAS_EXCEL` auto-detection block in the root `CMakeLists.txt`; the multi-project refactor `fe16992e` (#71) dropped the detection but left the two `if(DAL_HAS_EXCEL)` guards — undefined ever since, so the example silently never built.

Wired condition (decision: **keep the example, make the guard real**):

- `DAL_HAS_EXCEL` is now **defined in `dal-cpp/examples/CMakeLists.txt`**, next to the guards that consume it.
- It is `ON` exactly when `WIN32 AND MSVC` **and** all three Office files are located by `find_file` over the standard Office installation roots; the `OFFICE_*` variables are normal cache variables, so users with non-standard layouts can pass `-DOFFICE_MSO_DLL=...` etc. explicitly.
- Otherwise it stays `OFF`: the example is skipped with a `Office not found - excelwriter example skipped` status line (on Windows) or silently (elsewhere). Linux/macOS builds are completely unaffected — verified below.
- The guard's requirements are documented in a comment at the definition site.

## Test plan

- [x] Submodule-guard probes in a fresh worktree with **uninitialized** submodules — each fails at configure with the intended remediation:
  - default preset → `Required git submodule sources are missing: .../externals/googletest/CMakeLists.txt` + `Initialize them with: git submodule update --init --recursive` (cmake exit 1)
  - `-DDAL_CPP_BUILD_TESTS=OFF` → fires at `externals/xad/CMakeLists.txt`
  - tests+examples OFF → fires at `externals/rapidjson/include/rapidjson/document.h`
  - `-DDAL_USE_ADEPT_AAD=ON` → fires at `externals/adept/CMakeLists.txt`
- [x] Same worktree after populating externals: `cmake --preset=Release-linux -S . -B build/Release-linux` exits 0 (`Configuring done`).
- [x] Linux configure + full build with the wired H11 guard: `DAL_HAS_EXCEL` stays OFF (non-Windows), configure exits 0, `cmake --build -j` exits 0; the `WIN32 AND MSVC` branch is validated by parse + review and by the Windows CI legs (no Office on the runners, so they take the documented skip path).
- [x] `./build/Release-linux/dal-cpp/dal_cpp_tests` — **994/994 passed**; `./build/Release-linux/dal-public/dal_public_tests` — **56/56 passed**.
- [x] `python3 .github/scripts/check_docs.py` — passes (32 Markdown files: 28 published + 4 agent-facing); `python3 -m unittest discover -s .github/scripts/tests` — **37 tests OK** (also green under `pytest`).
- [x] Checker failure modes proven end-to-end: a bogus `dal-cpp/dal/nonexistent_module/` reference in `AGENTS.md` fails the gate with `referenced repository path does not exist`; a re-added `bin/dal_cpp_tests` line fails with the stale-binary message. Both reverted; gate green again.
- [ ] Windows CI legs validate the bat (`build_windows.bat (configure-only)` job) and the guard's skip path (MSVC matrix + Benchmarks, no Office installed).

**Deferred:** nothing from this tranche. (`dal-cpp/dal/io/exceldriverlite` remains the support module for the kept example; no longer a removal candidate.)
