### PR TITLE
test: close dal-web frontend test gaps (vitest + valuation e2e)

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -225,6 +225,11 @@ jobs:
           npm ci
           npm run build
 
+      - name: Run frontend unit tests
+        working-directory: dal-web/frontend
+        run: |
+          npm test
+
       - name: Prepare Chrome
         run: |
           ./dal-web/scripts/setup-playwright.sh

--- a/dal-web/README.md
+++ b/dal-web/README.md
@@ -292,8 +292,14 @@ uv run --no-sync pytest     # uses a fake dal module (no C++ build needed)
 ./dal-web/scripts/setup-playwright.sh
 cd dal-web/frontend
 npm run build               # type-check + production build
+npm test                    # vitest unit tests (jsdom; no browser or backend needed)
 npm run test:e2e            # Playwright smoke tests (starts/stops the web UI)
 ```
+
+The vitest unit suite under `frontend/tests/unit/` covers the API client, the
+valuation panel, model-form parsing, and the formatting helpers. It runs in
+jsdom against mocked API responses, needs neither a browser nor a backend,
+and also runs in the web-quality CI job.
 
 The default Playwright command uses the native-only application startup path.
 CI uses an explicit canned DAL test double while retaining the real FastAPI
@@ -305,7 +311,8 @@ DAL_PLAYWRIGHT_TEST_BACKEND=1 npm run test:e2e
 
 The test-backend entry point refuses to start without that flag and reports
 `backend=canned-dal`, `is_native=false` from the health endpoint. It is a
-browser integration fixture, not a development or production fallback.
+browser integration fixture, not a development or production fallback. Specs
+that require the canned backend skip themselves when the flag is absent.
 
 ## Screens
 

--- a/dal-web/frontend/package-lock.json
+++ b/dal-web/frontend/package-lock.json
@@ -14,12 +14,67 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^5.2.0",
+        "jsdom": "^29.1.1",
         "typescript": "^5.5.4",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -255,6 +310,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -303,6 +368,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -335,6 +553,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -705,6 +941,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -715,6 +1006,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -760,6 +1058,31 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -810,6 +1133,162 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.34",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
@@ -821,6 +1300,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -878,6 +1367,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -885,12 +1384,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -910,6 +1437,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -920,12 +1464,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
       "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -935,6 +1506,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -980,11 +1571,82 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1295,6 +1957,33 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1330,6 +2019,40 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1427,6 +2150,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1451,6 +2199,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -1494,6 +2249,16 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -1535,6 +2300,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1554,6 +2332,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1562,6 +2347,44 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1579,6 +2402,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -1601,6 +2480,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1711,6 +2600,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/dal-web/frontend/package.json
+++ b/dal-web/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -15,11 +16,15 @@
     "react-router-dom": "^6.26.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-react": "^5.2.0",
+    "jsdom": "^29.1.1",
     "typescript": "^5.5.4",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.10"
   }
 }

--- a/dal-web/frontend/src/components/ValuationPanel.tsx
+++ b/dal-web/frontend/src/components/ValuationPanel.tsx
@@ -141,7 +141,7 @@ export default function ValuationPanel({ onRun, title = "Run valuation" }: Props
         </button>
       </div>
 
-      {result && result.status !== "running" && (
+      {result && result.status === "completed" && (
         <div>
           <div {...css("cards")} {...inlineStyle({ marginBottom: 12 })}>
             <div {...css("card")}>

--- a/dal-web/frontend/tests/e2e/valuation.spec.ts
+++ b/dal-web/frontend/tests/e2e/valuation.spec.ts
@@ -6,6 +6,11 @@ const TOTAL_PV_TEXT = new Intl.NumberFormat(undefined, { maximumFractionDigits: 
 const PATH_COUNT_TEXT = (1024).toLocaleString();
 
 test("runs a trade valuation end to end", async ({ page }) => {
+  test.skip(
+    process.env.DAL_PLAYWRIGHT_TEST_BACKEND !== "1",
+    "Only applies to the explicit Playwright test backend"
+  );
+
   await page.goto("/products");
   await page.locator("#product-name").fill("E2E call");
   await page.getByPlaceholder(/STRIKE or START/).fill("STRIKE");

--- a/dal-web/frontend/tests/e2e/valuation.spec.ts
+++ b/dal-web/frontend/tests/e2e/valuation.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
 
+// The app formats numbers via toLocaleString(undefined, ...); derive expected
+// text instead of hard-coding en-US separators.
+const TOTAL_PV_TEXT = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(8_000_000);
+const PATH_COUNT_TEXT = (1024).toLocaleString();
+
 test("runs a trade valuation end to end", async ({ page }) => {
   await page.goto("/products");
   await page.locator("#product-name").fill("E2E call");
@@ -32,7 +37,7 @@ test("runs a trade valuation end to end", async ({ page }) => {
 
   // Canned backend prices every trade at unit PV 8.0; notional 1,000,000 x 1.
   await expect(page.getByText("Total PV")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("8,000,000")).toBeVisible();
+  await expect(page.getByText(TOTAL_PV_TEXT)).toBeVisible();
   await expect(page.getByRole("heading", { name: "d_spot" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Run valuation" })).toBeEnabled();
 
@@ -40,7 +45,7 @@ test("runs a trade valuation end to end", async ({ page }) => {
   const runRow = page.getByRole("row").filter({ hasText: "canned-dal" }).first();
   await expect(runRow).toContainText("trade");
   await expect(runRow).toContainText("completed");
-  await expect(runRow).toContainText("1,024");
+  await expect(runRow).toContainText(PATH_COUNT_TEXT);
 
   await runRow.getByRole("button", { name: "Details" }).click();
   await expect(page.getByRole("heading", { name: "Greeks" })).toBeVisible();

--- a/dal-web/frontend/tests/e2e/valuation.spec.ts
+++ b/dal-web/frontend/tests/e2e/valuation.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test("runs a trade valuation end to end", async ({ page }) => {
+  await page.goto("/products");
+  await page.locator("#product-name").fill("E2E call");
+  await page.getByPlaceholder(/STRIKE or START/).fill("STRIKE");
+  await page.getByPlaceholder(/event script/).fill("call pays MAX(spot() - STRIKE, 0.0)");
+  await page.getByRole("button", { name: "Save product" }).click();
+  await expect(page.getByRole("row").filter({ hasText: "E2E call" })).toBeVisible();
+
+  await page.goto("/models");
+  await page.locator("#model-name").fill("E2E BS");
+  await page.getByRole("button", { name: "Create model" }).click();
+  await expect(page.getByRole("row").filter({ hasText: "E2E BS" })).toBeVisible();
+
+  await page.goto("/trades");
+  await page.locator("#trade-name").fill("E2E trade");
+  await page.locator("#trade-product").selectOption({ label: "E2E call" });
+  await page.locator("#trade-model").selectOption({ label: "E2E BS" });
+  await page.getByRole("button", { name: "Create" }).click();
+
+  const tradeRow = page.getByRole("row").filter({ hasText: "E2E trade" });
+  await expect(tradeRow).toBeVisible();
+  await tradeRow.getByRole("button", { name: "Price" }).click();
+
+  await expect(page.getByRole("heading", { name: "Price trade: E2E trade" })).toBeVisible();
+  await page.getByLabel("Number of paths").fill("1024");
+  await page.getByRole("button", { name: "Run valuation" }).click();
+
+  // The backend accepts the run as pending; the panel polls until it settles.
+  await expect(page.getByRole("button", { name: /submitting…|pricing…/ })).toBeDisabled();
+
+  // Canned backend prices every trade at unit PV 8.0; notional 1,000,000 x 1.
+  await expect(page.getByText("Total PV")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("8,000,000")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "d_spot" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Run valuation" })).toBeEnabled();
+
+  await page.goto("/valuations");
+  const runRow = page.getByRole("row").filter({ hasText: "canned-dal" }).first();
+  await expect(runRow).toContainText("trade");
+  await expect(runRow).toContainText("completed");
+  await expect(runRow).toContainText("1,024");
+
+  await runRow.getByRole("button", { name: "Details" }).click();
+  await expect(page.getByRole("heading", { name: "Greeks" })).toBeVisible();
+  await expect(page.getByText(/d_spot:/)).toBeVisible();
+  await expect(page.getByRole("cell", { name: "E2E trade", exact: true })).toBeVisible();
+});

--- a/dal-web/frontend/tests/unit/api_client.test.ts
+++ b/dal-web/frontend/tests/unit/api_client.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api, type ProductDefinition } from "../../src/api/client";
+
+const ORIGIN = window.location.origin;
+
+function jsonResponse(body: unknown, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+describe("api client", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("issues GET requests without a JSON content-type", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: "ok", backend: "b", is_native: true, evaluation_date: "d" }));
+
+    await api.health();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(String(url)).toBe(`${ORIGIN}/api/health`);
+    expect(init.headers).toEqual({});
+  });
+
+  it("attaches a JSON content-type and serialized body on POST", async () => {
+    const created: ProductDefinition = { id: "p1", name: "n", description: "", rows: [] };
+    fetchMock.mockResolvedValue(jsonResponse(created));
+
+    const result = await api.createProduct({ name: "n", description: "", rows: [] });
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(String(url)).toBe(`${ORIGIN}/api/products`);
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(String(init.body))).toEqual({ name: "n", description: "", rows: [] });
+  });
+
+  it("interpolates path parameters under the /api prefix", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: "v42" }));
+
+    await api.getValuation("v42");
+
+    const [url] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(String(url)).toBe(`${ORIGIN}/api/valuations/v42`);
+  });
+
+  it("resolves 204 No Content to undefined", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(api.deleteProduct("p1")).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(String(url)).toBe(`${ORIGIN}/api/products/p1`);
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("throws status and string detail from error responses", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: "trade not found" }, { status: 404 }));
+
+    await expect(api.getValuation("missing")).rejects.toThrow("404: trade not found");
+  });
+
+  it("serializes structured error details", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ detail: [{ loc: ["body", "num_paths"], msg: "too big" }] }, { status: 422 }),
+    );
+
+    await expect(api.getValuation("x")).rejects.toThrow('422: [{"loc":["body","num_paths"],"msg":"too big"}]');
+  });
+
+  it("falls back to statusText when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue(new Response("gateway exploded", { status: 502, statusText: "Bad Gateway" }));
+
+    await expect(api.listModels()).rejects.toThrow("502: Bad Gateway");
+  });
+
+  it("propagates network failures", async () => {
+    fetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(api.listTrades()).rejects.toThrow("fetch failed");
+  });
+
+  it.each(["..", ".", "a..b/../c", "x://evil"])(
+    "rejects SSRF-shaped path segment %r before any fetch",
+    async (badId) => {
+      await expect(api.getValuation(badId)).rejects.toThrow("Invalid API path");
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/dal-web/frontend/tests/unit/format.test.ts
+++ b/dal-web/frontend/tests/unit/format.test.ts
@@ -1,18 +1,32 @@
 import { describe, expect, it } from "vitest";
 import { classNames, css, fmtMoney, fmtNum, inlineStyle } from "../../src/format";
 
+// fmtNum/fmtMoney format via toLocaleString(undefined, ...), so expectations
+// derive from Intl.NumberFormat with the same options instead of hard-coded
+// en-US separators.
+function grouped(value: number, digits: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  }).format(value);
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value);
+}
+
 describe("fmtNum", () => {
   it("formats with the default four fraction digits", () => {
-    expect(fmtNum(1234.5)).toBe("1,234.5000");
+    expect(fmtNum(1234.5)).toBe(grouped(1234.5, 4));
   });
 
   it("honours a custom digit count", () => {
-    expect(fmtNum(0.123456, 2)).toBe("0.12");
-    expect(fmtNum(8, 0)).toBe("8");
+    expect(fmtNum(0.123456, 2)).toBe(grouped(0.123456, 2));
+    expect(fmtNum(8, 0)).toBe(grouped(8, 0));
   });
 
   it("groups thousands", () => {
-    expect(fmtNum(1_000_000, 2)).toBe("1,000,000.00");
+    expect(fmtNum(1_000_000, 2)).toBe(grouped(1_000_000, 2));
   });
 
   it("renders non-finite values as a dash", () => {
@@ -22,14 +36,14 @@ describe("fmtNum", () => {
   });
 
   it("keeps negative values", () => {
-    expect(fmtNum(-42.5, 1)).toBe("-42.5");
+    expect(fmtNum(-42.5, 1)).toBe(grouped(-42.5, 1));
   });
 });
 
 describe("fmtMoney", () => {
   it("formats with at most two fraction digits", () => {
-    expect(fmtMoney(8_000_000)).toBe("8,000,000");
-    expect(fmtMoney(1234.567)).toBe("1,234.57");
+    expect(fmtMoney(8_000_000)).toBe(money(8_000_000));
+    expect(fmtMoney(1234.567)).toBe(money(1234.567));
   });
 
   it("renders non-finite values as a dash", () => {

--- a/dal-web/frontend/tests/unit/format.test.ts
+++ b/dal-web/frontend/tests/unit/format.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { classNames, css, fmtMoney, fmtNum, inlineStyle } from "../../src/format";
+
+describe("fmtNum", () => {
+  it("formats with the default four fraction digits", () => {
+    expect(fmtNum(1234.5)).toBe("1,234.5000");
+  });
+
+  it("honours a custom digit count", () => {
+    expect(fmtNum(0.123456, 2)).toBe("0.12");
+    expect(fmtNum(8, 0)).toBe("8");
+  });
+
+  it("groups thousands", () => {
+    expect(fmtNum(1_000_000, 2)).toBe("1,000,000.00");
+  });
+
+  it("renders non-finite values as a dash", () => {
+    expect(fmtNum(Number.NaN)).toBe("-");
+    expect(fmtNum(Number.POSITIVE_INFINITY)).toBe("-");
+    expect(fmtNum(Number.NEGATIVE_INFINITY)).toBe("-");
+  });
+
+  it("keeps negative values", () => {
+    expect(fmtNum(-42.5, 1)).toBe("-42.5");
+  });
+});
+
+describe("fmtMoney", () => {
+  it("formats with at most two fraction digits", () => {
+    expect(fmtMoney(8_000_000)).toBe("8,000,000");
+    expect(fmtMoney(1234.567)).toBe("1,234.57");
+  });
+
+  it("renders non-finite values as a dash", () => {
+    expect(fmtMoney(Number.NaN)).toBe("-");
+    expect(fmtMoney(Number.POSITIVE_INFINITY)).toBe("-");
+  });
+});
+
+describe("classNames", () => {
+  it("joins truthy parts with a single space", () => {
+    expect(classNames("a", "b", "c")).toBe("a b c");
+  });
+
+  it("drops false and undefined parts", () => {
+    expect(classNames("a", false, undefined, "b")).toBe("a b");
+  });
+
+  it("returns an empty string when nothing is truthy", () => {
+    expect(classNames(false, undefined)).toBe("");
+  });
+});
+
+describe("css", () => {
+  it("wraps joined class names in a className prop object", () => {
+    expect(css("panel")).toEqual({ className: "panel" });
+    expect(css("metric", false, "pos")).toEqual({ className: "metric pos" });
+  });
+});
+
+describe("inlineStyle", () => {
+  it("wraps the style record in a style prop object", () => {
+    const style = { marginBottom: 12, display: "flex" };
+    expect(inlineStyle(style)).toEqual({ style });
+  });
+});

--- a/dal-web/frontend/tests/unit/models.test.tsx
+++ b/dal-web/frontend/tests/unit/models.test.tsx
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import Models from "../../src/pages/Models";
+import { api, type ModelDefinition } from "../../src/api/client";
+
+function makeModel(overrides: Partial<ModelDefinition> = {}): ModelDefinition {
+  return { id: "m1", name: "m", kind: "BSModelData_", ...overrides };
+}
+
+describe("Models", () => {
+  let createModelSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(api, "listModels").mockResolvedValue([]);
+    createModelSpy = vi.spyOn(api, "createModel").mockResolvedValue(makeModel());
+  });
+
+  it("creates a Black-Scholes model from the scalar form fields", async () => {
+    render(<Models />);
+    await screen.findByText("New model");
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "BS test" } });
+    fireEvent.change(screen.getByLabelText("Spot"), { target: { value: "105" } });
+    fireEvent.change(screen.getByLabelText("Vol"), { target: { value: "0.25" } });
+    fireEvent.change(screen.getByLabelText("Rate"), { target: { value: "0.01" } });
+    fireEvent.change(screen.getByLabelText("Dividend"), { target: { value: "0.02" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create model" }));
+
+    await vi.waitFor(() => {
+      expect(createModelSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(createModelSpy.mock.calls[0][0]).toEqual({
+      name: "BS test",
+      kind: "BSModelData_",
+      bs: { spot: 105, vol: 0.25, rate: 0.01, div: 0.02 },
+    });
+  });
+
+  it("parses Dupire strikes, times, and the vols matrix from text", async () => {
+    render(<Models />);
+    await screen.findByText("New model");
+
+    fireEvent.change(screen.getByLabelText("Model kind"), { target: { value: "DupireModelData_" } });
+    fireEvent.change(screen.getByLabelText("Spot strikes (comma-separated)"), {
+      target: { value: "90, 100" },
+    });
+    fireEvent.change(screen.getByLabelText("Times in years (comma-separated)"), {
+      target: { value: "0.25, 0.5" },
+    });
+    fireEvent.change(screen.getByLabelText("Vols matrix (one row per strike, whitespace-separated)"), {
+      target: { value: "0.24, 0.23\n0.21, 0.20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create model" }));
+
+    await vi.waitFor(() => {
+      expect(createModelSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(createModelSpy.mock.calls[0][0]).toEqual({
+      name: "BS spot=100 vol=20%",
+      kind: "DupireModelData_",
+      dupire: {
+        spot: 100,
+        rate: 0,
+        repo: 0,
+        spots: [90, 100],
+        times: [0.25, 0.5],
+        vols: [
+          [0.24, 0.23],
+          [0.21, 0.2],
+        ],
+      },
+    });
+  });
+
+  it("tolerates mixed separators and blank lines in the numeric text fields", async () => {
+    render(<Models />);
+    await screen.findByText("New model");
+
+    fireEvent.change(screen.getByLabelText("Model kind"), { target: { value: "DupireModelData_" } });
+    fireEvent.change(screen.getByLabelText("Spot strikes (comma-separated)"), {
+      target: { value: "90  100,\t110" },
+    });
+    fireEvent.change(screen.getByLabelText("Vols matrix (one row per strike, whitespace-separated)"), {
+      target: { value: "0.24\n\n0.21   0.20\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create model" }));
+
+    await vi.waitFor(() => {
+      expect(createModelSpy).toHaveBeenCalledTimes(1);
+    });
+    const dupire = createModelSpy.mock.calls[0][0].dupire;
+    expect(dupire?.spots).toEqual([90, 100, 110]);
+    expect(dupire?.vols).toEqual([[0.24], [0.21, 0.2]]);
+  });
+});

--- a/dal-web/frontend/tests/unit/setup.ts
+++ b/dal-web/frontend/tests/unit/setup.ts
@@ -1,0 +1,6 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/dal-web/frontend/tests/unit/valuation_panel.test.tsx
+++ b/dal-web/frontend/tests/unit/valuation_panel.test.tsx
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ValuationPanel from "../../src/components/ValuationPanel";
+import { api, type ValuationConfig, type ValuationResult } from "../../src/api/client";
+
+function makeResult(overrides: Partial<ValuationResult> = {}): ValuationResult {
+  return {
+    id: "v1",
+    target_kind: "trade",
+    target_id: "t1",
+    backend: "canned-dal",
+    is_native: false,
+    config: {
+      num_paths: 1024,
+      method: "sobol",
+      use_brownian_bridge: false,
+      enable_aad: true,
+      smooth: 0.01,
+      evaluation_date: "2022-09-15",
+    },
+    total_pv: 8_000_000,
+    total_greeks: { d_spot: 500_000, d_vol: 200_000 },
+    trades: [
+      { trade_id: "t1", trade_name: "Trade One", pv: 8, scaled_pv: 8_000_000, greeks: { d_spot: 500_000 } },
+    ],
+    created_at: "2026-07-19T00:00:00Z",
+    status: "completed",
+    ...overrides,
+  };
+}
+
+function runButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /run valuation|pricing|submitting/i });
+}
+
+describe("ValuationPanel", () => {
+  let getValuationSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getValuationSpy = vi.spyOn(api, "getValuation");
+  });
+
+  it("submits the configured valuation request and renders an immediately-completed result", async () => {
+    const onRun = vi.fn<(config: ValuationConfig) => Promise<ValuationResult>>().mockResolvedValue(makeResult());
+    render(<ValuationPanel onRun={onRun} />);
+
+    fireEvent.change(screen.getByLabelText("Number of paths"), { target: { value: "2048" } });
+    fireEvent.change(screen.getByLabelText("RNG method"), { target: { value: "pseudo" } });
+    fireEvent.click(screen.getByLabelText("Enable AAD (Greeks)"));
+    fireEvent.click(screen.getByLabelText("Brownian bridge"));
+    fireEvent.change(screen.getByLabelText("Evaluation date"), { target: { value: "" } });
+    fireEvent.click(runButton());
+
+    await screen.findByText("Total PV");
+    expect(onRun).toHaveBeenCalledTimes(1);
+    expect(onRun.mock.calls[0][0]).toEqual({
+      num_paths: 2048,
+      method: "pseudo",
+      use_brownian_bridge: true,
+      enable_aad: false,
+      smooth: 0.01,
+      evaluation_date: null,
+    });
+    expect(getValuationSpy).not.toHaveBeenCalled();
+    expect(screen.getByText("8,000,000")).toBeTruthy();
+    expect(screen.getByText("d_spot")).toBeTruthy();
+    expect(screen.getByText("d_vol")).toBeTruthy();
+    expect(runButton().disabled).toBe(false);
+  });
+
+  it("clamps the path count to the allowed maximum", async () => {
+    const onRun = vi.fn<(config: ValuationConfig) => Promise<ValuationResult>>().mockResolvedValue(makeResult());
+    render(<ValuationPanel onRun={onRun} />);
+
+    const input = screen.getByLabelText("Number of paths") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "999999999" } });
+    expect(input.value).toBe(String(2 ** 24));
+
+    fireEvent.click(runButton());
+    await screen.findByText("Total PV");
+    expect(onRun.mock.calls[0][0].num_paths).toBe(2 ** 24);
+  });
+
+  it("resets the path count to 1 on non-numeric input", () => {
+    const onRun = vi.fn<(config: ValuationConfig) => Promise<ValuationResult>>();
+    render(<ValuationPanel onRun={onRun} />);
+
+    const input = screen.getByLabelText("Number of paths") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input.value).toBe("1");
+    expect(onRun).not.toHaveBeenCalled();
+  });
+
+  it("polls while running and renders cards once completed", async () => {
+    const onRun = vi
+      .fn<(config: ValuationConfig) => Promise<ValuationResult>>()
+      .mockResolvedValue(makeResult({ status: "running" }));
+    getValuationSpy
+      .mockResolvedValueOnce(makeResult({ status: "running" }))
+      .mockResolvedValueOnce(makeResult());
+    render(<ValuationPanel onRun={onRun} />);
+
+    fireEvent.click(runButton());
+
+    expect(await screen.findByRole("button", { name: "pricing…" })).toHaveProperty("disabled", true);
+
+    await screen.findByText("Total PV", undefined, { timeout: 3000 });
+    expect(getValuationSpy).toHaveBeenCalledTimes(2);
+    expect(getValuationSpy).toHaveBeenCalledWith("v1");
+    expect(screen.getByText("8,000,000")).toBeTruthy();
+    expect(screen.queryByText("Unit PV")).toBeNull();
+    expect(runButton().disabled).toBe(false);
+  });
+
+  it("renders the per-trade table for multi-trade results", async () => {
+    const onRun = vi.fn<(config: ValuationConfig) => Promise<ValuationResult>>().mockResolvedValue(
+      makeResult({
+        trades: [
+          { trade_id: "t1", trade_name: "Trade One", pv: 8, scaled_pv: 8_000_000, greeks: {} },
+          { trade_id: "t2", trade_name: "Trade Two", pv: 3, scaled_pv: 3_000_000, greeks: {} },
+        ],
+      }),
+    );
+    render(<ValuationPanel onRun={onRun} />);
+
+    fireEvent.click(runButton());
+
+    await screen.findByText("Unit PV");
+    expect(screen.getByText("Trade One")).toBeTruthy();
+    expect(screen.getByText("Trade Two")).toBeTruthy();
+  });
+
+  it("surfaces submission errors and re-enables the form", async () => {
+    const onRun = vi
+      .fn<(config: ValuationConfig) => Promise<ValuationResult>>()
+      .mockRejectedValue(new Error("404: trade not found"));
+    render(<ValuationPanel onRun={onRun} />);
+
+    fireEvent.click(runButton());
+
+    await screen.findByText(/404: trade not found/);
+    expect(runButton().disabled).toBe(false);
+  });
+
+  it("disables the run button while the submission is in flight", async () => {
+    let resolveRun: (result: ValuationResult) => void = () => undefined;
+    const onRun = vi.fn<(config: ValuationConfig) => Promise<ValuationResult>>().mockImplementation(
+      () =>
+        new Promise<ValuationResult>((resolve) => {
+          resolveRun = resolve;
+        }),
+    );
+    render(<ValuationPanel onRun={onRun} />);
+
+    fireEvent.click(runButton());
+
+    const busy = (await screen.findByRole("button", { name: "submitting…" })) as HTMLButtonElement;
+    expect(busy.disabled).toBe(true);
+
+    resolveRun(makeResult());
+    await screen.findByText("Total PV");
+    expect(runButton().disabled).toBe(false);
+  });
+});

--- a/dal-web/frontend/tests/unit/valuation_panel.test.tsx
+++ b/dal-web/frontend/tests/unit/valuation_panel.test.tsx
@@ -33,6 +33,10 @@ function runButton(): HTMLButtonElement {
   return screen.getByRole("button", { name: /run valuation|pricing|submitting/i });
 }
 
+// fmtMoney renders via toLocaleString(undefined, ...); derive the expected
+// text instead of hard-coding en-US separators.
+const TOTAL_PV_TEXT = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(8_000_000);
+
 describe("ValuationPanel", () => {
   let getValuationSpy: ReturnType<typeof vi.spyOn>;
 
@@ -62,7 +66,7 @@ describe("ValuationPanel", () => {
       evaluation_date: null,
     });
     expect(getValuationSpy).not.toHaveBeenCalled();
-    expect(screen.getByText("8,000,000")).toBeTruthy();
+    expect(screen.getByText(TOTAL_PV_TEXT)).toBeTruthy();
     expect(screen.getByText("d_spot")).toBeTruthy();
     expect(screen.getByText("d_vol")).toBeTruthy();
     expect(runButton().disabled).toBe(false);
@@ -107,7 +111,7 @@ describe("ValuationPanel", () => {
     await screen.findByText("Total PV", undefined, { timeout: 3000 });
     expect(getValuationSpy).toHaveBeenCalledTimes(2);
     expect(getValuationSpy).toHaveBeenCalledWith("v1");
-    expect(screen.getByText("8,000,000")).toBeTruthy();
+    expect(screen.getByText(TOTAL_PV_TEXT)).toBeTruthy();
     expect(screen.queryByText("Unit PV")).toBeNull();
     expect(runButton().disabled).toBe(false);
   });

--- a/dal-web/frontend/tests/unit/valuation_panel.test.tsx
+++ b/dal-web/frontend/tests/unit/valuation_panel.test.tsx
@@ -130,6 +130,22 @@ describe("ValuationPanel", () => {
     expect(screen.getByText("Trade Two")).toBeTruthy();
   });
 
+  it("surfaces a server-side valuation failure without result cards", async () => {
+    const onRun = vi
+      .fn<(config: ValuationConfig) => Promise<ValuationResult>>()
+      .mockResolvedValue(makeResult({ status: "running" }));
+    getValuationSpy.mockResolvedValue(makeResult({ status: "failed" }));
+    render(<ValuationPanel onRun={onRun} />);
+
+    fireEvent.click(runButton());
+
+    await screen.findByText("Valuation failed on the server. Check the backend logs.", undefined, {
+      timeout: 3000,
+    });
+    expect(screen.queryByText("Total PV")).toBeNull();
+    expect(runButton().disabled).toBe(false);
+  });
+
   it("surfaces submission errors and re-enables the form", async () => {
     const onRun = vi
       .fn<(config: ValuationConfig) => Promise<ValuationResult>>()

--- a/dal-web/frontend/tests/unit/valuation_panel.test.tsx
+++ b/dal-web/frontend/tests/unit/valuation_panel.test.tsx
@@ -163,11 +163,12 @@ describe("ValuationPanel", () => {
   });
 
   it("disables the run button while the submission is in flight", async () => {
-    let resolveRun: (result: ValuationResult) => void = () => undefined;
     const onRun = vi.fn<(config: ValuationConfig) => Promise<ValuationResult>>().mockImplementation(
       () =>
         new Promise<ValuationResult>((resolve) => {
-          resolveRun = resolve;
+          setTimeout(() => {
+            resolve(makeResult());
+          }, 50);
         }),
     );
     render(<ValuationPanel onRun={onRun} />);
@@ -177,7 +178,6 @@ describe("ValuationPanel", () => {
     const busy = (await screen.findByRole("button", { name: "submitting…" })) as HTMLButtonElement;
     expect(busy.disabled).toBe(true);
 
-    resolveRun(makeResult());
     await screen.findByText("Total PV");
     expect(runButton().disabled).toBe(false);
   });

--- a/dal-web/frontend/tsconfig.json
+++ b/dal-web/frontend/tsconfig.json
@@ -16,5 +16,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "tests/unit"]
 }

--- a/dal-web/frontend/vite.config.ts
+++ b/dal-web/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 // Vite dev server proxies /api to the FastAPI backend on :8001.
@@ -12,5 +12,9 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    environment: "jsdom",
+    include: ["tests/unit/**/*.test.{ts,tsx}"],
   },
 });

--- a/dal-web/frontend/vite.config.ts
+++ b/dal-web/frontend/vite.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
     environment: "jsdom",
     include: ["tests/unit/**/*.test.{ts,tsx}"],
     setupFiles: ["tests/unit/setup.ts"],
+    restoreMocks: true,
   },
 });

--- a/dal-web/frontend/vite.config.ts
+++ b/dal-web/frontend/vite.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     include: ["tests/unit/**/*.test.{ts,tsx}"],
+    setupFiles: ["tests/unit/setup.ts"],
   },
 });

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -316,6 +316,7 @@ Python and web checks:
 (cd dal-python && python -m pytest tests -v)
 (cd dal-web/backend && uv run --no-sync pytest)
 (cd dal-web/frontend && npm run build)
+(cd dal-web/frontend && npm test)
 ./dal-web/scripts/setup-playwright.sh
 (cd dal-web/frontend && npm run test:e2e)
 ```


