### PR TITLE
test: Add core unit tests for model, risk, indice, optimization

### DIFF
--- a/dal-cpp/dal/model/ivs.hpp
+++ b/dal-cpp/dal/model/ivs.hpp
@@ -20,10 +20,7 @@ namespace Dal::AAD {
     public:
         RiskView_() : isEmpty_(true){};
         RiskView_(const Vector_<>& strikes, const Vector_<>& mats)
-            : isEmpty_(false), strikes_(strikes), mats_(mats), spreads_(strikes.size(), mats.size()) {
-            for (auto& spr : spreads_)
-                spr = T_(0.0);
-        }
+            : isEmpty_(false), strikes_(strikes), mats_(mats), spreads_(strikes.size(), mats.size(), T_(0.0)) {}
 
         T_ Spread(double strike, double mat) const {
             return isEmpty_ ? T_(0.0) : Interp2DLinearImplX(strikes_, mats_, spreads_, strike, mat);

--- a/dal-cpp/tests/indice/index/test_ir.cpp
+++ b/dal-cpp/tests/indice/index/test_ir.cpp
@@ -22,3 +22,77 @@ TEST(IndexTest, TestLiborNameWithStart) {
     Index::Libor_ libor(ccy, tenor, start);
     ASSERT_EQ(libor.Name(), "IR:USD,LIBOR_3M_LCH,2022-02-03");
 }
+
+TEST(IndexTest, TestSwapName) {
+    Index::Swap_ swap(Ccy_("USD"), "10Y");
+    ASSERT_EQ(swap.Name(), "IR:USD,10Y");
+}
+
+TEST(IndexTest, TestSwapNameWithStart) {
+    Cell_ start(Date_(2022, 2, 3));
+    Index::Swap_ swap(Ccy_("USD"), "10Y", start);
+    ASSERT_EQ(swap.Name(), "IR:USD,10Y,2022-02-03");
+}
+
+TEST(IndexTest, TestDFName) {
+    {
+        Index::DF_ df(Ccy_("USD"), Cell_(Date_(2023, 6, 15)));
+        ASSERT_EQ(df.Name(), "IR[DF]:USD,2023-06-15");
+    }
+    {
+        Index::DF_ df(Ccy_("USD"), Cell_(String_("3M")));
+        ASSERT_EQ(df.Name(), "IR[DF]:USD,3M");
+    }
+    {
+        Cell_ start(Date_(2022, 1, 3));
+        Index::DF_ df(Ccy_("USD"), Cell_(Date_(2023, 6, 15)), &start);
+        ASSERT_EQ(df.Name(), "IR[DF]:USD,2022-01-03,2023-06-15");
+    }
+}
+
+TEST(IndexTest, TestDFStartAndMaturityFromCellForms) {
+    const DateTime_ fixing_time(Date_(2022, 2, 2));
+
+    {
+        // empty start defaults to the fixing date
+        Index::DF_ df(Ccy_("USD"), Cell::FromInt(30));
+        ASSERT_EQ(df.StartDate(fixing_time), Date_(2022, 2, 2));
+        ASSERT_EQ(df.Maturity(fixing_time), Date_(2022, 3, 4));
+    }
+    {
+        // date cells are used verbatim
+        Cell_ start(Date_(2022, 1, 15));
+        Index::DF_ df(Ccy_("USD"), Cell_(Date_(2023, 6, 15)), &start);
+        ASSERT_EQ(df.StartDate(fixing_time), Date_(2022, 1, 15));
+        ASSERT_EQ(df.Maturity(fixing_time), Date_(2023, 6, 15));
+    }
+    {
+        // string cells are date increments forward of the fixing date
+        Index::DF_ df(Ccy_("USD"), Cell_(String_("1W")));
+        ASSERT_EQ(df.Maturity(fixing_time), Date_(2022, 2, 9));
+    }
+}
+
+TEST(IndexTest, TestLiborStartDateAppliesFixingLag) {
+    Ccy_ ccy("USD");
+    TradedRate_ tenor("LIBOR3MLCH");
+    Index::Libor_ libor(ccy, tenor);
+
+    {
+        // default conventions: two business-day lag, no holiday calendar
+        const DateTime_ fixing_time(Date_(2022, 2, 2)); // Wednesday
+        ASSERT_EQ(libor.StartDate(fixing_time), Date_(2022, 2, 4));
+    }
+    {
+        // the lag rolls over the weekend
+        const DateTime_ fixing_time(Date_(2022, 2, 4)); // Friday
+        ASSERT_EQ(libor.StartDate(fixing_time), Date_(2022, 2, 8));
+    }
+    {
+        // an explicit date start bypasses the fixing-lag roll, even on a weekend
+        Cell_ start(Date_(2022, 2, 5)); // Saturday
+        Index::Libor_ libor_with_start(ccy, tenor, start);
+        const DateTime_ fixing_time(Date_(2022, 2, 2));
+        ASSERT_EQ(libor_with_start.StartDate(fixing_time), Date_(2022, 2, 5));
+    }
+}

--- a/dal-cpp/tests/indice/parser/test_equity.cpp
+++ b/dal-cpp/tests/indice/parser/test_equity.cpp
@@ -6,7 +6,9 @@
 #include <dal/platform/platform.hpp>
 #include <dal/string/strings.hpp>
 #include <dal/indice/index.hpp>
+#include <dal/indice/index/equity.hpp>
 #include <dal/indice/parser/equity.hpp>
+#include <dal/time/datetime.hpp>
 
 using namespace Dal;
 
@@ -26,4 +28,29 @@ TEST(IndexTest, TestParserWithTenor) {
     String_ name = "EQ[IBM]>3M";
     std::unique_ptr<Index_> index(Index::EquityParser(name));
     ASSERT_EQ(index->Name(), name);
+}
+
+TEST(IndexTest, TestParserWithTenorVariants) {
+    for (const char* name : {"EQ[IBM]>1W", "EQ[IBM]>6M", "EQ[IBM]>2Y"}) {
+        std::unique_ptr<Index_> index(Index::EquityParser(String_(name)));
+        ASSERT_EQ(index->Name(), String_(name));
+    }
+}
+
+TEST(IndexTest, TestParserRejectsMalformedDeliveryDate) {
+    ASSERT_THROW((void)Index::EquityParser(String_("EQ[IBM]@not-a-date")), Dal::Exception_);
+}
+
+TEST(IndexTest, TestParserDeliveryOfParsedForms) {
+    const DateTime_ fixing_time(Date_(2022, 1, 22));
+
+    std::unique_ptr<Index_> with_date(Index::EquityParser(String_("EQ[IBM]@2022-01-24")));
+    auto eq_with_date = dynamic_cast<const Index::Equity_*>(with_date.get());
+    ASSERT_TRUE(eq_with_date != nullptr);
+    ASSERT_EQ(eq_with_date->Delivery(fixing_time), Date_(2022, 1, 24));
+
+    std::unique_ptr<Index_> with_delay(Index::EquityParser(String_("EQ[IBM]>3M")));
+    auto eq_with_delay = dynamic_cast<const Index::Equity_*>(with_delay.get());
+    ASSERT_TRUE(eq_with_delay != nullptr);
+    ASSERT_EQ(eq_with_delay->Delivery(fixing_time), Date_(2022, 4, 22));
 }

--- a/dal-cpp/tests/indice/parser/test_fx.cpp
+++ b/dal-cpp/tests/indice/parser/test_fx.cpp
@@ -25,3 +25,15 @@ TEST(IndexTest, TestFxParserRegisteredWithIndexParse) {
     std::unique_ptr<Index_> index(Index::Parse(name));
     ASSERT_EQ(index->Name(), name);
 }
+
+TEST(IndexTest, TestFxParserRejectsMissingOpenBracket) {
+    ASSERT_THROW((void)Index::FxParser(String_("FXUSD/JPY]")), Dal::Exception_);
+}
+
+TEST(IndexTest, TestFxParserRejectsMissingCloseBracket) {
+    ASSERT_THROW((void)Index::FxParser(String_("FX[USD/JPY")), Dal::Exception_);
+}
+
+TEST(IndexTest, TestFxParserRejectsMissingSeparator) {
+    ASSERT_THROW((void)Index::FxParser(String_("FX[USDJPY]")), Dal::Exception_);
+}

--- a/dal-cpp/tests/indice/parser/test_indexparse.cpp
+++ b/dal-cpp/tests/indice/parser/test_indexparse.cpp
@@ -1,0 +1,68 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#include <gtest/gtest.h>
+#include <dal/platform/platform.hpp>
+#include <dal/indice/index.hpp>
+#include <dal/indice/index/equity.hpp>
+#include <dal/indice/index/fx.hpp>
+#include <dal/indice/indexparse.hpp>
+#include <dal/string/strings.hpp>
+
+using namespace Dal;
+
+TEST(IndexParseTest, TestParseDispatchesEquityForms) {
+    {
+        std::unique_ptr<Index_> index(Index::Parse(String_("EQ[IBM]")));
+        ASSERT_EQ(index->Name(), String_("EQ[IBM]"));
+    }
+    {
+        std::unique_ptr<Index_> index(Index::Parse(String_("EQ[IBM]@2022-01-24")));
+        ASSERT_EQ(index->Name(), String_("EQ[IBM]@2022-01-24"));
+    }
+    {
+        std::unique_ptr<Index_> index(Index::Parse(String_("EQ[IBM]>3M")));
+        ASSERT_EQ(index->Name(), String_("EQ[IBM]>3M"));
+    }
+}
+
+TEST(IndexParseTest, TestParseDispatchesFxForm) {
+    std::unique_ptr<Index_> index(Index::Parse(String_("FX[EUR/GBP]")));
+    ASSERT_EQ(index->Name(), String_("FX[EUR/GBP]"));
+}
+
+TEST(IndexParseTest, TestParseRejectsUnknownPrefix) {
+    ASSERT_THROW((void)Index::Parse(String_("XX[ABC]")), Dal::Exception_);
+    ASSERT_THROW((void)Index::Parse(String_("IR:USD,3M")), Dal::Exception_);
+}
+
+TEST(IndexParseTest, TestParseBareNameReturnsNull) {
+    // bare names route to the (not yet supported) supershot parser, which yields null
+    std::unique_ptr<Index_> index(Index::Parse(String_("IBM")));
+    ASSERT_TRUE(index == nullptr);
+}
+
+TEST(IndexParseTest, TestCloneRoundTripsThroughName) {
+    std::unique_ptr<Index_> index(Index::Parse(String_("FX[USD/JPY]")));
+    const Handle_<Index_> cloned = Index::Clone(*index);
+    ASSERT_FALSE(cloned.IsEmpty());
+    ASSERT_EQ(cloned->Name(), String_("FX[USD/JPY]"));
+}
+
+TEST(IndexParseTest, TestRegisterParserAddsNewPrefix) {
+    Index::RegisterParser(String_("TST"), [](const String_&) -> std::unique_ptr<Index_> {
+        return std::make_unique<Index::Fx_>(Ccy_("USD"), Ccy_("EUR"));
+    });
+    std::unique_ptr<Index_> index(Index::Parse(String_("TST[ANYTHING]")));
+    ASSERT_EQ(index->Name(), String_("FX[EUR/USD]"));
+}
+
+TEST(IndexParseTest, TestRegisterParserKeepsFirstRegistration) {
+    // std::map::insert does not overwrite, so re-registering an existing prefix is a no-op
+    Index::RegisterParser(String_("FX"), [](const String_&) -> std::unique_ptr<Index_> {
+        return std::make_unique<Index::Fx_>(Ccy_("USD"), Ccy_("EUR"));
+    });
+    std::unique_ptr<Index_> index(Index::Parse(String_("FX[USD/JPY]")));
+    ASSERT_EQ(index->Name(), String_("FX[USD/JPY]"));
+}

--- a/dal-cpp/tests/math/optimization/test_underdetermined.cpp
+++ b/dal-cpp/tests/math/optimization/test_underdetermined.cpp
@@ -112,6 +112,16 @@ namespace {
         [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] * x[0] - 4.0}; }
     };
 
