### PR TITLE
refactor: Return std::unique_ptr from owning factory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,26 @@ here as the baseline rather than dated releases:
 
 ## 2026-07
 
+- `core`: Migrated owning factory returns from raw pointers to `std::unique_ptr`
+  across the `dal-cpp` core headers: the interpolation factories
+  (`Interp::NewLinear`/`NewLinear2`/`NewLogLinear`/`NewCubic`, `NewMixedLogDF`),
+  the PDE coordinate-map, coefficient, and derivative-operator factories, the
+  random generators (`Random_::Clone`, `PseudoRandom_::Branch`/`New`,
+  `SequenceSet_::TakeAway`, `NewSobol`), the direct curve factories
+  (`NewDiscountPWC`/`ZeroRate`/`PWLF`/`LogDF`, `YCComponent_::Clone`,
+  `BuildCurveCalibrationWeights`), the sparse decompositions, the matrix-writer
+  helpers, the index parsers, `Underdetermined::Function_::Gradient`,
+  `ModelData_::MutantModel`, and `Environment_`/`Composite_` iteration and
+  cloning. `Handle_` gained a converting constructor from `std::unique_ptr`.
+  **Breaking** for direct consumers of the `dal-cpp` core headers — code holding
+  raw results or calling `.reset()`/`.release()` must now take the `unique_ptr`;
+  `dal-public`, Python, and Excel signatures are unchanged. The
+  Machinist-generated `Archive::Reader_::Build()` interface keeps its raw return
+  and migrates in a follow-up.
+- `matrix`: Fixed the `Matrix_` move constructor to value-initialize `cols_` —
+  a moved-from matrix previously carried an indeterminate column count (latent
+  UB present since 2022) and now has defined zero dimensions.
+
 - `aad`: Fixed multi-result adjoint propagation on the native backend. Reverse
   sweeps now dispatch to the vector-adjoint path (`TapNode_::PropagateAll`)
   whenever `SetNumResultsForAAD(true, m)` is active; previously every sweep took

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -315,7 +315,7 @@ namespace Dal {
         }
     } // namespace
 
