### PR TITLE
test: Excel registration-table and IVS analytic test coverage

### DIFF
--- a/dal-cpp/tests/model/test_ivs.cpp
+++ b/dal-cpp/tests/model/test_ivs.cpp
@@ -4,10 +4,25 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include <dal/platform/platform.hpp>
 #include <dal/model/ivs.hpp>
 
+#include "../math/aad/models/flat_ivs.hpp"
+
 using namespace Dal;
+
+namespace {
+    double NormalCdf(double x) { return 0.5 * std::erfc(-x / std::sqrt(2.0)); }
+
+    double ReferenceBlackCall(double fwd, double strike, double vol, double mat) {
+        const double stdDev = vol * std::sqrt(mat);
+        const double dPlus = std::log(fwd / strike) / stdDev + 0.5 * stdDev;
+        const double dMinus = dPlus - stdDev;
+        return fwd * NormalCdf(dPlus) - strike * NormalCdf(dMinus);
+    }
+} // namespace
 
 TEST(ModelTest, TestEmptyRiskViewHasZeroSpread) {
     const AAD::RiskView_<double> risk_view;
@@ -49,4 +64,87 @@ TEST(ModelTest, TestRiskViewSpreadInterpolatesBilinearly) {
     // halfway in both coordinates picks up one quarter of the bumped knot
     ASSERT_NEAR(risk_view.Spread(95.0, 1.5), 0.005, 1e-10);
     ASSERT_NEAR(risk_view.Spread(105.0, 1.5), 0.005, 1e-10);
+}
+
+TEST(ModelTest, TestFlatIVSCallMatchesBlackClosedForm) {
+    const double spot = 100.0;
+    const double vol = 0.20;
+    const double rate = 0.05;
+    const double div = 0.01;
+    const AAD::FlatIVS_ ivs(spot, rate, div, vol);
+
+    for (const double strike : {80.0, 100.0, 120.0}) {
+        for (const double mat : {0.5, 1.0, 2.0}) {
+            const double fwd = spot * std::exp((rate - div) * mat);
+            const double expected = std::exp(-rate * mat) * ReferenceBlackCall(fwd, strike, vol, mat);
+            ASSERT_NEAR(ivs.Call(strike, mat), expected, 1e-10);
+        }
+    }
+}
+
+TEST(ModelTest, TestFlatIVSCallDefaultsToZeroRates) {
+    const AAD::FlatIVS_ ivs(100.0, 0.0, 0.0, 0.25);
+    ASSERT_NEAR(ivs.Spot(), 100.0, 1e-14);
+
+    {
+        const double expected = ReferenceBlackCall(100.0, 100.0, 0.25, 1.0);
+        ASSERT_NEAR(ivs.Call(100.0, 1.0), expected, 1e-10);
+    }
+    {
+        const double expected = ReferenceBlackCall(100.0, 90.0, 0.25, 0.5);
+        ASSERT_NEAR(ivs.Call(90.0, 0.5), expected, 1e-10);
+    }
+}
+
+TEST(ModelTest, TestFlatIVSCallAddsRiskViewSpread) {
+    const AAD::FlatIVS_ ivs(100.0, 0.0, 0.0, 0.20);
+    AAD::RiskView_<double> risk_view({90.0, 100.0, 110.0}, {1.0, 2.0});
+    risk_view.Bump(1, 1, 0.03);
+
+    {
+        const double expected = ReferenceBlackCall(100.0, 100.0, 0.23, 2.0);
+        ASSERT_NEAR(ivs.Call(100.0, 2.0, &risk_view), expected, 1e-10);
+    }
+    {
+        // neighbouring knots keep the base vol
+        const double expected = ReferenceBlackCall(100.0, 100.0, 0.20, 1.0);
+        ASSERT_NEAR(ivs.Call(100.0, 1.0, &risk_view), expected, 1e-10);
+    }
+    {
+        // an empty view prices exactly like no view
+        const AAD::RiskView_<double> empty_view;
+        ASSERT_NEAR(ivs.Call(100.0, 2.0, &empty_view), ivs.Call(100.0, 2.0), 1e-14);
+    }
+}
+
+TEST(ModelTest, TestFlatIVSLocalVolIsFlat) {
+    {
+        const AAD::FlatIVS_ ivs(100.0, 0.0, 0.0, 0.25);
+        for (const double strike : {80.0, 100.0, 120.0})
+            for (const double mat : {0.5, 1.0, 2.0})
+                ASSERT_NEAR(ivs.LocalVol(strike, mat), 0.25, 1e-7);
+    }
+    {
+        // deterministic rates do not tilt the flat surface
+        const AAD::FlatIVS_ ivs(100.0, 0.05, 0.02, 0.20);
+        for (const double strike : {90.0, 110.0})
+            for (const double mat : {1.0, 2.0})
+                ASSERT_NEAR(ivs.LocalVol(strike, mat), 0.20, 1e-7);
+    }
+}
+
+TEST(ModelTest, TestMertonIVSZeroIntensityImpliedVolIsFlat) {
+    const AAD::MertonIVS_ ivs(100.0, 0.20, 0.0, -0.10, 0.05);
+    for (const double strike : {80.0, 100.0, 120.0})
+        for (const double mat : {0.5, 1.0, 2.0})
+            ASSERT_NEAR(ivs.ImpliedVol(strike, mat), 0.20, 1e-9);
+}
+
+TEST(ModelTest, TestMertonIVSZeroIntensityCallMatchesBlack) {
+    const AAD::MertonIVS_ ivs(100.0, 0.20, 0.0, -0.10, 0.05);
+    for (const double strike : {80.0, 100.0, 120.0})
+        for (const double mat : {0.5, 1.0, 2.0}) {
+            const double expected = ReferenceBlackCall(100.0, strike, 0.20, mat);
+            ASSERT_NEAR(ivs.Call(strike, mat), expected, 1e-8);
+        }
 }

--- a/dal-excel/src/__excel_test_api.hpp
+++ b/dal-excel/src/__excel_test_api.hpp
@@ -1,0 +1,35 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#pragma once
+
+#include <dal/platform/platform.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/string/strings.hpp>
+
+#if defined(_WIN32) && defined(DAL_EXCEL_TEST_API_EXPORTS)
+#define DAL_EXCEL_TEST_API __declspec(dllexport)
+#elif defined(_WIN32) && defined(DAL_EXCEL_TEST_API_IMPORTS)
+#define DAL_EXCEL_TEST_API __declspec(dllimport)
+#else
+#define DAL_EXCEL_TEST_API
+#endif
+
+namespace Dal {
+    struct ExcelFuncRegistration_ {
+        String_ cName_;
+        String_ xlName_;
+        String_ argTypes_;
+        String_ argNames_;
+        int argHelpCount_;
+        bool volatile_;
+    };
+
+    DAL_EXCEL_TEST_API Vector_<ExcelFuncRegistration_> RegisteredFunctionsForTest();
+    DAL_EXCEL_TEST_API bool EmptyHandleOutputIsErrorForTest(String_* message);
+    DAL_EXCEL_TEST_API String_ ErrorCellTextForTest(const String_& what);
+    DAL_EXCEL_TEST_API bool EmptyVectorOutputIsBlankForTest(int* rows, int* cols);
+} // namespace Dal
+
+#undef DAL_EXCEL_TEST_API

--- a/dal-excel/src/_excel.cpp
+++ b/dal-excel/src/_excel.cpp
@@ -1566,6 +1566,7 @@ func_with_args is string
     }
 
     bool EmptyHandleOutputIsErrorForTest(String_* message) {
+        REQUIRE(message, "null output pointer");
         try {
             Excel::Retval_ retval;
             retval.LoadBase(nullptr, Handle_<Storable_>());
@@ -1587,6 +1588,7 @@ func_with_args is string
     }
 
     bool EmptyVectorOutputIsBlankForTest(int* rows, int* cols) {
+        REQUIRE(rows && cols, "null output pointer");
         Excel::Retval_ retval;
         retval.Load(Vector_<>());
         OPER_* output = retval.ToXloper();

--- a/dal-excel/src/_excel.cpp
+++ b/dal-excel/src/_excel.cpp
@@ -2,6 +2,7 @@
 
 #define _Regex_traits _Regex_traits_Excel
 #include "_excel.hpp"
+#include "__excel_test_api.hpp"
 #include "_xlcall.hpp"
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
@@ -1555,6 +1556,48 @@ func_with_args is string
 
 #include "dal-excel/auto/MG_Format_Output_public.inc"
 #include "dal-excel/auto/MG_Paste_WithArgs_public.inc"
-}
+
+    Vector_<ExcelFuncRegistration_> RegisteredFunctionsForTest() {
+        Vector_<ExcelFuncRegistration_> retval;
+        for (const auto& func : TheFunctions())
+            retval.push_back(ExcelFuncRegistration_{func.cName_, func.xlName_, func.argTypes_, func.argNames_,
+                                                    static_cast<int>(func.argHelp_.size()), func.volatile_});
+        return retval;
+    }
+
+    bool EmptyHandleOutputIsErrorForTest(String_* message) {
+        try {
+            Excel::Retval_ retval;
+            retval.LoadBase(nullptr, Handle_<Storable_>());
+        } catch (const Exception_& e) {
+            *message = String_(e.what());
+            return true;
+        }
+        return false;
+    }
+
+    String_ ErrorCellTextForTest(const String_& what) {
+        OPER_* error = Excel::Error(what, nullptr);
+        REQUIRE(error->xltype & xltypeMulti && error->val.array.rows * error->val.array.columns == 1,
+                "error output is not a single cell");
+        const String_ retval = Excel::ToString(&error->val.array.lparray[0]);
+        FreeContents(*error, true);
+        free(error);
+        return retval;
+    }
+
+    bool EmptyVectorOutputIsBlankForTest(int* rows, int* cols) {
+        Excel::Retval_ retval;
+        retval.Load(Vector_<>());
+        OPER_* output = retval.ToXloper();
+        *rows = output->val.array.rows;
+        *cols = output->val.array.columns;
+        const bool blank = (output->xltype & xltypeMulti) != 0 && *rows * *cols >= 1 &&
+                           (output->val.array.lparray[0].xltype & (xltypeMissing | xltypeNil)) != 0;
+        FreeContents(*output, true);
+        free(output);
+        return blank;
+    }
+} // namespace Dal
 
 #endif

