### PR TITLE
chore: repo polish (review plan P2.18)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -37,4 +37,4 @@ exclude_paths:
   # context and don't need glossary entries here.
   - 'CLAUDE.md'
   - '.claude/**'
-  - 'doc/**'
+  - 'docs/**'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Text files are normalized to LF in the repository; classification is
+# automatic unless overridden below.
+* text=auto
+
+# Platform-mandated line endings.
+*.sh  text eol=lf
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+
+# Sources and generated code stay LF on every platform (MSVC accepts LF).
+*.c    text eol=lf
+*.cpp  text eol=lf
+*.h    text eol=lf
+*.hpp  text eol=lf
+*.inc  text eol=lf
+*.java text eol=lf
+*.py   text eol=lf
+*.ts   text eol=lf
+*.tsx  text eol=lf
+
+# Binary payloads — never normalize.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.xls  binary
+*.xlsx binary

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,16 @@ CMakeUserPresets.json
 .claude/scheduled_tasks.lock
 /cmake/
 /pyproject.toml
+
+# Coverage and benchmark artifacts produced by the CI workflows at repo root
+coverage_filtered.info
+benchmark-results/
+
+# Visual Studio / CMake Tools default build tree
+out/
+
+# Ruff lint cache (CI runs ruff in dal-web/backend)
+.ruff_cache/
+
+# Local SQLite store used by the dal-web backend when DAL_WEB_DB_URL is unset
+dal-web/backend/.data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ here as the baseline rather than dated releases:
 
 ## 2026-07
 
+- `curve`: Made calibration settings dictionaries strict on the Python and Excel
+  surfaces. `dal.calibrate_curve` raises `ValueError` on an unknown settings key,
+  and the Excel single-curve, staged-XCCY, and joint-XCCY settings parsers throw
+  via `RequireKnownSettingsKey`; both name the offending key and the accepted set.
+  Unknown keys were previously ignored silently, so a misspelled key now fails
+  loudly instead of calibrating with defaults. Correct usage is unaffected.
+
 - `core`: Migrated owning factory returns from raw pointers to `std::unique_ptr`
   across the `dal-cpp` core headers: the interpolation factories
   (`Interp::NewLinear`/`NewLinear2`/`NewLogLinear`/`NewCubic`, `NewMixedLogDF`),

--- a/dal-excel/src/__curvespec.cpp
+++ b/dal-excel/src/__curvespec.cpp
@@ -6,6 +6,7 @@
 
 #include "__platform.hpp"
 #include "__curve_storable.hpp"
+#include "__settingskeys.hpp"
 #include <dal/math/cell.hpp>
 #include <dal-public/src/curvespec.hpp>
 #include <dal-public/src/curveprotocol.hpp>
