### PR TITLE
docs: Consolidate agent guides, add PR template and conceptual notes

### DIFF
--- a/.claude/agents/dal-implementer.md
+++ b/.claude/agents/dal-implementer.md
@@ -147,12 +147,16 @@ Implement just enough production code to make the failing test pass — nothing 
 - Source files: `<dal/platform/platform.hpp>` first DAL header, then the module's own header; `REQUIRE(cond, msg)`
   for runtime invariants; `THROW(msg)` for error conditions; minimal comments — "why" not "what".
 
-**If you added or changed a Machinist enum markup block,** regenerate auto files before building:
+**If you added or changed a Machinist enum markup block,** regenerate auto files before building with the
+`dal_generate` CMake target — it builds the Machinist binary from the `dal-cpp/externals/machinist/`
+submodule (the prebuilt `bin/Machinist` is git-ignored there and absent on fresh clones), sets
+`MACHINIST_TEMPLATE_DIR`, and runs Machinist for both the core and Excel output trees:
 ```bash
-export MACHINIST_TEMPLATE_DIR=$PWD/dal-cpp/externals/machinist/template/
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-cpp/dal
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-excel
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_generate
 ```
+`bash ./build_linux.sh --generate` runs the same target before the normal build, and `dal_check_generated`
+fails on drift between markup and generated files.
 This produces `dal-cpp/dal/auto/MG_<EnumName>_enum.hpp` (class definition) and `.inc` (implementation).
 Include the `.hpp` inside `namespace Dal { }` in your header, and the `.inc` inside `namespace Dal { }` in your `.cpp`.
 Commit the generated files together with your markup source.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -131,13 +131,14 @@ namespace Dal {
 
 ### Building after adding or changing enum markup
 
-Run Machinist from the repo root to regenerate auto files before compiling:
+Regenerate the auto files with the `dal_generate` CMake target before compiling:
 
 ```bash
-export MACHINIST_TEMPLATE_DIR=$PWD/dal-cpp/externals/machinist/template/
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-cpp/dal
-./dal-cpp/externals/machinist/bin/Machinist -c dal-cpp/config/dal.ifc -l dal-cpp/config/dal.mgl -d ./dal-excel
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --target dal_generate
 ```
+
+The target builds the Machinist binary from the `dal-cpp/externals/machinist/` submodule (the prebuilt `bin/Machinist` is git-ignored in the submodule and absent on fresh clones), sets `MACHINIST_TEMPLATE_DIR`, and runs Machinist twice — once with `-d ./dal-cpp/dal` for core output and once with `-d ./dal-excel` for Excel stubs. `bash ./build_linux.sh --generate` runs the same target before the normal build, and `dal_check_generated` fails on drift between markup and generated files.
 
 Then build normally. The auto-generated files (`dal-cpp/dal/auto/MG_*_enum.hpp`, `dal-cpp/dal/auto/MG_*_enum.inc`, plus `dal-excel/auto/MG_*_public.inc` for Excel stubs) must be committed to the repository alongside the markup source.
 

--- a/.codex/skills/dal-agent-team/references/shared-rules.md
+++ b/.codex/skills/dal-agent-team/references/shared-rules.md
@@ -12,13 +12,9 @@ style, test, review, docs, and artifact conventions.
 
 ## Build And Test
 
-Release build:
-
-```bash
-cmake --preset=Release-linux -S . -B build/Release-linux
-cmake --build build/Release-linux -j$(nproc)
-cmake --install build/Release-linux
-```
+C++ build commands, workspace CMake options, and the preset matrix are canonical in
+[CLAUDE.md](../../../../CLAUDE.md#build-commands) and
+[CLAUDE.md](../../../../CLAUDE.md#running-tests).
 
 Full Linux workflow:
 
@@ -43,6 +39,9 @@ Web tests:
 
 ## C++ Style
 
+Canonical reference: [code-style.md](../../../../.claude/rules/code-style.md). The digest
+below is what the Codex role skills apply inline.
+
 - C++17. Use `.clang-format`: 4 spaces, attached braces, 150 columns, `T*` pointer binding.
 - Classes/structs: PascalCase plus trailing `_`.
 - Template params: short name plus trailing `_`.
@@ -57,6 +56,7 @@ Web tests:
 
 ## Machinist Enums
 
+The markup format is specified in [code-style.md](../../../../.claude/rules/code-style.md#enums).
 When enum markup changes, regenerate both core and Excel output. The `Machinist`
 binary is a git-ignored build artifact, not checked in, so the reliable route is
 the CMake target, which builds Machinist first and runs it with the right inputs:
@@ -69,6 +69,8 @@ cmake --build build/Release-linux --target dal_generate
 Commit generated `dal-cpp/dal/auto/MG_*` and `dal-excel/auto/MG_*` files with the markup source when committing is requested.
 
 ## Google Test
+
+Canonical reference: [unit-test-style.md](../../../../.claude/rules/unit-test-style.md).
 
 - Core tests: `dal-cpp/tests/<module>/test_<name>.cpp`.
 - Include `<gtest/gtest.h>` first.
@@ -89,6 +91,9 @@ Commit generated `dal-cpp/dal/auto/MG_*` and `dal-excel/auto/MG_*` files with th
 - Do not submit GitHub reviews or merge unless explicitly asked.
 
 ## Documentation Rules
+
+Canonical reference: the Documentation section of
+[code-style.md](../../../../.claude/rules/code-style.md#documentation).
 
 - Docs describe the current/latest library only.
 - Historical context belongs in `CHANGELOG.md`, not docs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,52 +3,54 @@
 C++17 quantitative finance library with built-in Automatic Adjoint Differentiation (AAD),
 organized as a multi-project CMake workspace.
 
+[CLAUDE.md](../CLAUDE.md) is the agent-facing source of truth for build/test commands,
+workspace CMake options, and the architecture map; [docs/installation.md](../docs/installation.md)
+is the published setup guide. The essentials:
+
 ## Build, Test, Lint
 
 ```bash
-# Full build from workspace root
-mkdir build && cd build
-cmake .. && cmake --build . --parallel
+# Default Linux workflow (configures core + public C++ + examples via the
+# Release-linux preset, installs into build/stage/Release-linux, runs CTest)
+bash ./build_linux.sh
 
-# With presets (see CMakePresets.json)
-cmake --preset=full-dev && cmake --build build/full-dev --parallel
+# Manual preset flow (Release-linux/Debug-linux declare no binaryDir, so pass -S/-B)
+cmake --preset=Release-linux -S . -B build/Release-linux
+cmake --build build/Release-linux --parallel
+cmake --install build/Release-linux
 ```
 
-CMake installs per preset into `build/stage/<preset>/`: binaries in `bin/`, libs in `lib/`, headers in `include/`.
+CMake installs per preset into `build/stage/<preset>/`: binaries in `bin/`, libs in `lib/`,
+headers in `include/`.
 
-Tests run through CTest or directly:
+Tests run through CTest or directly from the build tree:
 
 ```bash
-ctest --test-dir build/full-dev --output-on-failure          # all registered tests
-build/full-dev/dal-cpp/dal_cpp_tests                         # one binary directly
-build/full-dev/dal-cpp/dal_cpp_tests --gtest_filter=<Suite>.*   # one suite
+ctest --test-dir build/Release-linux --output-on-failure
+./build/Release-linux/dal-cpp/dal_cpp_tests
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.*
 ```
 
 Formatting is enforced by `.clang-format` (LLVM base, 4-space indent, 150 column limit,
 `T*` not `T *`, attach braces).
 
-### CMake options
-
-Key cache variables (all AAD backends default OFF; pick one or use native "aadet"):
-
-- `DAL_USE_XAD_AAD` / `DAL_USE_ADEPT_AAD` / `DAL_USE_CODIPACK_AAD`
-- `DAL_BUILD_PUBLIC`, `DAL_BUILD_PYTHON`, `DAL_BUILD_EXCEL` (Windows-only)
-- `DAL_CPP_BUILD_TESTS`, `DAL_CPP_BUILD_EXAMPLES`, `DAL_CPP_BUILD_BENCHMARKS`
-
-CI runs the full matrix: native/xad/codipack/adept × gcc-13/14, clang-18/19, plus MSVC.
+CMake cache variables (AAD backends, sub-project/test/example/benchmark toggles, sanitizers)
+are listed in [CLAUDE.md](../CLAUDE.md#build-commands) and the
+[installation guide options table](../docs/installation.md#common-cmake-options). CI runs
+the full matrix: native/xad/codipack/adept × gcc-13/14, clang-18/19, plus MSVC.
 
 ## Architecture
 
 Dependency graph: `dal-cpp ← dal-public ← {dal-python, dal-excel}`; `dal-web` consumes
-the Python public API.
+the Python public API. The published map is [docs/architecture.md](../docs/architecture.md).
 
-| Sub-project   | Target / purpose                                                   |
-|---------------|--------------------------------------------------------------------|
-| `dal-cpp/`    | `DAL::cpp` — core: math, curves, models, scripting, AAD            |
-| `dal-public/` | `DAL::public` — stable public API wrapping `DAL::cpp`              |
-| `dal-python/` | pybind11 Python bindings (`dal` package)                           |
-| `dal-excel/`  | `.xll` add-in, Windows-only                                        |
-| `dal-web/`    | FastAPI backend + React/Vite frontend                              |
+| Sub-project   | Target / purpose                                        |
+|---------------|---------------------------------------------------------|
+| `dal-cpp/`    | `DAL::cpp` — core: math, curves, models, scripting, AAD |
+| `dal-public/` | `DAL::public` — stable public API wrapping `DAL::cpp`   |
+| `dal-python/` | pybind11 Python bindings (`dal` package)                |
+| `dal-excel/`  | `.xll` add-in, Windows-only                             |
+| `dal-web/`    | FastAPI backend + React/Vite frontend                   |
 
 Core modules: `math/` (interp, opt, PDE, RNG, matrix, `aad/`), `script/` (lexer → parser →
 AST → simulation), `model/`, `curve/`, `indice/`, `risk/`, `concurrency/`, `storage/`,
@@ -57,7 +59,8 @@ AST → simulation), `model/`, `curve/`, `indice/`, `risk/`, `concurrency/`, `st
 ## Codegen (Machinist)
 
 Enums are declared in Machinist markup `/*IF---- ... -IF----*/` blocks before `namespace Dal {`.
-Machinist generates `dal-cpp/dal/auto/MG_*_enum.{hpp,inc}`.
+Machinist generates `dal-cpp/dal/auto/MG_*_enum.{hpp,inc}`; the markup format and regeneration
+contract live in [.claude/rules/code-style.md](../.claude/rules/code-style.md).
 
 **Regenerate only when markup changes.** The `Machinist` binary is a git-ignored build
 artifact, not checked in, so use the CMake target, which builds Machinist first and runs
@@ -69,6 +72,10 @@ cmake --build build/Release-linux --target dal_generate
 ```
 
 ## Conventions
+
+Naming, type idioms, error handling, and enum markup follow
+[.claude/rules/code-style.md](../.claude/rules/code-style.md); tests follow
+[.claude/rules/unit-test-style.md](../.claude/rules/unit-test-style.md). Highlights:
 
 - Classes: PascalCase + trailing `_` (`Date_`); members `camelCase_`; methods PascalCase.
 - `Handle_<T_>` wraps `shared_ptr<const T_>`; `Vector_<E_>` privately inherits `std::vector`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+PR title: mandatory category prefix — feat:, fix:, docs:, chore:, refactor:,
+test:, style:, perf:, or ci: — followed by an imperative summary under 70
+characters (e.g. "fix: Restore evaluation date in DalGateway.value").
+Branch from master, keep the PR to one feature or fix, and make sure all
+tests pass before requesting review. See .claude/rules/git-commit-pr.md.
+-->
+
+## Summary
+
+- Bullet points describing the key changes
+
+## Test plan
+
+- [ ] Ran focused test filters covering the new/changed functionality
+- [ ] Full `ctest --test-dir build/Release-linux --output-on-failure` (and other relevant CTest targets) to confirm no regressions

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -86,8 +86,8 @@ AGENT_ROOT_FILE_RE = re.compile(
 )
 
 STALE_DOCUMENTATION = {
-    "bin/dal_cpp_tests": "dal_cpp_tests is a build-tree target, not an installed binary",
-    "bin/dal_public_tests": "dal_public_tests is a build-tree target, not an installed binary",
+    "bin/dal_cpp_tests": "reference the build-tree test binary; staged bin/ installs go stale",
+    "bin/dal_public_tests": "reference the build-tree test binary; staged bin/ installs go stale",
     "--gtest_filter=CurveTest.*": "the CurveTest suite does not exist",
     "dal_stub.py": "the web backend has no runtime stub module",
     "DAL_REQUIRE_NATIVE": "native DAL is the only supported production backend",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ Last updated: 2026-07-18
 Codex-native guidance for working in this repository. This file is intentionally separate from
 `CLAUDE.md` and `.claude/`; do not edit the Claude originals unless the user explicitly asks.
 
+[CLAUDE.md](CLAUDE.md) is the agent-facing source of truth for build/test commands, workspace
+CMake options, and the architecture map. This file keeps Codex-specific routing and work style,
+and links back instead of duplicating.
+
 ## Codex Artifacts
 
 | Priority  | Guidance                                                                                                                                     |
@@ -17,41 +21,23 @@ Codex-native guidance for working in this repository. This file is intentionally
 ## Repository Shape
 
 This is a C++17 quantitative finance workspace with Automatic Adjoint Differentiation (AAD) support.
-
-| Priority  | Path           | Role                                                                            |
-|-----------|----------------|---------------------------------------------------------------------------------|
-| Reference | `dal-cpp/`     | Core library, enabled in the normal CMake workspace.                            |
-| Reference | `dal-public/`  | C++ API wrapper around the core library.                                        |
-| Reference | `dal-python/`  | pybind11 bindings and Python package.                                           |
-| Reference | `dal-excel/`   | Windows Excel add-in.                                                           |
-| Reference | `dal-web/`     | FastAPI backend plus React/Vite frontend; not built by CMake.                   |
-
-The dependency direction is `dal-cpp <- dal-public <- {dal-python, dal-excel}`.
+The dependency direction is `dal-cpp <- dal-public <- {dal-python, dal-excel}`; `dal-web/` (FastAPI
+backend plus React/Vite frontend) is not built by CMake. The sub-project map lives in
+[CLAUDE.md](CLAUDE.md#architecture) and the published [architecture guide](docs/architecture.md).
 
 ## Build And Test
 
-Use the existing project scripts and presets:
+Build commands, workspace CMake options, and test invocations are canonical in
+[CLAUDE.md](CLAUDE.md#build-commands) and [CLAUDE.md](CLAUDE.md#running-tests); the published
+setup guide is [docs/installation.md](docs/installation.md). The short form:
 
 ```bash
 bash ./build_linux.sh
-```
-
-```bash
-cmake --preset=Release-linux -S . -B build/Release-linux
-cmake --build build/Release-linux -j$(nproc)
-cmake --install build/Release-linux
-```
-
-Run tests through CTest or the build-tree binaries:
-
-```bash
 ctest --test-dir build/Release-linux --output-on-failure
-./build/Release-linux/dal-cpp/dal_cpp_tests
-./build/Release-linux/dal-public/dal_public_tests
-./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=<SuiteName>.*
 ```
 
-If enum Machinist markup changes, regenerate both core and Excel auto files before building.
+If enum Machinist markup changes, regenerate both core and Excel auto files before building —
+see [Machinist enums](.codex/skills/dal-agent-team/references/shared-rules.md#machinist-enums).
 
 ## Work Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Keep this as operational guidance for agents; keep public project orientation in [README.md](README.md), and put method-level explanations under `docs/methodology/`.
 
+This file is the agent-facing source of truth for build/test commands, workspace CMake options, and the architecture map. Sibling agent guides — [AGENTS.md](AGENTS.md) (Codex), [.github/copilot-instructions.md](.github/copilot-instructions.md) (GitHub Copilot), and [.codex/skills/dal-agent-team/references/shared-rules.md](.codex/skills/dal-agent-team/references/shared-rules.md) (Codex skill reference) — keep per-audience specifics and link back here rather than duplicating. Coding and test conventions live in [.claude/rules/](.claude/rules/) (linked below); published setup and architecture docs live in [docs/](docs/).
+
 ## Build Commands
 
 ```bash
@@ -79,6 +81,8 @@ Formatting is enforced via `.clang-format` (LLVM-based):
 - `PointerBindsToType: true` (use `T*` not `T *`)
 - Braces attach style (`BreakBeforeBraces: Attach`)
 
+The full conventions live in the [code style guide](.claude/rules/code-style.md); test conventions in the [unit test style guide](.claude/rules/unit-test-style.md).
+
 ## Architecture
 
 This is a C++17 quantitative finance library with AAD (Automatic Adjoint Differentiation) support, organized as a multi-project workspace.
@@ -93,7 +97,7 @@ Derivatives-Algorithms-Lib/
 └── dal-web/                Portfolio management web app (FastAPI + React)
 ```
 
-The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Each sub-project owns its own `CMakeLists.txt` and stands alone as a buildable target.
+The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Each sub-project owns its own `CMakeLists.txt` and stands alone as a buildable target. The published deep-dive — component boundaries, runtime ownership, and execution flows — is [docs/architecture.md](docs/architecture.md).
 
 **Core library (`dal-cpp/`)** — built as the `dal_cpp` target (alias `DAL::cpp`):
 - `dal-cpp/dal/math/` — numerical algorithms: interpolation, optimization, PDE solvers, random number generation, matrix ops, root finding, AAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,8 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Black / Bachelier Vanilla Pricing** — [Black / Bachelier vanilla pricing](docs/methodology/black_scholes.md)
 - **Numerical Quadrature** — [Numerical quadrature](docs/methodology/quadrature.md)
 - **Random Number Generation and Path Construction** — [Random and path generation](docs/methodology/random.md)
+- **Dates, Calendars, and Schedules** — [Dates and calendars](docs/methodology/dates.md)
+- **Index Names and Parsing** — [Index parsing](docs/methodology/index_parsing.md)
 
 Notable fundamental changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The top-level `CMakeLists.txt` is a thin workspace that selects sub-projects via
 - `DAL_CPP_BUILD_EXAMPLES` (default `ON`) — build the `dal-cpp` example programs
 - `DAL_CPP_BUILD_BENCHMARKS` (CMake option default `ON`, but the `base` preset in `CMakePresets.json` overrides it to `off`, so preset-driven builds — including `build_linux.sh` without `--benchmarks`/`--full` — disable benchmarks) — build the `dal-cpp` benchmark programs
 - `DAL_USE_ADEPT_AAD` / `DAL_USE_XAD_AAD` / `DAL_USE_CODIPACK_AAD` — pick the AAD backend (source default: all three OFF, i.e. the native backend; CMake presets also override all three to OFF unless explicitly enabled)
-- `DAL_ENABLE_SANITIZERS` (default empty, i.e. instrumentation off) — semicolon-separated sanitizer list (e.g. `"address;undefined"` or `"thread"`); GCC/Clang only, applies `-fsanitize=<list>` plus `-fno-omit-frame-pointer` to the compile and link of every target in the workspace
+- `DAL_ENABLE_SANITIZERS` (default empty, i.e. instrumentation off) — semicolon-separated sanitizer list (e.g. `"address;undefined"` or `"thread"`); GCC/Clang only, applies `-fsanitize=<list>` to the compile and link of every target in the workspace, plus compile-only `-fno-omit-frame-pointer`
 
 CMake installs into a per-preset stage directory (`CMAKE_INSTALL_PREFIX=${sourceDir}/build/stage/${presetName}` in `CMakePresets.json`); `build_linux.sh` installs into `build/stage/Release-linux/`, placing binaries in `bin/`, libraries in `lib/`, and headers in `include/` under that stage directory.
 
@@ -135,7 +135,7 @@ The backend persists all entities through a SQLAlchemy 2.x store (`app/services/
 
 Start the web UI with `./dal-web/scripts/start.sh` on Linux/macOS or `dal-web/scripts/start.ps1` on Windows (requires Python 3.13+, uv, Node.js 20+, npm). Frontend at http://localhost:5173, backend API docs at http://127.0.0.1:8001/docs. For frontend e2e, run `./dal-web/scripts/setup-playwright.sh` once, then `cd dal-web/frontend && npm run test:e2e`.
 
-**Code generation** — `dal-cpp/config/dal.ifc` is processed by the Machinist tool. `build_linux.sh` runs Machinist twice:
+**Code generation** — `dal-cpp/config/dal.ifc` is processed by the Machinist tool. Regeneration is opt-in: `build_linux.sh --generate` (or `cmake --build build/Release-linux --target dal_generate` on a configured tree) runs Machinist twice:
 - once with `-d ./dal-cpp/dal` to produce core enum and serialization files under `dal-cpp/dal/auto/`
 - once with `-d ./dal-excel` to produce Excel public-function stubs under `dal-excel/auto/`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,6 +130,16 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - Sobol inverse-CDF policy table and clone-equivalent state/flag preservation
   - Path seeking via direct state reconstruction (`SobolSet_::SkipTo`, MRG32k32a matrix jump)
 
+- **[dates.md](methodology/dates.md)** — Dates, Calendars, and Schedules
+  - `Date_` serial-day value type, Excel conversion, and string parsing
+  - Process-wide holiday centers, `Holidays_` unions, and business-day adjustment
+  - Tenor and special-day increments, schedule generation, and day-count bases
+
+- **[index_parsing.md](methodology/index_parsing.md)** — Index Names and Parsing
+  - `Index_` interface, environment fixing lookup, and name-driven `Index::Parse`
+  - Registered `EQ` and `FX` parser grammars; IR indices constructed in C++
+  - Composite indices and historical index paths
+
 ## Experimental (`experimental/`)
 
 Reference studies and capability explorations that are not normative methodology:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -114,20 +114,21 @@ with an unknown CPU baseline.
 
 ### Common CMake options
 
-| Option | Base default | Description |
-|--------|----------------|-------------|
-| `DAL_BUILD_PUBLIC` | `ON` | Build the public convenience facade |
-| `DAL_BUILD_PYTHON` | `OFF` | Build the pybind11 module |
-| `DAL_BUILD_EXCEL` | `OFF` | Build the Windows Excel add-in |
-| `DAL_CPP_BUILD_TESTS` | `ON` | Build core tests |
-| `DAL_PUBLIC_BUILD_TESTS` | `ON` | Build public-facade tests |
-| `DAL_CPP_BUILD_EXAMPLES` | `ON` | Build C++ examples |
-| `DAL_CPP_BUILD_BENCHMARKS` | `OFF` | Build benchmarks |
-| `DAL_ENABLE_NATIVE_ARCH` | `OFF` | Tune Release code for the build machine |
-| `DAL_ENABLE_SANITIZERS` | `""` | Semicolon-separated sanitizer list for all targets (GCC/Clang only) |
-| `DAL_USE_XAD_AAD` | `OFF` | Use XAD |
-| `DAL_USE_CODIPACK_AAD` | `OFF` | Use CoDiPack |
-| `DAL_USE_ADEPT_AAD` | `OFF` | Use Adept |
+| Option                     | Base default | Description                                                                           |
+|----------------------------|--------------|---------------------------------------------------------------------------------------|
+| `DAL_BUILD_PUBLIC`         | `ON`         | Build the public convenience facade                                                   |
+| `DAL_BUILD_PYTHON`         | `OFF`        | Build the pybind11 module                                                             |
+| `DAL_BUILD_EXCEL`          | `OFF`        | Build the Windows Excel add-in                                                        |
+| `DAL_CPP_BUILD_TESTS`      | `ON`         | Build core tests                                                                      |
+| `DAL_PUBLIC_BUILD_TESTS`   | `ON`         | Build public-facade tests                                                             |
+| `DAL_CPP_BUILD_EXAMPLES`   | `ON`         | Build C++ examples                                                                    |
+| `DAL_CPP_BUILD_BENCHMARKS` | `OFF`        | Build benchmarks                                                                      |
+| `DAL_ENABLE_NATIVE_ARCH`   | `OFF`        | Tune Release code for the build machine                                               |
+| `DAL_ENABLE_SANITIZERS`    | `""`         | Semicolon-separated sanitizer list for all targets (GCC/Clang only)                   |
+| `DAL_USE_XAD_AAD`          | `OFF`        | Use XAD                                                                               |
+| `DAL_USE_CODIPACK_AAD`     | `OFF`        | Use CoDiPack                                                                          |
+| `DAL_USE_ADEPT_AAD`        | `OFF`        | Use Adept                                                                             |
+| `MSVC_RUNTIME`             | `dynamic`    | MSVC-only C++ runtime: `static` for `/MT` (`/MTd` in Debug), otherwise `/MD` (`/MDd`) |
 
 ## Windows C++ and Excel
 
@@ -143,6 +144,14 @@ cmake --install build/Release-windows
 `Release-windows` enables the Excel add-in. Use `Debug-windows` for a Debug
 configuration. The staged prefix is `build/stage/Release-windows` or
 `build/stage/Debug-windows`.
+
+Both Windows presets set `MSVC_RUNTIME=static`, so every workspace target
+links the static C++ runtime (`/MT`, or `/MTd` in Debug). `MSVC_RUNTIME` is a
+workspace-level cache variable in the top-level `CMakeLists.txt`; it applies
+only under MSVC, defaults to `dynamic` (`/MD`, or `/MDd` in Debug), and any
+value other than `static` selects the dynamic runtime. The installed package
+republishes the linked runtime as `DAL_CPP_MSVC_RUNTIME_LIBRARY` — see
+[Installed CMake Packages](#installed-cmake-packages).
 
 ## Installed CMake Packages
 

--- a/docs/methodology/dates.md
+++ b/docs/methodology/dates.md
@@ -1,0 +1,86 @@
+# Dates, Calendars, and Schedules
+
+This note describes the date machinery in `dal-cpp/dal/time/`: the `Date_`
+value type, holiday centers and business-day adjustment, date increments,
+schedule generation, and day-count bases.
+
+## Dates
+
+`Date_` (`dal-cpp/dal/time/date.hpp`) is a value type wrapping a `uint16_t`
+serial day count. Construction from year, month, and day validates each field
+and accepts years in [1900, 2199]; a default-constructed `Date_` is invalid
+(`IsValid()` returns false). Comparisons and `operator-` (a day difference)
+work directly on the serial, and `AddDays`, `++`, and `--` shift by whole
+days.
+
+Free functions in `namespace Dal::Date` cover component access (`Year`,
+`Month`, `Day`, `DayOfWeek`), month arithmetic (`AddMonths` with optional
+end-of-month preservation, `EndOfMonth`), and Excel interop: `FromExcel` /
+`ToExcel` convert to and from the Excel 1900 date system, and
+`NumericValueOf` exposes the Excel serial as a `double` for storage and
+interpolation coordinates. `Date::FromString`
+(`dal-cpp/dal/time/dateutils.cpp`) recognizes `mm/dd/yyyy` (two-digit years
+map to 20xx) and `yyyy-mm-dd`; `Date::IsDateString` predicts whether a string
+matches one of those formats.
+
+`DateTime_` (`dal-cpp/dal/time/datetime.hpp`) pairs a `Date_` with a `double`
+day fraction, giving roughly one-second resolution for fixing times.
+
+## Holiday centers and business days
+
+Holiday data lives in process-wide named centers
+(`dal-cpp/dal/time/holidaydata.hpp`). Each `HolidayCenterData_` holds a center
+name, a sorted holiday list, and a sorted work-weekend list (weekend days
+that count as business days). `Holidays::AddCenter` registers a center;
+`Calendars_::Init` (`dal-cpp/dal/time/calendars/init.cpp`) registers the
+built-in centers — `CN.SSE`, `CN.IB` (which adds work weekends), and `TARGET`
+(computed over 2000-2100) — when `RegisterAll_::Init` runs at library
+initialization.
+
+A `Holidays_` object (`dal-cpp/dal/time/holidays.hpp`) is built from a
+space-separated list of center names and unions their calendars; the empty
+string selects no holidays (`Holidays::None()`). A date is a business day
+when it is a listed work weekend, or a weekday that is not a holiday in any
+constituent center (`Holidays::IsBusinessDay`). `Holidays::NextBus` and
+`PrevBus` roll a date to the nearest business day, and `Holidays::Adjust`
+applies a `BizDayConvention_` — `Unadjusted`, `Following`,
+`ModifiedFollowing`, or `Preceding`.
+
+`CountBusDays_` counts business days in a range. Multi-center combinations
+are merged once into a cached combined center; counting then handles full
+weeks arithmetically and scans only the partial week at the end of the range.
+
+## Date increments
+
+`Date::Increment_` (`dal-cpp/dal/time/dateincrement.hpp`) is the step
+interface: `FwdFrom` and `BackFrom` move a date forward or backward.
+`Date::ParseIncrement` builds increments from strings:
+
+- tenor steps such as `3M`, `10Y`, or `2W`, with step sizes from the
+  `DateStepSize_` enumeration (`Y`, `M`, `W`, `BD`, `CD`);
+- an optional holiday suffix after `;` (for example `5BD;CN.IB`) that rolls
+  the stepped date to a business day on those calendars;
+- special-day names (`IMM`, `IMM1`, `CDS`, `EOM`) that step to the next or
+  previous quarterly or monthly IMM date, CDS standard maturity, or month
+  end; and
+- `&`-joined compounds that apply each sub-increment in sequence.
+
+`Date::NBusDays` and `Date::ToIMM` are factory shortcuts for business-day
+steps and IMM rolls. `IsLiborTenor` / `IsSwapTenor` classify tenor strings: a
+tenor containing `Y` (or `y`) is a swap tenor; anything else is a Libor
+tenor.
+
+## Schedules and day counts
+
+A `Schedule_` is a `Vector_<Date_>` (`dal-cpp/dal/time/schedules.hpp`).
+`DateGenerate` lays out an unadjusted strip at a fixed tenor, forward from
+the start or backward from the maturity (`DateGeneration_`), and
+`MakeSchedule` applies holiday adjustment on top. `MakeSchedulePeriods`
+returns `SchedulePeriod_` records carrying unadjusted and accrual dates,
+fixing and payment dates with independent lags and calendars, a stub flag,
+and a `DayBasis::Context_` for coupon-aware day counts.
+
+`DayBasis_` (`dal-cpp/dal/time/daybasis.hpp`) is the extensible day-count
+enumeration — `ACT_365F`, `ACT_365L`, `ACT_360`, `ACT_ACT`, and `BOND`
+(30/360). Calling a basis with start and end dates, plus an optional coupon
+context, returns the year fraction used for accrual.

--- a/docs/methodology/index_parsing.md
+++ b/docs/methodology/index_parsing.md
@@ -1,0 +1,84 @@
+# Index Names and Parsing
+
+This note describes how `dal-cpp/dal/indice/` turns index name strings into
+`Index_` objects and how indices resolve fixings.
+
+## The `Index_` interface
+
+`Index_` (`dal-cpp/dal/indice/index.hpp`) is the minimal market-observable
+interface: `Name()` returns the canonical name, and
+`Fixing(_ENV, fixingTime)` returns the value at a fixing time. The base
+implementation of `Fixing` resolves the index by name through the
+environment: `Index::PastFixing` fetches the `FixingsAccess_` environment
+entry, retrieves the `Fixings_` record held for the name, and looks up the
+exact `DateTime_` in its map. A missing record or time throws unless the
+caller passes the `quiet` flag, which returns $-\infty$ instead. `IndexKey_`
+wraps a handle with its name so scenario containers can order indices.
+
+## Parse dispatch
+
+`Index::Parse(const String_&)` (`dal-cpp/dal/indice/indexparse.cpp`) first
+tries composite parsing, then single-index parsing. Single parsing splits the
+name at the first `:` or `[`: the prefix before the separator selects a
+parser from a process-wide registry, and the selected parser interprets the
+remainder of the string. A name with no separator currently matches nothing,
+and an unregistered prefix throws.
+
+Parsers self-register through `Index::RegisterParser(name, func)` under a
+mutex. The built-in registrations are installed once by
+`IndexParsers_::Init()` (`dal-cpp/dal/indice/parser/init.cpp`), which runs as
+part of `RegisterAll_::Init` at library initialization:
+
+| Prefix | Parser                                                         | Produces         |
+|--------|----------------------------------------------------------------|------------------|
+| `EQ`   | `Index::EquityParser` (`dal-cpp/dal/indice/parser/equity.cpp`) | `Index::Equity_` |
+| `FX`   | `Index::FxParser` (`dal-cpp/dal/indice/parser/fx.cpp`)         | `Index::Fx_`     |
+
+`Index::Clone` re-parses `src.Name()`, so round-tripping an index through its
+name works only for families with a registered parser.
+
+## Equity names
+
+The equity grammar is `EQ[stock]` with an optional delivery suffix
+(`dal-cpp/dal/indice/parser/equity.cpp`):
+
+- `EQ[stock]` — spot equity; the delivery date falls back to
+  `Date::Maximum()`;
+- `EQ[stock]@2027-06-18` — forward with an explicit delivery date parsed by
+  `Date::FromString`;
+- `EQ[stock]>3M` — forward whose delivery is the fixing date stepped by a
+  date increment (see [dates, calendars, and schedules](dates.md)).
+
+## FX names
+
+The FX grammar is `FX[fgn/dom]` (`dal-cpp/dal/indice/parser/fx.cpp`) — for
+example `FX[USD/JPY]` is one USD priced in JPY. `Index::Fx_::Fixing` first
+looks up `FX[fgn/dom]` in the environment's fixings and falls back to the
+reciprocal of `FX[dom/fgn]`.
+
+## IR indices are constructed, not parsed
+
+Interest-rate indices (`dal-cpp/dal/indice/index/ir.hpp`) have canonical name
+formats but no registered string parser: `Libor_`, `Swap_`, and `DF_` are
+built directly in C++:
+
+- `Libor_(ccy, tenor)` names itself `IR:<ccy>,<tenor>` (for example
+  `IR:USD,Libor3M`);
+- `Swap_(ccy, tenor)` names itself `IR:<ccy>,<tenor>` with a numeric-leading
+  tenor (for example `IR:USD,5Y`);
+- `DF_(ccy, maturity)` names itself `IR[DF]:<ccy>,<maturity>`.
+
+Start and maturity offsets are `Cell_` values resolved against the fixing
+date: empty means the fixing date itself, an integer is a day offset, a date
+or datetime is absolute, and a string is applied as a date increment.
+`Libor_` and `Swap_` start dates then roll by the currency's spot-lag
+convention (`Libor::StartFromFix` in `dal-cpp/dal/protocol/conventions.cpp`).
+
+## Composites and historical paths
+
+`Index::Composite_` (`dal-cpp/dal/indice/indexcomposite.hpp`) declares a
+weighted component list; the composite parsing hook is a placeholder that
+currently matches nothing. `IndexPathHistorical_`
+(`dal-cpp/dal/indice/indexpath.hpp`) adapts a fixing time series to the
+`IndexPath_` interface used where models need path-level expectations and
+range probabilities.


### PR DESCRIPTION
## Summary

- Consolidate the four agent-facing guides (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `.codex/skills/dal-agent-team/references/shared-rules.md`) around one source of truth: `CLAUDE.md` owns build/test commands, workspace CMake options, and the architecture map; `.claude/rules/` owns coding and test conventions; the siblings keep per-audience specifics and cross-link instead of duplicating (codebase-review plan P2.17).
- Add `.github/pull_request_template.md` encoding the PR conventions from `.claude/rules/git-commit-pr.md` (prefixed imperative title under 70 chars, `## Summary` + `## Test plan` sections).
- Add conceptual notes `docs/methodology/dates.md` (dates, holiday centers, increments, schedules, day bases; grounded in `dal-cpp/dal/time/`) and `docs/methodology/index_parsing.md` (name-driven `Index::Parse`, EQ/FX grammars, constructed IR indices; grounded in `dal-cpp/dal/indice/`), linked from `docs/README.md` and the `CLAUDE.md` methodology list.
- Document `MSVC_RUNTIME` in `docs/installation.md` (common-options table row plus a Windows-section paragraph; re-aligned the options table).
- Folded-in fixes: route enum regeneration through the `dal_generate` target in `.claude/rules/code-style.md` (the prebuilt Machinist binary is git-ignored on fresh clones); note in `CLAUDE.md` that codegen is `--generate`-gated; replace the legacy `mkdir build` flow in copilot instructions with the preset flow; correct the `DAL_ENABLE_SANITIZERS` wording (`-fno-omit-frame-pointer` is compile-only); fix the `check_docs.py` stale-table wording for `bin/` test binaries (they are installed to the staged `bin/` but go stale there).

## Test plan

- [x] `python3 .github/scripts/check_docs.py` — green locally ("Documentation checks passed for 34 Markdown files.")
- [x] `python3 -m pytest .github/scripts/tests/test_check_docs.py -q` — green locally (18 passed)
- [x] Docs-only change (Markdown, one GitHub template, one checker wording string) — no C++ build required; CI Docs job reruns both checkers
