### PR TITLE
fix: harden exception safety in matrix, stack, exception utilities

### DIFF
--- a/dal-cpp/dal/math/matrix/cholesky.cpp
+++ b/dal-cpp/dal/math/matrix/cholesky.cpp
@@ -61,7 +61,8 @@ namespace Dal {
                 REQUIRE(reg > 0.0, "regularization factor should be greater than 0.0");
                 for (int ii = 0; ii < n; ++ii)
                     (*lower_)(ii, ii) /= reg + Square((*lower_)(ii, ii));
-                lower_ = owned.release();
+                if (owned)
+                    lower_ = owned.release();
             }
 
             ~Cholesky_() override {

--- a/dal-cpp/dal/math/matrix/cholesky.cpp
+++ b/dal-cpp/dal/math/matrix/cholesky.cpp
@@ -61,7 +61,7 @@ namespace Dal {
                 REQUIRE(reg > 0.0, "regularization factor should be greater than 0.0");
                 for (int ii = 0; ii < n; ++ii)
                     (*lower_)(ii, ii) /= reg + Square((*lower_)(ii, ii));
-                owned.release();
+                lower_ = owned.release();
             }
 
             ~Cholesky_() override {

--- a/dal-cpp/dal/math/matrix/cholesky.cpp
+++ b/dal-cpp/dal/math/matrix/cholesky.cpp
@@ -2,6 +2,8 @@
 // Created by wegamekinglc on 22-12-17.
 //
 
+#include <memory>
+
 #include <dal/platform/strict.hpp>
 #include <dal/math/matrix/cholesky.hpp>
 #include <dal/math/matrix/sparse.hpp>
@@ -42,12 +44,14 @@ namespace Dal {
 
         public:
             explicit Cholesky_(const SquareMatrix_<>& src, SquareMatrix_<>* lower = nullptr, double regularization = Dal::EPSILON) {
+                std::unique_ptr<SquareMatrix_<>> owned;
                 if (lower) {
                     lower_ = lower;
                     needKeep_ = true;
                 }
                 else {
-                    lower_ = new SquareMatrix_<>(src.Rows(), src.Cols());
+                    owned.reset(new SquareMatrix_<>(src.Rows(), src.Cols()));
+                    lower_ = owned.get();
                     needKeep_ = false;
                 }
 
@@ -57,6 +61,7 @@ namespace Dal {
                 REQUIRE(reg > 0.0, "regularization factor should be greater than 0.0");
                 for (int ii = 0; ii < n; ++ii)
                     (*lower_)(ii, ii) /= reg + Square((*lower_)(ii, ii));
+                owned.release();
             }
 
             ~Cholesky_() override {

--- a/dal-cpp/dal/math/matrix/matrixs.hpp
+++ b/dal-cpp/dal/math/matrix/matrixs.hpp
@@ -20,12 +20,13 @@ namespace Dal {
         int cols_;
         Vector_<I_> hooks_;
         void SetHook(size_t from = 0);
+        static size_t Extent(int rows, int cols) { return (static_cast<size_t>(rows) + 1) * static_cast<size_t>(cols); }
 
     public:
         virtual ~Matrix_() = default;
         Matrix_() : cols_(0) {}
         Matrix_(int rows, int cols, E_ val = E_())
-            : vals_(static_cast<size_t>((rows + 1) * cols)), cols_(cols), hooks_(static_cast<size_t>(rows)) {
+            : vals_(Extent(rows, cols)), cols_(cols), hooks_(static_cast<size_t>(rows)) {
             SetHook();
             vals_.Fill(val);
         }
@@ -64,12 +65,10 @@ namespace Dal {
             return *this;
         }
 
-        Matrix_& operator=(const Matrix_& rhs) noexcept {
+        Matrix_& operator=(const Matrix_& rhs) {
             if (this != &rhs) {
-                vals_ = rhs.vals_;
-                cols_ = rhs.cols_;
-                hooks_ = Vector_<I_>(rhs.hooks_.size());
-                SetHook();
+                Matrix_<E_> temp(rhs);
+                swap(temp);
             }
             return *this;
         }
@@ -223,13 +222,13 @@ namespace Dal {
         void Resize(int rows, int cols) {
             const auto old_rows = hooks_.size();
             if (cols == cols_ && rows * old_rows > 0) {
-                vals_.Resize((rows + 1) * cols);
+                vals_.Resize(Extent(rows, cols));
                 hooks_.Resize(rows);
                 SetHook(hooks_[0] == vals_.begin() ? old_rows : 0);
             } else {
                 const auto n_copy = std::min(cols, cols_);
                 cols_ = cols;
-                Vector_<E_> new_vals((rows + 1) * cols);
+                Vector_<E_> new_vals(Extent(rows, cols));
                 for (int ir = 0; ir < rows && ir < old_rows; ++ir) {
                     copy(hooks_[ir], hooks_[ir] + n_copy, new_vals.begin() + ir * cols);
                 }

--- a/dal-cpp/dal/math/pde/pdeoperators.cpp
+++ b/dal-cpp/dal/math/pde/pdeoperators.cpp
@@ -2,6 +2,8 @@
 // Created by dal-implementer on 2026/7/8.
 //
 
+#include <memory>
+
 #include <dal/math/pde/pdeoperators.hpp>
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
@@ -19,7 +21,7 @@ namespace Dal::PDE {
     Sparse::TriDiagonal_* NewDx(const Vector_<>& x) {
         RequireOperatorLocations(x);
         const int n = static_cast<int>(x.size());
-        auto* ret = new Sparse::TriDiagonal_(n);
+        std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
         for (int i = 1; i < n - 1; ++i) {
             const double dxl = x[i] - x[i - 1];
             const double dxu = x[i + 1] - x[i];
@@ -28,13 +30,13 @@ namespace Dal::PDE {
             ret->Set(i, i, (dxu - dxl) / (dxl * dxu));
             ret->Set(i, i + 1, dxl / (dxu * dxm));
         }
-        return ret;
+        return ret.release();
     }
 
     Sparse::TriDiagonal_* NewDxx(const Vector_<>& x) {
         RequireOperatorLocations(x);
         const int n = static_cast<int>(x.size());
-        auto* ret = new Sparse::TriDiagonal_(n);
+        std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
         for (int i = 1; i < n - 1; ++i) {
             const double dxl = x[i] - x[i - 1];
             const double dxu = x[i + 1] - x[i];
@@ -43,6 +45,6 @@ namespace Dal::PDE {
             ret->Set(i, i, -2.0 / (dxl * dxu));
             ret->Set(i, i + 1, 2.0 / (dxu * dxm));
         }
-        return ret;
+        return ret.release();
     }
 } // namespace Dal::PDE

--- a/dal-cpp/dal/math/stacks.hpp
+++ b/dal-cpp/dal/math/stacks.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <utility>
 
 #include <dal/platform/platform.hpp>
@@ -23,11 +24,11 @@ namespace Dal {
             REQUIRE(size_ <= std::numeric_limits<int>::max() / 2, "stack capacity overflow");
             const int defaultSize = DefaultSize > 0 ? static_cast<int>(DefaultSize) : 1;
             const int newSize = size_ > 0 ? size_ * 2 : defaultSize;
-            E_* newData = new E_[newSize];
+            std::unique_ptr<E_[]> newData(new E_[newSize]);
             if (sp_ > 0)
-                std::move(data_, data_ + sp_, newData);
+                std::move(data_, data_ + sp_, newData.get());
             delete[] data_;
-            data_ = newData;
+            data_ = newData.release();
             size_ = newSize;
         }
 
@@ -42,10 +43,12 @@ namespace Dal {
         virtual ~Stack_() { delete[] data_; }
 
         Stack_(const Stack_& rhs) : size_(rhs.size_), sp_(rhs.sp_) {
-            if (size_ > 0)
-                data_ = new E_[size_];
-            if (sp_ > 0)
-                std::copy(rhs.data_, rhs.data_ + sp_, data_);
+            if (size_ > 0) {
+                std::unique_ptr<E_[]> newData(new E_[size_]);
+                if (sp_ > 0)
+                    std::copy(rhs.data_, rhs.data_ + sp_, newData.get());
+                data_ = newData.release();
+            }
         }
 
         Stack_& operator=(const Stack_& rhs) {

--- a/dal-cpp/dal/utilities/exceptions.hpp
+++ b/dal-cpp/dal/utilities/exceptions.hpp
@@ -87,7 +87,7 @@ namespace Dal {
             const char* name_;
             const void* value_;
             StackInfoType_ type_;
-            template <class T_> XStackInfo_(const char*, T_) = delete; // other data type is not allowed
+            template <class T_> XStackInfo_(const char*, T_) = delete; // other data types are not allowed
 
         public:
             XStackInfo_(const char* name, const int& val);

--- a/dal-cpp/dal/utilities/exceptions.hpp
+++ b/dal-cpp/dal/utilities/exceptions.hpp
@@ -87,7 +87,7 @@ namespace Dal {
             const char* name_;
             const void* value_;
             StackInfoType_ type_;
-            template <class T_> XStackInfo_(const char*, T_) {}; // other data type is not allowed
+            template <class T_> XStackInfo_(const char*, T_) = delete; // other data type is not allowed
 
         public:
             XStackInfo_(const char* name, const int& val);

--- a/dal-cpp/tests/math/matrix/test_cholesky.cpp
+++ b/dal-cpp/tests/math/matrix/test_cholesky.cpp
@@ -62,7 +62,7 @@ TEST(MatrixTest, TestCholeskyDecompositionV2) {
 
 TEST(MatrixTest, TestCholeskyDecompositionThrowsOnZeroMatrix) {
     SquareMatrix_<> m(3);
-    ASSERT_THROW(CholeskyDecomposition(m), Exception_);
+    ASSERT_THROW((void)Handle_<SymmetricMatrixDecomposition_>(CholeskyDecomposition(m)), Exception_);
 }
 
 TEST(MatrixTest, TestCholeskySolveThrowsOnZeroRegularization) {

--- a/dal-cpp/tests/math/matrix/test_cholesky.cpp
+++ b/dal-cpp/tests/math/matrix/test_cholesky.cpp
@@ -9,6 +9,7 @@
 #include <dal/math/matrix/matrixarithmetic.hpp>
 #include <dal/math/matrix/cholesky.hpp>
 #include <dal/math/random/sobol.hpp>
+#include <dal/utilities/exceptions.hpp>
 #include <dal/utilities/numerics.hpp>
 
 using namespace Dal;
@@ -57,6 +58,30 @@ TEST(MatrixTest, TestCholeskyDecompositionV2) {
     Vector_<> expected = {-0.00869565, 0.2,  0.2173913};
     for(int i = 0; i < n; ++i)
         ASSERT_NEAR(expected[i], x[i], 1e-7);
+}
+
+TEST(MatrixTest, TestCholeskyDecompositionThrowsOnZeroMatrix) {
+    SquareMatrix_<> m(3);
+    ASSERT_THROW(CholeskyDecomposition(m), Exception_);
+}
+
+TEST(MatrixTest, TestCholeskySolveThrowsOnZeroRegularization) {
+    const int n = 3;
+    double tmp[n][n] = {
+        {6.0, 2.0, 3.0},
+        {2.0, 9.0, 1.0},
+        {3.0, 1.0, 13.0}
+    };
+
+    SquareMatrix_<> m(n);
+    for (int i = 0; i < n; ++i)
+        for (int j = 0; j < n; ++j)
+            m(i, j) = tmp[i][j];
+
+    Vector_<Vector_<>> b(1);
+    b[0] = {1.0, 2.0, 3.0};
+
+    ASSERT_THROW(CholeskySolve(&m, &b, 0.0), Exception_);
 }
 
 TEST(MatrixTest, TestCholeskySolve) {

--- a/dal-cpp/tests/math/matrix/test_matrixs.cpp
+++ b/dal-cpp/tests/math/matrix/test_matrixs.cpp
@@ -3,10 +3,15 @@
 //
 
 #include <gtest/gtest.h>
+
+#include <type_traits>
+
 #include <dal/math/matrix/matrixs.hpp>
 #include <dal/platform/platform.hpp>
 
 using matrix_t = Dal::Matrix_<>;
+
+static_assert(!std::is_nothrow_copy_assignable<matrix_t>::value, "Matrix_ copy assignment allocates and must not be noexcept");
 
 TEST(MatrixTest, TestMatrixNullConstructor) {
     matrix_t m1;
@@ -40,6 +45,39 @@ TEST(MatrixTest, TestMatrixCopyMoveConstructor) {
     auto m2 = matrix_t(3, 4);
     ASSERT_EQ(m2.Rows(), 3);
     ASSERT_EQ(m2.Cols(), 4);
+}
+
+TEST(MatrixTest, TestMatrixCopyAssign) {
+    matrix_t m1(2, 2);
+    m1(0, 0) = 1.;
+    m1(0, 1) = 2.;
+    m1(1, 0) = 3.;
+    m1(1, 1) = 4.;
+
+    {
+        matrix_t m2(3, 3);
+        m2 = m1;
+        ASSERT_EQ(m2.Rows(), 2);
+        ASSERT_EQ(m2.Cols(), 2);
+        ASSERT_DOUBLE_EQ(m2(0, 0), 1.);
+        ASSERT_DOUBLE_EQ(m2(0, 1), 2.);
+        ASSERT_DOUBLE_EQ(m2(1, 0), 3.);
+        ASSERT_DOUBLE_EQ(m2(1, 1), 4.);
+        ASSERT_NE(&m2(0, 0), &m1(0, 0));
+    }
+    {
+        matrix_t m2;
+        m2 = m1;
+        ASSERT_EQ(m2.Rows(), 2);
+        ASSERT_EQ(m2.Cols(), 2);
+        ASSERT_DOUBLE_EQ(m2(1, 1), 4.);
+    }
+    {
+        m1 = m1;
+        ASSERT_EQ(m1.Rows(), 2);
+        ASSERT_EQ(m1.Cols(), 2);
+        ASSERT_DOUBLE_EQ(m1(1, 1), 4.);
+    }
 }
 
 TEST(MatrixTest, TestMatrixEmpty) {

--- a/dal-cpp/tests/math/test_stacks.cpp
+++ b/dal-cpp/tests/math/test_stacks.cpp
@@ -75,6 +75,38 @@ TEST(StackTest, TestDynamicStackRvalueSelfAliasAtCapacity) {
     ASSERT_EQ(stack.Size(), 3);
 }
 
+TEST(StackTest, TestDynamicStackCopy) {
+    Stack_<std::string, 2> stack;
+    stack.Push("first");
+    stack.Push("second");
+    stack.Push("third");
+
+    {
+        Stack_<std::string, 2> copied(stack);
+        ASSERT_EQ(copied.Size(), 3);
+        ASSERT_EQ(copied.Capacity(), stack.Capacity());
+        ASSERT_EQ(copied[0], "third");
+        ASSERT_EQ(copied[1], "second");
+        ASSERT_EQ(copied[2], "first");
+
+        copied.Pop();
+        ASSERT_EQ(stack.Size(), 3);
+        ASSERT_EQ(stack.Top(), "third");
+    }
+    {
+        Stack_<std::string, 2> assigned(1);
+        assigned.Push("old");
+        assigned = stack;
+        ASSERT_EQ(assigned.Size(), 3);
+        ASSERT_EQ(assigned[0], "third");
+        ASSERT_EQ(assigned[2], "first");
+
+        assigned = assigned;
+        ASSERT_EQ(assigned.Size(), 3);
+        ASSERT_EQ(assigned.Top(), "third");
+    }
+}
+
 TEST(StackTest, TestStaticStackBounds) {
     StaticStack_<int, 2> stack;
     ASSERT_THROW(stack.Top(), Exception_);


### PR DESCRIPTION
## Summary

Tranche 3 of the codebase-review plan (P2.14 exception-safety sweep):

- **`Cholesky_` ctor leak** (`dal-cpp/dal/math/matrix/cholesky.cpp`) — the owned lower-triangle allocation was held in a raw member while `CholeskyImpl` and a `REQUIRE` check ran, so a throw during construction leaked it. The allocation is now held in a `std::unique_ptr` until construction succeeds, then released into the member. New tests lock the `REQUIRE` throw behavior (zero matrix; explicit zero regularization); the leak itself is covered by the ASan CI legs.
- **`XStackInfo_` catch-all ctor UB** (`dal-cpp/dal/utilities/exceptions.hpp`) — the private templated catch-all constructor had an empty body, leaving `name_`/`value_`/`type_` uninitialized (UB if ever formatted). It is now `= delete`. No call sites relied on it: it is only reachable from inside the class, and the full build stays green.
- **`Matrix_` exception-safety family** (`dal-cpp/dal/math/matrix/matrixs.hpp`) — dropped the false `noexcept` on copy assignment (its body allocates, so OOM called `std::terminate`) and reimplemented it as copy-and-swap, which also removes the mid-assignment state where `hooks_` dangled into freed storage. The `(rows+1)*cols` extent is now computed in `size_t` via a shared `Extent` helper (constructor and both `Resize` sites) instead of overflowing `int` arithmetic at large dimensions. Behavior on the success path is unchanged; a compile-time `static_assert` locks the not-`noexcept` contract.
- **New-then-REQUIRE sweep** (`dal-cpp/dal/`) — audited every raw-`new` site (`grep -E "= new [A-Z]|= new \("`, plus a looser `\bnew\b` pass and a `malloc/calloc/realloc/free` pass — none found), excluding `auto/MG_*` and the build-excluded `storage/_repository.*`. Two further instances of the pattern found and fixed the same way:
  - `Stack_::Grow` and the `Stack_` copy constructor (`dal-cpp/dal/math/stacks.hpp`) moved/copied elements into a raw `new[]` buffer; with a throwing element type (the `Stack_<String_>` instantiation in `script/visitor/debugger.hpp` can throw on copy) a throw leaks the buffer. Both now guard with `unique_ptr<E_[]>` until the elements are transferred.
  - `PDE::NewDx`/`NewDxx` (`dal-cpp/dal/math/pde/pdeoperators.cpp`) filled a raw `TriDiagonal_` via `Set` calls that contain a throwing `REQUIRE`; the matrix is now held in a `unique_ptr` and released at return.
  - Audited and found clean: `utilities/exceptions.cpp` (thread_local takes immediate ownership), `math/random/pseudorandom.cpp` (`THROW` precedes allocation), `math/pde/pde.cpp` (direct return), `math/matrix/matrixutils.cpp` (ownership transferred immediately; `REQUIRE` precedes allocation), `storage/audit.hpp` (`shared_ptr` member takes immediate ownership), and the `Handle_(new ...)` factories in `curve/`, `time/`, `indice/`.

Deferred observation (pre-existing on master, out of scope here): the `Matrix_` move constructor does not value-initialize `cols_` before `swap(rhs)`, so the moved-from object's `cols_` becomes indeterminate — a read of it (e.g. `Cols()`, `Empty()`) is formally UB. Worth a follow-up.

## Test plan

- [x] New tests: `MatrixTest.TestMatrixCopyAssign`, compile-time `static_assert` on the `Matrix_` copy-assign `noexcept` lie (fails to compile pre-fix), `MatrixTest.TestCholeskyDecompositionThrowsOnZeroMatrix`, `MatrixTest.TestCholeskySolveThrowsOnZeroRegularization`, `StackTest.TestDynamicStackCopy`
- [x] Full `./build/Release-linux/dal-cpp/dal_cpp_tests`: 998/998 pass
- [x] Full `./build/Release-linux/dal-public/dal_public_tests`: 56/56 pass
- [x] Full workspace build (library, tests, examples) green after the pervasive `exceptions.hpp` change