--- a/dal-excel/tests/test_empty_result.cpp
+++ b/dal-excel/tests/test_empty_result.cpp
@@ -1,0 +1,33 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#ifdef _WIN32
+
+#include <gtest/gtest.h>
+
+#include <dal-excel/src/__excel_test_api.hpp>
+
+using namespace Dal;
+
+TEST(ExcelEmptyResultTest, TestEmptyHandleOutputRaisesError) {
+    String_ message;
+    ASSERT_TRUE(EmptyHandleOutputIsErrorForTest(&message));
+    ASSERT_NE(message.find("Output handle is NULL"), String_::npos) << message.c_str();
+}
+
+TEST(ExcelEmptyResultTest, TestErrorOutputIsAVisibleErrorCell) {
+    const String_ text = ErrorCellTextForTest(String_("something broke"));
+    ASSERT_EQ(text.substr(0, 9), String_("#Error:  ")) << text.c_str();
+    ASSERT_NE(text.find("something broke"), String_::npos) << text.c_str();
+}
+
+TEST(ExcelEmptyResultTest, TestEmptyVectorOutputIsABlankCell) {
+    int rows = 0;
+    int cols = 0;
+    ASSERT_TRUE(EmptyVectorOutputIsBlankForTest(&rows, &cols));
+    ASSERT_EQ(rows, 1);
+    ASSERT_EQ(cols, 1);
+}
+
+#endif

