### PR TITLE
fix: Prevent lost holiday centers under concurrent writes

### DIFF
--- a/dal-cpp/dal/time/holidaydata.cpp
+++ b/dal-cpp/dal/time/holidaydata.cpp
@@ -2,7 +2,6 @@
 // Created by wegam on 2020/11/27.
 //
 
-
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
 #include <dal/time/holidaydata.hpp>
@@ -33,11 +32,6 @@ namespace Dal {
         HolidayData_& TheHolidayData() { RETURN_STATIC(HolidayData_); }
         std::shared_mutex& TheHolidayMutex() { RETURN_STATIC(std::shared_mutex); }
 
-        HolidayData_ CopyHolidayData() {
-            std::shared_lock<std::shared_mutex> lock(TheHolidayMutex());
-            return TheHolidayData();
-        }
-
         bool ContainsNoWeekends(const Vector_<Date_>& dates) {
             for (const auto& d : dates)
                 if (Date::DayOfWeek(d) % 6 == 0)
@@ -60,13 +54,13 @@ namespace Dal {
         REQUIRE(IsMonotonic(workWeekends), "Working weekends should be in ascending order");
         NOTICE(city);
 
-        HolidayData_ temp(CopyHolidayData());
+        std::unique_lock<std::shared_mutex> lock(TheHolidayMutex());
+        HolidayData_ temp(TheHolidayData());
         REQUIRE(temp.IsValid(), "Holiday data is not valid");
         REQUIRE(!temp.centerIndex_.count(city), "Duplicate holiday center");
         temp.centerIndex_[city] = static_cast<int>(temp.holidays_.size());
         temp.holidays_.push_back(Handle_(std::make_shared<const HolidayCenterData_>(city, holidays, workWeekends)));
 
-        std::unique_lock<std::shared_mutex> lock(TheHolidayMutex());
         TheHolidayData().Swap(&temp);
         REQUIRE(TheHolidayData().IsValid(), "Holiday data is not valid");
     }

--- a/dal-cpp/tests/time/test_holidaydata.cpp
+++ b/dal-cpp/tests/time/test_holidaydata.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <exception>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <dal/platform/platform.hpp>
+#include <dal/string/strings.hpp>
+#include <dal/time/date.hpp>
+#include <dal/time/holidaydata.hpp>
+
+using namespace Dal;
+
+namespace {
+    String_ ConcurrentCenterName(int run, int batch, int writer) {
+        return String_("CONCURRENT_HOLIDAY_") + String::FromInt(run) + "_" + String::FromInt(batch) + "_" + String::FromInt(writer);
+    }
+
+    Vector_<Date_> LargeHolidaySet() {
+        Vector_<Date_> result;
+        for (Date_ date(2020, 1, 1); date <= Date::Maximum(); ++date) {
+            if (!Date::IsWeekEnd(date))
+                result.push_back(date);
+        }
+        return result;
+    }
+} // namespace
+
+TEST(HolidayDataTest, TestConcurrentAddCenterPreservesAllCenters) {
+    constexpr int NUM_BATCHES = 4;
+    constexpr int NUM_WRITERS = 32;
+    static std::atomic<int> nextRun{0};
+    const int run = nextRun.fetch_add(1);
+    const Vector_<Date_> holidays = LargeHolidaySet();
+
+    for (int batch = 0; batch < NUM_BATCHES; ++batch) {
+        std::mutex gateMutex;
+        std::condition_variable gateCv;
+        int ready = 0;
+        bool start = false;
+        std::vector<std::exception_ptr> errors(NUM_WRITERS);
+        std::vector<std::thread> writers;
+        writers.reserve(NUM_WRITERS);
+
+        for (int writer = 0; writer < NUM_WRITERS; ++writer) {
+            writers.emplace_back([&, writer]() {
+                {
+                    std::unique_lock<std::mutex> lock(gateMutex);
+                    ++ready;
+                    gateCv.notify_all();
+                    gateCv.wait(lock, [&]() { return start; });
+                }
+                try {
+                    Holidays::AddCenter(ConcurrentCenterName(run, batch, writer), holidays);
+                } catch (...) {
+                    errors[writer] = std::current_exception();
+                }
+            });
+        }
+
+        {
+            std::unique_lock<std::mutex> lock(gateMutex);
+            gateCv.wait(lock, [&]() { return ready == NUM_WRITERS; });
+            start = true;
+        }
+        gateCv.notify_all();
+
+        for (auto& writer : writers)
+            writer.join();
+
+        for (const auto& error : errors)
+            ASSERT_FALSE(error);
+        for (int writer = 0; writer < NUM_WRITERS; ++writer) {
+            const String_ name = ConcurrentCenterName(run, batch, writer);
+            Handle_<HolidayCenterData_> center;
+            ASSERT_NO_THROW(center = Holidays::OfCenter(name));
+            ASSERT_TRUE(center);
+            ASSERT_EQ(center->center_, name);
+            ASSERT_EQ(center->holidays_, holidays);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- serialize the full Holidays::AddCenter read-modify-write transaction under the holiday-data mutex
- add synchronized multi-writer regression coverage that verifies every registered center remains retrievable

## Test plan
- [x] confirm the regression test fails before the production fix with Invalid holiday center
- [x] run the concurrent regression test 10 times successfully
- [x] build dal_cpp_tests with MSVC/Ninja
- [x] run all 999 core tests successfully
- [x] run clang-format --dry-run --Werror and git diff --check