### PR TITLE
test: close dal-web backend test gaps (eval date, failures, restart)

### DIFF
--- a/dal-web/README.md
+++ b/dal-web/README.md
@@ -94,7 +94,9 @@ directory.
 
 For ephemeral or read-only environments where no database is wanted, set
 `DAL_WEB_STORE=memory` to fall back to the original in-memory store -- no file,
-no SQLAlchemy.
+no SQLAlchemy. Everything then lives in process memory, so a backend restart
+loses all entities and any in-flight valuations. With the database store,
+entities and finished valuation results survive a restart.
 
 ## Running
 
@@ -280,6 +282,19 @@ valuation. Pricing dispatch therefore remains serialized within a backend
 process. The result is updated in-place once it completes, and the frontend polls
 `GET /api/valuations/{id}` at 300ms intervals until the status becomes
 `"completed"` or `"failed"`.
+
+A settled valuation distinguishes two failure layers. A per-trade pricing
+failure is contained per trade: the valuation still reaches `"completed"`, the
+failing trade's row carries an `error` and contributes zero PV, and the
+remaining trades price and aggregate normally -- one bad trade cannot abort a
+portfolio. A task-level failure (anything outside an individual trade's
+pricing) flips the whole valuation to `"failed"` with `error_message` set,
+zeroed PV, empty Greeks, and no trade rows.
+
+Pricing tasks live inside the backend process, so a valuation still `"running"`
+when the server stops cannot resume. On startup, such orphaned rows are
+reconciled to `"failed"` with `error_message: "Server restarted while
+pricing"`; completed and already-failed rows are left untouched.
 
 ### Tests
 