--- a/dal-excel/tests/test_registration.cpp
+++ b/dal-excel/tests/test_registration.cpp
@@ -33,8 +33,8 @@ namespace {
         return 1 + static_cast<int>(std::count(reg.argNames_.begin(), reg.argNames_.end(), ','));
     }
 
-    std::string UpperDotted(const String_& c_name) {
-        std::string retval(c_name.begin(), c_name.end());
+    std::string UpperDotted(const String_& cName) {
+        std::string retval(cName.begin(), cName.end());
         for (auto& ch : retval)
             ch = ch == '_' ? '.' : static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
         return retval;

--- a/dal-excel/tests/test_registration.cpp
+++ b/dal-excel/tests/test_registration.cpp
@@ -1,0 +1,94 @@
+//
+// Created by wegam on 2026/7/19.
+//
+
+#ifdef _WIN32
+
+#include <gtest/gtest.h>
+
+#define NOMINMAX
+#include <Windows.h>
+
+#include <algorithm>
+#include <cctype>
+#include <set>
+#include <string>
+
+#include <dal-excel/src/__excel_test_api.hpp>
+
+using namespace Dal;
+
+namespace {
+    int DeclaredArgCount(const ExcelFuncRegistration_& reg) {
+        // trailing Excel type-text modifiers (e.g. '!' for volatile) declare no argument
+        String_ types = reg.argTypes_;
+        while (!types.empty() && (types.back() == '!' || types.back() == '#' || types.back() == '$'))
+            types.pop_back();
+        return static_cast<int>(types.size()) - 1;
+    }
+
+    int NamedArgCount(const ExcelFuncRegistration_& reg) {
+        if (reg.argNames_.empty())
+            return 0;
+        return 1 + static_cast<int>(std::count(reg.argNames_.begin(), reg.argNames_.end(), ','));
+    }
+
+    std::string UpperDotted(const String_& c_name) {
+        std::string retval(c_name.begin(), c_name.end());
+        for (auto& ch : retval)
+            ch = ch == '_' ? '.' : static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+        return retval;
+    }
+} // namespace
+
+TEST(ExcelRegistrationTest, TestRegistrationTableIsPopulated) {
+    ASSERT_GE(RegisteredFunctionsForTest().size(), 62);
+}
+
+TEST(ExcelRegistrationTest, TestEveryRegisteredFunctionResolvesToAnEntryPoint) {
+    const HMODULE dll = ::GetModuleHandleA("dal_excel.xll");
+    ASSERT_TRUE(dll != nullptr);
+    for (const auto& reg : RegisteredFunctionsForTest())
+        ASSERT_TRUE(::GetProcAddress(dll, reg.cName_.c_str()) != nullptr) << reg.cName_.c_str();
+}
+
+TEST(ExcelRegistrationTest, TestNoDuplicateExcelNames) {
+    std::set<std::string> seen;
+    for (const auto& reg : RegisteredFunctionsForTest()) {
+        const std::string name(reg.xlName_.c_str());
+        ASSERT_TRUE(seen.insert(name).second) << "duplicate Excel name: " << name;
+    }
+}
+
+TEST(ExcelRegistrationTest, TestNoDuplicateCNames) {
+    std::set<std::string> seen;
+    for (const auto& reg : RegisteredFunctionsForTest()) {
+        const std::string name(reg.cName_.c_str());
+        ASSERT_TRUE(seen.insert(name).second) << "duplicate C entry point: " << name;
+    }
+}
+
+TEST(ExcelRegistrationTest, TestArgumentMetadataIsConsistent) {
+    for (const auto& reg : RegisteredFunctionsForTest()) {
+        const int declared = DeclaredArgCount(reg);
+        ASSERT_EQ(declared, NamedArgCount(reg)) << reg.cName_.c_str();
+        ASSERT_EQ(declared, reg.argHelpCount_) << reg.cName_.c_str();
+    }
+}
+
+TEST(ExcelRegistrationTest, TestCNamesFollowWrapperConvention) {
+    for (const auto& reg : RegisteredFunctionsForTest()) {
+        ASSERT_EQ(reg.cName_.substr(0, 3), String_("xl_")) << reg.cName_.c_str();
+        ASSERT_FALSE(reg.xlName_.empty());
+    }
+}
+
+TEST(ExcelRegistrationTest, TestExcelNameMatchesCNameConvention) {
+    for (const auto& reg : RegisteredFunctionsForTest()) {
+        const std::string expected = UpperDotted(reg.cName_.substr(3));
+        const std::string actual(reg.xlName_.c_str());
+        ASSERT_TRUE(actual == expected || actual == "DA." + expected) << reg.cName_.c_str() << " -> " << actual;
+    }
+}
+
+#endif

--- a/docs/superpowers/plans/2026-07-13-xccy-resettable-mtm.md
+++ b/docs/superpowers/plans/2026-07-13-xccy-resettable-mtm.md
@@ -168,7 +168,7 @@ Expected: both commands succeed and core plus Excel generated enum files are pre
 
 - [ ] **Step 5: Run the protocol tests**
 
-Run: `bin/dal_cpp_tests --gtest_filter=CurrencyDataTest.*:XccyMarketTest.TestResetConfigRequiresExplicitFixingIdentity`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=CurrencyDataTest.*:XccyMarketTest.TestResetConfigRequiresExplicitFixingIdentity`
 
 Expected: all selected tests pass.
 
@@ -254,7 +254,7 @@ String_ FxIndexName(const Ccy_& domestic, const Ccy_& foreign) {
 
 - [ ] **Step 5: Run fixing tests**
 
-Run: `bin/dal_cpp_tests --gtest_filter=FixingSnapshotTest.*:IndexFxTest.*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=FixingSnapshotTest.*:IndexFxTest.*`
 
 Expected: all selected tests pass.
 
@@ -339,7 +339,7 @@ Filter coupons with `paymentDate >= valuationTime.Date()`. Add rate requests onl
 
 - [ ] **Step 5: Run plan tests**
 
-Run: `bin/dal_cpp_tests --gtest_filter=XccyPricingTest.Test*Plan*:XccyPricingTest.TestRequiredHistoricalFixings*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=XccyPricingTest.Test*Plan*:XccyPricingTest.TestRequiredHistoricalFixings*`
 
 Expected: all selected tests pass.
 
@@ -424,7 +424,7 @@ Keep `CrossCurrencySwap_::Rate_::operator()(const CrossCurrencyMarket_&)` for co
 
 - [ ] **Step 6: Run pricing tests**
 
-Run: `bin/dal_cpp_tests --gtest_filter=XccyPricingTest.*:XccyMarketTest.TestCrossCurrencySwap*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=XccyPricingTest.*:XccyMarketTest.TestCrossCurrencySwap*`
 
 Expected: fixing, manual MTM, in-progress, fixed regression, missing-fixing, and matured-trade tests pass.
 
@@ -489,7 +489,7 @@ Pass `effJacobianInverse_` and forward Jacobian pointers to `Underdetermined::Fi
 
 - [ ] **Step 7: Run staged and Jacobian tests**
 
-Run: `bin/dal_cpp_tests --gtest_filter=XccyMarketTest.*:XccyBasisJacobianTest.*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=XccyMarketTest.*:XccyBasisJacobianTest.*`
 
 Expected: staged fixed/reset/MTM calibration, started-trade calibration, analytic/central-difference comparison, and bumped mode pass.
 
@@ -571,7 +571,7 @@ Compare analytic and central-difference matrices for every domestic, foreign, an
 
 Move slot definitions, validation, parameter slicing, typed curve construction, smoothing assembly, and diagnostics from the anonymous namespace in `jointcalibration.cpp` into `jointcalibration_internal.hpp`. Keep the original `CalibrateJointMultiCurve` public types and output unchanged.
 
-Run: `bin/dal_cpp_tests --gtest_filter=JointCalibrationTest.*:JointAnalyticJacobianTest.*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=JointCalibrationTest.*:JointAnalyticJacobianTest.*`
 
 Expected: all existing joint tests pass before adding XCCY solve logic.
 
@@ -591,7 +591,7 @@ Use block-diagonal smoothing over all declarations. Exact mode returns both effe
 
 - [ ] **Step 7: Run joint XCCY tests**
 
-Run: `bin/dal_cpp_tests --gtest_filter=XccyJointCalibrationTest.*:XccyJointJacobianTest.*:JointCalibrationTest.*:JointAnalyticJacobianTest.*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=XccyJointCalibrationTest.*:XccyJointJacobianTest.*:JointCalibrationTest.*:JointAnalyticJacobianTest.*`
 
 Expected: synthetic recovery, validation, exact/approximate, analytic/bumped, layout, and all pre-existing joint tests pass.
 
@@ -868,7 +868,7 @@ Record the new XCCY capability and the breaking replacement of the two public co
 
 - [ ] **Step 5: Run targeted functional suites**
 
-Run: `bin/dal_cpp_tests --gtest_filter=FixingSnapshotTest.*:XccyPricingTest.*:XccyMarketTest.*:XccyBasisJacobianTest.*:XccyJointCalibrationTest.*:XccyJointJacobianTest.*:JointCalibrationTest.*:JointAnalyticJacobianTest.*`
+Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=FixingSnapshotTest.*:XccyPricingTest.*:XccyMarketTest.*:XccyBasisJacobianTest.*:XccyJointCalibrationTest.*:XccyJointJacobianTest.*:JointCalibrationTest.*:JointAnalyticJacobianTest.*`
 
 Run: `build/dal-public/dal_public_tests --gtest_filter=CurveProtocolTest.*:CurveInstrumentTest.*:XccyCalibrationTest.*`
 

--- a/docs/superpowers/plans/2026-07-13-xccy-resettable-mtm.md
+++ b/docs/superpowers/plans/2026-07-13-xccy-resettable-mtm.md
@@ -625,7 +625,7 @@ Set every reset, fixing identity, collateral, snapshot, curve declaration, solve
 
 - [ ] **Step 2: Run and verify failure**
 
-Run: `cmake --build build --target dal_public_tests -j 4`
+Run: `cmake --build build/Release-linux --target dal_public_tests -j 4`
 
 Expected: compilation fails because the new public builders are undefined.
 
@@ -645,7 +645,7 @@ Handle_<CrossCurrencySwap_> CrossCurrencySwapNew(const Date_& tradeDate,
 
 - [ ] **Step 4: Run public tests**
 
-Run: `build/dal-public/dal_public_tests --gtest_filter=CurveProtocolTest.*:CurveInstrumentTest.TestCrossCurrency*:XccyCalibrationTest.*`
+Run: `build/Release-linux/dal-public/dal_public_tests --gtest_filter=CurveProtocolTest.*:CurveInstrumentTest.TestCrossCurrency*:XccyCalibrationTest.*`
 
 Expected: old and new instrument builders, snapshot, staged builder, joint builder, and result layout pass.
 
@@ -870,7 +870,7 @@ Record the new XCCY capability and the breaking replacement of the two public co
 
 Run: `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=FixingSnapshotTest.*:XccyPricingTest.*:XccyMarketTest.*:XccyBasisJacobianTest.*:XccyJointCalibrationTest.*:XccyJointJacobianTest.*:JointCalibrationTest.*:JointAnalyticJacobianTest.*`
 
-Run: `build/dal-public/dal_public_tests --gtest_filter=CurveProtocolTest.*:CurveInstrumentTest.*:XccyCalibrationTest.*`
+Run: `build/Release-linux/dal-public/dal_public_tests --gtest_filter=CurveProtocolTest.*:CurveInstrumentTest.*:XccyCalibrationTest.*`
 
 Run: `python -m pytest dal-python/tests/test_xccy_calibration.py dal-python/tests/test_xccy_resettable.py dal-python/tests/test_xccy_joint.py -q`
 


### PR DESCRIPTION
## Summary

Tranche 7b of the codebase-review plan (Excel + IVS test gaps).

- **IVS analytic coverage** (`dal-cpp`, `ModelTest` in `dal-cpp/tests/model/test_ivs.cpp`): 6 new tests pinning `IVS_::Call`, `IVS_::LocalVol`, and `MertonIVS_::ImpliedVol` against closed-form values, reusing the shared `FlatIVS_` fixture:
  - `TestFlatIVSCallMatchesBlackClosedForm` — constant vol ⇒ Black formula prices over a 3x3 strike/maturity grid with nonzero rate/dividend carry (1e-10).
  - `TestFlatIVSCallDefaultsToZeroRates` — zero rate/dividend default pins forward = spot, no discount (1e-10), plus `Spot()`.
  - `TestFlatIVSCallAddsRiskViewSpread` — `RiskView_` spread is added to implied vol at the bumped knot (1e-10), neighbouring knots keep the base vol, and an empty view prices bit-identically to no view.
  - `TestFlatIVSLocalVolIsFlat` — Dupire central-difference inversion of a flat implied surface returns the input vol, with and without deterministic rates (1e-7; measured max err ~5e-9).
  - `TestMertonIVSZeroIntensityImpliedVolIsFlat` — zero jump intensity ⇒ implied vol flat at the input vol (1e-9; measured max err ~2e-11).
  - `TestMertonIVSZeroIntensityCallMatchesBlack` — zero-intensity Merton prices equal Black prices (1e-8).
- **dal-excel test seam** (`dal-excel/src/__excel_test_api.hpp` + `_excel.cpp`, own commit): the registration table (`TheFunctions()`) and `Retval_` output machinery are file-local to `_excel.cpp`, so `dal_excel_tests` could not observe them. Adds a minimal `DAL_EXCEL_TEST_API` surface (same dllexport/dllimport pattern as `__xccy_test_api.hpp`): a read-only view of the 62-entry registration table, plus three probes for empty-output behavior.
- **dal-excel registration + empty-result tests** (`dal-excel/tests/test_registration.cpp`, `test_empty_result.cpp`):
  - Every registered function's C name resolves to a real exported entry point in `dal_excel.xll` via `GetProcAddress`; no duplicate Excel or C names; type-text arity (with Excel modifiers like the `!` volatile suffix stripped) equals named-arg and arg-help counts; Excel names match the Machinist upper-dotted convention.
  - Empty handle output raises "Output handle is NULL" (xl_ wrappers surface it as an `#Error` cell, not UB); an error result is a visible `"#Error:  ..."` string cell; an empty vector result renders as a single blank cell.
- No production-code defects found: the registration table is healthy today (62 entries, no duplicates, consistent metadata); the tests pin that.
- Deferred exclusions honored: EquityParser trailing-suffix behavior and `RiskView_` non-const `begin()/end()` are untouched.

Note: `AADTest.TestRateAwareFlatVolLocalVol`/`TestMertonIVS` already pin a flat-vol Call at one point and LocalVol at one maturity, and Merton internal consistency at nonzero intensity. The new tests extend this to strike/maturity grids, the zero-rate default, `RiskView_` interaction, and the zero-intensity analytic limit; the single-point overlap is intentional.

## Test plan

- [x] `./build/Release-linux/dal-cpp/dal_cpp_tests` — 1063/1063 passed (1057 before, +6 new)
- [x] `./build/Release-linux/dal-public/dal_public_tests` — 56/56 passed
- [x] New tests visible in `ctest -N` discovery (`ModelTest.TestFlatIVS*`, `ModelTest.TestMertonIVSZeroIntensity*`)
- [x] New C++ tests run 3x consecutively — no flakes
- [x] Mutation-checked: perturbing the Call forward carry, the Dupire numerator, or the Merton price inversion fails exactly the intended tests (then reverted; production code pristine)
- [x] **MSVC CI legs are the execution evidence for the dal-excel part**: `dal_excel_tests` builds and runs only on Windows (`cmake-windows.yml` builds `DAL_BUILD_EXCEL=ON` and runs ctest). The Excel tests and seam cannot be compiled on Linux; they were verified by close reading against `_excel.cpp` internals and the `__xccy_test_api.hpp` export pattern, then executed on the Windows legs: all three `build (msvc, *)` legs pass with 1136/1136 ctest entries, including `ExcelRegistrationTest.*` (7/7) and `ExcelEmptyResultTest.*` (3/3).
- [x] All CI legs green (gcc-13/14, clang-18/19, msvc x all 4 AAD backends, ASan/UBSan, TSan, warning-clean GCC, benchmarks, Codacy) except `Documentation integrity`, which fails identically on master at the merge base (pre-existing: `docs/superpowers/plans/2026-07-13-xccy-resettable-mtm.md` references `bin/dal_cpp_tests`; unrelated to this PR)