+    class MixedVectorFunc_ : public Underdetermined::Function_ {
+    public:
+        [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] + 2.0 * x[1], x[0] * x[1] - 1.0}; }
+    };
+
+    class ProductFunc_ : public Underdetermined::Function_ {
+    public:
+        [[nodiscard]] Vector_<> F(const Vector_<>& x) const override { return Vector_<>{x[0] * x[1] - 2.0}; }
+    };
+
     class BacktrackProbeFunc_ : public Underdetermined::Function_ {
         Vector_<Vector_<>>& evaluations_;
 
@@ -457,4 +467,99 @@ TEST(UnderdeterminedTest, TestFindSkipsAtSolutionGradientWhenOutParamNull) {
 
     ASSERT_FALSE(WasGradientCalledAt(xsNull, solved, 1e-9));
     ASSERT_TRUE(WasGradientCalledAt(xsOut, solved, 1e-9));
+}
+
+TEST(UnderdeterminedTest, TestControlsRejectInvalidSettings) {
+    {
+        Dictionary_ dict;
+        dict.Insert("MAXEVALUATIONS", Cell_(0.0));
+        dict.Insert("MAXRESTARTS", Cell_(10.0));
+        ASSERT_THROW((void)UnderdeterminedControls_(dict), Exception_);
+    }
+    {
+        Dictionary_ dict;
+        dict.Insert("MAXEVALUATIONS", Cell_(20.0));
+        dict.Insert("MAXRESTARTS", Cell_(0.0));
+        ASSERT_THROW((void)UnderdeterminedControls_(dict), Exception_);
+    }
+    {
+        Dictionary_ dict;
+        dict.Insert("MAXEVALUATIONS", Cell_(20.0));
+        dict.Insert("MAXRESTARTS", Cell_(10.0));
+        dict.Insert("RESTARTTOLERANCE", Cell_(1.5));
+        ASSERT_THROW((void)UnderdeterminedControls_(dict), Exception_);
+    }
+    {
+        // maxBacktrack must exceed backtrackTolerance
+        Dictionary_ dict;
+        dict.Insert("MAXEVALUATIONS", Cell_(20.0));
+        dict.Insert("MAXRESTARTS", Cell_(10.0));
+        dict.Insert("BACKTRACKTOLERANCE", Cell_(0.9));
+        ASSERT_THROW((void)UnderdeterminedControls_(dict), Exception_);
+    }
+}
+
+TEST(UnderdeterminedTest, TestControlsDefaults) {
+    const UnderdeterminedControls_ controls = MakeControls();
+    ASSERT_EQ(controls.maxEvaluations_, 20);
+    ASSERT_EQ(controls.maxRestarts_, 10);
+    ASSERT_EQ(controls.maxBacktrackTries_, 5);
+    ASSERT_NEAR(controls.restartTolerance_, 0.4, 1e-10);
+    ASSERT_NEAR(controls.backtrackTolerance_, 0.1, 1e-10);
+    ASSERT_NEAR(controls.maxBacktrack_, 0.8, 1e-10);
+}
+
+TEST(UnderdeterminedTest, TestFiniteDifferenceGradientMatchesAnalytic) {
+    {
+        // component-wise linear map: the forward-difference Jacobian is exact
+        MixedVectorFunc_ func;
+        const Vector_<> x{1.5, 2.0};
+        Matrix_<> j;
+        func.Gradient(x, func.F(x), &j);
+        ASSERT_EQ(j.Rows(), 2);
+        ASSERT_EQ(j.Cols(), 2);
+        ASSERT_NEAR(j(0, 0), 1.0, 1e-8);
+        ASSERT_NEAR(j(0, 1), 2.0, 1e-8);
+        ASSERT_NEAR(j(1, 0), 2.0, 1e-8);
+        ASSERT_NEAR(j(1, 1), 1.5, 1e-8);
+    }
+    {
+        // quadratic term: forward differences pick up half the second derivative times the bump
+        NonlinearSquareDenseFunc_ func;
+        const Vector_<> x{3.0};
+        Matrix_<> j;
+        func.Gradient(x, func.F(x), &j);
+        ASSERT_EQ(j.Rows(), 1);
+        ASSERT_EQ(j.Cols(), 1);
+        ASSERT_NEAR(j(0, 0), 6.0 + 1.0e-4, 1e-8);
+    }
+}
+
+TEST(UnderdeterminedTest, TestApproximateReturnsGuessWhenAlreadyWithinFitTolerance) {
+    LinearSumFunc_ func(0.5);
+    const Vector_<> guess = {0.0, 0.0};
+    const Vector_<> funcTol = {1.0};
+
+    TriDiagonal_ weights(2);
+    SetDiagonalWeights(&weights, 1.0, 1.0);
+    // scaled residual at the guess has norm 0.5, below the fit tolerance
+    const Vector_<> calculated = Underdetermined::Approximate(func, guess, funcTol, 1.0, weights, MakeControls());
+    ASSERT_NEAR(calculated[0], 0.0, 1e-10);
+    ASSERT_NEAR(calculated[1], 0.0, 1e-10);
+}
+
+TEST(UnderdeterminedTest, TestFindSolvesNonlinearMinNormSolution) {
+    ProductFunc_ func;
+    const Vector_<> guess = {1.0, 1.0};
+    const Vector_<> tol = {1.0e-10};
+
+    TriDiagonal_ weights(2);
+    SetDiagonalWeights(&weights, 1.0, 1.0);
+    std::unique_ptr<SymmetricDecomposition_> decomp(weights.DecomposeSymmetric());
+
+    // minimum-norm solution of x0 * x1 = 2 nearest the guess is (sqrt(2), sqrt(2))
+    const Vector_<> calculated = Underdetermined::Find(func, guess, tol, *decomp, MakeControls());
+    ASSERT_NEAR(calculated[0], std::sqrt(2.0), 1e-8);
+    ASSERT_NEAR(calculated[1], std::sqrt(2.0), 1e-8);
+    ASSERT_NEAR(func.F(calculated)[0], 0.0, 1e-9);
 }

--- a/dal-cpp/tests/math/optimization/test_underdeterminedutils.cpp
+++ b/dal-cpp/tests/math/optimization/test_underdeterminedutils.cpp
@@ -1,0 +1,88 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/platform/platform.hpp>
+#include <dal/math/matrix/banded.hpp>
+#include <dal/math/optimization/underdeterminedutils.hpp>
+
+using Dal::DateTime_;
+using Dal::Exception_;
+using Dal::Vector_;
+using Dal::Sparse::TriDiagonal_;
+
+TEST(UnderdeterminedUtilsTest, TestSelfCouplePWCBuildsExpectedWeights) {
+    TriDiagonal_ weights(3);
+    const Vector_<DateTime_> knots(3);
+    Dal::Underdetermined::SelfCouplePWC(&weights, knots, 0.5);
+
+    ASSERT_EQ(weights.Size(), 3);
+    ASSERT_NEAR(weights(0, 0), 1.0, 1e-10);
+    ASSERT_NEAR(weights(1, 1), 1.5, 1e-10);
+    ASSERT_NEAR(weights(2, 2), 1.0, 1e-10);
+    ASSERT_NEAR(weights(0, 1), -0.5, 1e-10);
+    ASSERT_NEAR(weights(1, 0), -0.5, 1e-10);
+    ASSERT_NEAR(weights(1, 2), -0.5, 1e-10);
+    ASSERT_NEAR(weights(2, 1), -0.5, 1e-10);
+}
+
+TEST(UnderdeterminedUtilsTest, TestSelfCouplePWCRespectsOffset) {
+    TriDiagonal_ weights(4);
+    const Vector_<DateTime_> knots(2);
+    Dal::Underdetermined::SelfCouplePWC(&weights, knots, 1.0, 2);
+
+    ASSERT_NEAR(weights(0, 0), 0.0, 1e-10);
+    ASSERT_NEAR(weights(1, 1), 0.0, 1e-10);
+    // each of the two knots couples to the other, so both diagonal entries are 2 * tau
+    ASSERT_NEAR(weights(2, 2), 2.0, 1e-10);
+    ASSERT_NEAR(weights(3, 3), 2.0, 1e-10);
+    ASSERT_NEAR(weights(2, 3), -1.0, 1e-10);
+    ASSERT_NEAR(weights(3, 2), -1.0, 1e-10);
+}
+
+TEST(UnderdeterminedUtilsTest, TestSelfCouplePWCAccumulatesIntoExistingWeights) {
+    TriDiagonal_ weights(2);
+    const Vector_<DateTime_> knots(2);
+    Dal::Underdetermined::SelfCouplePWC(&weights, knots, 0.5);
+    Dal::Underdetermined::SelfCouplePWC(&weights, knots, 0.5);
+
+    ASSERT_NEAR(weights(0, 0), 2.0, 1e-10);
+    ASSERT_NEAR(weights(1, 1), 2.0, 1e-10);
+    ASSERT_NEAR(weights(0, 1), -1.0, 1e-10);
+    ASSERT_NEAR(weights(1, 0), -1.0, 1e-10);
+}
+
+TEST(UnderdeterminedUtilsTest, TestSelfCouplePWCRejectsInvalidInputs) {
+    const Vector_<DateTime_> knots(2);
+    {
+        ASSERT_THROW(Dal::Underdetermined::SelfCouplePWC(nullptr, knots, 0.5), Exception_);
+    }
+    {
+        TriDiagonal_ weights(3);
+        ASSERT_THROW(Dal::Underdetermined::SelfCouplePWC(&weights, knots, 0.5, -1), Exception_);
+    }
+    {
+        TriDiagonal_ weights(3);
+        ASSERT_THROW(Dal::Underdetermined::SelfCouplePWC(&weights, knots, 0.0), Exception_);
+    }
+    {
+        // 2 knots at offset 1 need a 3x3 matrix
+        TriDiagonal_ weights(2);
+        ASSERT_THROW(Dal::Underdetermined::SelfCouplePWC(&weights, knots, 0.5, 1), Exception_);
+    }
+}
+
+TEST(UnderdeterminedUtilsTest, TestWeightsPWCReturnsSizedTridiagonal) {
+    const Vector_<DateTime_> knots(4);
+    const std::unique_ptr<TriDiagonal_> weights = Dal::Underdetermined::WeightsPWC(knots, 0.25);
+
+    ASSERT_EQ(weights->Size(), 4);
+    ASSERT_NEAR((*weights)(0, 0), 0.5, 1e-10);
+    ASSERT_NEAR((*weights)(1, 1), 0.75, 1e-10);
+    ASSERT_NEAR((*weights)(2, 2), 0.75, 1e-10);
+    ASSERT_NEAR((*weights)(3, 3), 0.5, 1e-10);
+    ASSERT_NEAR((*weights)(0, 1), -0.25, 1e-10);
+    ASSERT_NEAR((*weights)(3, 2), -0.25, 1e-10);
+}

--- a/dal-cpp/tests/model/test_blackscholes.cpp
+++ b/dal-cpp/tests/model/test_blackscholes.cpp
@@ -3,7 +3,11 @@
 //
 
 #include <gtest/gtest.h>
+
+#include <cmath>
+
 #include <dal/platform/platform.hpp>
+#include <dal/math/aad/sample.hpp>
 #include <dal/model/blackscholes.hpp>
 #include <dal/storage/json.hpp>
 
@@ -38,4 +42,144 @@ TEST(ModelTest, TestBlackScholesMutantModelRejectsSlides) {
     ModelData_& base = model_data;
     Vector_<Handle_<Slide_>> slides{Handle_<Slide_>(std::make_shared<Slide_>())};
     ASSERT_THROW((void)base.MutantModel(String_("renamed"), slides), Dal::Exception_);
+}
+
+TEST(ModelTest, TestBlackScholesModelDataParameterLabels) {
+    const BSModelData_ model_data("my_model", 100.0, 0.20, 0.05, 0.01);
+    ASSERT_EQ(model_data.parameterLabels_.size(), 4);
+    ASSERT_EQ(model_data.parameterLabels_[0], String_("spot"));
+    ASSERT_EQ(model_data.parameterLabels_[1], String_("vol"));
+    ASSERT_EQ(model_data.parameterLabels_[2], String_("rate"));
+    ASSERT_EQ(model_data.parameterLabels_[3], String_("div"));
+}
+
+TEST(ModelTest, TestBlackScholesModelParametersTrackMembers) {
+    AAD::BlackScholes_<> model(100.0, 0.20, 0.05, 0.01);
+    ASSERT_EQ(model.NumParams(), 4);
+    ASSERT_EQ(model.Parameters().size(), 4);
+    ASSERT_EQ(model.ParameterLabels().size(), 4);
+    ASSERT_EQ(model.ParameterLabels()[0], String_("spot"));
+    ASSERT_EQ(model.ParameterLabels()[1], String_("vol"));
+    ASSERT_EQ(model.ParameterLabels()[2], String_("rate"));
+    ASSERT_EQ(model.ParameterLabels()[3], String_("div"));
+
+    ASSERT_NEAR(model.Spot(), 100.0, 1e-10);
+    ASSERT_NEAR(model.Vol(), 0.20, 1e-10);
+    ASSERT_NEAR(model.Rate(), 0.05, 1e-10);
+    ASSERT_NEAR(model.Div(), 0.01, 1e-10);
+
+    // Parameters() exposes the live members, so writes through it move the model
+    *model.Parameters()[0] = 110.0;
+    *model.Parameters()[1] = 0.25;
+    ASSERT_NEAR(model.Spot(), 110.0, 1e-10);
+    ASSERT_NEAR(model.Vol(), 0.25, 1e-10);
+}
+
+TEST(ModelTest, TestBlackScholesModelDefaultsRateAndDivToZero) {
+    const AAD::BlackScholes_<> model(100.0, 0.20);
+    ASSERT_NEAR(model.Rate(), 0.0, 1e-14);
+    ASSERT_NEAR(model.Div(), 0.0, 1e-14);
+}
+
+TEST(ModelTest, TestBlackScholesModelCloneIsIndependent) {
+    AAD::BlackScholes_<> model(100.0, 0.20, 0.05, 0.01);
+    std::unique_ptr<AAD::Model_<>> cloned(model.Clone());
+
+    *cloned->Parameters()[0] = 50.0;
+    ASSERT_NEAR(model.Spot(), 100.0, 1e-10);
+    ASSERT_NEAR(model.Vol(), 0.20, 1e-10);
+
+    auto bs_clone = dynamic_cast<const AAD::BlackScholes_<>*>(cloned.get());
+    ASSERT_TRUE(bs_clone != nullptr);
+    ASSERT_NEAR(bs_clone->Spot(), 50.0, 1e-10);
+    ASSERT_NEAR(bs_clone->Vol(), 0.20, 1e-10);
+    ASSERT_NEAR(bs_clone->Rate(), 0.05, 1e-10);
+    ASSERT_NEAR(bs_clone->Div(), 0.01, 1e-10);
+}
+
+TEST(ModelTest, TestBlackScholesAllocateRejectsEmptyTimeline) {
+    AAD::BlackScholes_<> model(100.0, 0.20, 0.05, 0.01);
+    const Vector_<> empty_timeline;
+    const Vector_<AAD::SampleDef_> definitions;
+    ASSERT_THROW(model.Allocate(empty_timeline, definitions), Dal::Exception_);
+}
+
+TEST(ModelTest, TestBlackScholesDeterministicPathWithToday) {
+    constexpr double spot = 100.0;
+    constexpr double vol = 0.20;
+    constexpr double rate = 0.05;
+    constexpr double div = 0.01;
+
+    AAD::BlackScholes_<> model(spot, vol, rate, div);
+    const Vector_<> timeline{0.0, 1.0, 2.0};
+    Vector_<AAD::SampleDef_> definitions(3);
+    model.Allocate(timeline, definitions);
+    model.Init(timeline, definitions);
+    ASSERT_EQ(model.SimDim(), 2);
+
+    AAD::Scenario_<> path;
+    AAD::AllocatePath(definitions, path);
+    AAD::InitializePath(path);
+
+    const Vector_<> gaussian(model.SimDim(), 0.0);
+    model.GeneratePath(gaussian, &path);
+
+    // zero Gaussian increments leave the pure drift path spot * exp((rate - div - vol^2 / 2) * t)
+    const double drift = rate - div - 0.5 * vol * vol;
+    ASSERT_NEAR(path[0].spot_, spot, 1e-10);
+    ASSERT_NEAR(path[1].spot_, spot * std::exp(drift * 1.0), 1e-10);
+    ASSERT_NEAR(path[2].spot_, spot * std::exp(drift * 2.0), 1e-10);
+
+    for (int i = 0; i < 3; ++i)
+        ASSERT_NEAR(path[i].numeraire_, std::exp(rate * timeline[i]), 1e-10);
+}
+
+TEST(ModelTest, TestBlackScholesDeterministicPathWithoutToday) {
+    constexpr double spot = 100.0;
+    constexpr double vol = 0.20;
+    constexpr double rate = 0.05;
+    constexpr double div = 0.01;
+
+    AAD::BlackScholes_<> model(spot, vol, rate, div);
+    const Vector_<> timeline{1.0, 2.0};
+    Vector_<AAD::SampleDef_> definitions(2);
+    model.Allocate(timeline, definitions);
+    model.Init(timeline, definitions);
+    ASSERT_EQ(model.SimDim(), 2);
+
+    AAD::Scenario_<> path;
+    AAD::AllocatePath(definitions, path);
+    AAD::InitializePath(path);
+
+    const Vector_<> gaussian(model.SimDim(), 0.0);
+    model.GeneratePath(gaussian, &path);
+
+    const double drift = rate - div - 0.5 * vol * vol;
+    ASSERT_NEAR(path[0].spot_, spot * std::exp(drift * 1.0), 1e-10);
+    ASSERT_NEAR(path[1].spot_, spot * std::exp(drift * 2.0), 1e-10);
+}
+
+TEST(ModelTest, TestBlackScholesGeneratePathWithNonzeroGaussian) {
+    constexpr double spot = 100.0;
+    constexpr double vol = 0.20;
+    constexpr double rate = 0.05;
+    constexpr double div = 0.01;
+
+    AAD::BlackScholes_<> model(spot, vol, rate, div);
+    const Vector_<> timeline{0.0, 1.5};
+    Vector_<AAD::SampleDef_> definitions(2);
+    model.Allocate(timeline, definitions);
+    model.Init(timeline, definitions);
+    ASSERT_EQ(model.SimDim(), 1);
+
+    AAD::Scenario_<> path;
+    AAD::AllocatePath(definitions, path);
+    AAD::InitializePath(path);
+
+    const Vector_<> gaussian{1.0};
+    model.GeneratePath(gaussian, &path);
+
+    const double drift = rate - div - 0.5 * vol * vol;
+    ASSERT_NEAR(path[0].spot_, spot, 1e-10);
+    ASSERT_NEAR(path[1].spot_, spot * std::exp(drift * 1.5 + vol * std::sqrt(1.5)), 1e-10);
 }

--- a/dal-cpp/tests/model/test_factory.cpp
+++ b/dal-cpp/tests/model/test_factory.cpp
@@ -1,0 +1,56 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/platform/platform.hpp>
+#include <dal/model/factory.hpp>
+#include <dal/storage/archive.hpp>
+
+using namespace Dal;
+
+namespace {
+    class UnsupportedModelData_ : public ModelData_ {
+    public:
+        UnsupportedModelData_() : ModelData_("UnsupportedModelData_", "unsupported") {}
+
+        void Write(Archive::Store_&) const override {}
+
+    private:
+        std::unique_ptr<ModelData_> MutantModel(const String_*, const Slide_*) const override {
+            return std::make_unique<UnsupportedModelData_>();
+        }
+    };
+} // namespace
+
+TEST(ModelTest, TestCreateModelBuildsBlackScholes) {
+    const Handle_<ModelData_> model_data(std::make_shared<BSModelData_>("my_model", 100.0, 0.20, 0.05, 0.01));
+    std::unique_ptr<AAD::Model_<>> model = CreateModel<double>(model_data);
+
+    auto bs = dynamic_cast<const AAD::BlackScholes_<>*>(model.get());
+    ASSERT_TRUE(bs != nullptr);
+    ASSERT_NEAR(bs->Spot(), 100.0, 1e-10);
+    ASSERT_NEAR(bs->Vol(), 0.20, 1e-10);
+    ASSERT_NEAR(bs->Rate(), 0.05, 1e-10);
+    ASSERT_NEAR(bs->Div(), 0.01, 1e-10);
+}
+
+TEST(ModelTest, TestCreateModelBuildsDupire) {
+    const Vector_<> spots = {90.0, 100.0, 110.0};
+    const Vector_<> times = {0.25, 0.5, 1.0};
+    const Matrix_<> vols(3, 3, 0.2);
+    const Handle_<ModelData_> model_data(std::make_shared<DupireModelData_>("my_model", 100.0, 0.05, 0.01, spots, times, vols));
+    std::unique_ptr<AAD::Model_<>> model = CreateModel<double>(model_data);
+
+    auto dupire = dynamic_cast<const AAD::Dupire_<>*>(model.get());
+    ASSERT_TRUE(dupire != nullptr);
+    ASSERT_NEAR(dupire->Spot(), 100.0, 1e-10);
+    ASSERT_EQ(dupire->Spots(), spots);
+    ASSERT_EQ(dupire->Times(), times);
+}
+
+TEST(ModelTest, TestCreateModelRejectsUnknownModelData) {
+    const Handle_<ModelData_> model_data(std::make_shared<UnsupportedModelData_>());
+    ASSERT_THROW((void)CreateModel<double>(model_data), Dal::Exception_);
+}

--- a/dal-cpp/tests/model/test_ivs.cpp
+++ b/dal-cpp/tests/model/test_ivs.cpp
@@ -1,0 +1,52 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/platform/platform.hpp>
+#include <dal/model/ivs.hpp>
+
+using namespace Dal;
+
+TEST(ModelTest, TestEmptyRiskViewHasZeroSpread) {
+    const AAD::RiskView_<double> risk_view;
+    ASSERT_TRUE(risk_view.IsEmpty());
+    ASSERT_NEAR(risk_view.Spread(100.0, 1.0), 0.0, 1e-10);
+    ASSERT_NEAR(risk_view.Spread(50.0, 5.0), 0.0, 1e-10);
+}
+
+TEST(ModelTest, TestRiskViewGridAccessors) {
+    const Vector_<> strikes{90.0, 100.0, 110.0};
+    const Vector_<> mats{1.0, 2.0};
+    const AAD::RiskView_<double> risk_view(strikes, mats);
+    ASSERT_FALSE(risk_view.IsEmpty());
+    ASSERT_EQ(risk_view.Rows(), 3);
+    ASSERT_EQ(risk_view.Cols(), 2);
+    ASSERT_EQ(risk_view.Strikes(), strikes);
+    ASSERT_EQ(risk_view.Mats(), mats);
+}
+
+TEST(ModelTest, TestRiskViewBumpAccumulatesIntoSpreads) {
+    AAD::RiskView_<double> risk_view({90.0, 100.0, 110.0}, {1.0, 2.0});
+    ASSERT_NEAR(risk_view.Spread(100.0, 2.0), 0.0, 1e-10);
+
+    risk_view.Bump(1, 1, 0.02);
+    risk_view.Bump(1, 1, 0.01);
+    ASSERT_NEAR(risk_view.Risks()(1, 1), 0.03, 1e-10);
+    ASSERT_NEAR(risk_view.Spread(100.0, 2.0), 0.03, 1e-10);
+}
+
+TEST(ModelTest, TestRiskViewSpreadInterpolatesBilinearly) {
+    AAD::RiskView_<double> risk_view({90.0, 100.0, 110.0}, {1.0, 2.0});
+    risk_view.Bump(1, 1, 0.02);
+
+    // on-grid neighbours of the bumped knot stay at zero
+    ASSERT_NEAR(risk_view.Spread(100.0, 1.0), 0.0, 1e-10);
+    ASSERT_NEAR(risk_view.Spread(90.0, 2.0), 0.0, 1e-10);
+    ASSERT_NEAR(risk_view.Spread(110.0, 2.0), 0.0, 1e-10);
+
+    // halfway in both coordinates picks up one quarter of the bumped knot
+    ASSERT_NEAR(risk_view.Spread(95.0, 1.5), 0.005, 1e-10);
+    ASSERT_NEAR(risk_view.Spread(105.0, 1.5), 0.005, 1e-10);
+}

--- a/dal-cpp/tests/model/test_utilities.cpp
+++ b/dal-cpp/tests/model/test_utilities.cpp
@@ -1,0 +1,59 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/platform/platform.hpp>
+#include <dal/model/utilities.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+TEST(ModelTest, TestFillDataLeavesWideSpacedGridUntouched) {
+    const Vector_<> original{0.0, 1.0, 2.0};
+    const Vector_<> filled = AAD::FillData(original, 10.0);
+    ASSERT_EQ(filled, original);
+}
+
+TEST(ModelTest, TestFillDataRefinesToMaxSpacing) {
+    const Vector_<> original{0.0, 1.0};
+    const Vector_<> filled = AAD::FillData(original, 0.3);
+    ASSERT_EQ(filled.size(), 5);
+    ASSERT_NEAR(filled[0], 0.0, 1e-10);
+    ASSERT_NEAR(filled[1], 0.25, 1e-10);
+    ASSERT_NEAR(filled[2], 0.5, 1e-10);
+    ASSERT_NEAR(filled[3], 0.75, 1e-10);
+    ASSERT_NEAR(filled[4], 1.0, 1e-10);
+}
+
+TEST(ModelTest, TestFillDataDropsPointsCloserThanMinSpacing) {
+    const Vector_<> original{0.0, 1.0};
+    // refinement spacing is 0.25; the candidate at 0.75 is within 0.26 of the knot at 1.0
+    const Vector_<> filled = AAD::FillData(original, 0.3, 0.26);
+    ASSERT_EQ(filled.size(), 4);
+    ASSERT_NEAR(filled[0], 0.0, 1e-10);
+    ASSERT_NEAR(filled[1], 0.25, 1e-10);
+    ASSERT_NEAR(filled[2], 0.5, 1e-10);
+    ASSERT_NEAR(filled[3], 1.0, 1e-10);
+}
+
+TEST(ModelTest, TestFillDataUnionsAddedPoints) {
+    const Vector_<> original{0.0, 1.0, 2.0};
+    const Vector_<> added{0.5, 1.5};
+    const Vector_<> filled = AAD::FillData(original, 10.0, 0.0, added.begin(), added.end());
+    ASSERT_EQ(filled.size(), 5);
+    ASSERT_NEAR(filled[0], 0.0, 1e-10);
+    ASSERT_NEAR(filled[1], 0.5, 1e-10);
+    ASSERT_NEAR(filled[2], 1.0, 1e-10);
+    ASSERT_NEAR(filled[3], 1.5, 1e-10);
+    ASSERT_NEAR(filled[4], 2.0, 1e-10);
+}
+
+TEST(ModelTest, TestFillDataIgnoresAddedPointNearExistingKnot) {
+    const Vector_<> original{0.0, 1.0};
+    const Vector_<> added{1.005};
+    // 1.005 is within minDx of the existing knot at 1.0, so the union keeps only the original knot
+    const Vector_<> filled = AAD::FillData(original, 10.0, 0.01, added.begin(), added.end());
+    ASSERT_EQ(filled, original);
+}