### PR DESCRIPTION
## Summary

Tranche 7c of the codebase-review plan (item 16, frontend slice). The dal-web frontend had **no unit-test runner at all** — only 4 Playwright e2e tests. This PR:

- **Adds a vitest harness** (`npm test`, jsdom environment, `tests/unit/`, `restoreMocks`) and extends the tsconfig include so `npm run build` type-checks the specs. 35 unit tests:
  - `src/format.ts` — number/money formatting (incl. non-finite → `-`), `classNames`/`css`/`inlineStyle` prop helpers.
  - `src/api/client.ts` — request shaping (no JSON content-type on bodyless GETs, JSON body on POST), 204 → `undefined`, error mapping (`<status>: <detail>` for string and structured FastAPI details, `statusText` fallback for non-JSON bodies), network-failure propagation, and the SSRF path guard rejecting traversal/absolute-URL segments before any fetch.
  - `ValuationPanel` — valuation-form state (payload mapping, 2^24 path clamp, reset to 1 on non-numeric input), the running → poll → completed flow, multi-trade result table, submission-error surfacing, busy/disabled state.
  - `Models` page — Dupire strike/time/vols text → number matrix mapping (comma/whitespace tolerant, blank lines skipped).
- **Adds a valuation-flow e2e** (`tests/e2e/valuation.spec.ts`) against the existing canned Playwright backend: product → model → trade → submit valuation → busy running state → completed result cards (canned PV 8.0 × notional) with AAD greeks → Valuation Runs page shows the completed run with greek/per-trade detail.
- **Wires `npm test` into CI** as its own step in the existing `web-quality` job (own commit, `e928fbf1`); the existing e2e step already discovers the new spec.