--- a/dal-web/backend/tests/test_eval_date.py
+++ b/dal-web/backend/tests/test_eval_date.py
@@ -1,0 +1,229 @@
+"""Evaluation-date restore semantics at the service / API layer.
+
+The gateway-level save/restore contract is pinned by ``tests/test_dal_gateway.py``
+(H5 regression tests).  These tests pin the same contract one level up: a
+request that carries ``evaluation_date`` must leave the process-global DAL
+evaluation date untouched once the request settles -- including when pricing
+fails and when concurrent in-flight requests carry different dates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import date
+
+import dal  # the fake installed by conftest
+
+from app.schemas import (
+    BSModelParams,
+    EventRow,
+    ModelDefinition,
+    ProductDefinition,
+    Trade,
+    ValuationConfig,
+)
+
+SENTINEL = (2020, 1, 1)
+
+
+def _set_global_eval_date(year: int, month: int, day: int) -> str:
+    dal.EvaluationDate_Set(dal.Date_(year, month, day))
+    return repr(dal.EvaluationDate_Get())
+
+
+def _create_european_product(client, strike: str = "100.0") -> str:
+    payload = {
+        "name": "Call",
+        "description": "",
+        "rows": [
+            {"date_kind": "label", "label": "STRIKE", "event": strike},
+            {
+                "date_kind": "date",
+                "date": "2023-09-15",
+                "event": "call pays MAX(spot() - STRIKE, 0.0)",
+            },
+        ],
+    }
+    resp = client.post("/api/products", json=payload)
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _create_bs_model(client) -> str:
+    resp = client.post(
+        "/api/models",
+        json={
+            "name": "BS",
+            "kind": "BSModelData_",
+            "bs": {"spot": 100.0, "vol": 0.2, "rate": 0.0, "div": 0.0},
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _create_trade(client, product_id: str, model_id: str) -> str:
+    resp = client.post(
+        "/api/trades",
+        json={"name": "t", "product_id": product_id, "model_id": model_id, "notional": 1.0},
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _create_portfolio_with_trade(client, trade_id: str) -> str:
+    resp = client.post("/api/portfolios", json={"name": "PF"})
+    assert resp.status_code == 201
+    portfolio_id = resp.json()["id"]
+    add = client.post(f"/api/portfolios/{portfolio_id}/trades/{trade_id}")
+    assert add.status_code == 200
+    return portfolio_id
+
+
+def _wait_for_valuation(client, valuation_id: str, max_polls: int = 20) -> dict:
+    for _ in range(max_polls):
+        resp = client.get(f"/api/valuations/{valuation_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        if body["status"] != "running":
+            return body
+        time.sleep(0.1)
+    raise AssertionError(f"Valuation {valuation_id} did not settle within {max_polls} polls")
+
+
+def test_trade_valuation_restores_global_eval_date(client) -> None:
+    sentinel = _set_global_eval_date(*SENTINEL)
+    trade_id = _create_trade(client, _create_european_product(client), _create_bs_model(client))
+
+    resp = client.post(
+        f"/api/trades/{trade_id}/value",
+        json={"num_paths": 64, "enable_aad": False, "evaluation_date": "2022-09-15"},
+    )
+    assert resp.status_code == 200
+    body = _wait_for_valuation(client, resp.json()["id"])
+
+    assert body["status"] == "completed"
+    assert repr(dal.EvaluationDate_Get()) == sentinel
+
+
+def test_portfolio_valuation_restores_global_eval_date(client) -> None:
+    sentinel = _set_global_eval_date(*SENTINEL)
+    trade_id = _create_trade(client, _create_european_product(client), _create_bs_model(client))
+    portfolio_id = _create_portfolio_with_trade(client, trade_id)
+
+    resp = client.post(
+        f"/api/portfolios/{portfolio_id}/value",
+        json={"num_paths": 64, "enable_aad": False, "evaluation_date": "2022-09-15"},
+    )
+    assert resp.status_code == 200
+    body = _wait_for_valuation(client, resp.json()["id"])
+
+    assert body["status"] == "completed"
+    assert repr(dal.EvaluationDate_Get()) == sentinel
+
+
+def test_failed_trade_valuation_restores_global_eval_date(client, monkeypatch) -> None:
+    sentinel = _set_global_eval_date(*SENTINEL)
+    trade_id = _create_trade(client, _create_european_product(client), _create_bs_model(client))
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dal, "MonteCarlo_Value", _boom)
+
+    resp = client.post(
+        f"/api/trades/{trade_id}/value",
+        json={"num_paths": 64, "enable_aad": False, "evaluation_date": "2022-09-15"},
+    )
+    assert resp.status_code == 200
+    body = _wait_for_valuation(client, resp.json()["id"])
+
+    assert body["trades"][0]["error"] is not None
+    assert repr(dal.EvaluationDate_Get()) == sentinel
+
+
+def test_concurrent_valuations_isolate_evaluation_dates(store, monkeypatch) -> None:
+    """Concurrent in-flight pricings must not leak evaluation dates.
+
+    The gateway serializes ``value()`` behind a lock and restores the previous
+    date in a ``finally``, so each concurrent request prices under its own
+    date and the process-global date survives the batch unchanged.
+    """
+    import app.services.valuation as valuation_service
+    from app.services.dal_gateway import DalGateway
+
+    sentinel = _set_global_eval_date(*SENTINEL)
+
+    seen: list[tuple[str, str]] = []
+
+    def _recording_monte_carlo(
+        product,
+        model_data,
+        num_path,
+        method="sobol",
+        use_bb=False,
+        enable_aad=False,
+        smooth=0.01,
+    ):
+        _dates, events = product
+        seen.append((str(events[0]), repr(dal.EvaluationDate_Get())))
+        return {"PV": 1.0}
+
+    monkeypatch.setattr(dal, "MonteCarlo_Value", _recording_monte_carlo)
+
+    def _add_strike_trade(strike: str) -> Trade:
+        product = store.add_product(
+            ProductDefinition(
+                name=f"p{strike}",
+                rows=[
+                    EventRow(date_kind="label", label="STRIKE", event=strike),
+                    EventRow(
+                        date_kind="date",
+                        date=date(2023, 9, 15),
+                        event="call pays MAX(spot() - STRIKE, 0.0)",
+                    ),
+                ],
+            )
+        )
+        model = store.add_model(
+            ModelDefinition(
+                name=f"m{strike}",
+                kind="BSModelData_",
+                bs=BSModelParams(spot=100.0, vol=0.2, rate=0.0, div=0.0),
+            )
+        )
+        return store.add_trade(Trade(name=f"t{strike}", product_id=product.id, model_id=model.id))
+
+    trade_a = _add_strike_trade("100.0")
+    trade_b = _add_strike_trade("200.0")
+    gateway = DalGateway()
+
+    async def _run_both() -> None:
+        await asyncio.gather(
+            valuation_service.value_single_trade_async(
+                store,
+                gateway,
+                trade_a.id,
+                ValuationConfig(num_paths=8, evaluation_date=date(2021, 3, 1)),
+            ),
+            valuation_service.value_single_trade_async(
+                store,
+                gateway,
+                trade_b.id,
+                ValuationConfig(num_paths=8, evaluation_date=date(2023, 6, 15)),
+            ),
+        )
+        # Drain the scheduled pricing tasks deterministically (no sleep-polling);
+        # completed tasks have already discarded themselves from the set.
+        pending = list(valuation_service._BACKGROUND_TASKS)
+        if pending:
+            await asyncio.gather(*pending)
+
+    asyncio.run(_run_both())
+
+    assert set(seen) == {("100.0", "2021-03-01"), ("200.0", "2023-06-15")}
+    assert repr(dal.EvaluationDate_Get()) == sentinel
+    for valuation in store.list_valuations():
+        assert valuation.status == "completed"
+        assert valuation.trades[0].error is None

--- a/dal-web/backend/tests/test_restart_recovery.py
+++ b/dal-web/backend/tests/test_restart_recovery.py
@@ -1,0 +1,195 @@
+"""Restart-recovery tests for the SQLAlchemy-backed store.
+
+A "restart" is simulated by resetting the process-wide store/gateway
+singletons and building a fresh app (new engine, new sessions) over the same
+on-disk SQLite file.  The pinned semantics:
+
+* entities created through the API in one process are fully visible in the
+  next;
+* a valuation left at ``status="running"`` by a killed process is reconciled
+  at startup to ``status="failed"`` with ``error_message="Server restarted
+  while pricing"`` (``main._reconcile_orphaned_valuations``, H6), while
+  completed and already-failed rows are left untouched;
+* under ``DAL_WEB_STORE=memory`` a restart simply loses everything -- the
+  documented in-memory trade-off.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.schemas import ValuationConfig, ValuationResult
+
+_CREATED_AT = "2026-07-19T00:00:00+00:00"
+
+
+def _reset_singletons() -> None:
+    # Mirrors tests/conftest.py: the next get_store()/get_gateway() call then
+    # rebuilds from the current environment, simulating a fresh process.
+    import app.services.dal_gateway as gw
+    import app.services.store as st
+
+    gw._gateway_box[0] = None
+    st._store_box[0] = None
+
+
+@contextlib.contextmanager
+def _fresh_app(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, memory: bool = False
+) -> Iterator[TestClient]:
+    """Yield a TestClient for a fresh "process" over tmp_path's SQLite file."""
+    _reset_singletons()
+    if memory:
+        monkeypatch.setenv("DAL_WEB_STORE", "memory")
+    else:
+        monkeypatch.delenv("DAL_WEB_STORE", raising=False)
+        monkeypatch.setenv("DAL_WEB_DB_URL", f"sqlite:///{tmp_path / 'restart.db'}")
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        yield client
+
+    import app.services.store as st
+
+    store = st._store_box[0]
+    if store is not None and hasattr(store, "close"):
+        store.close()
+
+
+def _create_product_model_trade(client) -> tuple[str, str, str]:
+    product = client.post(
+        "/api/products",
+        json={
+            "name": "Restart Call",
+            "description": "",
+            "rows": [
+                {"date_kind": "label", "label": "STRIKE", "event": "100.0"},
+                {
+                    "date_kind": "date",
+                    "date": "2023-09-15",
+                    "event": "call pays MAX(spot() - STRIKE, 0.0)",
+                },
+            ],
+        },
+    )
+    assert product.status_code == 201
+    model = client.post(
+        "/api/models",
+        json={
+            "name": "Restart BS",
+            "kind": "BSModelData_",
+            "bs": {"spot": 100.0, "vol": 0.2, "rate": 0.0, "div": 0.0},
+        },
+    )
+    assert model.status_code == 201
+    trade = client.post(
+        "/api/trades",
+        json={
+            "name": "restart trade",
+            "book": "EQ",
+            "notional": 2.0,
+            "quantity": 3.0,
+            "product_id": product.json()["id"],
+            "model_id": model.json()["id"],
+        },
+    )
+    assert trade.status_code == 201
+    return product.json()["id"], model.json()["id"], trade.json()["id"]
+
+
+def _valuation(target_id: str, status: str, **overrides) -> ValuationResult:
+    base: dict = {
+        "target_kind": "trade",
+        "target_id": target_id,
+        "backend": "dal",
+        "is_native": True,
+        "config": ValuationConfig(num_paths=64),
+        "total_pv": 0.0,
+        "trades": [],
+        "created_at": _CREATED_AT,
+        "status": status,
+    }
+    base.update(overrides)
+    return ValuationResult(**base)
+
+
+def test_entities_created_via_api_survive_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with _fresh_app(monkeypatch, tmp_path) as client:
+        product_id, model_id, trade_id = _create_product_model_trade(client)
+        portfolio = client.post("/api/portfolios", json={"name": "Restart PF"})
+        assert portfolio.status_code == 201
+        portfolio_id = portfolio.json()["id"]
+        add = client.post(f"/api/portfolios/{portfolio_id}/trades/{trade_id}")
+        assert add.status_code == 200
+
+    with _fresh_app(monkeypatch, tmp_path) as client:
+        product = client.get(f"/api/products/{product_id}")
+        assert product.status_code == 200
+        assert product.json()["name"] == "Restart Call"
+        assert len(product.json()["rows"]) == 2
+
+        model = client.get(f"/api/models/{model_id}")
+        assert model.status_code == 200
+        assert model.json()["bs"]["spot"] == 100.0
+
+        trade = client.get(f"/api/trades/{trade_id}")
+        assert trade.status_code == 200
+        assert trade.json()["book"] == "EQ"
+        assert trade.json()["notional"] == 2.0
+        assert trade.json()["quantity"] == 3.0
+
+        portfolio = client.get(f"/api/portfolios/{portfolio_id}")
+        assert portfolio.status_code == 200
+        assert portfolio.json()["trade_ids"] == [trade_id]
+
+        members = client.get(f"/api/portfolios/{portfolio_id}/trades")
+        assert members.status_code == 200
+        assert [t["id"] for t in members.json()] == [trade_id]
+
+
+def test_running_valuation_reconciles_to_failed_on_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from app.services.store import get_store
+
+    with _fresh_app(monkeypatch, tmp_path) as client:
+        _product_id, _model_id, trade_id = _create_product_model_trade(client)
+        store = get_store()
+        running = store.add_valuation(_valuation(trade_id, "running"))
+        completed = store.add_valuation(_valuation(trade_id, "completed", total_pv=5.0))
+        failed = store.add_valuation(_valuation(trade_id, "failed", error_message="original boom"))
+
+    with _fresh_app(monkeypatch, tmp_path) as client:
+        orphaned = client.get(f"/api/valuations/{running.id}")
+        assert orphaned.status_code == 200
+        assert orphaned.json()["status"] == "failed"
+        assert orphaned.json()["error_message"] == "Server restarted while pricing"
+
+        untouched_completed = client.get(f"/api/valuations/{completed.id}")
+        assert untouched_completed.json()["status"] == "completed"
+        assert untouched_completed.json()["total_pv"] == 5.0
+        assert untouched_completed.json()["error_message"] is None
+
+        untouched_failed = client.get(f"/api/valuations/{failed.id}")
+        assert untouched_failed.json()["status"] == "failed"
+        assert untouched_failed.json()["error_message"] == "original boom"
+
+
+def test_memory_store_loses_valuations_on_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from app.services.store import get_store
+
+    with _fresh_app(monkeypatch, tmp_path, memory=True) as client:
+        get_store().add_valuation(_valuation("any-trade", "running"))
+        assert len(client.get("/api/valuations").json()) == 1
+
+    with _fresh_app(monkeypatch, tmp_path, memory=True) as client:
+        assert client.get("/api/valuations").json() == []