--- a/dal-cpp/tests/risk/test_report.cpp
+++ b/dal-cpp/tests/risk/test_report.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <dal/risk/report.hpp>
+#include <dal/storage/json.hpp>
 
 using namespace Dal;
 
@@ -48,4 +49,160 @@ TEST(RiskTest, TestReportHeader) {
 
     header = report.Header("header2");
     ASSERT_EQ(header.labels_, Vector_<String_>({"b", "c"}));
+}
+
+TEST(RiskTest, TestReportRejectsEmptyAxes) {
+    const Vector_<Report::Axis_> no_axes;
+    ASSERT_THROW(Report_("test_report", no_axes), Dal::Exception_);
+}
+
+TEST(RiskTest, TestReportRejectsZeroSizeAfterFirstAxis) {
+    const Vector_<Report::Axis_> axes = {{"header1", 1, {"a"}},
+                                         {"header2", 0, {}}};
+    ASSERT_THROW(Report_("test_report", axes), Dal::Exception_);
+}
+
+TEST(RiskTest, TestReportRejectsUnknownAxisLookup) {
+    const Vector_<Report::Axis_> axes = {{"header1", 1, {"a"}}};
+    Report_ report("test_report", axes);
+    ASSERT_THROW((void)report.Size("bogus"), Dal::Exception_);
+    ASSERT_THROW((void)report.Header("bogus"), Dal::Exception_);
+
+    auto address = report.MakeAddress();
+    ASSERT_THROW((void)address["bogus"], Dal::Exception_);
+}
+
+TEST(RiskTest, TestReportMultiAxisLayout) {
+    const Vector_<Report::Axis_> axes = {{"header1", 2, {"a", "b"}},
+                                         {"header2", 3, {"c", "d", "e"}}};
+    Report_ report("test_report", axes);
+    ASSERT_EQ(report.Size("header1"), 2);
+    ASSERT_EQ(report.Size("header2"), 3);
+
+    auto address = report.MakeAddress();
+    double value = 0.0;
+    for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 3; ++j) {
+            address["header1"] = i;
+            address["header2"] = j;
+            report[address] = value;
+            value += 1.0;
+        }
+
+    value = 0.0;
+    for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 3; ++j) {
+            address["header1"] = i;
+            address["header2"] = j;
+            ASSERT_NEAR(report[address], value, 1e-10);
+            value += 1.0;
+        }
+}
+
+TEST(RiskTest, TestReportConstAccessRejectsOutOfRangeAddress) {
+    const Vector_<Report::Axis_> axes = {{"header1", 2, {"a", "b"}},
+                                         {"header2", 3, {"c", "d", "e"}}};
+    const Report_ report("test_report", axes);
+
+    auto address = report.MakeAddress();
+    address["header1"] = 1;
+    address["header2"] = 5;
+    ASSERT_THROW((void)report[address], Dal::Exception_);
+}
+
+TEST(RiskTest, TestReportFirstAxisGrowsOnWrite) {
+    const Vector_<Report::Axis_> axes = {{"trade", 0, {}},
+                                         {"view", 2, {"x", "y"}}};
+    Report_ report("test_report", axes);
+    ASSERT_EQ(report.Size("trade"), 0);
+    ASSERT_EQ(report.Size("view"), 2);
+
+    auto address = report.MakeAddress();
+    address["trade"] = 1;
+    address["view"] = 1;
+    report[address] = 5.0;
+
+    ASSERT_EQ(report.Size("trade"), 2);
+    ASSERT_NEAR(report[address], 5.0, 1e-10);
+
+    address["trade"] = 0;
+    address["view"] = 0;
+    ASSERT_NEAR(report[address], 0.0, 1e-10);
+}
+
+TEST(RiskTest, TestReportSetAll) {
+    const Vector_<Report::Axis_> axes = {{"header1", 2, {"a", "b"}},
+                                         {"header2", 3, {"c", "d", "e"}}};
+    Report_ report("test_report", axes);
+
+    {
+        // 5 values is not a multiple of the first stride (3)
+        ASSERT_THROW(report.SetAll(Vector_<>(5, 1.0)), Dal::Exception_);
+    }
+    {
+        // 3 values would silently drop existing storage
+        ASSERT_THROW(report.SetAll(Vector_<>(3, 1.0)), Dal::Exception_);
+    }
+    {
+        Vector_<> all(6);
+        for (int i = 0; i < 6; ++i)
+            all[i] = 10.0 + i;
+        report.SetAll(all);
+
+        auto address = report.MakeAddress();
+        address["header1"] = 1;
+        address["header2"] = 2;
+        ASSERT_NEAR(report[address], 15.0, 1e-10);
+    }
+}
+
+TEST(RiskTest, TestReportAddHeaderRowRejectsWrongWidth) {
+    const Vector_<Report::Axis_> axes = {{"header1", 2, {"a", "b"}}};
+    Report_ report("test_report", axes);
+    ASSERT_THROW(report.AddHeaderRow("header1", 0, {Cell_(1.0)}), Dal::Exception_);
+}
+
+TEST(RiskTest, TestReportAddHeaderRowExtendsValues) {
+    const Vector_<Report::Axis_> axes = {{"header1", 1, {"a"}}};
+    Report_ report("test_report", axes);
+
+    report.AddHeaderRow("header1", 2, {Cell_(42.0)});
+    const auto& header = report.Header("header1");
+    ASSERT_EQ(header.values_.Rows(), 3);
+    ASSERT_NEAR(Cell::ToDouble(header.values_(2, 0)), 42.0, 1e-10);
+}
+
+TEST(RiskTest, TestReportRoundTripsThroughJSON) {
+    const Vector_<Report::Axis_> axes = {{"header1", 2, {"a", "b"}},
+                                         {"header2", 2, {"c", "d"}}};
+    Report_ report("test_report", axes);
+    report.AddHeaderRow("header1", 0, {Cell_(1.0), Cell_(10.0)});
+    report.AddHeaderRow("header1", 1, {Cell_(2.0), Cell_(20.0)});
+    report.AddHeaderRow("header2", 0, {Cell_("sample1"), Cell_("sample2")});
+    report.AddHeaderRow("header2", 1, {Cell_("sample3"), Cell_("sample4")});
+
+    auto address = report.MakeAddress();
+    address["header1"] = 0;
+    address["header2"] = 1;
+    report[address] = 3.5;
+    address["header1"] = 1;
+    address["header2"] = 0;
+    report[address] = -2.5;
+
+    const String_ dst = JSON::WriteString(report);
+    Handle_<Storable_> rtn = JSON::ReadString(dst, true);
+    auto restored = std::dynamic_pointer_cast<const Report_>(rtn);
+    ASSERT_TRUE(restored != nullptr);
+    ASSERT_EQ(restored->Name(), String_("test_report"));
+    ASSERT_EQ(restored->Axes(), report.Axes());
+    ASSERT_EQ(restored->Size("header1"), 2);
+    ASSERT_EQ(restored->Size("header2"), 2);
+    ASSERT_EQ(restored->Header("header2").labels_, Vector_<String_>({"c", "d"}));
+
+    address["header1"] = 0;
+    address["header2"] = 1;
+    ASSERT_NEAR((*restored)[address], 3.5, 1e-10);
+    address["header1"] = 1;
+    address["header2"] = 0;
+    ASSERT_NEAR((*restored)[address], -2.5, 1e-10);
 }