-    Sparse::TriDiagonal_* BuildCurveCalibrationWeights(const Vector_<Date_>& knotDates, int paramsPerKnot, double smoothingWeight) {
+    std::unique_ptr<Sparse::TriDiagonal_> BuildCurveCalibrationWeights(const Vector_<Date_>& knotDates, int paramsPerKnot, double smoothingWeight) {
         REQUIRE(!knotDates.empty(), "Curve calibration weights require knot dates");
         REQUIRE(paramsPerKnot > 0, "Curve calibration weights require positive params-per-knot");
         REQUIRE(smoothingWeight > 0.0, "Curve calibration smoothing weight must be positive");

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -182,7 +182,7 @@ namespace Dal {
             }
 
             // Returns AAD-tape Jacobian when ANALYTIC + eligible; nullptr otherwise (solver falls back to dense bumping).
-            [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
+            [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& x, const Vector_<>& f) const override {
                 if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC) {
                     static_cast<void>(x);
                     static_cast<void>(f);
@@ -247,7 +247,7 @@ namespace Dal {
                 return true;
             }
 
-            [[nodiscard]] Underdetermined::Jacobian_* AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const;
+            [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const;
 
             template <class T_> [[nodiscard]] Handle_<Tape::Rate_<T_>> PhaseARateAt(int i) const {
                 return VisitRate(
@@ -256,7 +256,7 @@ namespace Dal {
             }
         };
 
-        Underdetermined::Jacobian_* YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
+        std::unique_ptr<Underdetermined::Jacobian_> YieldCurveCalibrationFunc_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& f) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
             static_cast<void>(f); // the residual values themselves are unused; we recompute on the tape
@@ -276,7 +276,7 @@ namespace Dal {
                 residuals[i] = (*rateT)(ctx) - static_cast<double>(marketRates_[i]);
             }
 
-            return new XCurveJacobian_(HarvestCurveJacobian(*tape, parameters, residuals));
+            return std::make_unique<XCurveJacobian_>(HarvestCurveJacobian(*tape, parameters, residuals));
         }
 
         Vector_<> ModelRates(const Vector_<Handle_<YCInstrument_>>& instruments, const YieldCurve_& curve, const Handle_<YieldCurve_>& fundingCurve) {

--- a/dal-cpp/dal/curve/calibration.hpp
+++ b/dal-cpp/dal/curve/calibration.hpp
@@ -145,7 +145,7 @@ namespace Dal {
         Vector_<CurveCalibrationDiagnostics_> diagnostics_;
     };
 
-    Sparse::TriDiagonal_* BuildCurveCalibrationWeights(const Vector_<Date_>& knotDates, int paramsPerKnot, double smoothingWeight);
+    std::unique_ptr<Sparse::TriDiagonal_> BuildCurveCalibrationWeights(const Vector_<Date_>& knotDates, int paramsPerKnot, double smoothingWeight);
     Vector_<Date_> BuildCurveCalibrationKnots(const Date_& today,
                                               const Vector_<Handle_<YCInstrument_>>& instruments,
                                               const Vector_<Date_>& inputKnots,

--- a/dal-cpp/dal/curve/curveblock.cpp
+++ b/dal-cpp/dal/curve/curveblock.cpp
@@ -95,7 +95,7 @@ namespace Dal {
         REQUIRE(false, "CurveBlock_ is not serializable");
     }
 
-    DiscountCurve_* CalibrateYieldCurve(const Date_& today,
+    std::unique_ptr<DiscountCurve_> CalibrateYieldCurve(const Date_& today,
                                         const String_& ccy,
                                         const Vector_<Handle_<YCInstrument_>>& instruments,
                                         const Vector_<Date_>& knotDates,
@@ -117,7 +117,7 @@ namespace Dal {
         auto result = CalibrateYieldCurve(spec);
         if (effJacobianInverse)
             *effJacobianInverse = result.diagnostics_.effJacobianInverse_;
-        return result.curve_.release();
+        return std::move(result.curve_);
     }
 
 } // namespace Dal

--- a/dal-cpp/dal/curve/curveblock.hpp
+++ b/dal-cpp/dal/curve/curveblock.hpp
@@ -39,7 +39,7 @@ namespace Dal {
         void Write(Archive::Store_& dst) const override;
     };
 
-    DiscountCurve_* CalibrateYieldCurve(const Date_& today,
+    std::unique_ptr<DiscountCurve_> CalibrateYieldCurve(const Date_& today,
                                         const String_& ccy,
                                         const Vector_<Handle_<YCInstrument_>>& instruments,
                                         const Vector_<Date_>& knotDates,

--- a/dal-cpp/dal/curve/jointcalibration.cpp
+++ b/dal-cpp/dal/curve/jointcalibration.cpp
@@ -137,7 +137,7 @@ namespace Dal {
                 return cachedEligibility_ == AnalyticEligibility_::Value_::ELIGIBLE;
             }
 
-            [[nodiscard]] Underdetermined::Jacobian_* AnalyticJacobian(const Vector_<>& x, const Vector_<>& /*f*/) const;
+            [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> AnalyticJacobian(const Vector_<>& x, const Vector_<>& /*f*/) const;
 
         public:
             JointResidualFunction_(const JointMultiCurveCalibrationSpec_& spec, const std::vector<CurveSlot_>& slots, CurveJacobianMode_ jacobianMode)
@@ -161,7 +161,7 @@ namespace Dal {
             }
 
             // Returns AAD-tape Jacobian when ANALYTIC + eligible; nullptr otherwise (solver dense-bumps).
-            [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
+            [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& x, const Vector_<>& f) const override {
                 if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC)
                     return nullptr;
                 EvaluateEligibilityOnce();
@@ -180,7 +180,7 @@ namespace Dal {
             }
         };
 
-        Underdetermined::Jacobian_* JointResidualFunction_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& /*f*/) const {
+        std::unique_ptr<Underdetermined::Jacobian_> JointResidualFunction_::AnalyticJacobian(const Vector_<>& x, const Vector_<>& /*f*/) const {
             auto* tape = Dal::AAD::Tape();
             TapeGuard_ guard(tape);
 
@@ -189,7 +189,7 @@ namespace Dal {
 
             const auto storage = JointCalibrationInternal::BuildTypedCurveBlock<Dal::AAD::Number_>(InternalSpec(*spec_), *slots_, parameters);
             Vector_<Dal::AAD::Number_> residuals = ComputeTemplatedResiduals(storage.block_);
-            return new XCurveJacobian_(HarvestCurveJacobian(*tape, parameters, residuals));
+            return std::make_unique<XCurveJacobian_>(HarvestCurveJacobian(*tape, parameters, residuals));
         }
 
         Vector_<> RunJointSolver(const JointMultiCurveCalibrationSpec_& spec,

--- a/dal-cpp/dal/curve/piecewiseconstant.hpp
+++ b/dal-cpp/dal/curve/piecewiseconstant.hpp
@@ -42,8 +42,8 @@ namespace Dal {
             return func.IntegralTo(to) - func.IntegralTo(from);
         }
 
-        inline PiecewiseConstant_ *NewConstant(double val, const Date_ &from = Date::Minimum()) {
-            return new PiecewiseConstant_(Vector::V1(from), Vector::V1(val));
+        inline std::unique_ptr<PiecewiseConstant_> NewConstant(double val, const Date_ &from = Date::Minimum()) {
+            return std::make_unique<PiecewiseConstant_>(Vector::V1(from), Vector::V1(val));
         }
     } // namespace PWC
 } // namespace Dal

--- a/dal-cpp/dal/curve/xccybasiscalibration.cpp
+++ b/dal-cpp/dal/curve/xccybasiscalibration.cpp
@@ -102,8 +102,8 @@ namespace Dal {
             T_ operator()(const Date_& from, const Date_& to) const override { return T_((*source_)(from, to)); }
             void Poll(Vector_<const YCComponent_*>* all) const override { all->push_back(this); }
             void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>*) const override {}
-            [[nodiscard]] PassiveDiscountCurve_* Clone(const String_&, const YCComponent_::substitutions_t&) const override {
-                return new PassiveDiscountCurve_(*source_);
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_&, const YCComponent_::substitutions_t&) const override {
+                return std::make_unique<PassiveDiscountCurve_>(*source_);
             }
             void Write(Archive::Store_&) const override {}
         };

--- a/dal-cpp/dal/curve/xccybasiscalibration.cpp
+++ b/dal-cpp/dal/curve/xccybasiscalibration.cpp
@@ -184,7 +184,7 @@ namespace Dal {
 
             [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Residuals<double>(x); }
 
-            [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>&) const override {
+            [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& x, const Vector_<>&) const override {
                 if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC)
                     return nullptr;
                 auto* tape = Dal::AAD::Tape();
@@ -192,7 +192,7 @@ namespace Dal {
                 Vector_<Dal::AAD::Number_> parameters = RegisterCurveParameters(x);
                 Dal::AAD::NewRecording(*tape);
                 Vector_<Dal::AAD::Number_> residuals = Residuals<Dal::AAD::Number_>(parameters);
-                return new XCurveJacobian_(HarvestCurveJacobian(*tape, parameters, residuals));
+                return std::make_unique<XCurveJacobian_>(HarvestCurveJacobian(*tape, parameters, residuals));
             }
         };
 

--- a/dal-cpp/dal/curve/xccyjointcalibration.cpp
+++ b/dal-cpp/dal/curve/xccyjointcalibration.cpp
@@ -258,7 +258,7 @@ namespace Dal {
                 return Residuals<double>(parameters);
             }
 
-            [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& parameters, const Vector_<>&) const override {
+            [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& parameters, const Vector_<>&) const override {
                 if (jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC)
                     return nullptr;
                 auto* tape = Dal::AAD::Tape();
@@ -266,7 +266,7 @@ namespace Dal {
                 Vector_<Dal::AAD::Number_> activeParameters = RegisterCurveParameters(parameters);
                 Dal::AAD::NewRecording(*tape);
                 Vector_<Dal::AAD::Number_> residuals = Residuals<Dal::AAD::Number_>(activeParameters);
-                return new XCurveJacobian_(HarvestCurveJacobian(*tape, activeParameters, residuals));
+                return std::make_unique<XCurveJacobian_>(HarvestCurveJacobian(*tape, activeParameters, residuals));
             }
         };
 

--- a/dal-cpp/dal/curve/yccomponent.hpp
+++ b/dal-cpp/dal/curve/yccomponent.hpp
@@ -18,7 +18,7 @@ namespace Dal {
         virtual void Poll(std::map<const YCComponent_ *, Handle_<YCComponent_>> *) const = 0; // state which ones we have handles for
         // clone, using new base curves in place of old
         using substitutions_t = std::map<const YCComponent_*, Handle_<YCComponent_>>;
-        [[nodiscard]] virtual YCComponent_* Clone(const String_ &newName, const substitutions_t &baseChanges) const = 0;
+        [[nodiscard]] virtual std::unique_ptr<YCComponent_> Clone(const String_ &newName, const substitutions_t &baseChanges) const = 0;
     };
 
     template<class T_, class B_ = T_>

--- a/dal-cpp/dal/curve/ycconst.cpp
+++ b/dal-cpp/dal/curve/ycconst.cpp
@@ -74,8 +74,8 @@ namespace Dal {
         template <class T_, class B_> void DiscountPWC_<T_, B_>::Write(Archive::Store_&) const { THROW("DiscountPWC_ persistence is not supported"); }
 
         template <class T_, class B_>
-        DiscountPWC_<T_, B_>* DiscountPWC_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
-            return new DiscountPWC_<T_, B_>(newName, this->ccy_.String(), knotDates_, fRightT_, this->NewBase(baseChanges));
+        std::unique_ptr<YCComponent_> DiscountPWC_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
+            return std::make_unique<DiscountPWC_<T_, B_>>(newName, this->ccy_.String(), knotDates_, fRightT_, this->NewBase(baseChanges));
         }
 
         template class DiscountPWC_<double>;
@@ -83,8 +83,8 @@ namespace Dal {
         template class DiscountPWC_<AAD::Number_, DiscountCurve_<AAD::Number_>>;
     } // namespace Tape
 
-    DiscountCurve_* NewDiscountPWC(const String_& name, const String_& ccy, const PiecewiseConstant_& fwds, const Handle_<DiscountCurve_>& base) {
-        return new Tape::DiscountPWC_<double>(name, ccy, fwds.knotDates_, fwds.fRight_, base);
+    std::unique_ptr<DiscountCurve_> NewDiscountPWC(const String_& name, const String_& ccy, const PiecewiseConstant_& fwds, const Handle_<DiscountCurve_>& base) {
+        return std::make_unique<Tape::DiscountPWC_<double>>(name, ccy, fwds.knotDates_, fwds.fRight_, base);
     }
 
 } // namespace Dal

--- a/dal-cpp/dal/curve/ycconst.cpp
+++ b/dal-cpp/dal/curve/ycconst.cpp
@@ -83,7 +83,10 @@ namespace Dal {
         template class DiscountPWC_<AAD::Number_, DiscountCurve_<AAD::Number_>>;
     } // namespace Tape
 
-    std::unique_ptr<DiscountCurve_> NewDiscountPWC(const String_& name, const String_& ccy, const PiecewiseConstant_& fwds, const Handle_<DiscountCurve_>& base) {
+    std::unique_ptr<DiscountCurve_> NewDiscountPWC(const String_& name,
+                                                   const String_& ccy,
+                                                   const PiecewiseConstant_& fwds,
+                                                   const Handle_<DiscountCurve_>& base) {
         return std::make_unique<Tape::DiscountPWC_<double>>(name, ccy, fwds.knotDates_, fwds.fRight_, base);
     }
 

--- a/dal-cpp/dal/curve/ycconst.hpp
+++ b/dal-cpp/dal/curve/ycconst.hpp
@@ -33,7 +33,8 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName,
+                                                              const YCComponent_::substitutions_t& baseChanges) const override;
 
             [[nodiscard]] const Vector_<Date_>& KnotDates() const { return knotDates_; }
             [[nodiscard]] Vector_<T_> FRight() const { return fRightT_; }

--- a/dal-cpp/dal/curve/ycconst.hpp
+++ b/dal-cpp/dal/curve/ycconst.hpp
@@ -33,14 +33,14 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] DiscountPWC_* Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
 
             [[nodiscard]] const Vector_<Date_>& KnotDates() const { return knotDates_; }
             [[nodiscard]] Vector_<T_> FRight() const { return fRightT_; }
         };
     } // namespace Tape
 
-    DiscountCurve_* NewDiscountPWC(const String_& name,
+    std::unique_ptr<DiscountCurve_> NewDiscountPWC(const String_& name,
                                    const String_& ccy,
                                    const PiecewiseConstant_& fwds,
                                    const Handle_<DiscountCurve_>& base = Handle_<DiscountCurve_>());

--- a/dal-cpp/dal/curve/ycimp.cpp
+++ b/dal-cpp/dal/curve/ycimp.cpp
@@ -31,11 +31,11 @@ base is ?handle DiscountCurve
 
 namespace Dal {
 
-    DiscountCurve_* NewDiscountPWLF(const String_ &name,
-                                    const String_ &ccy,
-                                    const PiecewiseLinear_& fwds,
-                                    const Handle_ <DiscountCurve_>& base) {
-        return new Tape::DiscountPWLF_<double>(name, ccy, fwds.knotDates_, fwds.fLeft_, fwds.fRight_, base);
+    std::unique_ptr<DiscountCurve_> NewDiscountPWLF(const String_ &name,
+                                                    const String_ &ccy,
+                                                    const PiecewiseLinear_& fwds,
+                                                    const Handle_ <DiscountCurve_>& base) {
+        return std::make_unique<Tape::DiscountPWLF_<double>>(name, ccy, fwds.knotDates_, fwds.fLeft_, fwds.fRight_, base);
     }
     #include <dal/auto/MG_DiscountPWLF_v1_Read.inc>
 

--- a/dal-cpp/dal/curve/ycimp.hpp
+++ b/dal-cpp/dal/curve/ycimp.hpp
@@ -9,7 +9,7 @@
 namespace Dal {
     struct PiecewiseLinear_;
 
-    DiscountCurve_* NewDiscountPWLF(const String_ &name,
+    std::unique_ptr<DiscountCurve_> NewDiscountPWLF(const String_ &name,
                                     const String_ &ccy,
                                     const PiecewiseLinear_& fwds,
                                     const Handle_ <DiscountCurve_>& base = Handle_<DiscountCurve_>());

--- a/dal-cpp/dal/curve/yclogdf.cpp
+++ b/dal-cpp/dal/curve/yclogdf.cpp
@@ -108,7 +108,8 @@ namespace Dal {
 
         template <class T_, class B_>
         std::unique_ptr<YCComponent_> DiscountLogDF_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
-            return std::make_unique<DiscountLogDF_<T_, B_>>(newName, this->ccy_.String(), nodeDates_, logDF_, dayCount_, scheme_, this->NewBase(baseChanges));
+            return std::make_unique<DiscountLogDF_<T_, B_>>(
+                newName, this->ccy_.String(), nodeDates_, logDF_, dayCount_, scheme_, this->NewBase(baseChanges));
         }
 
         template <class T_, class B_> Vector_<> DiscountLogDF_<T_, B_>::NodeDF() const {

--- a/dal-cpp/dal/curve/yclogdf.cpp
+++ b/dal-cpp/dal/curve/yclogdf.cpp
@@ -107,8 +107,8 @@ namespace Dal {
         }
 
         template <class T_, class B_>
-        DiscountLogDF_<T_, B_>* DiscountLogDF_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
-            return new DiscountLogDF_<T_, B_>(newName, this->ccy_.String(), nodeDates_, logDF_, dayCount_, scheme_, this->NewBase(baseChanges));
+        std::unique_ptr<YCComponent_> DiscountLogDF_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
+            return std::make_unique<DiscountLogDF_<T_, B_>>(newName, this->ccy_.String(), nodeDates_, logDF_, dayCount_, scheme_, this->NewBase(baseChanges));
         }
 
         template <class T_, class B_> Vector_<> DiscountLogDF_<T_, B_>::NodeDF() const {
@@ -131,14 +131,14 @@ namespace Dal {
 
     } // namespace Tape
 
-    DiscountCurve_* NewDiscountLogDF(const String_& name,
-                                     const String_& ccy,
-                                     const Vector_<Date_>& nodeDates,
-                                     const Vector_<>& logDF,
-                                     const DayBasis_& dayCount,
-                                     LogDfScheme_ scheme,
-                                     const Handle_<DiscountCurve_>& base) {
-        return new Tape::DiscountLogDF_<double>(name, ccy, nodeDates, logDF, dayCount, scheme, base);
+    std::unique_ptr<DiscountCurve_> NewDiscountLogDF(const String_& name,
+                                                      const String_& ccy,
+                                                      const Vector_<Date_>& nodeDates,
+                                                      const Vector_<>& logDF,
+                                                      const DayBasis_& dayCount,
+                                                      LogDfScheme_ scheme,
+                                                      const Handle_<DiscountCurve_>& base) {
+        return std::make_unique<Tape::DiscountLogDF_<double>>(name, ccy, nodeDates, logDF, dayCount, scheme, base);
     }
 
 #include <dal/auto/MG_DiscountLogDF_v1_Read.inc>

--- a/dal-cpp/dal/curve/yclogdf.hpp
+++ b/dal-cpp/dal/curve/yclogdf.hpp
@@ -39,7 +39,7 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] DiscountLogDF_<T_, B_>* Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
 
             [[nodiscard]] const Vector_<Date_>& NodeDates() const { return nodeDates_; }
             [[nodiscard]] Vector_<> NodeLogDF() const;
@@ -51,7 +51,7 @@ namespace Dal {
 
     using DiscountLogDF_ = Tape::DiscountLogDF_<double>;
 
-    DiscountCurve_* NewDiscountLogDF(const String_& name,
+    std::unique_ptr<DiscountCurve_> NewDiscountLogDF(const String_& name,
                                      const String_& ccy,
                                      const Vector_<Date_>& nodeDates,
                                      const Vector_<>& logDF,

--- a/dal-cpp/dal/curve/yclogdf.hpp
+++ b/dal-cpp/dal/curve/yclogdf.hpp
@@ -39,7 +39,8 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName,
+                                                              const YCComponent_::substitutions_t& baseChanges) const override;
 
             [[nodiscard]] const Vector_<Date_>& NodeDates() const { return nodeDates_; }
             [[nodiscard]] Vector_<> NodeLogDF() const;

--- a/dal-cpp/dal/curve/ycpwlf.cpp
+++ b/dal-cpp/dal/curve/ycpwlf.cpp
@@ -144,9 +144,9 @@ namespace Dal {
         }
 
         template <class T_, class B_>
-        DiscountPWLF_<T_, B_>* DiscountPWLF_<T_, B_>::Clone(const String_& new_name,
-                                                             const YCComponent_::substitutions_t& base_changes) const {
-            return new DiscountPWLF_<T_, B_>(new_name, this->ccy_.String(), knotDates_, fLeftT_, fRightT_, this->NewBase(base_changes));
+        std::unique_ptr<YCComponent_> DiscountPWLF_<T_, B_>::Clone(const String_& new_name,
+                                                                    const YCComponent_::substitutions_t& base_changes) const {
+            return std::make_unique<DiscountPWLF_<T_, B_>>(new_name, this->ccy_.String(), knotDates_, fLeftT_, fRightT_, this->NewBase(base_changes));
         }
 
         // See docs/methodology/yield_curve_jacobian.md §Joint Multi-Curve Analytic Jacobian.

--- a/dal-cpp/dal/curve/ycpwlf.hpp
+++ b/dal-cpp/dal/curve/ycpwlf.hpp
@@ -44,8 +44,8 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] DiscountPWLF_<T_, B_>* Clone(const String_& new_name,
-                                                       const YCComponent_::substitutions_t& base_changes) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& new_name,
+                                                              const YCComponent_::substitutions_t& base_changes) const override;
 
             [[nodiscard]] const Vector_<Date_>& KnotDates() const { return knotDates_; }
             [[nodiscard]] Vector_<T_> FLeft() const { return fLeftT_; }

--- a/dal-cpp/dal/curve/yczerorate.cpp
+++ b/dal-cpp/dal/curve/yczerorate.cpp
@@ -111,7 +111,8 @@ namespace Dal {
         }
 
         template <class T_, class B_>
-        std::unique_ptr<YCComponent_> DiscountZeroRate_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
+        std::unique_ptr<YCComponent_> DiscountZeroRate_<T_, B_>::Clone(const String_& newName,
+                                                                        const YCComponent_::substitutions_t& baseChanges) const {
             return std::make_unique<DiscountZeroRate_<T_, B_>>(newName, this->ccy_.String(), anchorDate_, nodeDates_, zeroRates_, dayCount_,
                                                                scheme_, this->NewBase(baseChanges));
         }

--- a/dal-cpp/dal/curve/yczerorate.cpp
+++ b/dal-cpp/dal/curve/yczerorate.cpp
@@ -111,9 +111,9 @@ namespace Dal {
         }
 
         template <class T_, class B_>
-        DiscountZeroRate_<T_, B_>* DiscountZeroRate_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
-            return new DiscountZeroRate_<T_, B_>(newName, this->ccy_.String(), anchorDate_, nodeDates_, zeroRates_, dayCount_, scheme_,
-                                                 this->NewBase(baseChanges));
+        std::unique_ptr<YCComponent_> DiscountZeroRate_<T_, B_>::Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const {
+            return std::make_unique<DiscountZeroRate_<T_, B_>>(newName, this->ccy_.String(), anchorDate_, nodeDates_, zeroRates_, dayCount_,
+                                                               scheme_, this->NewBase(baseChanges));
         }
 
         template <class T_, class B_> Vector_<> DiscountZeroRate_<T_, B_>::NodeZeroRates() const {
@@ -128,7 +128,7 @@ namespace Dal {
         template class DiscountZeroRate_<AAD::Number_, DiscountCurve_<AAD::Number_>>;
     } // namespace Tape
 
-    DiscountCurve_* NewDiscountZeroRate(const String_& name,
+    std::unique_ptr<DiscountCurve_> NewDiscountZeroRate(const String_& name,
                                         const String_& ccy,
                                         const Date_& anchorDate,
                                         const Vector_<Date_>& nodeDates,
@@ -136,7 +136,7 @@ namespace Dal {
                                         const DayBasis_& dayCount,
                                         LogDfScheme_ scheme,
                                         const Handle_<DiscountCurve_>& base) {
-        return new Tape::DiscountZeroRate_<double>(name, ccy, anchorDate, nodeDates, zeroRates, dayCount, scheme, base);
+        return std::make_unique<Tape::DiscountZeroRate_<double>>(name, ccy, anchorDate, nodeDates, zeroRates, dayCount, scheme, base);
     }
 
 #include <dal/auto/MG_DiscountZeroRate_v1_Read.inc>

--- a/dal-cpp/dal/curve/yczerorate.hpp
+++ b/dal-cpp/dal/curve/yczerorate.hpp
@@ -41,7 +41,8 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName,
+                                                              const YCComponent_::substitutions_t& baseChanges) const override;
 
             [[nodiscard]] const Date_& AnchorDate() const { return anchorDate_; }
             [[nodiscard]] const Vector_<Date_>& NodeDates() const { return nodeDates_; }

--- a/dal-cpp/dal/curve/yczerorate.hpp
+++ b/dal-cpp/dal/curve/yczerorate.hpp
@@ -41,7 +41,7 @@ namespace Dal {
             [[nodiscard]] int NX() const override;
             void ApplyDX(Vector_<>::const_iterator dx, double leverage) override;
             void Write(Archive::Store_& dst) const override;
-            [[nodiscard]] DiscountZeroRate_<T_, B_>* Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
+            [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t& baseChanges) const override;
 
             [[nodiscard]] const Date_& AnchorDate() const { return anchorDate_; }
             [[nodiscard]] const Vector_<Date_>& NodeDates() const { return nodeDates_; }
@@ -53,7 +53,7 @@ namespace Dal {
 
     using DiscountZeroRate_ = Tape::DiscountZeroRate_<double>;
 
-    DiscountCurve_* NewDiscountZeroRate(const String_& name,
+    std::unique_ptr<DiscountCurve_> NewDiscountZeroRate(const String_& name,
                                         const String_& ccy,
                                         const Date_& anchorDate,
                                         const Vector_<Date_>& nodeDates,

--- a/dal-cpp/dal/indice/indexparse.cpp
+++ b/dal-cpp/dal/indice/indexparse.cpp
@@ -13,11 +13,11 @@
 
 namespace Dal {
     namespace {
-        Index_* ParseSuperShot(const String_&) { return nullptr; }
+        std::unique_ptr<Index_> ParseSuperShot(const String_&) { return nullptr; }
 
         std::map<String_, Index::parser_t>& TheIndexParsers() { RETURN_STATIC(std::map<String_, Index::parser_t>); }
 
-        Index_* ParseSingle(const String_& name) {
+        std::unique_ptr<Index_> ParseSingle(const String_& name) {
             auto stop = name.find_first_of(":[");
             if (stop == String_::npos)
                 return ParseSuperShot(name);
@@ -27,11 +27,11 @@ namespace Dal {
             return (*pp->second)(name);
         }
 
-        Index::Composite_* ParseComposite(const String_&) { return nullptr; }
+        std::unique_ptr<Index::Composite_> ParseComposite(const String_&) { return nullptr; }
     } // namespace
 
-    Index_* Index::Parse(const String_& name) {
-        if (Index::Composite_* test = ParseComposite(name))
+    std::unique_ptr<Index_> Index::Parse(const String_& name) {
+        if (auto test = ParseComposite(name))
             return test;
         return ParseSingle(name);
     }

--- a/dal-cpp/dal/indice/indexparse.hpp
+++ b/dal-cpp/dal/indice/indexparse.hpp
@@ -4,13 +4,15 @@
 
 #pragma once
 
+#include <memory>
+
 namespace Dal {
     class Index_;
     class String_;
 
     namespace Index {
-        Index_* Parse(const String_& name);
-        using parser_t = Index_* (*)(const String_&);
+        std::unique_ptr<Index_> Parse(const String_& name);
+        using parser_t = std::unique_ptr<Index_> (*)(const String_&);
         void RegisterParser(const String_& name, parser_t func);
         Handle_<Index_> Clone(const Index_&);
     } // namespace Index

--- a/dal-cpp/dal/indice/parser/equity.cpp
+++ b/dal-cpp/dal/indice/parser/equity.cpp
@@ -9,23 +9,23 @@
 #include <dal/time/dateutils.hpp>
 
 namespace Dal::Index {
-    Index_* EquityParser(const String_& name) {
+    std::unique_ptr<Index_> EquityParser(const String_& name) {
         auto eq_start = name.find_first_of("[");
         auto eq_stop = name.find_first_of("]");
 
         String_ eq_name = name.substr(eq_start + 1, eq_stop - eq_start - 1);
         auto tenor_start = name.find_first_of("@>", eq_stop + 1);
         if (tenor_start == String_::npos)
-            return new Equity_(eq_name, nullptr, nullptr);
+            return std::make_unique<Equity_>(eq_name, nullptr, nullptr);
 
         if (name[tenor_start] == '@') {
             auto delivery_date = Date::FromString(name.substr(tenor_start + 1, name.length() - tenor_start - 1));
-            return new Equity_(eq_name, &delivery_date, nullptr);
+            return std::make_unique<Equity_>(eq_name, &delivery_date, nullptr);
         }
 
         if (name[tenor_start] == '>') {
             String_ delay_increment = name.substr(tenor_start + 1, name.length() - tenor_start - 1);
-            return new Equity_(eq_name, nullptr, &delay_increment);
+            return std::make_unique<Equity_>(eq_name, nullptr, &delay_increment);
         }
         THROW("index pattern is not good");
     }

--- a/dal-cpp/dal/indice/parser/equity.hpp
+++ b/dal-cpp/dal/indice/parser/equity.hpp
@@ -8,6 +8,6 @@ namespace Dal {
     class Index_;
     class String_;
     namespace Index {
-        Index_* EquityParser(const String_&);
+        std::unique_ptr<Index_> EquityParser(const String_&);
     } // namespace Index
 } // namespace Dal

--- a/dal-cpp/dal/indice/parser/fx.cpp
+++ b/dal-cpp/dal/indice/parser/fx.cpp
@@ -8,7 +8,7 @@
 #include <dal/indice/index/fx.hpp>
 
 namespace Dal::Index {
-    Index_* FxParser(const String_& name) {
+    std::unique_ptr<Index_> FxParser(const String_& name) {
         auto fx_start = name.find_first_of("[");
         auto fx_stop = name.find_first_of("]");
         auto fx_sep = name.find_first_of("/");
@@ -16,6 +16,6 @@ namespace Dal::Index {
 
         String_ fgn = name.substr(fx_start + 1, fx_sep - fx_start - 1);
         String_ dom = name.substr(fx_sep + 1, fx_stop - fx_sep - 1);
-        return new Fx_(Ccy_(dom), Ccy_(fgn));
+        return std::make_unique<Fx_>(Ccy_(dom), Ccy_(fgn));
     }
 } // namespace Dal::Index

--- a/dal-cpp/dal/indice/parser/fx.hpp
+++ b/dal-cpp/dal/indice/parser/fx.hpp
@@ -8,6 +8,6 @@ namespace Dal {
     class Index_;
     class String_;
     namespace Index {
-        Index_* FxParser(const String_&);
+        std::unique_ptr<Index_> FxParser(const String_&);
     } // namespace Index
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interp2d.cpp
+++ b/dal-cpp/dal/math/interp/interp2d.cpp
@@ -11,8 +11,8 @@ namespace Dal {
     Interp2_::Interp2_(const String_& name) : Storable_("Interp2", name) {}
 
     namespace Interp {
-        Interp2_* NewLinear2(const String_& name, const Vector_<>& x, const Vector_<>& y, const Matrix_<>& f) {
-            return new Interp2Linear_(name, x, y, f);
+        std::unique_ptr<Interp2_> NewLinear2(const String_& name, const Vector_<>& x, const Vector_<>& y, const Matrix_<>& f) {
+            return std::make_unique<Interp2Linear_>(name, x, y, f);
         }
     } // namespace Interp
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interp2d.hpp
+++ b/dal-cpp/dal/math/interp/interp2d.hpp
@@ -64,6 +64,6 @@ namespace Dal {
     };
 
     namespace Interp {
-        Interp2_* NewLinear2(const String_& name, const Vector_<>& x, const Vector_<>& y, const Matrix_<>& f);
+        std::unique_ptr<Interp2_> NewLinear2(const String_& name, const Vector_<>& x, const Vector_<>& y, const Matrix_<>& f);
     } // namespace Interp
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interpcubic.cpp
+++ b/dal-cpp/dal/math/interp/interpcubic.cpp
@@ -121,9 +121,9 @@ namespace Dal {
         }
     } // namespace
 
-    Interp1_* Interp::NewCubic(
+    std::unique_ptr<Interp1_> Interp::NewCubic(
         const String_& name, const Vector_<>& x, const Vector_<>& f, const Boundary_& lhs, const Boundary_& rhs) {
-        return new Cubic1_(name, x, f, lhs, rhs);
+        return std::make_unique<Cubic1_>(name, x, f, lhs, rhs);
     }
 
 #include <dal/auto/MG_Cubic1_Read.inc>

--- a/dal-cpp/dal/math/interp/interpcubic.hpp
+++ b/dal-cpp/dal/math/interp/interpcubic.hpp
@@ -15,7 +15,7 @@ namespace Dal {
             Boundary_(int o, double v) : order_(o), value_(v) {}
         };
 
-        Interp1_* NewCubic(
+        std::unique_ptr<Interp1_> NewCubic(
             const String_& name, const Vector_<>& x, const Vector_<>& f, const Boundary_& lhs, const Boundary_& rhs);
     } // namespace Interp
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interplinear.cpp
+++ b/dal-cpp/dal/math/interp/interplinear.cpp
@@ -57,8 +57,8 @@ namespace Dal {
 
     namespace Interp {
 
-        Interp1_* NewLinear(const String_& name, const Vector_<>& x, const Vector_<>& f) {
-            return new Interp1Linear_(name, x, f);
+        std::unique_ptr<Interp1_> NewLinear(const String_& name, const Vector_<>& x, const Vector_<>& f) {
+            return std::make_unique<Interp1Linear_>(name, x, f);
         }
     } // namespace Interp
     

--- a/dal-cpp/dal/math/interp/interplinear.hpp
+++ b/dal-cpp/dal/math/interp/interplinear.hpp
@@ -10,6 +10,6 @@
 namespace Dal {
 
     namespace Interp {
-        Interp1_* NewLinear(const String_& name, const Vector_<>& x, const Vector_<>& f);
+        std::unique_ptr<Interp1_> NewLinear(const String_& name, const Vector_<>& x, const Vector_<>& f);
     } // namespace Interp
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interploglinear.cpp
+++ b/dal-cpp/dal/math/interp/interploglinear.cpp
@@ -45,7 +45,7 @@ namespace Dal {
 #include <dal/auto/MG_LogLinear1_Write.inc>
 
     void LogLinear1_::Write(Archive::Store_& dst) const { LogLinear1::XWrite(dst, name_, x_, f_); }
-    Interp1_* Interp::NewLogLinear(const String_& name, const Vector_<>& x, const Vector_<>& f) {
-        return new LogLinear1_(name, x, f);
+    std::unique_ptr<Interp1_> Interp::NewLogLinear(const String_& name, const Vector_<>& x, const Vector_<>& f) {
+        return std::make_unique<LogLinear1_>(name, x, f);
     }
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interploglinear.hpp
+++ b/dal-cpp/dal/math/interp/interploglinear.hpp
@@ -8,6 +8,6 @@
 
 namespace Dal {
     namespace Interp {
-        Interp1_* NewLogLinear(const String_& name, const Vector_<>& x, const Vector_<>& f);
+        std::unique_ptr<Interp1_> NewLogLinear(const String_& name, const Vector_<>& x, const Vector_<>& f);
     } // namespace Interp
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interpmixed.cpp
+++ b/dal-cpp/dal/math/interp/interpmixed.cpp
@@ -49,12 +49,12 @@ namespace Dal {
                 // linear head: knots [0 .. cutoffIndex_]
                 Vector_<> headYf(yf_.begin(), yf_.begin() + cutoffIndex_ + 1);
                 Vector_<> headLogDF(logDF_.begin(), logDF_.begin() + cutoffIndex_ + 1);
-                linear_.reset(Interp::NewLinear(name + "_lin", headYf, headLogDF));
+                linear_ = Handle_<Interp1_>(Interp::NewLinear(name + "_lin", headYf, headLogDF));
 
                 // cubic tail: knots [cutoffIndex_ .. end]
                 Vector_<> tailYf(yf_.begin() + cutoffIndex_, yf_.end());
                 Vector_<> tailLogDF(logDF_.begin() + cutoffIndex_, logDF_.end());
-                cubic_.reset(Interp::NewCubic(name + "_cub", tailYf, tailLogDF, spec.cubicLhs_, spec.cubicRhs_));
+                cubic_ = Handle_<Interp1_>(Interp::NewCubic(name + "_cub", tailYf, tailLogDF, spec.cubicLhs_, spec.cubicRhs_));
             }
 
             double operator()(double x) const override {
@@ -77,10 +77,10 @@ namespace Dal {
         };
     } // namespace
 
-    Interp1_* NewMixedLogDF(const String_& name,
-                            const Vector_<>& yf,
-                            const Vector_<>& logDF,
-                            const MixedSchemeSpec_& spec) {
-        return new MixedLogDF_(name, yf, logDF, spec);
+    std::unique_ptr<Interp1_> NewMixedLogDF(const String_& name,
+                                            const Vector_<>& yf,
+                                            const Vector_<>& logDF,
+                                            const MixedSchemeSpec_& spec) {
+        return std::make_unique<MixedLogDF_>(name, yf, logDF, spec);
     }
 } // namespace Dal

--- a/dal-cpp/dal/math/interp/interpmixed.hpp
+++ b/dal-cpp/dal/math/interp/interpmixed.hpp
@@ -14,7 +14,7 @@ namespace Dal {
         Interp::Boundary_ cubicRhs_ = Interp::Boundary_(2, 0.0);
     };
 
-    Interp1_* NewMixedLogDF(const String_& name,
+    std::unique_ptr<Interp1_> NewMixedLogDF(const String_& name,
                             const Vector_<>& yf,
                             const Vector_<>& logDF,
                             const MixedSchemeSpec_& spec);

--- a/dal-cpp/dal/math/matrix/banded.cpp
+++ b/dal-cpp/dal/math/matrix/banded.cpp
@@ -304,9 +304,9 @@ namespace Dal {
                 }
                 return true;
             }
-            [[nodiscard]] SquareMatrixDecomposition_* Decompose() const override {
+            [[nodiscard]] std::unique_ptr<SquareMatrixDecomposition_> Decompose() const override {
                 REQUIRE(IsSymmetric(), "Cholesky decomposition requires a symmetric matrix");
-                return new BandedCholesky_(val_);
+                return std::make_unique<BandedCholesky_>(val_);
             }
 
             const double& operator()(int row, int col) const override { return val_(row, col); }
@@ -334,17 +334,17 @@ namespace Dal {
         void TriDiagonal_::MultiplyRight(const Vector_<>& x, Vector_<>* b) const {
             TriMultiply(x, diag_, below_, above_, b);
         }
-        SquareMatrixDecomposition_* TriDiagonal_::Decompose() const {
+        std::unique_ptr<SquareMatrixDecomposition_> TriDiagonal_::Decompose() const {
             if (IsSymmetric())
-                return new TriDecompSymm_(diag_, above_);
-            return new TriDecomp_(diag_, above_, below_);
+                return std::make_unique<TriDecompSymm_>(diag_, above_);
+            return std::make_unique<TriDecomp_>(diag_, above_, below_);
         }
 
-        Square_* NewBandDiagonal(int size, int nAbove, int nBelow) {
+        std::unique_ptr<Square_> NewBandDiagonal(int size, int nAbove, int nBelow) {
             REQUIRE(size > 0, "size should be larger than 0");
             if (nAbove <= 1 && nBelow <= 1)
-                return new TriDiagonal_(size);
-            return new Banded_(size, nAbove, nBelow);
+                return std::make_unique<TriDiagonal_>(size);
+            return std::make_unique<Banded_>(size, nAbove, nBelow);
         }
     } // namespace Sparse
 

--- a/dal-cpp/dal/math/matrix/banded.hpp
+++ b/dal-cpp/dal/math/matrix/banded.hpp
@@ -40,10 +40,10 @@ namespace Dal {
 
             void MultiplyLeft(const Vector_<>& x, Vector_<>* b) const override;
             void MultiplyRight(const Vector_<>& x, Vector_<>* b) const override ;
-            [[nodiscard]] SquareMatrixDecomposition_* Decompose() const override ;
+            [[nodiscard]] std::unique_ptr<SquareMatrixDecomposition_> Decompose() const override ;
         };
 
-        Square_* NewBandDiagonal(int size, int nAbove, int nBelow);
+        std::unique_ptr<Square_> NewBandDiagonal(int size, int nAbove, int nBelow);
     } // namespace Sparse
 
     class LowerBandAccumulator_ {

--- a/dal-cpp/dal/math/matrix/cholesky.cpp
+++ b/dal-cpp/dal/math/matrix/cholesky.cpp
@@ -113,8 +113,8 @@ namespace Dal {
         };
     } // namespace
 
-    Sparse::SymmetricDecomposition_* CholeskyDecomposition(const SquareMatrix_<>& src) {
-        return new Cholesky_(src);
+    std::unique_ptr<Sparse::SymmetricDecomposition_> CholeskyDecomposition(const SquareMatrix_<>& src) {
+        return std::make_unique<Cholesky_>(src);
     }
 
     void CholeskySolve(SquareMatrix_<>* a, Vector_<Vector_<>>* b, double regularization) {

--- a/dal-cpp/dal/math/matrix/cholesky.hpp
+++ b/dal-cpp/dal/math/matrix/cholesky.hpp
@@ -9,6 +9,6 @@
 namespace Dal {
     class SquareMatrixDecomposition_;
 
-    Sparse::SymmetricDecomposition_* CholeskyDecomposition(const SquareMatrix_<>& src);
+    std::unique_ptr<Sparse::SymmetricDecomposition_> CholeskyDecomposition(const SquareMatrix_<>& src);
     void CholeskySolve(SquareMatrix_<>* a, Vector_<Vector_<>>* b, double regularization = Dal::EPSILON);
 } // namespace Dal

--- a/dal-cpp/dal/math/matrix/decompositionsmisc.cpp
+++ b/dal-cpp/dal/math/matrix/decompositionsmisc.cpp
@@ -102,11 +102,11 @@ namespace Dal {
         };
     } // namespace
 
-    SymmetricMatrixDecomposition_* DiagonalAsDecomposition(const Vector_<> &diag) {
-        return new Diagonal_(diag);
+    std::unique_ptr<SymmetricMatrixDecomposition_> DiagonalAsDecomposition(const Vector_<> &diag) {
+        return std::make_unique<Diagonal_>(diag);
     }
 
-    SquareMatrixDecomposition_* LowerTriangularAsDecomposition(const SquareMatrix_<> &elements) {
-        return new LowerTriangular_(elements);
+    std::unique_ptr<SquareMatrixDecomposition_> LowerTriangularAsDecomposition(const SquareMatrix_<> &elements) {
+        return std::make_unique<LowerTriangular_>(elements);
     }
 } // namespace Dal

--- a/dal-cpp/dal/math/matrix/decompositionsmisc.hpp
+++ b/dal-cpp/dal/math/matrix/decompositionsmisc.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <memory>
+
 namespace Dal {
     class SquareMatrixDecomposition_;
     class SymmetricMatrixDecomposition_;
 
-    SymmetricMatrixDecomposition_* DiagonalAsDecomposition(const Vector_<>& diag);
-    SquareMatrixDecomposition_* LowerTriangularAsDecomposition(const SquareMatrix_<>& src);
+    std::unique_ptr<SymmetricMatrixDecomposition_> DiagonalAsDecomposition(const Vector_<>& diag);
+    std::unique_ptr<SquareMatrixDecomposition_> LowerTriangularAsDecomposition(const SquareMatrix_<>& src);
 } // namespace Dal

--- a/dal-cpp/dal/math/matrix/matrixs.hpp
+++ b/dal-cpp/dal/math/matrix/matrixs.hpp
@@ -55,7 +55,7 @@ namespace Dal {
             std::swap(hooks_, rhs.hooks_);
         }
 
-        Matrix_(Matrix_&& rhs) noexcept { swap(rhs); }
+        Matrix_(Matrix_&& rhs) noexcept : cols_(0) { swap(rhs); }
 
         Matrix_& operator=(Matrix_&& rhs) noexcept {
             if (this != &rhs) {

--- a/dal-cpp/dal/math/matrix/matrixutils.cpp
+++ b/dal-cpp/dal/math/matrix/matrixutils.cpp
@@ -228,14 +228,14 @@ namespace Dal {
         }
 
         std::unique_ptr<Writer_> XNewWriter(const String_& format) {
-            if (auto vr = MultipleWriter(format, ':', []() { return new VerticalWriter_(true); }))
+            if (auto vr = MultipleWriter(format, ':', []() { return std::make_unique<VerticalWriter_>(true); }))
                 return vr;
-            if (auto vl = MultipleWriter(format, ';', []() { return new VerticalWriter_(false); }))
+            if (auto vl = MultipleWriter(format, ';', []() { return std::make_unique<VerticalWriter_>(false); }))
                 return vl;
             // ok, no unparenthesized semicolons
-            if (auto hr = MultipleWriter(format, '.', []() { return new HorizontalWriter_(true); }))
+            if (auto hr = MultipleWriter(format, '.', []() { return std::make_unique<HorizontalWriter_>(true); }))
                 return hr;
-            if (auto hl = MultipleWriter(format, ',', []() { return new HorizontalWriter_(false); }))
+            if (auto hl = MultipleWriter(format, ',', []() { return std::make_unique<HorizontalWriter_>(false); }))
                 return hl;
 
             // no commas:  just one element

--- a/dal-cpp/dal/math/matrix/matrixutils.cpp
+++ b/dal-cpp/dal/math/matrix/matrixutils.cpp
@@ -66,7 +66,7 @@ namespace Dal {
 
         struct TransposedWriter_ : Writer_ {
             scoped_ptr<Writer_> base_;
-            TransposedWriter_(Writer_* base) : base_(base) {}
+            explicit TransposedWriter_(std::unique_ptr<Writer_> base) : base_(std::move(base)) {}
             int Rows(const Vector_<const Table_*>& args) const { return base_->Cols(args); }
             int Cols(const Vector_<const Table_*>& args) const { return base_->Rows(args); }
             void Write(const WriterView_& dst, const Vector_<const Table_*>& args) const {
@@ -76,7 +76,7 @@ namespace Dal {
 
         struct InvertedWriter_ : Writer_ {
             scoped_ptr<Writer_> base_;
-            InvertedWriter_(Writer_* base) : base_(base) {}
+            explicit InvertedWriter_(std::unique_ptr<Writer_> base) : base_(std::move(base)) {}
             int Rows(const Vector_<const Table_*>& args) const { return base_->Rows(args); }
             int Cols(const Vector_<const Table_*>& args) const { return base_->Cols(args); }
             void Write(const WriterView_& dst, const Vector_<const Table_*>& args) const {
@@ -87,7 +87,7 @@ namespace Dal {
         struct LinearWriter_ : Writer_ // puts everything in a single row
         {
             scoped_ptr<Writer_> base_;
-            LinearWriter_(Writer_* base) : base_(base) {}
+            explicit LinearWriter_(std::unique_ptr<Writer_> base) : base_(std::move(base)) {}
             int Rows(const Vector_<const Table_*>&) const { return 1; }
             int Cols(const Vector_<const Table_*>& args) const { return base_->Rows(args) * base_->Cols(args); }
             void Write(const WriterView_& dst, const Vector_<const Table_*>& args) const {
@@ -215,19 +215,19 @@ namespace Dal {
                        : src;
         }
 
-        Writer_* NewWriter(const String_& format);
-        template <class M_> Writer_* MultipleWriter(const String_& format, char separator, M_ make_multiple) {
+        std::unique_ptr<Writer_> NewWriter(const String_& format);
+        template <class M_> std::unique_ptr<Writer_> MultipleWriter(const String_& format, char separator, M_ make_multiple) {
             typedef typename std::remove_reference<decltype(*make_multiple())>::type multiple_t;
             Vector_<String_> subs = Split(format, separator);
             if (subs.size() <= 1)
                 return nullptr;
             std::unique_ptr<multiple_t> ret_val(make_multiple());
             for (const auto& s : subs)
-                ret_val->elements_.emplace_back(NewWriter(s));
-            return ret_val.release();
+                ret_val->elements_.emplace_back(Handle_<Writer_>(NewWriter(s)));
+            return ret_val;
         }
 
-        Writer_* XNewWriter(const String_& format) {
+        std::unique_ptr<Writer_> XNewWriter(const String_& format) {
             if (auto vr = MultipleWriter(format, ':', []() { return new VerticalWriter_(true); }))
                 return vr;
             if (auto vl = MultipleWriter(format, ';', []() { return new VerticalWriter_(false); }))
@@ -240,20 +240,20 @@ namespace Dal {
 
             // no commas:  just one element
             if (toupper(format.back()) == 'T')
-                return new TransposedWriter_(NewWriter(format.substr(0, format.size() - 1)));
+                return std::make_unique<TransposedWriter_>(NewWriter(format.substr(0, format.size() - 1)));
             else if (toupper(format.back()) == 'I')
-                return new InvertedWriter_(NewWriter(format.substr(0, format.size() - 1)));
+                return std::make_unique<InvertedWriter_>(NewWriter(format.substr(0, format.size() - 1)));
             else if (format.back() == '*')
-                return new LinearWriter_(NewWriter(format.substr(0, format.size() - 1)));
+                return std::make_unique<LinearWriter_>(NewWriter(format.substr(0, format.size() - 1)));
             else {
                 REQUIRE(format.size() == 1 && format.front() >= '0' && format.front() <= '9',
                         "Can't recognize format element -- expected argument index (format = '" + format + "')");
                 return format.front() == '0'
-                           ? (Writer_*)new EmptyCell_
-                           : new ArgWriter_(format.front() - '1'); // implements 1-offset count of args
+                           ? std::unique_ptr<Writer_>(new EmptyCell_)
+                           : std::make_unique<ArgWriter_>(format.front() - '1'); // implements 1-offset count of args
             }
         }
-        Writer_* NewWriter(const String_& format) { return XNewWriter(Strip(format)); }
+        std::unique_ptr<Writer_> NewWriter(const String_& format) { return XNewWriter(Strip(format)); }
     } // namespace
 
     Matrix_<Cell_> Matrix::Format(const Vector_<const Table_*>& args, const String_& format) {

--- a/dal-cpp/dal/math/matrix/sparse.cpp
+++ b/dal-cpp/dal/math/matrix/sparse.cpp
@@ -25,11 +25,11 @@ namespace Dal::Sparse {
         }
     }
 
-    SymmetricDecomposition_* Square_::DecomposeSymmetric() const {
-        std::unique_ptr<SquareMatrixDecomposition_> d(Decompose());
-        if (auto ret_val = dynamic_cast<SymmetricDecomposition_*>(d.get())) {
+    std::unique_ptr<SymmetricDecomposition_> Square_::DecomposeSymmetric() const {
+        auto d = Decompose();
+        if (auto* ret_val = dynamic_cast<SymmetricDecomposition_*>(d.get())) {
             d.release();
-            return ret_val;
+            return std::unique_ptr<SymmetricDecomposition_>(ret_val);
         }
 
         REQUIRE(!IsSymmetric(), "symmetric matrix should return a type that implements QForm");

--- a/dal-cpp/dal/math/matrix/sparse.hpp
+++ b/dal-cpp/dal/math/matrix/sparse.hpp
@@ -21,8 +21,8 @@ namespace Dal::Sparse {
         virtual void MultiplyRight(const Vector_<>& x, Vector_<>* b) const = 0;
 
         [[nodiscard]] virtual bool IsSymmetric() const = 0;
-        [[nodiscard]] virtual SquareMatrixDecomposition_* Decompose() const = 0;
-        [[nodiscard]] SymmetricDecomposition_* DecomposeSymmetric() const;
+        [[nodiscard]] virtual std::unique_ptr<SquareMatrixDecomposition_> Decompose() const = 0;
+        [[nodiscard]] std::unique_ptr<SymmetricDecomposition_> DecomposeSymmetric() const;
         virtual const double& operator()(int iRow, int jCol) const = 0;
         virtual void Set(int iRow, int jCol, double val) = 0;
         virtual void Add(int iRow, int jCol, double val) { Set(iRow, jCol, val + operator()(iRow, jCol)); }

--- a/dal-cpp/dal/math/optimization/underdetermined.cpp
+++ b/dal-cpp/dal/math/optimization/underdetermined.cpp
@@ -188,7 +188,7 @@ namespace Dal {
                 return true;
             }
 
-            [[nodiscard]] Sparse::SymmetricDecomposition_* Decompose() const override;
+            [[nodiscard]] std::unique_ptr<SquareMatrixDecomposition_> Decompose() const override;
 
             const double& operator()(int iRow, int iCol) const override {
                 THROW("Penalty weight element access is not supported");
@@ -225,7 +225,7 @@ namespace Dal {
             }
         };
 
-        Sparse::SymmetricDecomposition_* XPenaltyWeight_::Decompose() const { return new XDecompByCG_(*this); }
+        std::unique_ptr<SquareMatrixDecomposition_> XPenaltyWeight_::Decompose() const { return std::make_unique<XDecompByCG_>(*this); }
 
         Vector_<> ApproxQPStep(const Vector_<>& x0,
                                const Vector_<>& x,

--- a/dal-cpp/dal/math/optimization/underdetermined.cpp
+++ b/dal-cpp/dal/math/optimization/underdetermined.cpp
@@ -101,26 +101,26 @@ namespace Dal {
                 return retVal;
             }
 
-            Underdetermined::Jacobian_* J(const Vector_<>& x, const Vector_<>& f) {
+            std::unique_ptr<Underdetermined::Jacobian_> J(const Vector_<>& x, const Vector_<>& f) {
                 REQUIRE(nRestarts_-- > 0, "Exhausted gradient evaluations in underdetermined search");
                 return BuildJacobian(x, f);
             }
 
-            Underdetermined::Jacobian_* JAtSolution(const Vector_<>& x, const Vector_<>& scaledF) {
+            std::unique_ptr<Underdetermined::Jacobian_> JAtSolution(const Vector_<>& x, const Vector_<>& scaledF) {
                 Vector_<> unscaledF = scaledF;
                 Transform(&unscaledF, tol_, std::multiplies<>());
                 return BuildJacobian(x, unscaledF);
             }
 
-            Underdetermined::Jacobian_* BuildJacobian(const Vector_<>& x, const Vector_<>& f) {
+            std::unique_ptr<Underdetermined::Jacobian_> BuildJacobian(const Vector_<>& x, const Vector_<>& f) {
                 if (auto sparse = func_.Gradient(x, f)) {
                     sparse->DivideRows(tol_);
                     return sparse;
                 }
                 func_.Gradient(x, f, &jDense_);
-                std::unique_ptr<XJDense_> retVal(new XJDense_(jDense_));
+                auto retVal = std::make_unique<XJDense_>(jDense_);
                 retVal->DivideRows(tol_);
-                return retVal.release();
+                return retVal;
             }
         };
 
@@ -344,7 +344,7 @@ namespace Dal {
 
         for (;;) {
             if (state.restart_) {
-                state.jacobian_.reset(func.J(state.xOld_, state.fOld_));
+                state.jacobian_ = func.J(state.xOld_, state.fOld_);
                 state.approximateJacobian_ = false;
                 state.restart_ = false;
             }
@@ -374,7 +374,7 @@ namespace Dal {
 
         for (int ie = 3, ticker = 0; ie < controls.maxEvaluations_; ++ie, ticker -= controls.maxRestarts_) {
             if (ticker <= 0) {
-                j.reset(func.J(xOld, fOld));
+                j = func.J(xOld, fOld);
                 ticker = controls.maxEvaluations_;
                 ++ie; // we used up an evaluation too
             }

--- a/dal-cpp/dal/math/optimization/underdetermined.hpp
+++ b/dal-cpp/dal/math/optimization/underdetermined.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <dal/math/vectors.hpp>
 #include <dal/string/strings.hpp>
 #include <dal/utilities/dictionary.hpp>
@@ -65,7 +67,7 @@ namespace Dal {
         public:
             virtual ~Function_() = default;
             [[nodiscard]] virtual Vector_<> F(const Vector_<>& x) const = 0;
-            [[nodiscard]] virtual Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const {
+            [[nodiscard]] virtual std::unique_ptr<Jacobian_> Gradient(const Vector_<>& x, const Vector_<>& f) const {
                 return nullptr;
             }
             virtual void Gradient(const Vector_<>& x, const Vector_<>& f, Matrix_<>* j) const;

--- a/dal-cpp/dal/math/optimization/underdeterminedutils.hpp
+++ b/dal-cpp/dal/math/optimization/underdeterminedutils.hpp
@@ -15,9 +15,9 @@ namespace Dal::Underdetermined {
                        double tau_smoothing,
                        int offset = 0);
 
-    FORCE_INLINE Sparse::TriDiagonal_ *WeightsPWC(const Vector_<DateTime_> &knots, double tau_s) {
-        std::unique_ptr <Sparse::TriDiagonal_> ret_val(new Sparse::TriDiagonal_(knots.size()));
+    FORCE_INLINE std::unique_ptr<Sparse::TriDiagonal_> WeightsPWC(const Vector_<DateTime_> &knots, double tau_s) {
+        auto ret_val = std::make_unique<Sparse::TriDiagonal_>(knots.size());
         SelfCouplePWC(ret_val.get(), knots, tau_s, 0);
-        return ret_val.release();
+        return ret_val;
     }
 } // namespace Dal::Underdetermined

--- a/dal-cpp/dal/math/pde/pde.cpp
+++ b/dal-cpp/dal/math/pde/pde.cpp
@@ -144,52 +144,52 @@ namespace Dal::PDE {
         };
     } // namespace
 
-    CoordinateMap_* NewSinhMap(double xWidth, double dxdyRange) {
+    std::unique_ptr<CoordinateMap_> NewSinhMap(double xWidth, double dxdyRange) {
         REQUIRE(IsPositive(xWidth) && dxdyRange >= 1.0, "xWidth should be positive and dxdyRange should be greater than 1");
         double sinhMaxY = std::sqrt(Square(dxdyRange) - 1.0);
-        return IsZero(Square(sinhMaxY)) ? (CoordinateMap_*)new IdentityMap_ : new SinhMap_(xWidth / sinhMaxY);
+        return IsZero(Square(sinhMaxY)) ? std::unique_ptr<CoordinateMap_>(new IdentityMap_) : std::make_unique<SinhMap_>(xWidth / sinhMaxY);
     }
 
-    CoordinateMap_* NewConcentratingMap(double xLow, double xHigh, double cPoint, double density) {
+    std::unique_ptr<CoordinateMap_> NewConcentratingMap(double xLow, double xHigh, double cPoint, double density) {
         REQUIRE(xHigh > xLow, "concentrating map requires xHigh > xLow");
         REQUIRE(cPoint >= xLow && cPoint <= xHigh, "concentrating map requires cPoint in [xLow, xHigh]");
         REQUIRE(density > 0.0, "concentrating map requires density > 0");
-        return new ConcentratingMap_(xLow, xHigh, cPoint, density);
+        return std::make_unique<ConcentratingMap_>(xLow, xHigh, cPoint, density);
     }
 
-    ScalarCoeff_* NewConstCoeff(double val) { return new ConstScalarCoeff_(val); }
+    std::unique_ptr<ScalarCoeff_> NewConstCoeff(double val) { return std::make_unique<ConstScalarCoeff_>(val); }
 
-    VectorCoeff_* NewConstCoeff(const Vector_<>& val) { return new ConstVectorCoeff_(val); }
+    std::unique_ptr<VectorCoeff_> NewConstCoeff(const Vector_<>& val) { return std::make_unique<ConstVectorCoeff_>(val); }
 
-    MatrixCoeff_* NewConstCoeff(const Matrix_<>& val) {
+    std::unique_ptr<MatrixCoeff_> NewConstCoeff(const Matrix_<>& val) {
         REQUIRE(val.Rows() == val.Cols(), "constant matrix coefficient must be square");
-        return new ConstMatrixCoeff_(val);
+        return std::make_unique<ConstMatrixCoeff_>(val);
     }
 
-    ScalarCoeff_* NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep) {
+    std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep) {
         REQUIRE(static_cast<bool>(f), "coefficient callable must be non-empty");
-        return new CallableScalarCoeff_(std::move(f), dep);
+        return std::make_unique<CallableScalarCoeff_>(std::move(f), dep);
     }
 
-    VectorCoeff_* NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f, const Vector_<Coeff_::x_dep_t>& dep) {
+    std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f, const Vector_<Coeff_::x_dep_t>& dep) {
         REQUIRE(static_cast<bool>(f), "coefficient callable must be non-empty");
-        return new CallableVectorCoeff_(std::move(f), dep);
+        return std::make_unique<CallableVectorCoeff_>(std::move(f), dep);
     }
 
-    MatrixCoeff_* NewMatrixCoeff(std::function<void(const Vector_<>&, SquareMatrix_<>*)> f, const Matrix_<Coeff_::x_dep_t>& dep) {
+    std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<void(const Vector_<>&, SquareMatrix_<>*)> f, const Matrix_<Coeff_::x_dep_t>& dep) {
         REQUIRE(static_cast<bool>(f), "coefficient callable must be non-empty");
         REQUIRE(dep.Rows() == dep.Cols(), "matrix coefficient dependence must be square");
-        return new CallableMatrixCoeff_(std::move(f), dep);
+        return std::make_unique<CallableMatrixCoeff_>(std::move(f), dep);
     }
 
-    ScalarCoeff_* NewScalarCoeff(std::function<double(double)> f) {
+    std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(double)> f) {
         REQUIRE(static_cast<bool>(f), "coefficient callable must be non-empty");
         Coeff_::x_dep_t dep;
         dep.set(0);
         return NewScalarCoeff([f = std::move(f)](const Vector_<>& x) { return f(x[0]); }, dep);
     }
 
-    VectorCoeff_* NewVectorCoeff(std::function<double(double)> f) {
+    std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<double(double)> f) {
         REQUIRE(static_cast<bool>(f), "coefficient callable must be non-empty");
         Coeff_::x_dep_t dep;
         dep.set(0);
@@ -197,7 +197,7 @@ namespace Dal::PDE {
         return NewVectorCoeff([f = std::move(f)](const Vector_<>& x, Vector_<>* out) { (*out)[0] = f(x[0]); }, deps);
     }
 
-    MatrixCoeff_* NewMatrixCoeff(std::function<double(double)> f) {
+    std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<double(double)> f) {
         REQUIRE(static_cast<bool>(f), "coefficient callable must be non-empty");
         Coeff_::x_dep_t dep;
         dep.set(0);

--- a/dal-cpp/dal/math/pde/pde.hpp
+++ b/dal-cpp/dal/math/pde/pde.hpp
@@ -22,9 +22,9 @@ namespace Dal::PDE {
         [[nodiscard]] virtual double Y(double x) const = 0;
     };
 
-    CoordinateMap_* NewSinhMap(double xWidth, double dxdyRange);
-    inline CoordinateMap_* NewIdentityMap() { return NewSinhMap(1.0, 1.0); }
-    CoordinateMap_* NewConcentratingMap(double xLow, double xHigh, double cPoint, double density);
+    std::unique_ptr<CoordinateMap_> NewSinhMap(double xWidth, double dxdyRange);
+    inline std::unique_ptr<CoordinateMap_> NewIdentityMap() { return NewSinhMap(1.0, 1.0); }
+    std::unique_ptr<CoordinateMap_> NewConcentratingMap(double xLow, double xHigh, double cPoint, double density);
 
     struct CoordinateVector_ {
         double yLow_;
@@ -46,27 +46,27 @@ namespace Dal::PDE {
         virtual void Value(const Vector_<>& x, SquareMatrix_<>* value) const = 0;
         [[nodiscard]] virtual Matrix_<x_dep_t> XDependence() const = 0;
     };
-    MatrixCoeff_* NewConstCoeff(const Matrix_<>& val);
-    MatrixCoeff_* NewMatrixCoeff(std::function<void(const Vector_<>&, SquareMatrix_<>*)> f, const Matrix_<Coeff_::x_dep_t>& dep);
-    MatrixCoeff_* NewMatrixCoeff(std::function<double(double)> f);
+    std::unique_ptr<MatrixCoeff_> NewConstCoeff(const Matrix_<>& val);
+    std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<void(const Vector_<>&, SquareMatrix_<>*)> f, const Matrix_<Coeff_::x_dep_t>& dep);
+    std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<double(double)> f);
 
     class VectorCoeff_ : public Coeff_ {
     public:
         virtual void Value(const Vector_<>& x, Vector_<>* value) const = 0;
         [[nodiscard]] virtual Vector_<x_dep_t> XDependence() const = 0;
     };
-    VectorCoeff_* NewConstCoeff(const Vector_<>& val);
-    VectorCoeff_* NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f, const Vector_<Coeff_::x_dep_t>& dep);
-    VectorCoeff_* NewVectorCoeff(std::function<double(double)> f);
+    std::unique_ptr<VectorCoeff_> NewConstCoeff(const Vector_<>& val);
+    std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f, const Vector_<Coeff_::x_dep_t>& dep);
+    std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<double(double)> f);
 
     class ScalarCoeff_ : public Coeff_ {
     public:
         virtual void Value(const Vector_<>& x, double* value) const = 0;
         [[nodiscard]] virtual x_dep_t XDependence() const = 0;
     };
-    ScalarCoeff_* NewConstCoeff(double val);
-    ScalarCoeff_* NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep);
-    ScalarCoeff_* NewScalarCoeff(std::function<double(double)> f);
+    std::unique_ptr<ScalarCoeff_> NewConstCoeff(double val);
+    std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep);
+    std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(double)> f);
 
     class Rollback_ {
     public:

--- a/dal-cpp/dal/math/pde/pdeoperators.cpp
+++ b/dal-cpp/dal/math/pde/pdeoperators.cpp
@@ -18,7 +18,7 @@ namespace Dal::PDE {
         }
     } // namespace
 
-    Sparse::TriDiagonal_* NewDx(const Vector_<>& x) {
+    std::unique_ptr<Sparse::TriDiagonal_> NewDx(const Vector_<>& x) {
         RequireOperatorLocations(x);
         const int n = static_cast<int>(x.size());
         std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
@@ -30,10 +30,10 @@ namespace Dal::PDE {
             ret->Set(i, i, (dxu - dxl) / (dxl * dxu));
             ret->Set(i, i + 1, dxl / (dxu * dxm));
         }
-        return ret.release();
+        return ret;
     }
 
-    Sparse::TriDiagonal_* NewDxx(const Vector_<>& x) {
+    std::unique_ptr<Sparse::TriDiagonal_> NewDxx(const Vector_<>& x) {
         RequireOperatorLocations(x);
         const int n = static_cast<int>(x.size());
         std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
@@ -45,6 +45,6 @@ namespace Dal::PDE {
             ret->Set(i, i, -2.0 / (dxl * dxu));
             ret->Set(i, i + 1, 2.0 / (dxu * dxm));
         }
-        return ret.release();
+        return ret;
     }
 } // namespace Dal::PDE

--- a/dal-cpp/dal/math/pde/pdeoperators.hpp
+++ b/dal-cpp/dal/math/pde/pdeoperators.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <memory>
+
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/vectors.hpp>
 
 namespace Dal::PDE {
-    Sparse::TriDiagonal_* NewDx(const Vector_<>& x);
-    Sparse::TriDiagonal_* NewDxx(const Vector_<>& x);
+    std::unique_ptr<Sparse::TriDiagonal_> NewDx(const Vector_<>& x);
+    std::unique_ptr<Sparse::TriDiagonal_> NewDxx(const Vector_<>& x);
 } // namespace Dal::PDE

--- a/dal-cpp/dal/math/pde/thetascheme.cpp
+++ b/dal-cpp/dal/math/pde/thetascheme.cpp
@@ -174,7 +174,7 @@ namespace Dal::PDE {
         }
 
         if (theta_ > 0.0) {
-            implicitSolve_.reset(implicitOp->Decompose());
+            implicitSolve_ = implicitOp->Decompose();
             ++decompositions_;
         } else {
             implicitSolve_.reset();

--- a/dal-cpp/dal/math/random/base.hpp
+++ b/dal-cpp/dal/math/random/base.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <dal/math/vectors.hpp>
 
 namespace Dal {
@@ -13,7 +15,7 @@ namespace Dal {
         virtual void FillUniform(Vector_<>* deviates) = 0;
         virtual void FillNormal(Vector_<>* deviates) = 0;
         virtual void SkipTo(size_t nPoints) = 0;
-        [[nodiscard]] virtual Random_* Clone() const = 0;
+        [[nodiscard]] virtual std::unique_ptr<Random_> Clone() const = 0;
         [[nodiscard]] virtual size_t NDim() const = 0;
     };
 } // namespace Dal

--- a/dal-cpp/dal/math/random/brownianbridge.hpp
+++ b/dal-cpp/dal/math/random/brownianbridge.hpp
@@ -34,9 +34,8 @@ namespace Dal {
             rsg_->SkipTo(nPoints);
         }
 
-        [[nodiscard]] Random_* Clone() const override {
-            Random_* rsg = rsg_->Clone();
-            return new BrownianBridge_(std::move(std::unique_ptr<Random_>(rsg)));
+        [[nodiscard]] std::unique_ptr<Random_> Clone() const override {
+            return std::make_unique<BrownianBridge_>(rsg_->Clone());
         }
 
         [[nodiscard]] size_t NDim() const override {

--- a/dal-cpp/dal/math/random/pseudorandom.cpp
+++ b/dal-cpp/dal/math/random/pseudorandom.cpp
@@ -74,11 +74,11 @@ namespace Dal {
                     shuffle_[ii] = IRN();
             }
 
-            [[nodiscard]] PseudoRandom_* Branch(int iChild) const override {
-                return new ShuffledIRN_<M_, L_, S_>(irn_[0] ^ irn_[1]);
+            [[nodiscard]] std::unique_ptr<PseudoRandom_> Branch(int iChild) const override {
+                return std::make_unique<ShuffledIRN_<M_, L_, S_>>(irn_[0] ^ irn_[1]);
             }
 
-            [[nodiscard]] PseudoRandom_* Clone() const override { return new ShuffledIRN_(seed_, cache_.size()); }
+            [[nodiscard]] std::unique_ptr<Random_> Clone() const override { return std::make_unique<ShuffledIRN_>(seed_, cache_.size()); }
 
             void SkipTo(size_t nPaths) override {}
         };
@@ -126,10 +126,10 @@ namespace Dal {
                 return u;
             }
 
-            [[nodiscard]] PseudoRandom_* Branch(int iChild) const override { return new MRG32k32a_(); }
+            [[nodiscard]] std::unique_ptr<PseudoRandom_> Branch(int iChild) const override { return std::make_unique<MRG32k32a_>(); }
 
-            [[nodiscard]] PseudoRandom_* Clone() const override {
-                return new MRG32k32a_(static_cast<unsigned>(a_), static_cast<unsigned>(b_), cache_.size());
+            [[nodiscard]] std::unique_ptr<Random_> Clone() const override {
+                return std::make_unique<MRG32k32a_>(static_cast<unsigned>(a_), static_cast<unsigned>(b_), cache_.size());
             }
 
             void SkipTo(size_t nPaths) override {
@@ -220,15 +220,12 @@ namespace Dal {
 
 #include <dal/auto/MG_RNGType_enum.inc>
 
-    PseudoRandom_* New(const RNGType_& type, int seed, size_t nDim, bool precise) {
-        PseudoRandom_* ret;
+    std::unique_ptr<PseudoRandom_> New(const RNGType_& type, int seed, size_t nDim, bool precise) {
         if (type == RNGType_("IRN"))
-            ret = new ShuffledIRN_<55, 31, 128>(seed, nDim, precise);
-        else if (type == RNGType_("MRG32"))
-            ret = new MRG32k32a_(seed, seed + 1, nDim, precise);
-        else
-            THROW("RNG type is not recognized");
-        return ret;
+            return std::make_unique<ShuffledIRN_<55, 31, 128>>(seed, nDim, precise);
+        if (type == RNGType_("MRG32"))
+            return std::make_unique<MRG32k32a_>(seed, seed + 1, nDim, precise);
+        THROW("RNG type is not recognized");
     }
 
 #include <dal/auto/MG_PseudoRSG_v1_Read.inc>

--- a/dal-cpp/dal/math/random/pseudorandom.hpp
+++ b/dal-cpp/dal/math/random/pseudorandom.hpp
@@ -56,9 +56,11 @@ namespace Dal {
         bool precise_;
     public:
         PseudoRSG_(const String_& name, double seed, double ndim = 1, bool precise = true)
-        : Storable_("PseudoRSG", name), seed_(seed), ndim_(ndim), precise_(precise) {
-            rsg_ = New(RNGType_(name), static_cast<int>(seed), static_cast<size_t>(ndim), precise);
-        }
+            : Storable_("PseudoRSG", name),
+              rsg_(New(RNGType_(name), static_cast<int>(seed), static_cast<size_t>(ndim), precise)),
+              seed_(seed),
+              ndim_(ndim),
+              precise_(precise) {}
         void Write(Archive::Store_& dst) const override;
         void FillUniform(Vector_<>* deviates) const {
             rsg_->FillUniform(deviates);

--- a/dal-cpp/dal/math/random/pseudorandom.hpp
+++ b/dal-cpp/dal/math/random/pseudorandom.hpp
@@ -41,14 +41,13 @@ namespace Dal {
         virtual double NextUniform() = 0;
         void FillUniform(Vector_<>* deviates) override;
         void FillNormal(Vector_<>* deviates) override;
-        [[nodiscard]] PseudoRandom_* Clone() const override = 0;
         [[nodiscard]] size_t NDim() const override { return cache_.size(); }
-        [[nodiscard]] virtual PseudoRandom_* Branch(int iChild) const = 0;
+        [[nodiscard]] virtual std::unique_ptr<PseudoRandom_> Branch(int iChild) const = 0;
         const bool precise_;
     };
 
 #include <dal/auto/MG_RNGType_enum.hpp>
-    PseudoRandom_* New(const RNGType_& type, int seed, size_t nDim = 1, bool precise = true);
+    std::unique_ptr<PseudoRandom_> New(const RNGType_& type, int seed, size_t nDim = 1, bool precise = true);
 
     class BASE_EXPORT PseudoRSG_: public Storable_ {
         std::unique_ptr<PseudoRandom_> rsg_;
@@ -58,7 +57,7 @@ namespace Dal {
     public:
         PseudoRSG_(const String_& name, double seed, double ndim = 1, bool precise = true)
         : Storable_("PseudoRSG", name), seed_(seed), ndim_(ndim), precise_(precise) {
-            rsg_.reset(New(RNGType_(name), static_cast<int>(seed), static_cast<size_t>(ndim), precise));
+            rsg_ = New(RNGType_(name), static_cast<int>(seed), static_cast<size_t>(ndim), precise);
         }
         void Write(Archive::Store_& dst) const override;
         void FillUniform(Vector_<>* deviates) const {

--- a/dal-cpp/dal/math/random/quasirandom.hpp
+++ b/dal-cpp/dal/math/random/quasirandom.hpp
@@ -14,7 +14,6 @@ namespace Dal {
         [[nodiscard]] size_t NDim() const override = 0;
         void FillUniform(Vector_<>* dst) override = 0 ;
         void FillNormal(Vector_<>* dst) override = 0;
-        [[nodiscard]] SequenceSet_* Clone() const override = 0;
-        virtual SequenceSet_* TakeAway(int subSize) = 0;
+        virtual std::unique_ptr<SequenceSet_> TakeAway(int subSize) = 0;
     };
 } // namespace Dal

--- a/dal-cpp/dal/math/random/sobol.cpp
+++ b/dal-cpp/dal/math/random/sobol.cpp
@@ -21255,17 +21255,17 @@ const uint_least32_t* const DIRECTIONS[21201] = {
             [[nodiscard]] size_t NDim() const override { return static_cast<size_t>(state_.size()); }
             void FillUniform(Vector_<>* dst) override;
             void FillNormal(Vector_<>* dst) override;
-            SobolSet_* Clone() const override {
-                std::unique_ptr<SobolSet_> seq(new SobolSet_(iPath_, precise_, polish_));
+            std::unique_ptr<Random_> Clone() const override {
+                auto seq = std::make_unique<SobolSet_>(iPath_, precise_, polish_);
                 seq->directions_ = directions_;
                 seq->state_ = state_;
-                return seq.release();
+                return seq;
             }
             void SkipTo(size_t nPaths) override {
                 iPath_ = nPaths;
                 Seek(state_, iPath_, directions_);
             }
-            SobolSet_* TakeAway(int subSize) override;
+            std::unique_ptr<SequenceSet_> TakeAway(int subSize) override;
         };
 
         void SobolSet_::FillUniform(Vector_<>* dst) {
@@ -21286,7 +21286,7 @@ const uint_least32_t* const DIRECTIONS[21201] = {
             Transform(dst, func);
         }
 
-        SobolSet_* SobolSet_::TakeAway(int subSize) {
+        std::unique_ptr<SequenceSet_> SobolSet_::TakeAway(int subSize) {
             REQUIRE(subSize > 0 && subSize <= NDim(), "Invalid sequence subSize");
             std::unique_ptr<SobolSet_> ret_val(new SobolSet_(iPath_, precise_, polish_));
             if (subSize == NDim()) {
@@ -21305,16 +21305,16 @@ const uint_least32_t* const DIRECTIONS[21201] = {
                 ret_val->state_.Assign(state_.begin() + size, state_.end());
                 state_.Resize(size);
             }
-            return ret_val.release();
+            return ret_val;
         }
     } // namespace
 
-    SequenceSet_* NewSobol(int size, size_t iPath, bool precise, bool polish) {
-        std::unique_ptr<SobolSet_> seq(new SobolSet_(iPath, precise, polish));
+    std::unique_ptr<SequenceSet_> NewSobol(int size, size_t iPath, bool precise, bool polish) {
+        auto seq = std::make_unique<SobolSet_>(iPath, precise, polish);
         seq->state_.Resize(size);
         seq->directions_ = Directions(size);
         Seek(seq->state_, iPath, seq->directions_);
-        return seq.release();
+        return seq;
     }
 
 #include <dal/auto/MG_SobolRSG_v1_Read.inc>

--- a/dal-cpp/dal/math/random/sobol.hpp
+++ b/dal-cpp/dal/math/random/sobol.hpp
@@ -30,9 +30,12 @@ namespace Dal {
         bool polish_;
     public:
         SobolRSG_(const String_& name, double iPath, double nDim = 1, bool precise = false, bool polish = false)
-            : Storable_("SobolRSG", name), i_path_(iPath), ndim_(nDim), precise_(precise), polish_(polish) {
-            rsg_ = NewSobol(static_cast<int>(ndim_), static_cast<size_t>(i_path_), precise, polish);
-        }
+            : Storable_("SobolRSG", name),
+              rsg_(NewSobol(static_cast<int>(nDim), static_cast<size_t>(iPath), precise, polish)),
+              i_path_(iPath),
+              ndim_(nDim),
+              precise_(precise),
+              polish_(polish) {}
         void Write(Archive::Store_& dst) const override;
         void FillUniform(Vector_<>* deviates) const;
         void FillNormal(Vector_<>* deviates) const;

--- a/dal-cpp/dal/math/random/sobol.hpp
+++ b/dal-cpp/dal/math/random/sobol.hpp
@@ -20,7 +20,7 @@ polish is boolean
 -IF-------------------------------------------------------------------------*/
 
 namespace Dal {
-    SequenceSet_* NewSobol(int size, size_t iPath, bool precise = false, bool polish = false);
+    std::unique_ptr<SequenceSet_> NewSobol(int size, size_t iPath, bool precise = false, bool polish = false);
 
     class BASE_EXPORT SobolRSG_: public Storable_ {
         std::unique_ptr<SequenceSet_> rsg_;
@@ -31,7 +31,7 @@ namespace Dal {
     public:
         SobolRSG_(const String_& name, double iPath, double nDim = 1, bool precise = false, bool polish = false)
             : Storable_("SobolRSG", name), i_path_(iPath), ndim_(nDim), precise_(precise), polish_(polish) {
-            rsg_.reset(NewSobol(static_cast<int>(ndim_), static_cast<size_t>(i_path_), precise, polish));
+            rsg_ = NewSobol(static_cast<int>(ndim_), static_cast<size_t>(i_path_), precise, polish);
         }
         void Write(Archive::Store_& dst) const override;
         void FillUniform(Vector_<>* deviates) const;

--- a/dal-cpp/dal/math/specialfunctions.cpp
+++ b/dal-cpp/dal/math/specialfunctions.cpp
@@ -13,7 +13,7 @@ namespace Dal {
     namespace {
         constexpr double MIN_SPLINE_X = -3.734582185;
         constexpr double MIN_SPLINE_F = 9.47235E-05;
-        Interp1_* MakeNcdfSpline() {
+        std::unique_ptr<Interp1_> MakeNcdfSpline() {
             const Vector_<> x = {MIN_SPLINE_X, -3.347382781, -3.030883722, -2.75090681,  -2.492289824, -2.243141537,
                                  -1.992179668, -1.494029881, -1.290815576, -1.120050999, -0.954303629, -0.792072249,
                                  -0.629093487, -0.460389924, -0.276889742, 0.0};

--- a/dal-cpp/dal/model/base.hpp
+++ b/dal-cpp/dal/model/base.hpp
@@ -52,13 +52,13 @@ namespace Dal {
         Vector_<String_> parameterLabels_;
 
         ModelData_(const String_& type, const String_& name): Storable_(type.c_str(), name) {}
-        [[nodiscard]] ModelData_* MutantModel(const String_& newName, const Vector_<Handle_<Slide_> >& slides) const {
+        [[nodiscard]] std::unique_ptr<ModelData_> MutantModel(const String_& newName, const Vector_<Handle_<Slide_> >& slides) const {
             REQUIRE(slides.empty(), "slides are not supported for ModelData");
             return MutantModel(&newName, nullptr);
         }
 
     private:
-        virtual ModelData_* MutantModel(const String_* newName, const Slide_* slide) const = 0;
+        virtual std::unique_ptr<ModelData_> MutantModel(const String_* newName, const Slide_* slide) const = 0;
     };
 
 } // namespace Dal

--- a/dal-cpp/dal/model/blackscholes.cpp
+++ b/dal-cpp/dal/model/blackscholes.cpp
@@ -14,8 +14,8 @@ namespace Dal {
         BSModelData_v1::XWrite(dst, name_, spot_, vol_, rate_, div_);
     }
 
-    BSModelData_* BSModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
+    std::unique_ptr<ModelData_> BSModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
         REQUIRE(!slide, "slides are not supported for BSModelData");
-        return new BSModelData_(*newName, spot_, vol_, rate_, div_);
+        return std::make_unique<BSModelData_>(*newName, spot_, vol_, rate_, div_);
     }
 } // namespace Dal

--- a/dal-cpp/dal/model/blackscholes.hpp
+++ b/dal-cpp/dal/model/blackscholes.hpp
@@ -166,7 +166,7 @@ namespace Dal {
         void Write(Archive::Store_& dst) const override;
 
     private:
-        BSModelData_* MutantModel(const String_* newName, const Slide_* slide) const override;
+        std::unique_ptr<ModelData_> MutantModel(const String_* newName, const Slide_* slide) const override;
     };
 
 } // namespace Dal

--- a/dal-cpp/dal/model/dupire.cpp
+++ b/dal-cpp/dal/model/dupire.cpp
@@ -14,8 +14,8 @@ namespace Dal {
         DupireModelData_v1::XWrite(dst, name_, spot_, rate_, repo_, spots_, times_, vols_);
     }
 
-    DupireModelData_* DupireModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
+    std::unique_ptr<ModelData_> DupireModelData_::MutantModel(const String_* newName, const Slide_* slide) const {
         REQUIRE(!slide, "slides are not supported for DupireModelData");
-        return new DupireModelData_(*newName, spot_, rate_, repo_, spots_, times_, vols_);
+        return std::make_unique<DupireModelData_>(*newName, spot_, rate_, repo_, spots_, times_, vols_);
     }
 } // namespace Dal

--- a/dal-cpp/dal/model/dupire.hpp
+++ b/dal-cpp/dal/model/dupire.hpp
@@ -265,6 +265,6 @@ namespace Dal {
         void Write(Archive::Store_& dst) const override;
 
     private:
-        DupireModelData_* MutantModel(const String_* newName, const Slide_* slide) const override;
+        std::unique_ptr<ModelData_> MutantModel(const String_* newName, const Slide_* slide) const override;
     };
 } // namespace Dal::AAD

--- a/dal-cpp/dal/platform/platform.hpp
+++ b/dal-cpp/dal/platform/platform.hpp
@@ -83,7 +83,8 @@ namespace Dal {
 
         explicit Handle_(const T_* src) : base_t(src) {}
 
-        explicit Handle_(std::unique_ptr<T_>&& src) : base_t(std::move(src)) {}
+        template <class U_, class = std::enable_if_t<std::is_convertible_v<U_*, const T_*>>> explicit Handle_(std::unique_ptr<U_>&& src)
+            : base_t(std::move(src)) {}
 
         explicit Handle_(const base_t& src) : base_t(src) {}
         [[nodiscard]] bool IsEmpty() const { return !base_t::get(); }

--- a/dal-cpp/dal/platform/platform.hpp
+++ b/dal-cpp/dal/platform/platform.hpp
@@ -83,6 +83,8 @@ namespace Dal {
 
         explicit Handle_(const T_* src) : base_t(src) {}
 
+        explicit Handle_(std::unique_ptr<T_>&& src) : base_t(std::move(src)) {}
+
         explicit Handle_(const base_t& src) : base_t(src) {}
         [[nodiscard]] bool IsEmpty() const { return !base_t::get(); }
     };

--- a/dal-cpp/dal/script/simulation.cpp
+++ b/dal-cpp/dal/script/simulation.cpp
@@ -11,11 +11,11 @@ namespace Dal::Script {
     std::unique_ptr<Random_> CreateRNG(const String_& method, size_t nDim, bool useBb) {
         std::unique_ptr<Random_> rsg;
         if (method == "sobol")
-            rsg = std::unique_ptr<Random_>(NewSobol(static_cast<int>(nDim), 2048));
+            rsg = NewSobol(static_cast<int>(nDim), 2048);
         else if (method == "mrg32")
-            rsg = std::unique_ptr<Random_>(New(RNGType_("MRG32"), 1024, nDim));
+            rsg = New(RNGType_("MRG32"), 1024, nDim);
         else if (method == "irn")
-            rsg = std::unique_ptr<Random_>(New(RNGType_("IRN"), 1024, nDim));
+            rsg = New(RNGType_("IRN"), 1024, nDim);
         else
             THROW("rng method is not known");
 

--- a/dal-cpp/dal/utilities/composite.hpp
+++ b/dal-cpp/dal/utilities/composite.hpp
@@ -48,7 +48,7 @@ namespace Dal {
             for (const auto& sc : src.contents_)
                 Append(sc ? sc->Clone() : nullptr);
         }
-        Composite_<T_>* Clone() const { return new Composite_<T_>(*this); }
+        std::unique_ptr<Composite_<T_>> Clone() const { return std::make_unique<Composite_<T_>>(*this); }
         // Assignable if T_ is
         T_& operator=(const T_& rhs);
     };

--- a/dal-cpp/dal/utilities/environment.cpp
+++ b/dal-cpp/dal/utilities/environment.cpp
@@ -8,6 +8,6 @@
 namespace Dal {
     void Environment_::Iterator_::operator++() {
         if (IsValid())
-            return imp_.reset(imp_->Next());
+            imp_ = Handle_<IterImp_>(imp_->Next());
     }
 } // namespace Dal

--- a/dal-cpp/dal/utilities/environment.hpp
+++ b/dal-cpp/dal/utilities/environment.hpp
@@ -24,19 +24,19 @@ namespace Dal {
         struct IterImp_ : noncopyable {
             virtual ~IterImp_() = default;
             virtual bool Valid() const = 0;
-            virtual IterImp_* Next() const = 0;
+            virtual std::unique_ptr<IterImp_> Next() const = 0;
             virtual const Entry_& operator*() const = 0;
         };
 
         struct Iterator_ {
             Handle_<IterImp_> imp_;
-            explicit Iterator_(IterImp_* orphan) : imp_(orphan) {}
+            explicit Iterator_(std::unique_ptr<IterImp_> orphan) : imp_(std::move(orphan)) {}
             bool IsValid() const { return imp_.get() != nullptr && imp_.get()->Valid(); }
             void operator++();
             const Entry_& operator*() const { return **imp_; }
         };
 
-        virtual IterImp_* XBegin() const = 0;
+        virtual std::unique_ptr<IterImp_> XBegin() const = 0;
         Iterator_ Begin() const { return Iterator_(XBegin()); }
     };
 
@@ -83,13 +83,13 @@ namespace Dal {
                 MyIter_(const Vector_<Handle_<Entry_>>& all, const Vector_<Handle_<Entry_>>::const_iterator& me)
                     : all_(all), me_(me) {}
                 bool Valid() const override { return me_ != all_.end(); }
-                IterImp_* Next() const override { return new MyIter_(all_, Dal::Next(me_)); }
+                std::unique_ptr<IterImp_> Next() const override { return std::make_unique<MyIter_>(all_, Dal::Next(me_)); }
                 const Entry_& operator*() const override { return **me_; }
             };
 
         public:
             explicit Base_(const Vector_<Handle_<Entry_>>& vals = Vector_<Handle_<Entry_>>()) : vals_(vals) {}
-            MyIter_* XBegin() const override { return new MyIter_(vals_, vals_.begin()); }
+            std::unique_ptr<IterImp_> XBegin() const override { return std::make_unique<MyIter_>(vals_, vals_.begin()); }
         };
 
         class XDecorated_ : public Environment_ {
@@ -102,7 +102,7 @@ namespace Dal {
                 const Entry_& val_;
                 I1(const Environment_* parent, const Entry_& val) : parent_(parent), val_(val) {}
                 bool Valid() const override { return true; }
-                IterImp_* Next() const override { return parent_ ? parent_->XBegin() : nullptr; }
+                std::unique_ptr<IterImp_> Next() const override { return parent_ ? parent_->XBegin() : nullptr; }
                 const Entry_& operator*() const override { return val_; }
             };
 
@@ -113,7 +113,7 @@ namespace Dal {
             }
             ~XDecorated_() override { theEnv_ = parent_; }
 
-            IterImp_* XBegin() const override { return new I1(parent_, val_); }
+            std::unique_ptr<IterImp_> XBegin() const override { return std::make_unique<I1>(parent_, val_); }
         };
     } // namespace Environment
 } // namespace Dal

--- a/dal-cpp/examples/sobol/sobol.cpp
+++ b/dal-cpp/examples/sobol/sobol.cpp
@@ -57,7 +57,7 @@ int main() {
 
         int settingIdx = 0;
         for (const auto& setting: settings) {
-            rsg.reset(NewSobol(numDims, 1000, setting.precise_, setting.polish_));
+            rsg = NewSobol(numDims, 1000, setting.precise_, setting.polish_);
 
             timer.Reset();
             for (size_t j = 0; j < numPaths; ++j)

--- a/dal-cpp/tests/curve/test_calibration.cpp
+++ b/dal-cpp/tests/curve/test_calibration.cpp
@@ -30,8 +30,8 @@ namespace {
 
         void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>*) const override {}
 
-        [[nodiscard]] ConstantDiscountCurve_* Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
-            return new ConstantDiscountCurve_(newName, ccy_.String(), value_);
+        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
+            return std::make_unique<ConstantDiscountCurve_>(newName, ccy_.String(), value_);
         }
 
         void Write(Archive::Store_&) const override {}

--- a/dal-cpp/tests/curve/test_xccypricing.cpp
+++ b/dal-cpp/tests/curve/test_xccypricing.cpp
@@ -73,8 +73,8 @@ namespace {
         double operator()(const Date_&, const Date_&) const override { return value_; }
         void Poll(Vector_<const YCComponent_*>* all) const override { all->push_back(this); }
         void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>*) const override {}
-        [[nodiscard]] ConstantDiscountCurve_* Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
-            return new ConstantDiscountCurve_(newName, ccy_.String(), value_);
+        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
+            return std::make_unique<ConstantDiscountCurve_>(newName, ccy_.String(), value_);
         }
         void Write(Archive::Store_&) const override {}
     };
@@ -111,8 +111,8 @@ namespace {
         }
         void Poll(Vector_<const YCComponent_*>* all) const override { all->push_back(this); }
         void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>*) const override {}
-        [[nodiscard]] MappedDiscountCurve_* Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
-            return new MappedDiscountCurve_(newName, ccy_.String(), valuationDate_, valuationDfs_, forwardDfs_);
+        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
+            return std::unique_ptr<YCComponent_>(new MappedDiscountCurve_(newName, ccy_.String(), valuationDate_, valuationDfs_, forwardDfs_));
         }
         void Write(Archive::Store_&) const override {}
     };
@@ -129,8 +129,8 @@ namespace {
         T_ operator()(const Date_& from, const Date_&) const override { return from < split_ ? historical_ : future_; }
         void Poll(Vector_<const YCComponent_*>* all) const override { all->push_back(this); }
         void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>*) const override {}
-        [[nodiscard]] SplitForwardCurve_* Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
-            return new SplitForwardCurve_(newName, this->ccy_.String(), split_, historical_, future_);
+        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_& newName, const YCComponent_::substitutions_t&) const override {
+            return std::make_unique<SplitForwardCurve_>(newName, this->ccy_.String(), split_, historical_, future_);
         }
         void Write(Archive::Store_&) const override {}
     };

--- a/dal-cpp/tests/curve/test_zerorate_archive.cpp
+++ b/dal-cpp/tests/curve/test_zerorate_archive.cpp
@@ -63,7 +63,7 @@ TEST(ZeroRateArchiveTest, TestJsonRoundTripPreservesAllSchemesAndZeroRateBumps) 
         ASSERT_NE(restored, nullptr);
         AssertFieldsAndValues(*restored, original, "zero_archive", scheme);
 
-        std::unique_ptr<DiscountZeroRate_> mutableRestored(restored->Clone("zero_archive", {}));
+        std::unique_ptr<DiscountZeroRate_> mutableRestored(dynamic_cast<DiscountZeroRate_*>(restored->Clone("zero_archive", {}).release()));
         ASSERT_NE(mutableRestored, nullptr);
         original.ApplyDX(bump.begin(), 1.0);
         mutableRestored->ApplyDX(bump.begin(), 1.0);

--- a/dal-cpp/tests/math/matrix/test_banded.cpp
+++ b/dal-cpp/tests/math/matrix/test_banded.cpp
@@ -11,7 +11,7 @@ using namespace Dal;
 
 TEST(MatrixTest, TestNewBandedDiagonal) {
     const int n = 10;
-    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
     ASSERT_EQ(mat->Size(), n);
 
     mat->Set(9, 8, 1.0);
@@ -25,7 +25,7 @@ TEST(MatrixTest, TestNewBandedDiagonal) {
 
 TEST(MatrixTest, TestNewBandedBanded) {
     const int n = 10;
-    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 2, 1);
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 2, 1);
     ASSERT_EQ(mat->Size(), n);
 
     mat->Set(7, 9, 1.0);

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -84,7 +84,7 @@ namespace {
 TEST(MatrixTest, TestCGSolveSymmetricLowResidual) {
     const int n = 40;
     std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
-    BuildSymmetricTridiag(mat, n);
+    BuildSymmetricTridiag(mat.get(), n);
 
     Vector_<> b(n);
     for (int i = 0; i < n; ++i)
@@ -98,7 +98,7 @@ TEST(MatrixTest, TestCGSolveSymmetricLowResidual) {
 TEST(MatrixTest, TestBCGSolveAsymmetricLowResidual) {
     const int n = 40;
     std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
-    BuildAsymmetricTridiag(mat, n);
+    BuildAsymmetricTridiag(mat.get(), n);
 
     Vector_<> b(n);
     for (int i = 0; i < n; ++i)

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -13,7 +13,7 @@ using namespace Dal;
 
 TEST(MatrixTest, TestCGSolve) {
     const int n = 10;
-    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
     mat->Set(9, 8, 3.0);
     mat->Set(8, 9, 3.0);
 
@@ -30,7 +30,7 @@ TEST(MatrixTest, TestCGSolve) {
 
 TEST(MatrixTest, TestBCGSolve) {
     const int n = 10;
-    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
     mat->Set(9, 8, 3.0);
     mat->Set(8, 9, 2.0);
 
@@ -83,7 +83,7 @@ namespace {
 
 TEST(MatrixTest, TestCGSolveSymmetricLowResidual) {
     const int n = 40;
-    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
     BuildSymmetricTridiag(mat, n);
 
     Vector_<> b(n);
@@ -97,7 +97,7 @@ TEST(MatrixTest, TestCGSolveSymmetricLowResidual) {
 
 TEST(MatrixTest, TestBCGSolveAsymmetricLowResidual) {
     const int n = 40;
-    Sparse::Square_* mat = Sparse::NewBandDiagonal(n, 1, 1);
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
     BuildAsymmetricTridiag(mat, n);
 
     Vector_<> b(n);

--- a/dal-cpp/tests/math/matrix/test_matrixs.cpp
+++ b/dal-cpp/tests/math/matrix/test_matrixs.cpp
@@ -41,6 +41,24 @@ TEST(MatrixTest, TestMatrixMoveConstructor) {
     ASSERT_EQ(m2.Cols(), 4);
 }
 
+TEST(MatrixTest, TestMatrixMovedFromHasDefinedDimensions) {
+    {
+        matrix_t m1(3, 4);
+        matrix_t m2(std::move(m1));
+        ASSERT_EQ(m1.Rows(), 0);
+        ASSERT_EQ(m1.Cols(), 0);
+        ASSERT_TRUE(m1.Empty());
+    }
+    {
+        matrix_t m1(3, 4);
+        matrix_t m2;
+        m2 = std::move(m1);
+        ASSERT_EQ(m1.Rows(), 0);
+        ASSERT_EQ(m1.Cols(), 0);
+        ASSERT_TRUE(m1.Empty());
+    }
+}
+
 TEST(MatrixTest, TestMatrixCopyMoveConstructor) {
     auto m2 = matrix_t(3, 4);
     ASSERT_EQ(m2.Rows(), 3);

--- a/dal-cpp/tests/math/matrix/test_sparse.cpp
+++ b/dal-cpp/tests/math/matrix/test_sparse.cpp
@@ -20,7 +20,7 @@ TEST(MatrixTest, TestSymmetricDecomposition) {
             diag.Set(i, i-1, 3.0);
     }
 
-    std::unique_ptr<SymmetricDecomposition_> de_comp(dynamic_cast<SymmetricDecomposition_*>(diag.Decompose()));
+    std::unique_ptr<SymmetricDecomposition_> de_comp(dynamic_cast<SymmetricDecomposition_*>(diag.Decompose().release()));
     Vector_<> b(n, 1.0);
     Vector_<> x(n);
     de_comp->Solve(b, &x);

--- a/dal-cpp/tests/math/optimization/test_underdetermined.cpp
+++ b/dal-cpp/tests/math/optimization/test_underdetermined.cpp
@@ -98,12 +98,12 @@ namespace {
 
         [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] * x[0] - 4.0}; }
 
-        [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
+        [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& x, const Vector_<>& f) const override {
             gradientState_->xs_.push_back(x);
             gradientState_->fs_.push_back(f);
             Matrix_<> j(1, 1);
             j(0, 0) = 2.0 * x[0];
-            return new DenseJacobian_(j);
+            return std::make_unique<DenseJacobian_>(j);
         }
     };
 
@@ -125,10 +125,10 @@ namespace {
             return Vector_<>{1.0 - x[0] - 3.0 * x[0] * x[0]};
         }
 
-        [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>&, const Vector_<>&) const override {
+        [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>&, const Vector_<>&) const override {
             Matrix_<> j(1, 2, 0.0);
             j(0, 0) = -1.0;
-            return new DenseJacobian_(j);
+            return std::make_unique<DenseJacobian_>(j);
         }
     };
 
@@ -140,13 +140,13 @@ namespace {
 
         [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] + x[2] - 3.0, x[1] + x[2] - 4.0}; }
 
-        [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>&, const Vector_<>&) const override {
+        [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>&, const Vector_<>&) const override {
             Matrix_<> j(2, 3, 0.0);
             j(0, 0) = 1.0;
             j(0, 2) = 1.0;
             j(1, 1) = 1.0;
             j(1, 2) = 1.0;
-            return new DenseJacobian_(j);
+            return std::make_unique<DenseJacobian_>(j);
         }
 
         [[nodiscard]] int FastCalls() const { return fastCalls_; }
@@ -167,14 +167,14 @@ namespace {
     public:
         [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] + x[2] - 3.0, x[1] + x[2] - 4.0}; }
 
-        [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>&) const override {
+        [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& x, const Vector_<>&) const override {
             gradientXs_.push_back(x);
             Matrix_<> j(2, 3, 0.0);
             j(0, 0) = 1.0;
             j(0, 2) = 1.0;
             j(1, 1) = 1.0;
             j(1, 2) = 1.0;
-            return new DenseJacobian_(j);
+            return std::make_unique<DenseJacobian_>(j);
         }
 
         [[nodiscard]] const Vector_<Vector_<>>& GradientXs() const { return gradientXs_; }
@@ -202,7 +202,7 @@ namespace {
     public:
         [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] + x[2] - 3.0, x[1] + x[2] - 4.0}; }
 
-        [[nodiscard]] Underdetermined::Jacobian_* Gradient(const Vector_<>& x, const Vector_<>& f) const override {
+        [[nodiscard]] std::unique_ptr<Underdetermined::Jacobian_> Gradient(const Vector_<>& x, const Vector_<>& f) const override {
             gradientXs_.push_back(x);
             gradientFs_.push_back(f);
             Matrix_<> j(2, 3, 0.0);
@@ -210,7 +210,7 @@ namespace {
             j(0, 2) = 1.0;
             j(1, 1) = 1.0;
             j(1, 2) = 1.0;
-            return new DenseJacobian_(j);
+            return std::make_unique<DenseJacobian_>(j);
         }
 
         // f passed to the Gradient call at the solution (the convergence call), or empty if Gradient

--- a/dal-cpp/tests/math/random/test_pseudorandom.cpp
+++ b/dal-cpp/tests/math/random/test_pseudorandom.cpp
@@ -98,8 +98,8 @@ TEST(PseudoRandomTest, TestPseudoRandomClone) {
     std::unique_ptr<Random_> gen2(gen->Clone());
     ASSERT_EQ(gen2->NDim(), n_dim);
 
-    gen.reset(New(RNGType_("MRG32"), 1024, n_dim));
-    gen2.reset(gen->Clone());
+    gen = New(RNGType_("MRG32"), 1024, n_dim);
+    gen2 = gen->Clone();
     ASSERT_EQ(gen2->NDim(), n_dim);
 }
 

--- a/dal-cpp/tests/math/random/test_sobol.cpp
+++ b/dal-cpp/tests/math/random/test_sobol.cpp
@@ -134,7 +134,7 @@ TEST(RandomTest, TestSobolNormalPrecisionPolicy) {
 TEST(RandomTest, TestSobolClonePreservesStateAndNormalPolicy) {
     constexpr size_t iPath = (1u << 20) - 2;
     std::unique_ptr<SequenceSet_> source(NewSobol(2, iPath, true, true));
-    std::unique_ptr<SequenceSet_> clone(source->Clone());
+    std::unique_ptr<Random_> clone(source->Clone());
     Vector_<> sourceValues;
     Vector_<> cloneValues;
 

--- a/dal-excel/src/__interp.cpp
+++ b/dal-excel/src/__interp.cpp
@@ -147,7 +147,7 @@ namespace Dal {
 
         void Interp1_New_Linear_Smoothed(const String_& name, const Vector_<>& x, const Vector_<>& y, double smoothing, const Vector_<>& fit_weights, Handle_<Interp1_>* f) {
             Vector_<> z = SmoothedVals(x, y, fit_weights, smoothing);
-            f->reset(Interp::NewLinear(name, x, z));
+            *f = Handle_<Interp1_>(Interp::NewLinear(name, x, z));
         }
 
         void Interp1_New_Cubic(const String_& name,
@@ -165,7 +165,7 @@ namespace Dal {
                     right.value_ = boundary_value.back();
                 }
             }
-            f->reset(Interp::NewCubic(name, x, y, left, right));
+            *f = Handle_<Interp1_>(Interp::NewCubic(name, x, y, left, right));
         }
 
         double CheckedInterp2(const Interp2_& f, double x, double y) {
@@ -186,7 +186,7 @@ namespace Dal {
                                 const Vector_<>& y,
                                 const Matrix_<>& z,
                                 Handle_<Interp2_>* f) {
-            f->reset(Interp::NewLinear2(name, x, y, z));
+            *f = Handle_<Interp2_>(Interp::NewLinear2(name, x, y, z));
         }
     } // namespace
 #ifdef _WIN32

--- a/docs/methodology/pde.md
+++ b/docs/methodology/pde.md
@@ -166,15 +166,15 @@ bit `i` means the coefficient depends on spatial coordinate `x[i]`. Time is not 
 dependence bit; time-dependent coefficients are handled by calling `Prepare` again before
 the next roll.
 
-The factory functions follow DAL's raw-pointer `New*` convention. Callers normally wrap
-the returned pointer in `Handle_` or `std::unique_ptr`.
+The factory functions return `std::unique_ptr`. Callers normally wrap the result in
+`Handle_` through its converting constructor or keep the `unique_ptr`.
 
 Constant factories:
 
 ```cpp
-ScalarCoeff_* NewConstCoeff(double val);
-VectorCoeff_* NewConstCoeff(const Vector_<>& val);
-MatrixCoeff_* NewConstCoeff(const Matrix_<>& val);
+std::unique_ptr<ScalarCoeff_> NewConstCoeff(double val);
+std::unique_ptr<VectorCoeff_> NewConstCoeff(const Vector_<>& val);
+std::unique_ptr<MatrixCoeff_> NewConstCoeff(const Matrix_<>& val);
 ```
 
 The matrix constant must be square. Constant coefficients report all-zero dependence.
@@ -182,11 +182,11 @@ The matrix constant must be square. Constant coefficients report all-zero depend
 Callable factories:
 
 ```cpp
-ScalarCoeff_* NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep);
-VectorCoeff_* NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f,
-                             const Vector_<Coeff_::x_dep_t>& dep);
-MatrixCoeff_* NewMatrixCoeff(std::function<void(const Vector_<>&, SquareMatrix_<>*)> f,
-                             const Matrix_<Coeff_::x_dep_t>& dep);
+std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep);
+std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f,
+                                             const Vector_<Coeff_::x_dep_t>& dep);
+std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<void(const Vector_<>&, SquareMatrix_<>*)> f,
+                                             const Matrix_<Coeff_::x_dep_t>& dep);
 ```
 
 For vector and matrix callables, `dep` declares both dependence and output shape. The
@@ -195,9 +195,9 @@ adapter resizes the output object to match `dep` before invoking the callable.
 The one-dimensional convenience overloads infer axis-0 dependence and length/shape 1:
 
 ```cpp
-ScalarCoeff_* NewScalarCoeff(std::function<double(double)> f);
-VectorCoeff_* NewVectorCoeff(std::function<double(double)> f);
-MatrixCoeff_* NewMatrixCoeff(std::function<double(double)> f);
+std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(double)> f);
+std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<double(double)> f);
+std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<double(double)> f);
 ```
 
 These make Black-Scholes coefficients concise:

--- a/docs/methodology/random.md
+++ b/docs/methodology/random.md
@@ -18,7 +18,7 @@ $$
 $$
 
 $$
-\texttt{void SkipTo(size\_t n)}, \qquad \texttt{Random\_* Clone() const}, \qquad \texttt{size\_t NDim() const}.
+\texttt{void SkipTo(size\_t n)}, \qquad \texttt{std::unique\_ptr<Random\_> Clone() const}, \qquad \texttt{size\_t NDim() const}.
 $$
 
 `NDim()` is the number of variates produced per call (one draw of a

--- a/docs/methodology/underdetermined_search.md
+++ b/docs/methodology/underdetermined_search.md
@@ -182,7 +182,7 @@ When the caller requests `fwdJacobianAtSolution` (non-null pointer), the converg
 branch in `Find` captures the **unscaled** dense forward Jacobian at the solution:
 
 1. The raw (unwrapped) `funcIn` is called: `funcIn.Gradient(xNew, fUnscaled)` returns a sparse
-   `Jacobian_*` (the dense overload is not used on this branch).
+   `Jacobian_` by `std::unique_ptr` (the dense overload is not used on this branch).
 2. The residual `fUnscaled` is reconstructed by element-wise multiplication of the
    scaled residual by the tolerance vector — avoiding a redundant `funcIn.F()` call
    that would bypass the solver's evaluation budget.


### PR DESCRIPTION
## Summary

Tranche 5 of the codebase review (P2.13): migrates every hand-written factory that returned a raw owning pointer to `std::unique_ptr`, per the repo ownership rule, plus the carried-over `Matrix_` move-constructor fix from #238. Ownership semantics are unchanged everywhere: call sites that already wrapped the orphan in `Handle_`/`unique_ptr` compile unchanged via a new converting `Handle_(std::unique_ptr<U_>&&)` constructor; the few `.reset()` targets now assign.

**Factory audit (factory → call sites → disposition):**

| Factory | Call sites | Disposition |
|---------|-----------|-------------|
| `ModelData_::MutantModel` (+ `BSModelData_`/`DupireModelData_` overrides) | 2 model tests (already wrapped) | migrated |
| `Interp::NewLinear` / `NewLinear2` / `NewLogLinear` / `NewCubic` / `NewMixedLogDF` | tests, examples, `dal-public` interp wrapper, `interpmixed` members, 3 `dal-excel` out-params, `specialfunctions` spline builder | migrated |
| `PDE::NewSinhMap` / `NewIdentityMap` / `NewConcentratingMap` | tests, `pdegrid` | migrated |
| `PDE::NewConstCoeff` (x3) / `NewScalarCoeff` / `NewVectorCoeff` / `NewMatrixCoeff` (x2 each) | tests, `european_fd` example, `pde_perf` | migrated |
| `PDE::NewDx` / `NewDxx` | `thetascheme`, operator tests | migrated |
| `Random_::Clone` (+ `ShuffledIRN_`/`MRG32k32a_`/`SobolSet_`/`BrownianBridge_` overrides) | `BrownianBridge_`, random tests | migrated; covariant re-declarations in `SequenceSet_`/`PseudoRandom_` dropped (add nothing once the base returns `unique_ptr`); one derived-typed test call site uses the base `Random_` type |
| `PseudoRandom_::Branch` / `PseudoRandom_::New` | `PseudoRSG_` member, `script/simulation`, tests, benchmarks | migrated |
| `SequenceSet_::TakeAway` / `NewSobol` | `SobolRSG_` member, `script/simulation`, sobol example, tests, benchmarks | migrated |
| `NewDiscountPWC` / `NewDiscountZeroRate` / `NewDiscountPWLF` / `NewDiscountLogDF` | tests, examples, benchmarks, `dal-public/curvedata` | migrated |
| `YCComponent_::Clone` (+ 5 overrides, incl. test-local curves) | 3 curve tests | migrated; covariance flattened to `unique_ptr<YCComponent_>`; the one caller needing the derived type downcasts from `.release()` explicitly |
| `CalibrateYieldCurve(Date_, ...)` legacy overload | 4 curveblock tests, underdetermined example | migrated (was already a `unique_ptr::release()` internally) |
| `BuildCurveCalibrationWeights` / `Underdetermined::WeightsPWC` / `PWC::NewConstant` | calibration internals, 2 tests | migrated |
| `Sparse::Square_::Decompose` / `DecomposeSymmetric` (+ `TriDiagonal_`/`Banded_`/`XPenaltyWeight_` overrides) | `thetascheme`, calibration internals, tests | migrated; 2 test locals that leaked the raw result now hold `unique_ptr`; 1 downcast site uses `.release()`; `Decompose()->Solve...()` temporaries now delete (previously leaked) |
| `Sparse::NewBandDiagonal` / `CholeskyDecomposition` / `DiagonalAsDecomposition` / `LowerTriangularAsDecomposition` | matrix tests, benchmarks | migrated |
| table-writer family (`NewWriter`/`XNewWriter`/`MultipleWriter` + make-lambdas, `matrixutils.cpp`) | `Matrix::Format` | migrated |
| `Index::Parse` / `parser_t` / `FxParser` / `EquityParser` | parser registry, `Index::Clone`, indice/protocol tests | migrated |
| `Underdetermined::Function_::Gradient` (+ 4 calibration overrides, 2 `AnalyticJacobian` helpers) | solver internals | migrated |
| `Environment_::XBegin` / `IterImp_::Next` (+ `Iterator_` orphan ctor) | environment internals (`Begin`/`Iterate`/`Find`) | migrated |
| `Composite_<T_>::Clone` | none (never instantiated for the sole `Increment_` composite) | migrated |
| `Archive::Reader_::Build()` (both overloads) + ~20 handwritten impls | archive read path | **not migrated**: the interface is declared in Machinist-generated `MG_*_Read.inc` files; changing it requires editing the Machinist templates in the `machinist` submodule and regenerating all auto files. Tracked as a follow-up |
| `Tape()` / `Tape_::RecordNode` / `BlockList_::EmplaceBack*` / `CreateMultiNode` | AAD hot path | **not migrated**: non-owning; the tape/blocklist owns the nodes |
| `ThreadPool_::GetInstance`, `Environment::Find`/`Collect`, `FloatConventionOf`, `XccyMarket_::BasisCurve` | — | **not migrated**: non-owning lookups |
| `dal-excel` `OPER_*` returns | — | **not migrated**: Excel XLOPER API memory convention, Windows-only |

**Carried-over follow-up (from #238, pre-existing since 2022):** `Matrix_(Matrix_&&)` never value-initialized `cols_` before swapping, so a moved-from `Matrix_` had an indeterminate `cols_` (formally UB on any read). Now value-initialized; the moved-from object is in the default-constructed state, pinned by a new regression test (`MatrixTest.TestMatrixMovedFromHasDefinedDimensions`) covering both move-construct and move-assign.

## Test plan

- [x] Full workspace build: `cmake --preset=Release-linux` + `cmake --build` — clean
- [x] `ctest --test-dir build/Release-linux -LE benchmark`: **1055/1055 passed**
- [x] `dal_cpp_tests`: **999/999 passed**; `dal_public_tests`: **56/56 passed**
- [x] New `MatrixTest.TestMatrixMovedFromHasDefinedDimensions` regression test passes post-fix (pre-fix it is UB, which this compiler happened to materialize as 0; the test pins the contract and bites under sanitizers)
- [x] Targeted re-run of touched-area suites (model, interp, random clone, zerorate archive): 30/30
- [x] `dal-python` call sites read-verified (bindings use only `dal-public` wrappers; no direct factory use); `dal-excel` read-verified (3 interp call sites migrated to `Handle_` assignment)
- [x] Style self-review: no new >150-col lines, no banned keywords, naming conventions preserved