--- a/dal-web/backend/tests/test_valuation_failures.py
+++ b/dal-web/backend/tests/test_valuation_failures.py
@@ -1,0 +1,239 @@
+"""Failure-path tests for the valuation API.
+
+Two failure layers are pinned here:
+
+* per-trade pricing failures (``gateway.value`` raising) are caught inside
+  ``_price_trade`` and surface as ``TradeValuation.error`` -- the valuation
+  itself still reaches ``status="completed"`` so one bad trade cannot abort
+  a whole portfolio;
+* task-level failures (the store raising inside the background pricing task)
+  are caught by the pricing coroutine and surface as ``status="failed"`` with
+  ``error_message`` set, zeroed PV and empty Greeks.
+
+Also pinned: the ``running -> completed | failed`` polling lifecycle for each
+layer, and the unchanged ``NotFoundError -> 404`` mapping on the valuation
+endpoints.
+"""
+
+from __future__ import annotations
+
+import time
+
+import dal  # the fake installed by conftest
+
+
+def _create_european_product(client, strike: str = "100.0") -> str:
+    payload = {
+        "name": "Call",
+        "description": "",
+        "rows": [
+            {"date_kind": "label", "label": "STRIKE", "event": strike},
+            {
+                "date_kind": "date",
+                "date": "2023-09-15",
+                "event": "call pays MAX(spot() - STRIKE, 0.0)",
+            },
+        ],
+    }
+    resp = client.post("/api/products", json=payload)
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _create_bs_model(client) -> str:
+    resp = client.post(
+        "/api/models",
+        json={
+            "name": "BS",
+            "kind": "BSModelData_",
+            "bs": {"spot": 100.0, "vol": 0.2, "rate": 0.0, "div": 0.0},
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _create_trade(client, product_id: str, model_id: str, name: str = "t") -> str:
+    resp = client.post(
+        "/api/trades",
+        json={"name": name, "product_id": product_id, "model_id": model_id, "notional": 1.0},
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _create_portfolio(client, trade_ids: list[str]) -> str:
+    resp = client.post("/api/portfolios", json={"name": "PF"})
+    assert resp.status_code == 201
+    portfolio_id = resp.json()["id"]
+    for trade_id in trade_ids:
+        add = client.post(f"/api/portfolios/{portfolio_id}/trades/{trade_id}")
+        assert add.status_code == 200
+    return portfolio_id
+
+
+def _wait_for_valuation(client, valuation_id: str, max_polls: int = 20) -> dict:
+    for _ in range(max_polls):
+        resp = client.get(f"/api/valuations/{valuation_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        if body["status"] != "running":
+            return body
+        time.sleep(0.1)
+    raise AssertionError(f"Valuation {valuation_id} did not settle within {max_polls} polls")
+
+
+def test_trade_pricing_error_surfaces_as_trade_error(client, monkeypatch) -> None:
+    """A gateway failure inside one trade's pricing yields an errored trade,
+    not a failed valuation: status stays 'completed' with the error carried
+    on the trade row."""
+    model_id = _create_bs_model(client)
+    trade_id = _create_trade(client, _create_european_product(client), model_id)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dal, "MonteCarlo_Value", _boom)
+
+    resp = client.post(
+        f"/api/trades/{trade_id}/value",
+        json={"num_paths": 64, "enable_aad": False, "evaluation_date": "2022-09-15"},
+    )
+    assert resp.status_code == 200
+    pending = resp.json()
+    assert pending["status"] == "running"
+
+    body = _wait_for_valuation(client, pending["id"])
+    assert body["status"] == "completed"
+    assert body["error_message"] is None
+    assert body["total_pv"] == 0.0
+    assert body["total_greeks"] == {}
+    assert len(body["trades"]) == 1
+    trade_row = body["trades"][0]
+    assert trade_row["trade_id"] == trade_id
+    assert "boom" in trade_row["error"]
+    assert trade_row["pv"] == 0.0
+    assert trade_row["scaled_pv"] == 0.0
+
+
+def test_portfolio_valuation_isolates_single_failing_trade(client, monkeypatch) -> None:
+    """One failing trade must not abort the portfolio: the healthy trade's PV
+    is still priced and aggregated, and only the failing row carries an error."""
+    model_id = _create_bs_model(client)
+    good_trade = _create_trade(client, _create_european_product(client, "100.0"), model_id, "good")
+    bad_product = _create_european_product(client, "BOMB")
+    bad_trade = _create_trade(client, bad_product, model_id, "bad")
+    portfolio_id = _create_portfolio(client, [good_trade, bad_trade])
+
+    real_monte_carlo = dal.MonteCarlo_Value
+
+    def _selective_boom(product, *args, **kwargs):
+        _dates, events = product
+        if any("BOMB" in str(event) for event in events):
+            raise RuntimeError("pricing exploded")
+        return real_monte_carlo(product, *args, **kwargs)
+
+    monkeypatch.setattr(dal, "MonteCarlo_Value", _selective_boom)
+
+    resp = client.post(
+        f"/api/portfolios/{portfolio_id}/value",
+        json={"num_paths": 64, "enable_aad": False, "evaluation_date": "2022-09-15"},
+    )
+    assert resp.status_code == 200
+
+    body = _wait_for_valuation(client, resp.json()["id"])
+    assert body["status"] == "completed"
+    assert len(body["trades"]) == 2
+    by_name = {row["trade_name"]: row for row in body["trades"]}
+    assert by_name["good"]["error"] is None
+    assert by_name["good"]["scaled_pv"] == 8.0  # canned fake PV
+    assert "pricing exploded" in by_name["bad"]["error"]
+    assert by_name["bad"]["scaled_pv"] == 0.0
+    # Only the healthy trade contributes to the aggregate.
+    assert body["total_pv"] == 8.0
+
+
+def test_portfolio_task_failure_marks_valuation_failed(client, monkeypatch) -> None:
+    """A store failure inside the pricing task (after the endpoint's existence
+    pre-check) flips the valuation to 'failed' with the documented shape."""
+    from app.services.store import get_store
+
+    model_id = _create_bs_model(client)
+    trade_id = _create_trade(client, _create_european_product(client), model_id)
+    portfolio_id = _create_portfolio(client, [trade_id])
+
+    def _unavailable(portfolio_id: str):
+        raise RuntimeError("store unavailable")
+
+    # The endpoint pre-check uses get_portfolio, so patching portfolio_trades
+    # fails only the background task, never the request itself.
+    monkeypatch.setattr(get_store(), "portfolio_trades", _unavailable)
+
+    resp = client.post(
+        f"/api/portfolios/{portfolio_id}/value",
+        json={"num_paths": 64, "enable_aad": False},
+    )
+    assert resp.status_code == 200
+    pending = resp.json()
+    assert pending["status"] == "running"
+
+    body = _wait_for_valuation(client, pending["id"])
+    assert body["status"] == "failed"
+    assert body["error_message"] == "store unavailable"
+    assert body["total_pv"] == 0.0
+    assert body["total_greeks"] == {}
+    assert body["trades"] == []
+
+
+def test_trade_task_failure_marks_valuation_failed(client, monkeypatch) -> None:
+    """Same task-level failure on the single-trade path: the endpoint's
+    pre-check succeeds (first get_trade call), the task's lookup raises."""
+    from app.services.store import get_store
+
+    model_id = _create_bs_model(client)
+    trade_id = _create_trade(client, _create_european_product(client), model_id)
+
+    store = get_store()
+    real_get_trade = store.get_trade
+    calls = {"n": 0}
+
+    def _flaky_get_trade(trade_id: str):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_get_trade(trade_id)
+        raise RuntimeError("store blew up")
+
+    monkeypatch.setattr(store, "get_trade", _flaky_get_trade)
+
+    resp = client.post(
+        f"/api/trades/{trade_id}/value",
+        json={"num_paths": 64, "enable_aad": False},
+    )
+    assert resp.status_code == 200
+    pending = resp.json()
+    assert pending["status"] == "running"
+
+    body = _wait_for_valuation(client, pending["id"])
+    assert body["status"] == "failed"
+    assert body["error_message"] == "store blew up"
+    assert body["total_pv"] == 0.0
+    assert body["total_greeks"] == {}
+    assert body["trades"] == []
+
+
+def test_get_unknown_valuation_returns_404(client) -> None:
+    resp = client.get("/api/valuations/does-not-exist")
+    assert resp.status_code == 404
+    assert "does-not-exist" in resp.json()["detail"]
+
+
+def test_value_unknown_trade_returns_404(client) -> None:
+    resp = client.post("/api/trades/does-not-exist/value", json={"num_paths": 64})
+    assert resp.status_code == 404
+    assert "does-not-exist" in resp.json()["detail"]
+
+
+def test_value_unknown_portfolio_returns_404(client) -> None:
+    resp = client.post("/api/portfolios/does-not-exist/value", json={"num_paths": 64})
+    assert resp.status_code == 404
+    assert "does-not-exist" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Tranche 7d of the codebase-review plan (review item 16, web slice): closes the three highest-value **backend** test gaps named by the review. Test-only change — 3 new files, 14 tests, no production code touched, no defects found (the semantics turned out to be implemented deliberately; they are now pinned).

- **`tests/test_eval_date.py`** — evaluation-date restore semantics at the service/API layer (gateway-level H5 restore was already covered in `test_dal_gateway.py`):
  - trade and portfolio valuations carrying `evaluation_date` leave the process-global DAL date untouched after the request settles;
  - a pricing failure (`MonteCarlo_Value` raising) still restores the date;
  - two concurrent async pricings with distinct dates each price under their own date (the gateway lock + `finally`-restore), with the global date unchanged afterwards; driven via `asyncio.run` and a deterministic drain of `_BACKGROUND_TASKS` (no sleep-polling).
- **`tests/test_valuation_failures.py`** — the two failure layers of the async pipeline, plus error mapping:
  - **per-trade layer**: `gateway.value` raising surfaces as `TradeValuation.error` while the valuation itself reaches `status="completed"` — one bad trade cannot abort a portfolio (healthy PVs still aggregate; pinned with a selectively-failing fake);
  - **task layer**: a store failure inside the background pricing task flips the valuation to `status="failed"` with `error_message`, zeroed PV and empty Greeks, on both the portfolio and single-trade paths;
  - the `running → completed | failed` polling lifecycle holds per layer, and `NotFoundError → 404` mapping is unchanged on the valuation GET and both value endpoints.
- **`tests/test_restart_recovery.py`** — Store restart recovery (restart = reset singletons + fresh app over the same SQLite file):
  - products/models/trades/portfolios created through the API survive into the next process;
  - a valuation persisted as `status="running"` is reconciled at startup to `failed` with `error_message="Server restarted while pricing"` (`main._reconcile_orphaned_valuations`, H6), while completed and already-failed rows keep status, PV and original error;
  - under `DAL_WEB_STORE=memory` a restart loses all valuations — pinning the documented in-memory trade-off.

**Findings / notes for reviewers**
- Restart semantics for in-flight valuations are **defined** (fail-at-startup reconciliation, H6) — not resumable. This is now pinned rather than papered over.
- The per-trade vs task-level failure split is deliberate in `app/services/valuation.py` (`_price_trade` docstring); a single-trade pricing error therefore yields `status="completed"` with an errored trade row, not `failed`. Pinned as-is; flag if the frontend ever relies on the opposite.
- Pre-existing `ruff format` drift in `tests/test_dal_gateway.py` exists on master (verified against `origin/master`); left untouched to keep this PR test-additive only.
- Sensitivity-verified: every load-bearing pin was shown to fail under a targeted mutation (gateway restore removed; per-trade catch removed; failed-status update dropped; reconciliation skipped; `status=="running"` guard removed) and pass again after revert.

## Test plan

- [x] `uv sync --locked --inexact && uv run --no-sync pytest` — **57 passed** (baseline was 43), run ×3 with identical results (no flake)
- [x] `uv run --no-sync ruff check .` — clean; new files also `ruff format`-clean
- [x] All tests use the fake-`dal` seam from `tests/conftest.py`/`tests/fake_dal.py`; no real pricing in unit tests
- [x] No production code changed — frontend, e2e and C++ CI unaffected; CI `web-quality` job runs the same pytest + ruff commands verified locally