### PR TITLE
ci: add DAL_ENABLE_SANITIZERS option, ccache, and CI cancellation

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -10,9 +10,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CMAKE_C_COMPILER_LAUNCHER: ccache
-      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     strategy:
       fail-fast: false
       matrix:
@@ -50,10 +47,19 @@ jobs:
       # The action's key gets only a "ccache-" prefix and a trailing
       # timestamp, so the key itself must carry every matrix dimension
       # (OS, compiler, backend) to keep the 16 jobs from colliding.
+      # Coverage legs are excluded: cache hits skip compilation, and the
+      # .gcno notes gcov needs are only emitted when the compiler runs.
       - name: Setup ccache
+        if: matrix.coverage == false
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.aad-backend }}
+
+      - name: Enable ccache launcher
+        if: matrix.coverage == false
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Setup
         run: |
@@ -379,9 +385,8 @@ jobs:
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest
-    env:
-      CMAKE_C_COMPILER_LAUNCHER: ccache
-      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+    # No ccache here: this job builds with -march=native, and cached objects
+    # restored on a different runner CPU generation crash with SIGILL.
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -394,11 +399,6 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: benchmark-base
           submodules: recursive
-
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
-        with:
-          key: ${{ runner.os }}-benchmark
 
       - name: Setup
         run: |

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +40,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
+
+      # The action's key gets only a "ccache-" prefix and a trailing
+      # timestamp, so the key itself must carry every matrix dimension
+      # (OS, compiler, backend) to keep the 16 jobs from colliding.
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.aad-backend }}
 
       - name: Setup
         run: |
@@ -116,10 +127,18 @@ jobs:
   # them against one representative configuration is sufficient.
   build-extended:
     runs-on: ubuntu-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-extended
 
       - name: Setup
         run: |
@@ -219,11 +238,19 @@ jobs:
   warning-clean:
     name: Warning-clean GCC build
     runs-on: ubuntu-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-warning-clean
 
       - name: Setup
         run: |
@@ -260,6 +287,9 @@ jobs:
   sanitizers:
     name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     strategy:
       fail-fast: false
       matrix:
@@ -281,6 +311,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-sanitizer-${{ matrix.slug }}
 
       - name: Setup
         run: |
@@ -338,6 +373,9 @@ jobs:
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -350,6 +388,11 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: benchmark-base
           submodules: recursive
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-benchmark
 
       - name: Setup
         run: |

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,6 +1,12 @@
 name: CMake Linux CI
 on: [push, pull_request]
 
+# Per-ref grouping: a new push cancels stale runs of the same ref only --
+# distinct PRs (refs/pull/N/merge) never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -266,12 +266,14 @@ jobs:
         include:
           - label: ASan + UBSan focused tests
             slug: asan-ubsan
-            flags: -O2 -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all
+            sanitizers: address;undefined
+            flags: -O2 -g -fno-sanitize-recover=all
             core-filter: ConcurrencyTest.*:DistributionTest.*:MatrixTest.TestLowerBandAccumulator:StackTest.*:UnderdeterminedTest.TestFindUsesQuadraticBacktrackMinimum:ScriptTest.Test*Batch*:StorageTest.TestEvaluationDate*
             public-filter: PublicApiTest.TestMonteCarlo*
           - label: TSan concurrency tests
             slug: tsan
-            flags: -O2 -g -fno-omit-frame-pointer -fsanitize=thread
+            sanitizers: thread
+            flags: -O2 -g
             core-filter: ConcurrencyTest.TestConcurrentQueuePushAndPop:ConcurrencyTest.TestThreadPoolStartsLazily:ConcurrencyTest.TestThreadPoolStartStopLifecycle:ConcurrencyTest.TestThreadPoolUsesEnvironmentLimit:ConcurrencyTest.TestThreadPoolTaskCannotStopOrRestartPool:ConcurrencyTest.TestThreadPoolStopDrainsClaimedCallerAndCancelsQueuedTasks:StorageTest.TestEvaluationDateScopeOwnsBarrierButAllowsConcurrentRead:StorageTest.TestEvaluationDateWorkersObserveOneStableDateWhileSetterWaits:ScriptTest.TestSimulationTaskGroupDrainsOnSubmissionFailureAndPoolRecovers:ScriptTest.TestAadSimulationPropagatesTaskFailureAndRemainsUsable
             public-filter: ""
 