**Defect found by the tests (fixed in own commit `a28c47c0`):** `ValuationPanel` rendered the Total PV / Greeks cards for *any* non-running status, so a failed valuation showed a misleading "Total PV 0" card next to the failure banner. Cards now render only for `status === "completed"`.

## Test plan

Ran locally (this machine, node 20.20 / uv 0.11):
- [x] `npm test` — 35/35 vitest tests pass (was: no unit tests → now 35)
- [x] `npm run build` — `tsc -b` (now also type-checks the specs) + `vite build` green
- [x] `DAL_PLAYWRIGHT_TEST_BACKEND=1 npm run test:e2e` — 5/5 pass (4 existing + new valuation flow). Local note: another project's dev server occupied :5173, so the local run used a temporary port override in `playwright.config.ts` / `playwright-test-backend-start.sh`, reverted afterwards — the committed files keep :5173 and CI is unaffected
- [x] Backend `pytest` 43/43 + `ruff check` clean (unchanged files, sanity for the e2e path)
- [x] e2e runs against the repo's canned DAL backend exactly like the existing suite (no new mocking)

CI proves, in the `web-quality` job: backend pytest + ruff, frontend `npm ci` + `npm run build`, **new** `npm test` step, and the Playwright e2e suite (canned backend) including the new valuation flow.