@@ -111,9 +112,14 @@ namespace Dal {
 
         // Helper: apply dictionary settings to a CurveCalibrationSpecBuilder_
         void ApplySettings(const Dictionary_& settings, CurveCalibrationSpecBuilder_& b) {
+            static const Vector_<String_> validKeys = {"curveName",      "calibrateDiscountCurve", "solveMode",      "parameterization",
+                                                       "logDfScheme",    "smoothingWeight",        "tolerance",      "fitTolerance",
+                                                       "initialGuess",   "maxEvaluations",         "maxRestarts",    "targetCollateral",
+                                                       "targetTenor",    "liborBasis"};
             for (const auto& kv : settings) {
                 const String_& key = kv.first;
                 const Cell_& val = kv.second;
+                RequireKnownSettingsKey(key, validKeys);
                 if (key == "calibrateDiscountCurve") {
                     if (Cell::IsBool(val))
                         b.calibrateDiscountCurve_ = Cell::ToBool(val);

--- a/dal-excel/src/__settingskeys.hpp
+++ b/dal-excel/src/__settingskeys.hpp
@@ -1,0 +1,19 @@
+//
+// Created by wegamekinglc on 2026/7/19.
+//
+
+#pragma once
+
+#include <algorithm>
+#include <dal/math/vectors.hpp>
+#include <dal/string/strings.hpp>
+#include <dal/utilities/exceptions.hpp>
+
+namespace Dal {
+    // Calibration settings dictionaries must not silently drop misspelled keys:
+    // name the offending key and the accepted set so sheet authors can fix it.
+    inline void RequireKnownSettingsKey(const String_& key, const Vector_<String_>& validKeys) {
+        if (std::find(validKeys.begin(), validKeys.end(), key) == validKeys.end())
+            THROW("Unknown settings key '" + key + "' (valid keys: " + String::Accumulate(validKeys, ", ") + ")");
+    }
+} // namespace Dal

--- a/dal-excel/src/__xccycalibration.cpp
+++ b/dal-excel/src/__xccycalibration.cpp
@@ -6,6 +6,7 @@
 
 #include "__platform.hpp"
 #include "__curve_storable.hpp"
+#include "__settingskeys.hpp"
 #include "__xccy_test_api.hpp"
 #include <cmath>
 #include <dal-public/src/xccycalibration.hpp>
@@ -185,9 +186,12 @@ namespace Dal {
         }
 
         void ApplyXccySettings(const Dictionary_& settings, CrossCurrencyCalibrationSpecBuilder_& b) {
+            static const Vector_<String_> validKeys = {"fxSpot",       "fxForwardCollateral", "smoothingWeight", "tolerance", "fitTolerance",
+                                                       "initialGuess", "maxEvaluations",      "maxRestarts",     "solveMode"};
             for (const auto& kv : settings) {
                 const String_& key = kv.first;
                 const Cell_& val = kv.second;
+                RequireKnownSettingsKey(key, validKeys);
                 ApplyXccyStringSettings(key, val, b);
                 ApplyXccyDoubleSettings(key, val, b);
                 ApplyXccyIntSettings(key, val, b);
@@ -326,7 +330,16 @@ namespace Dal {
         }
 
         void ApplyJointSettings(const Dictionary_& settings, JointXccyCalibrationSpecBuilder_& builder, JointXccyCalibrationOptions_& options) {
+            static const Vector_<String_> validKeys = {"domesticCurveName",      "foreignCurveName",         "basisCurveName",
+                                                       "domesticLiborBasis",     "foreignLiborBasis",        "domesticParameterization",
+                                                       "foreignParameterization", "basisParameterization",    "domesticLogDfScheme",
+                                                       "foreignLogDfScheme",     "domesticSmoothingWeight",   "foreignSmoothingWeight",
+                                                       "basisSmoothingWeight",   "tolerance",                 "fitTolerance",
+                                                       "initialGuess",           "maxEvaluations",            "maxRestarts",
+                                                       "solveMode",              "jacobianMode",              "computeEffJacobianInverse",
+                                                       "computeForwardJacobian"};
             for (const auto& setting : settings) {
+                RequireKnownSettingsKey(setting.first, validKeys);
                 ApplyJointStringSetting(setting.first, setting.second, builder, options);
                 ApplyJointDoubleSetting(setting.first, setting.second, builder);
                 ApplyJointIntSetting(setting.first, setting.second, builder);

--- a/dal-excel/tests/test_excel_api.cpp
+++ b/dal-excel/tests/test_excel_api.cpp
@@ -138,7 +138,8 @@ TEST(ExcelApiTest, TestUnknownJointSettingsKeyListsEveryAcceptedKey) {
         FAIL() << "Expected an unknown joint settings key to fail";
     } catch (const Dal::Exception_& exception) {
         const std::string message(exception.what());
-        ASSERT_NE(message.find("bogusKey"), std::string::npos) << message;
+        // the settings dictionary stores condensed (uppercase) keys, as in Dictionary_::At errors
+        ASSERT_NE(message.find("BOGUSKEY"), std::string::npos) << message;
         for (const char* key : {"domesticCurveName", "basisSmoothingWeight", "solveMode", "jacobianMode", "computeForwardJacobian"})
             ASSERT_NE(message.find(key), std::string::npos) << key << ": " << message;
     }

--- a/dal-excel/tests/test_excel_api.cpp
+++ b/dal-excel/tests/test_excel_api.cpp
@@ -38,7 +38,7 @@ namespace {
         return config;
     }
 
-    Handle_<StorableJointXccyCalibrationResult_> JointResult() {
+    Handle_<StorableJointXccyCalibrationResult_> JointResult(const Matrix_<Cell_>& settings) {
         const Date_ maturity = Today().AddDays(365);
         Vector_<Handle_<Storable_>> domestic;
         domestic.push_back(Handle_<Storable_>(new StorableYCInstrument_(DepositNew(
@@ -53,6 +53,14 @@ namespace {
 
         Handle_<StorableMarketFixingSnapshot_> fixings;
         MarketFixingSnapshot_New({}, {}, {}, &fixings);
+
+        Handle_<StorableJointXccyCalibrationResult_> result;
+        Calibrate_JointXccy(Cell_(DateTime_(Today(), 0, 0)), Pair(), "USD", 1.10, domestic, {maturity}, foreign, {maturity}, basis, {maturity},
+                            fixings, settings, &result);
+        return result;
+    }
+
+    Handle_<StorableJointXccyCalibrationResult_> JointResult() {
         Matrix_<Cell_> settings(3, 2);
         settings(0, 0) = Cell_("initialGuess");
         settings(0, 1) = Cell_(0.01);
@@ -60,11 +68,7 @@ namespace {
         settings(1, 1) = Cell_(1.0e-9);
         settings(2, 0) = Cell_("maxEvaluations");
         settings(2, 1) = Cell_(400.0);
-
-        Handle_<StorableJointXccyCalibrationResult_> result;
-        Calibrate_JointXccy(Cell_(DateTime_(Today(), 0, 0)), Pair(), "USD", 1.10, domestic, {maturity}, foreign, {maturity}, basis, {maturity},
-                            fixings, settings, &result);
-        return result;
+        return JointResult(settings);
     }
 } // namespace
 
@@ -122,6 +126,21 @@ TEST(ExcelApiTest, TestUnknownJointResultViewListsEveryAcceptedAttribute) {
         for (const char* attribute : {"domesticBlock", "foreignBlock", "basisCurve", "fxForwards", "marketRates", "modelRates", "residuals",
                                       "jacobian", "parameterRanges", "residualRanges"})
             ASSERT_NE(message.find(attribute), std::string::npos) << attribute << ": " << message;
+    }
+}
+
+TEST(ExcelApiTest, TestUnknownJointSettingsKeyListsEveryAcceptedKey) {
+    Dal::Matrix_<Dal::Cell_> settings(1, 2);
+    settings(0, 0) = Dal::Cell_("bogusKey");
+    settings(0, 1) = Dal::Cell_(1.0);
+    try {
+        JointResult(settings);
+        FAIL() << "Expected an unknown joint settings key to fail";
+    } catch (const Dal::Exception_& exception) {
+        const std::string message(exception.what());
+        ASSERT_NE(message.find("bogusKey"), std::string::npos) << message;
+        for (const char* key : {"domesticCurveName", "basisSmoothingWeight", "solveMode", "jacobianMode", "computeForwardJacobian"})
+            ASSERT_NE(message.find(key), std::string::npos) << key << ": " << message;
     }
 }
 

--- a/dal-python/src/dal/api.py
+++ b/dal-python/src/dal/api.py
@@ -16,30 +16,34 @@ _DAL_TYPE_CONVERTERS = {
     'libor_basis': lambda v: _bindings.DayBasis_(v) if isinstance(v, str) else v,
 }
 
+_OPTIONAL_SETTING_ATTRS = {
+    'curve_name': 'curveName_',
+    'target_collateral': 'targetCollateral_',
+    'target_tenor': 'targetTenor_',
+    'calibrate_discount': 'calibrateDiscountCurve_',
+    'libor_basis': 'liborBasis_',
+    'smoothing_weight': 'smoothingWeight_',
+    'tolerance': 'tolerance_',
+    'fit_tolerance': 'fitTolerance_',
+    'max_evaluations': 'maxEvaluations_',
+    'max_restarts': 'maxRestarts_',
+    'initial_guess': 'initialGuess_',
+    'solve_mode': 'solveMode_',
+    'parameterization': 'parameterization_',
+    'log_df_scheme': 'logDfScheme_',
+}
+
 
 def _apply_optional_setting(spec, name, value):
     """Apply a single optional setting to a spec builder if the value is not None."""
+    if name not in _OPTIONAL_SETTING_ATTRS:
+        valid = ', '.join(sorted(_OPTIONAL_SETTING_ATTRS))
+        raise ValueError(f"Unknown calibration setting {name!r}. Supported settings: {valid}")
     if value is None:
         return
-    attr = {
-        'curve_name': 'curveName_',
-        'target_collateral': 'targetCollateral_',
-        'target_tenor': 'targetTenor_',
-        'calibrate_discount': 'calibrateDiscountCurve_',
-        'libor_basis': 'liborBasis_',
-        'smoothing_weight': 'smoothingWeight_',
-        'tolerance': 'tolerance_',
-        'fit_tolerance': 'fitTolerance_',
-        'max_evaluations': 'maxEvaluations_',
-        'max_restarts': 'maxRestarts_',
-        'initial_guess': 'initialGuess_',
-        'solve_mode': 'solveMode_',
-        'parameterization': 'parameterization_',
-        'log_df_scheme': 'logDfScheme_',
-    }.get(name)
-    if attr is not None:
-        convert = _DAL_TYPE_CONVERTERS.get(name)
-        setattr(spec, attr, convert(value) if convert else value)
+    attr = _OPTIONAL_SETTING_ATTRS[name]
+    convert = _DAL_TYPE_CONVERTERS.get(name)
+    setattr(spec, attr, convert(value) if convert else value)
 
 
 def _build_calibration_spec(today, ccy, instruments, knot_dates, settings, base_curve=None):

--- a/dal-python/tests/test_curve_calibration.py
+++ b/dal-python/tests/test_curve_calibration.py
@@ -267,6 +267,42 @@ def test_api_calibrate_zero_rate_curve_with_base():
         assert spread_rate == pytest.approx(total_rate - 0.01, abs=1.0e-9)  # nosec B101 - intentional
 
 
+# ---- api.calibrate_curve settings validation ----
+
+def test_api_calibrate_curve_rejects_unknown_settings_key():
+    """api.calibrate_curve rejects an unknown settings key with a ValueError."""
+    instruments, knot_dates = _make_ois_instruments()
+    with pytest.raises(ValueError, match="smothing_weight"):
+        dal.api.calibrate_curve(
+            _today(), "USD", instruments, knot_dates,
+            settings=dict(smothing_weight=1.0),
+        )
+
+
+def test_api_calibrate_curve_unknown_key_error_lists_valid_keys():
+    """The unknown-key error names the bad key and the supported settings."""
+    instruments, knot_dates = _make_ois_instruments()
+    with pytest.raises(ValueError) as exc_info:
+        dal.api.calibrate_curve(
+            _today(), "USD", instruments, knot_dates,
+            settings=dict(bogus_key=1.0),
+        )
+    message = str(exc_info.value)
+    assert "bogus_key" in message  # nosec B101 - pytest assertions are intentional
+    for key in ("curve_name", "tolerance", "fit_tolerance", "solve_mode", "initial_guess"):
+        assert key in message  # nosec B101 - pytest assertions are intentional
+
+
+def test_api_calibrate_curve_rejects_unknown_key_with_none_value():
+    """An unknown key is rejected even when its value is None (unset)."""
+    instruments, knot_dates = _make_ois_instruments()
+    with pytest.raises(ValueError, match="bogus_key"):
+        dal.api.calibrate_curve(
+            _today(), "USD", instruments, knot_dates,
+            settings=dict(bogus_key=None),
+        )
+
+
 # ---- Multi-curve calibration ----
 
 def test_calibrate_multi_curve_bundle():


### PR DESCRIPTION
## Summary

Tranche 8 of the 2026-07-17 codebase review (plan item 18, repo polish — final plan item).

- **`.gitattributes` + EOL policy** (new): `* text=auto` baseline, explicit LF for sources/scripts, CRLF-on-checkout for `*.bat`/`*.ps1`, and explicit `binary` marking for images and Excel workbooks. The renormalization pass (`git add --renormalize .`) changed **0 files** — a byte-level scan confirmed the tree was already 100% LF, so there is no renormalization commit to make. `git check-attr` verifies png/xlsx resolve to binary and bat/ps1/sh to their mandated EOLs.
- **`.codacy.yml`**: `doc/**` → `docs/**`; the old path referenced a nonexistent directory, the real docs tree is `docs/`.
- **`.gitignore`**: added four verified gaps — `coverage_filtered.info` and `benchmark-results/` (generated at repo root by the CI workflows), `.ruff_cache/` (ruff lint step), `dal-web/backend/.data/` (default SQLite store when `DAL_WEB_DB_URL` is unset), plus `out/` (Visual Studio CMake default build tree, named by the review). Candidates that turned out already covered were left alone: `test_output.txt`, `node_modules`, `tsconfig.tsbuildinfo`, playwright `test-results/`/`playwright-report/`.
- **Stale root leftovers**: nothing to delete. The review's named leftovers (`cmake/` RapidJSON configs, old-layout `bin/*.exe`) are *untracked* local files from the reviewer's working copy; they do not exist in a fresh clone and are already covered by `.gitignore` (`/cmake/`, `bin/*`). (Adjacent finding, out of this item's scope: `dal-web/backend/requirements.txt` is stale — missing `sqlalchemy`/`alembic` — and unreferenced by CI/scripts/docs; belongs to the Medium build/CI findings, deferred rather than silently swept into this PR.)
- **Unknown settings keys now throw**:
  - `dal-python/src/dal/api.py` — `calibrate_curve` raised no error for misspelled settings keys (they were silently dropped). It now raises `ValueError` naming the bad key and the supported set, even when the value is `None`.
  - `dal-excel` — all three calibration settings parsers (single-curve, xccy-market, joint-xccy) validate each key via a new shared `RequireKnownSettingsKey` helper (`dal-excel/src/__settingskeys.hpp`) and `THROW` naming the offending key and the valid set. Valid-key lists match each function's Machinist doc block exactly (14 / 9 / 22 keys).

## Test plan

- [x] EOL: `git add --renormalize .` → 0 files changed; `git diff --cached` empty; byte scan for `\r` across all tracked files → 0 hits; `git check-attr` spot-checks (png/xlsx binary, bat→crlf, sh/hpp→lf) all correct
- [x] Codacy: `ls` confirms `doc/` absent, `docs/` present; exclude now matches the real tree
- [x] Gitignore: each new pattern verified with `git check-ignore`; no tracked-file collisions (`git ls-files`)
- [x] Python settings validation: 3 new pytest cases in `dal-python/tests/test_curve_calibration.py` (unknown key raises; message names bad key + valid set; `None`-valued unknown key still raises). Watched them fail (`DID NOT RAISE ValueError`) before the fix, pass after
- [x] Excel settings validation: helper compiled and behavior-tested against dal-cpp headers on Linux (known key passes incl. case-insensitive match; unknown key throws `Dal::Exception_` with key + valid set). New `ExcelApiTest.TestUnknownJointSettingsKeyListsEveryAcceptedKey` exercises the joint parser through the test API — dal-excel is Windows-only, so the MSVC CI jobs (`cmake-windows.yml`, `dal_excel_tests`) are the compile+run evidence; single-curve and xccy-market call sites use the identical helper + pattern and are covered by close-read plus the same CI build
- [x] Full `./build/Release-linux/dal-cpp/dal_cpp_tests` — 1064/1064 passed
- [x] Full `./build/Release-linux/dal-public/dal_public_tests` — 56/56 passed
- [x] Full dal-python pytest (build-tree package) — 243/243 passed
- [x] dal-web backend `uv run --no-sync pytest` — 43/43 passed (after `uv sync --locked --inexact`, same as CI); `ruff check` clean
- [x] Frontend `npm run test` (vitest) — 35/35 passed
- [x] `python .github/scripts/check_docs.py` — passed (38 Markdown files)