@@ -294,6 +296,7 @@ jobs:
           build_dir="$RUNNER_TEMP/dal-${{ matrix.slug }}"
           cmake -S . -B "$build_dir" \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DDAL_ENABLE_SANITIZERS='${{ matrix.sanitizers }}' \
             -DDAL_BUILD_PUBLIC=ON \
             -DDAL_CPP_BUILD_TESTS=ON \
             -DDAL_CPP_BUILD_EXAMPLES=OFF \

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +22,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
+
+      # Same key rule as cmake-linux.yml: the action adds only a "ccache-"
+      # prefix plus timestamp, so the key carries OS and backend itself.
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-${{ matrix.aad-backend }}
 
       - name: Setup MSVC environment
         shell: pwsh
@@ -189,11 +199,19 @@ jobs:
   benchmark:
     name: Benchmarks
     runs-on: windows-latest
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
+        with:
+          key: ${{ runner.os }}-benchmark
 
       - name: Setup MSVC environment
         shell: pwsh

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -205,19 +205,13 @@ jobs:
   benchmark:
     name: Benchmarks
     runs-on: windows-latest
-    env:
-      CMAKE_C_COMPILER_LAUNCHER: ccache
-      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+    # No ccache here: this job builds with -march=native, and cached objects
+    # restored on a different runner CPU generation crash with SIGILL.
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           submodules: recursive
-
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # @v1.2.23
-        with:
-          key: ${{ runner.os }}-benchmark
 
       - name: Setup MSVC environment
         shell: pwsh

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,6 +1,12 @@
 name: CMake Windows CI
 on: [push, pull_request]
 
+# Per-ref grouping: a new push cancels stale runs of the same ref only --
+# distinct PRs (refs/pull/N/merge) never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ The top-level `CMakeLists.txt` is a thin workspace that selects sub-projects via
 - `DAL_CPP_BUILD_EXAMPLES` (default `ON`) — build the `dal-cpp` example programs
 - `DAL_CPP_BUILD_BENCHMARKS` (CMake option default `ON`, but the `base` preset in `CMakePresets.json` overrides it to `off`, so preset-driven builds — including `build_linux.sh` without `--benchmarks`/`--full` — disable benchmarks) — build the `dal-cpp` benchmark programs
 - `DAL_USE_ADEPT_AAD` / `DAL_USE_XAD_AAD` / `DAL_USE_CODIPACK_AAD` — pick the AAD backend (source default: all three OFF, i.e. the native backend; CMake presets also override all three to OFF unless explicitly enabled)
+- `DAL_ENABLE_SANITIZERS` (default empty, i.e. instrumentation off) — semicolon-separated sanitizer list (e.g. `"address;undefined"` or `"thread"`); GCC/Clang only, applies `-fsanitize=<list>` plus `-fno-omit-frame-pointer` to the compile and link of every target in the workspace
 
 CMake installs into a per-preset stage directory (`CMAKE_INSTALL_PREFIX=${sourceDir}/build/stage/${presetName}` in `CMakePresets.json`); `build_linux.sh` installs into `build/stage/Release-linux/`, placing binaries in `bin/`, libraries in `lib/`, and headers in `include/` under that stage directory.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,23 @@ option(DAL_BUILD_PUBLIC "Build dal-public" ON)
 option(DAL_BUILD_PYTHON "Build dal-python" OFF)
 option(DAL_BUILD_EXCEL "Build dal-excel" OFF)
 