### PR DESCRIPTION
## Summary

Tranche 7a of the codebase-review plan (P2.16, first sub-tranche): close the highest-value core unit-test gaps in `dal-cpp` for `dal/model`, `dal/risk`, `dal/indice` parsers, and `dal/math/optimization`.

**Defect fix (own commit, `1a84c730`):** the two-argument `RiskView_` constructor in `dal-cpp/dal/model/ivs.hpp` did not compile anywhere it was instantiated — it zero-filled the spreads matrix by assigning through `Matrix_`'s const-only `begin()/end()` iterators. No call site existed, so the defect stayed latent until the new `RiskView_` tests instantiated it. Fixed by passing `T_(0.0)` to the `Matrix_` constructor (which already zero-fills via its default value argument) and dropping the broken loop.

New coverage by module (58 tests total):

- **model** (+20 tests, all in `ModelTest`): `BlackScholes_<double>` parameter labels and write-through `Parameters()`, default rate/div, clone independence (clone's `Parameters()` point at the clone), `Allocate` empty-timeline rejection, `SimDim`, and exact log-drift path generation with zero Gaussian increments (today and no-today timelines, numeraire values — deterministic, no Monte Carlo); `CreateModel` factory for `BSModelData_`/`DupireModelData_` plus rejection of unknown `ModelData_`; `FillData` refinement (max spacing, min-spacing drop, added-point union, near-knot dedup); `RiskView_` empty/grid accessors/bump accumulation/bilinear interpolation.
- **risk** (+10 tests, `RiskTest`): `Report_` axis validation (empty axes, zero size after the first axis, unknown axis on `Size`/`Header`/`Address_`), 2x3 stride layout, const-access bounds check, grow-on-write first axis, `SetAll` size validation, header-row width validation and extension, and a JSON storable round-trip.
- **indice** (+18 tests: new `IndexParseTest` suite with 7, `IndexTest` +11): `Index::Parse` dispatch for EQ forms (name/`@date`/`>tenor`) and FX, unknown-prefix `REQUIRE` failure, bare-name null fall-through (supershot placeholder), `Index::Clone` round-trip, `RegisterParser` add and insert-no-overwrite semantics; equity parser tenor variants, malformed delivery date rejection, parsed `Delivery()`; fx parser rejection of missing `[`/`]`/`/`; IR `Swap_`/`DF_` `Name()` forms, `DF_` start/maturity from empty/int/date/string cells, and Libor start-date fixing-lag conventions (2 business days, weekend roll, explicit-date bypass).
- **optimization** (+10 tests: `UnderdeterminedTest` +5, new `UnderdeterminedUtilsTest` suite with 5): controls condition validation (non-positive evaluation/restart limits, restart tolerance > 1, maxBacktrack <= backtrackTolerance) and defaults; finite-difference `Function_::Gradient` vs analytic Jacobians (exact linear case + first-order quadratic case); `Approximate` early return when the guess already fits; nonlinear `Find` converging to the known minimum-norm solution `(sqrt(2), sqrt(2))` of `x0*x1 = 2`; `SelfCouplePWC` weights (3-knot grid, offset block, accumulation semantics, null/negative-offset/non-positive-tau/too-small-matrix rejection) and `WeightsPWC` sizing.

All tests are `T_ = double`-only (no backend-sensitive casts or tolerances) so they pass identically on all four AAD backends.

## Test plan

- [x] `bash` preset build (`cmake --preset=Release-linux` + `cmake --build -j32`) clean
- [x] Full `./build/Release-linux/dal-cpp/dal_cpp_tests`: **1057 passed** (baseline 999; +58 tests, 86 -> 88 suites)
- [x] Full `./build/Release-linux/dal-public/dal_public_tests`: **56 passed** (unchanged)
- [x] `ctest --test-dir build/Release-linux -N` discovers the new suites; `ctest --test-dir build/Release-linux --output-on-failure -LE benchmark`: **1113/1113 passed**
- [x] New suites run through ctest: `ctest -R 'IndexParseTest|UnderdeterminedUtilsTest|ModelTest|RiskTest|UnderdeterminedTest'`: 68/68 passed
- [x] Flake check — 3 repeated runs of `--gtest_filter='ModelTest.*:RiskTest.*:IndexTest.*:IndexParseTest.*:UnderdeterminedTest.*:UnderdeterminedUtilsTest.*'`: 89/89 passed each time