+# Applied workspace-wide (like USE_COVERAGE): partially instrumented builds
+# miss errors at library boundaries. -fno-sanitize-recover=all is deliberately
+# left to the caller -- thread sanitizer has no recover mode.
+set(DAL_ENABLE_SANITIZERS "" CACHE STRING
+    "Semicolon-separated sanitizers for all targets (e.g. \"address;undefined\" or \"thread\"); empty disables instrumentation")
+if(DAL_ENABLE_SANITIZERS)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        message(FATAL_ERROR
+            "DAL_ENABLE_SANITIZERS requires a GCC- or Clang-compatible compiler, "
+            "got ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+    string(REPLACE ";" "," DAL_SANITIZER_LIST "${DAL_ENABLE_SANITIZERS}")
+    add_compile_options("-fsanitize=${DAL_SANITIZER_LIST}" -fno-omit-frame-pointer)
+    add_link_options("-fsanitize=${DAL_SANITIZER_LIST}")
+    message(STATUS "Sanitizer instrumentation enabled (DAL_ENABLE_SANITIZERS=${DAL_SANITIZER_LIST})")
+endif()
+
 enable_testing()
 
 # Sub-projects

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,6 +124,7 @@ with an unknown CPU baseline.
 | `DAL_CPP_BUILD_EXAMPLES` | `ON` | Build C++ examples |
 | `DAL_CPP_BUILD_BENCHMARKS` | `OFF` | Build benchmarks |
 | `DAL_ENABLE_NATIVE_ARCH` | `OFF` | Tune Release code for the build machine |
+| `DAL_ENABLE_SANITIZERS` | `""` | Semicolon-separated sanitizer list for all targets (GCC/Clang only) |
 | `DAL_USE_XAD_AAD` | `OFF` | Use XAD |
 | `DAL_USE_CODIPACK_AAD` | `OFF` | Use CoDiPack |
 | `DAL_USE_ADEPT_AAD` | `OFF` | Use Adept |


### PR DESCRIPTION
## Summary
- **`DAL_ENABLE_SANITIZERS` CMake option** (top-level `CMakeLists.txt`, documented in `CLAUDE.md`): a semicolon-separated sanitizer list (e.g. `"address;undefined"`, `"thread"`) that applies `-fsanitize=<list>` + `-fno-omit-frame-pointer` to the compile and link of every workspace target (GCC/Clang only, fatal error otherwise). The sanitizers CI job now passes `-DDAL_ENABLE_SANITIZERS='<list>'` instead of hiding `-fsanitize` inside `CXXFLAGS`/`LDFLAGS`; each matrix row's effective flag set is unchanged (see below).
- **ccache in CI** via `hendrikmuhs/ccache-action` (SHA-pinned to v1.2.23 per repo rule) on every job that compiles C++: Linux 16-job matrix, build-extended, warning-clean, sanitizers, benchmark, and the Windows build + benchmark jobs. CMake picks ccache up through job-level `CMAKE_{C,CXX}_COMPILER_LAUNCHER` env vars, so no configure lines changed. Keys carry OS + every matrix dimension (`<os>-<compiler>-<backend>`, `<os>-sanitizer-<slug>`, etc.) because the action adds only a `ccache-` prefix and a timestamp — without the dimensions in the key, matrix jobs would restore each other's caches.
- **`concurrency:` cancellation** in both workflows: group `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Pushing a new commit cancels stale runs of the same ref; distinct PRs (`refs/pull/N/merge`) never cancel each other; the two workflows have distinct names so they never cancel each other.

Old vs new sanitizer job semantics (flag-set identity, per row):
- asan-ubsan row, old: `CXXFLAGS=LDFLAG=-O2 -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all`. New: option contributes `-fsanitize=address,undefined -fno-omit-frame-pointer` (compile) / `-fsanitize=address,undefined` (link), row flags keep `-O2 -g -fno-sanitize-recover=all`. Union identical.
- tsan row, old: `-O2 -g -fno-omit-frame-pointer -fsanitize=thread`. New: option contributes `-fsanitize=thread -fno-omit-frame-pointer`, row flags keep `-O2 -g`. Union identical. `-fno-sanitize-recover=all` stays a per-row choice (TSan has no recover mode), which is why it is not baked into the option.
- Same build type (Debug), same targets, same focused gtest filters, same runtime env (`ASAN_OPTIONS`/`UBSAN_OPTIONS`/`TSAN_OPTIONS`, `DAL_NUM_THREADS`).

## Test plan
- [x] Local probe (sanitizers ON): configured with `-DDAL_ENABLE_SANITIZERS="address;undefined"` matching the CI recipe (Debug, tests on, externals off); configure prints the option's STATUS line; `flags.make` carries `-fsanitize=address,undefined -fno-omit-frame-pointer`; link line carries `-fsanitize=address,undefined`; `ldd` shows `libasan`+`libubsan` on both test binaries; the CI job's exact focused filters pass under the CI's runtime env — 37/37 core tests (`ConcurrencyTest.*:DistributionTest.*:MatrixTest.TestLowerBandAccumulator:StackTest.*:UnderdeterminedTest.TestFindUsesQuadraticBacktrackMinimum:ScriptTest.Test*Batch*:StorageTest.TestEvaluationDate*`) and 3/3 public tests (`PublicApiTest.TestMonteCarlo*`).
- [x] Local probe (default OFF): plain `Release-linux` configure shows no sanitizer message and no `-fsanitize` in generated flags; `dal_cpp` builds cleanly.
- [x] Local probe (launcher env): verified with a toy project that `CMAKE_CXX_COMPILER_LAUNCHER` env initializes the cache variable and the launcher is invoked at build time (mechanism the workflows rely on).
- [ ] Workflow YAML is execution-proven by this PR's own CI runs (cannot be fully exercised locally): the `ASan + UBSan focused tests` and `TSan concurrency tests` jobs must pass with the option-driven flags, and all other jobs must be unaffected.
- [ ] ccache smoke test: after this PR's first CI run saves caches, a re-run of the workflows must show cache restores/hits in the "Setup ccache" step logs and post-job ccache statistics.
- [ ] Watch the Benchmarks paired gate; single-run deltas within the ~±6% CI noise floor are not actionable.