### PR TITLE
docs: add C++ examples to methodology docs

### DIFF
--- a/docs/methodology/_cpp-example-style.md
+++ b/docs/methodology/_cpp-example-style.md
@@ -1,0 +1,220 @@
+# C++ Example Style Guide for Methodology Docs
+
+This is the internal style guide every doc-writer follows when adding C++ examples to a
+methodology note under `docs/methodology/`. It is not itself a methodology note. Read it before
+editing any doc in this directory.
+
+Its goal is consistency: a reader moving from `aad.md` to `yield_curve.md` to `script_engine.md`
+should see the same include style, the same naming, the same way of pointing at a runnable program,
+and the same rules about what may be invented.
+
+## Scope
+
+Apply this guide to every C++ snippet added to every file under `docs/methodology/`:
+
+`aad.md`, `black_scholes.md`, `dates.md`, `dupire.md`, `index_parsing.md`, `interpolation.md`,
+`log_discount_curve.md`, `matrix.md`, `pde.md`, `quadrature.md`, `random.md`, `script_engine.md`,
+`underdetermined_search.md`, `xccy_calibration.md`, `yield_curve.md`, `yield_curve_jacobian.md`.
+
+## Source of truth
+
+Snippets compile against the real public headers in `dal-cpp/dal/` (the `dal_cpp` target) and,
+where relevant, the public wrappers in `dal-public/src/`. The runnable programs under
+`dal-cpp/examples/` are the canonical reference for include sets, namespace usage, and factory
+patterns. When a snippet disagrees with a header or an example program, the header wins and the
+snippet is wrong.
+
+## Include style
+
+- Fenced code blocks only: open with ` ```cpp ` and close with ` ``` `.
+- Show a minimal-but-compilable include set at the top of each snippet. Order follows
+  `.claude/rules/code-style.md`: standard/system headers first, then `<dal/...>` headers, then
+  local headers. The example programs place `<dal/platform/platform.hpp>` before other `<dal/>`
+  headers; match that.
+- Draw includes from the real headers. Do not invent headers. The per-topic include sets observed
+  in `dal-cpp/examples/` are:
+
+| Topic | Minimal include set |
+|---|---|
+| AAD | `<dal/platform/platform.hpp>`, `<dal/math/aad/aad.hpp>`, `<dal/math/operators.hpp>`, `<dal/math/vectors.hpp>` |
+| Random / Sobol | `<dal/math/random/sobol.hpp>`, `<dal/math/random/quasirandom.hpp>`, `<dal/math/vectors.hpp>` |
+| Interpolation | `<dal/math/interp/interp.hpp>`, `<dal/math/interp/interplinear.hpp>` |
+| Yield curve / log-discount curve | `<dal/curve/calibration.hpp>`, `<dal/curve/curveblock.hpp>`, `<dal/curve/ycinstrument.hpp>`, `<dal/curve/yclogdf.hpp>`, `<dal/math/interp/interp.hpp>` |
+| Yield-curve Jacobian | `<dal/curve/calibration.hpp>`, `<dal/curve/curveblock.hpp>`, `<dal/math/matrix/matrixs.hpp>`, `<dal/math/matrix/matrixarithmetic.hpp>` |
+| Cross-currency calibration | `<dal/curve/calibration.hpp>`, `<dal/curve/curveblock.hpp>`, plus the xccy public wrapper when relevant |
+| Script engine | `<dal/platform/platform.hpp>`, `<dal/script/event.hpp>`, `<dal/script/simulation.hpp>`, `<dal/storage/globals.hpp>` |
+| Black / Dupire / MC / FD | `<dal/model/blackscholes.hpp>`, `<dal/math/distribution/black.hpp>`, `<dal/storage/globals.hpp>` |
+| Dates | `<dal/time/date.hpp>`, `<dal/time/dateincrement.hpp>`, `<dal/time/daybasis.hpp>`, `<dal/time/holidays.hpp>`, `<dal/time/periodlength.hpp>` |
+| Index parsing | the indice headers under `<dal/indice/...>` |
+| Quadrature | the quadrature headers under `<dal/math/...>` |
+| Globals / init | `<dal/platform/initall.hpp>` (`RegisterAll_::Init`), `<dal/storage/globals.hpp>` (`Global::Dates_::SetEvaluationDate`) |
+
+- Platform header: most `.cpp` files include `<dal/platform/platform.hpp>` first among `<dal/>`
+  headers. Show it once at the top of a multi-line snippet; omit it from one-liners.
+- `using` declarations: the example programs put `using namespace Dal;` (and where relevant
+  `using Dal::AAD::Number_;`) at file scope after the includes. Snippets may show the same.
+- Every snippet must be a plausible excerpt from a program that links against `dal_cpp`. Happy
+  path only: no `try`/`catch` ceremony, no error-handling boilerplate. The library's `REQUIRE`
+  is the project's precondition pattern; show it only where the example is specifically about
+  validating input.
+
+## Naming
+
+Follow `.claude/rules/code-style.md` exactly. The rows that matter most for snippets:
+
+| Element | Convention | Example |
+|---|---|---|
+| Classes/Structs | PascalCase + trailing `_` | `Date_`, `Vector_<>`, `DiscountCurve_`, `CurveCalibrationSpec_` |
+| Functions/Methods | PascalCase | `CalibrateYieldCurve()`, `NewSobol()`, `Date::AddMonths()` |
+| Local variables | camelCase | `numPaths`, `knotDates`, `today` |
+| Template params | single letter + `_` | `T_`, `E_` |
+| Constants/Macros | UPPER_SNAKE_CASE | `M_SQRT_2`, `THROW_REQUIRE` |
+
+Enum access uses the generated-class form, never a bare `enum class` literal:
+
+```cpp
+spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+spec.knotPolicy_       = CurveKnotPolicy_::Value_::INPUT;
+spec.solveMode_        = CurveSolveMode_::Value_::EXACT;
+```
+
+Factory functions follow `NewXxx()` (returns a handle or `std::unique_ptr`), e.g. `NewSobol(...)`.
+Calibration entry points such as `CalibrateYieldCurve(...)` are not factories and keep their
+verb-first name.
+
+## Pointers and ownership
+
+Match the header's return type exactly. The example programs show both shapes:
+
+- `Handle_<T_>` for shared, const ownership (`Handle_<YCInstrument_>(new Swap_(...))`).
+- `std::unique_ptr<T_>` for exclusive ownership, e.g.
+  `std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));`.
+
+Do not rewrite one form as the other to make a snippet tidier.
+
+## Example-program reference pattern
+
+A methodology doc that has a matching `dal-cpp/examples/<name>/` program must do both of the
+following:
+
+1. Link to the program directory with a project-relative markdown link. The canonical phrasing is:
+
+   ```markdown
+   See [`dal-cpp/examples/aad/`](../../dal-cpp/examples/aad/) for a runnable version.
+   ```
+
+   Use exactly the relative form `../../dal-cpp/examples/<name>/` from any file in
+   `docs/methodology/` (the lint resolves markdown links, and directory links with no fragment
+   pass). Keep the backtick path inside the link text so the project-relative path is visible.
+
+2. Show a one-line excerpt pointer at the top of any snippet copied from or mirroring an example
+   program, using a `// from dal-cpp/examples/<name>/<file>.cpp` comment:
+
+   ```cpp
+   // from dal-cpp/examples/sobol/sobol.cpp
+   #include <dal/math/random/sobol.hpp>
+   #include <dal/math/random/quasirandom.hpp>
+
+   auto rsg = Dal::NewSobol(numDims, 1000);
+   ```
+
+Notes on example filenames:
+
+- Example programs are named `<name>/<name>.cpp`, not `<name>/main.cpp`. Cite the real filename
+  (e.g. `dal-cpp/examples/aad/aad.cpp`, `dal-cpp/examples/interpolate_curve/interpolate_curve.cpp`).
+- The `european_mc` target's source file is misspelled on disk as
+  `dal-cpp/examples/european_mc/euorpean_mc.cpp`. Cite it as it is spelled; do not "fix" it in
+  prose without renaming the file.
+
+## Comment density
+
+Sparse, "why" not "what", per `.claude/rules/code-style.md`. A one-line `// why` pointer is the
+ceiling for inline comments. Do not paste multi-paragraph derivations into a snippet; methodology
+prose belongs in the doc text, not in the code block. If a snippet needs setup context, put it in
+the doc paragraph immediately before the fence.
+
+## Output illustration
+
+When a snippet shows what a program prints, mark the output with a `// ->` comment and use
+plausible, illustrative values. Do not claim exact benchmark timings, not even rounded ones; say
+"elapsed in the order of milliseconds on a workstation" in prose if timing matters, and keep
+numbers in code blocks clearly illustrative:
+
+```cpp
+std::cout << "PV = " << pv << "\n";
+// -> PV = 8.521...
+```
+
+## Hard rules
+
+- Never invent functions, types, enums, headers, or factory names. Every symbol must exist in
+  the real public header it comes from. Open the header and match the signature exactly,
+  including argument order and `const`/reference qualifiers. If unsure, grep the header rather
+  than guessing.
+- Use the project's enum access form `EnumName_::Value_::VALUE_NAME`. Never write
+  `EnumName_::VALUE_NAME` or a C-style cast.
+- `RegisterAll_::Init();` is called once at the start of every example program that touches
+  globals, curves, or the script engine. Show it at the top of `main` in any snippet that sets
+  the evaluation date or calibrates a curve.
+- The evaluation date is set via `Global::Dates_::SetEvaluationDate(Date_(...));`. Curves and
+  schedules depend on it; show the call when the snippet builds curve or schedule inputs.
+- Math notation uses only macros GitHub renders. Do not use the `operatorname` macro (GitHub's
+  renderer drops it); write `\mathrm{}` instead, or `\mathbb{}` for number sets. This is enforced
+  by `.github/scripts/check_docs.py` for every file under `docs/`.
+- No source line numbers in docs. Cite the struct, function, or file name (e.g. "the
+  `CurveCalibrationSpec_` struct in `dal-cpp/dal/curve/calibration.hpp`"), never
+  `calibration.hpp:70` or `dal/curve/yc.hpp:142-150`.
+- No trailing whitespace on any line. The lint fails on it.
+- Backtick paths in files under `docs/` are not existence-checked by the docs lint (path
+  verification runs only for the agent-facing guides listed in `check_docs.py`). Copy every
+  `dal-cpp/examples/<name>/` path verbatim from the mapping table below; do not retype it from
+  memory.
+
+## Canonical example-program to doc mapping
+
+Use exactly these paths. Every directory was verified against `dal-cpp/examples/` on this branch.
+
+| Methodology doc | Example program(s) |
+|---|---|
+| `aad.md` | `dal-cpp/examples/aad/` |
+| `black_scholes.md` | `dal-cpp/examples/vanilla/`, `dal-cpp/examples/european_mc/`, `dal-cpp/examples/european_fd/`, `dal-cpp/examples/digital/`, `dal-cpp/examples/uoc/`, `dal-cpp/examples/snowball/` |
+| `dupire.md` | `dal-cpp/examples/vanilla/`, `dal-cpp/examples/european_mc/`, `dal-cpp/examples/european_fd/`, `dal-cpp/examples/uoc/` |
+| `yield_curve.md` | `dal-cpp/examples/curve_calibration/`, `dal-cpp/examples/euribor3m_curve/`, `dal-cpp/examples/interpolate_curve/`, `dal-cpp/examples/joint_multi_curve_calibration/` |
+| `log_discount_curve.md` | `dal-cpp/examples/curve_calibration/`, `dal-cpp/examples/interpolate_curve/` |
+| `interpolation.md` | `dal-cpp/examples/interpolate_curve/` |
+| `yield_curve_jacobian.md` | `dal-cpp/examples/yield_curve_jacobian/` |
+| `random.md` | `dal-cpp/examples/sobol/` |
+| `script_engine.md` | `dal-cpp/examples/script/` |
+| `underdetermined_search.md` | `dal-cpp/examples/underdetermined/` |
+| `xccy_calibration.md` | `dal-cpp/examples/xccy_curve_calibration/`, `dal-cpp/examples/xccy_mtm_calibration/`, `dal-cpp/examples/xccy_reset_pricing/` |
+| `pde.md` | no new program needed; verify the existing C++ blocks stay consistent with this guide |
+| `matrix.md` | `dal-cpp/examples/concurrency/` where relevant, else an inline snippet from `dal-cpp/dal/math/matrix/` headers |
+| `dates.md` | inline snippet from `dal-cpp/dal/time/` headers; no dedicated example program exists |
+| `index_parsing.md` | inline snippet from `dal-cpp/dal/indice/` headers; no dedicated example program exists |
+| `quadrature.md` | inline snippet from the real quadrature headers under `dal-cpp/dal/math/`; no dedicated example program exists |
+
+Corrections to the mapping that was circulated during planning (later agents: use the table above,
+not the earlier draft):
+
+- The cross-currency mark-to-market example is `dal-cpp/examples/xccy_mtm_calibration/` (MTM =
+  mark-to-market), not `xccy_mitm_calibration/`.
+- Example sources are `<name>/<name>.cpp`, for example `dal-cpp/examples/aad/aad.cpp`. Earlier
+  drafts referenced a `main.cpp` that does not exist in this tree.
+
+## Docs-lint notes for doc-writers
+
+`.github/scripts/check_docs.py` runs on every `*.md` under `docs/` and fails the build on:
+
+- Markdown links that do not resolve (including missing `#anchor` targets). Use the
+  `../../dal-cpp/examples/<name>/` form for example-program links from any file in this directory.
+- Pipe tables whose header, delimiter, or body rows have differing cell counts.
+- Trailing whitespace on any line.
+- Stale command strings anywhere in the file, including inside fenced code blocks, such as
+  references to staged `bin/` test binaries. When illustrating a test invocation, point at the
+  build-tree binary (e.g. `./build/Release-linux/dal-cpp/dal_cpp_tests`) and a real
+  `--gtest_filter=SuiteName.*`, never the retired ones.
+- The forbidden `operatorname` macro; write `\mathrm` instead.
+
+Path-existence checks for `dal-cpp/...` tokens run only on the agent-facing guides, not on files
+under `docs/`. That is why the mapping table above is authoritative: nothing else checks it for
+you.

--- a/docs/methodology/aad.md
+++ b/docs/methodology/aad.md
@@ -422,6 +422,66 @@ recording is unconditional — and Adept's activity is governed by its
 without differentiation) should use a plain `double` evaluation rather than
 relying on tape passivity, which is backend-dependent.
 
+## Examples
+
+The recording contract of the previous section is exercised end to end by the
+AAD benchmark program, which prices a Black payoff and reads back every Greek
+from a single reverse sweep. See
+[`dal-cpp/examples/aad/`](../../dal-cpp/examples/aad/) for a runnable version;
+its core backend-neutral sweep is:
+
+```cpp
+// from dal-cpp/examples/aad/aad.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/math/aad/aad.hpp>
+#include <dal/math/operators.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+using Dal::AAD::Number_;
+
+Dal::RegisterAll_::Init();
+AAD::Clear(*AAD::Tape());
+
+Number_ fwdAad(fwd), volAad(vol), numeraireAad(numeraire), strikeAad(strike), expiryAad(expiry);
+PutOnTape(fwdAad);
+PutOnTape(volAad);
+PutOnTape(numeraireAad);
+PutOnTape(strikeAad);
+PutOnTape(expiryAad);
+AAD::NewRecording(*AAD::Tape());
+
+Number_ priceAad = BlackTest(fwdAad, volAad, numeraireAad, strikeAad, expiryAad, isCall);
+Adjoint(priceAad) = 1.0;
+AAD::PropagateToStart(*AAD::Tape());
+
+const double pv    = Value(priceAad);   // price
+const double delta = Adjoint(fwdAad);   // dP/dFwd
+const double vega  = Adjoint(volAad);   // dP/dVol
+// numeraire, strike, and expiry adjoints are read the same way
+```
+
+For the pathwise Monte Carlo estimator of the *Pathwise Adjoints in Monte Carlo*
+section, the same program wraps the forward evaluation and reverse sweep in a
+`Rewind`-bounded loop so the tape is reused per path while the parameter
+adjoints accumulate across paths:
+
+```cpp
+// from dal-cpp/examples/aad/aad.cpp
+Number_ priceAad{0.0};
+for (int i = 0; i < nRounds; ++i) {
+    AAD::Rewind(*AAD::Tape());
+    priceAad = BlackTest(fwdAad, volAad, numeraireAad, strikeAad, expiryAad, isCall);
+    Adjoint(priceAad) = 1.0;
+    AAD::PropagateToStart(*AAD::Tape());
+}
+const double delta = Adjoint(fwdAad) / nRounds;   // averaged pathwise estimator
+```
+
+The example also benchmarks the same payoff with the XAD, CoDiPack, and Adept
+backends side by side; only the recording and zeroing calls differ, as described
+under *Backends* above.
+
 ## Summary
 
 Reverse-mode AAD records the computational graph on a forward pass and applies

--- a/docs/methodology/black_scholes.md
+++ b/docs/methodology/black_scholes.md
@@ -182,22 +182,21 @@ the annualized $\sigma$.
 ## Examples
 
 The closed-form kernels above are the analytical benchmark that the pricing
-example programs converge to. The vanilla program computes the discounted
-forward and de-annualized volatility by hand and calls `Distribution::BlackOpt`
-directly, then prices the same European call by Monte Carlo on a
-`BSModelData_`-driven `BlackScholes_<T_>` model and by AAD on a closed-form
-payoff. See [`dal-cpp/examples/vanilla/`](../../dal-cpp/examples/vanilla/) for
-a runnable version; the closed-form benchmark line is:
+example programs converge to. The vanilla program prices a European call by
+Monte Carlo on a `BSModelData_`-driven `BlackScholes_<T_>` model and by AAD
+against an inlined closed-form payoff. The canonical kernel those runs measure
+against is `Distribution::BlackOpt`, defined in the header below; the European
+Monte Carlo and finite-difference examples call it directly as their benchmark.
+See [`dal-cpp/examples/vanilla/`](../../dal-cpp/examples/vanilla/) for a
+runnable version; the closed-form kernel is:
 
 ```cpp
-// from dal-cpp/examples/vanilla/vanilla.cpp
+// from dal-cpp/dal/math/distribution/black.hpp
 #include <dal/platform/platform.hpp>
 #include <dal/math/distribution/black.hpp>
-#include <dal/model/blackscholes.hpp>
 #include <dal/storage/globals.hpp>
 
 using namespace Dal;
-using Dal::AAD::BlackScholes_;
 
 RegisterAll_::Init();
 Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));

--- a/docs/methodology/black_scholes.md
+++ b/docs/methodology/black_scholes.md
@@ -236,6 +236,10 @@ using namespace Dal;
 using namespace Dal::Script;
 using Dal::AAD::BlackScholes_;
 
+// Closed-form benchmark (de-annualized inputs), as in euorpean_mc.cpp.
+double discounts = std::exp(-rate * t);      // P(0, T), t = time to expiry in years
+double fwd       = std::exp((rate - div) * t) * spot;
+double volStd    = std::sqrt(t) * vol;
 const auto benchmark = discounts * Distribution::BlackOpt(fwd, volStd, strike, OptionType_::Value_::CALL);
 
 Handle_<ModelData_> modelData(new BSModelData_("bsmodel", spot, vol, rate, div));

--- a/docs/methodology/black_scholes.md
+++ b/docs/methodology/black_scholes.md
@@ -179,6 +179,115 @@ The annualized implied-volatility helpers in `vanilla.hpp`,
 the `CALL` type, dispatch to the corresponding `*IV`, and divide by $\sqrt{T}$ to return
 the annualized $\sigma$.
 
+## Examples
+
+The closed-form kernels above are the analytical benchmark that the pricing
+example programs converge to. The vanilla program computes the discounted
+forward and de-annualized volatility by hand and calls `Distribution::BlackOpt`
+directly, then prices the same European call by Monte Carlo on a
+`BSModelData_`-driven `BlackScholes_<T_>` model and by AAD on a closed-form
+payoff. See [`dal-cpp/examples/vanilla/`](../../dal-cpp/examples/vanilla/) for
+a runnable version; the closed-form benchmark line is:
+
+```cpp
+// from dal-cpp/examples/vanilla/vanilla.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/math/distribution/black.hpp>
+#include <dal/model/blackscholes.hpp>
+#include <dal/storage/globals.hpp>
+
+using namespace Dal;
+using Dal::AAD::BlackScholes_;
+
+RegisterAll_::Init();
+Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
+
+const double spot = 100.0;
+const double vol = 0.15;
+const double rate = 0.05;
+const double div = 0.03;
+const double strike = 120.0;
+const Date_ maturity(2025, 9, 24);
+const double t = (maturity - Global::Dates_::EvaluationDate()) / 365.0;
+
+const double discount = std::exp(-rate * t);
+const double fwd = std::exp((rate - div) * t) * spot;
+const double volStd = std::sqrt(t) * vol;
+// de-annualized kernel: caller supplies forward and sigma * sqrt(T)
+const double price = discount * Distribution::BlackOpt(fwd, volStd, strike, OptionType_::Value_::CALL);
+```
+
+The `OptionType_::Value_::CALL` argument is the dispatch described in *The Black
+(Lognormal) Closed Form*; `PUT` and `STRADDLE` go through the same template. The
+European Monte Carlo program reuses this closed form as the convergence target
+of a quasi-Monte Carlo sweep on a `BSModelData_` model. See
+[`dal-cpp/examples/european_mc/`](../../dal-cpp/examples/european_mc/); its
+per-path pricing loop is:
+
+```cpp
+// from dal-cpp/examples/european_mc/euorpean_mc.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/math/distribution/black.hpp>
+#include <dal/model/blackscholes.hpp>
+#include <dal/script/event.hpp>
+#include <dal/script/simulation.hpp>
+#include <dal/storage/globals.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+using Dal::AAD::BlackScholes_;
+
+const auto benchmark = discounts * Distribution::BlackOpt(fwd, volStd, strike, OptionType_::Value_::CALL);
+
+Handle_<ModelData_> modelData(new BSModelData_("bsmodel", spot, vol, rate, div));
+ScriptProduct_ product(eventDates, events, "call");
+int maxNested = product.PreProcess(true, true);
+
+for (int i = 12; i <= 30; ++i) {
+    const int numPaths = std::pow(2, i);
+    SimResults_ results = MCSimulation<Real_>(product, modelData, numPaths, rsg, false, compiled, maxNested);
+    const double calculated = results.aggregated_ / static_cast<double>(numPaths);
+    // calculated -> benchmark as numPaths grows
+}
+```
+
+A finite-difference European pricer exercises the same closed form through
+explicit, implicit, and Crank-Nicolson $\theta$-schemes on the Black-Scholes
+PDE, and checks the recovered price against `Distribution::BlackOpt`. See
+[`dal-cpp/examples/european_fd/`](../../dal-cpp/examples/european_fd/); its PDE
+coefficient setup is:
+
+```cpp
+// from dal-cpp/examples/european_fd/european_fd.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/math/distribution/black.hpp>
+#include <dal/math/pde/pdegrid.hpp>
+#include <dal/math/pde/thetascheme.hpp>
+
+using namespace Dal;
+
+const double fwd = std::exp((kRate - kDiv) * kT) * kSpot;
+const double volStd = std::sqrt(kT) * kVol;
+const auto benchmark = std::exp(-kRate * kT)
+                     * Distribution::BlackOpt(fwd, volStd, kStrike, OptionType_::Value_::CALL);
+
+// Black-Scholes PDE coefficients: drift (r-q)S, variance sigma^2 S^2
+const Handle_<PDE::ScalarCoeff_> disc(PDE::NewConstCoeff(kRate));
+const Handle_<PDE::VectorCoeff_> mu(PDE::NewVectorCoeff([](double s) { return (kRate - kDiv) * s; }));
+const Handle_<PDE::MatrixCoeff_> var(PDE::NewMatrixCoeff([](double s) { return kVol * kVol * s * s; }));
+PDE::ThetaScheme_ scheme(theta);
+scheme.Prepare(dt, grids, *disc, *mu, *var);
+```
+
+Additional example programs that price off the Black/Bachelier kernels:
+
+- [`dal-cpp/examples/digital/`](../../dal-cpp/examples/digital/) — a digital
+  payoff priced analytically, by finite-difference bumps, and by pathwise AAD.
+- [`dal-cpp/examples/uoc/`](../../dal-cpp/examples/uoc/) — an up-and-out call
+  priced on a `Dupire_<T_>` local-volatility model fed by a flat vol surface.
+- [`dal-cpp/examples/snowball/`](../../dal-cpp/examples/snowball/) — a snowball
+  autocallable priced on a `BlackScholes_<T_>` model with scripted monitoring.
+
 ## See Also
 
 - [Yield-curve Jacobian](yield_curve_jacobian.md) — how greeks feed calibration risk.

--- a/docs/methodology/dates.md
+++ b/docs/methodology/dates.md
@@ -84,3 +84,57 @@ and a `DayBasis::Context_` for coupon-aware day counts.
 enumeration — `ACT_365F`, `ACT_365L`, `ACT_360`, `ACT_ACT`, and `BOND`
 (30/360). Calling a basis with start and end dates, plus an optional coupon
 context, returns the year fraction used for accrual.
+
+## Examples
+
+No dedicated example program exercises the date machinery in isolation; the
+snippet below is drawn from the public headers in `dal-cpp/dal/time/` and shows
+the typical call sequence. Every symbol matches the current signatures in
+`date.hpp`, `dateincrement.hpp`, `holidays.hpp`, `daybasis.hpp`,
+`datetime.hpp`, and `schedules.hpp`.
+
+```cpp
+// Inline snippet drawn from the public headers in dal-cpp/dal/time/.
+#include <dal/time/date.hpp>
+#include <dal/time/dateincrement.hpp>
+#include <dal/time/datetime.hpp>
+#include <dal/time/daybasis.hpp>
+#include <dal/time/holidays.hpp>
+#include <dal/time/schedules.hpp>
+
+using namespace Dal;
+
+// Date_ wraps a validated serial day count; years span [1900, 2199] and a
+// default-constructed Date_ fails IsValid().
+const Date_ today(2026, 4, 30);
+const int excelSerial = Date::ToExcel(today);
+const Date_ naiveSpot = Date::AddMonths(today, 2);   // T+2 spot, naive month roll
+
+// Holidays_ unions named centers; the empty string means no holidays. The
+// free functions in namespace Holidays roll and adjust against a calendar.
+const Holidays_ target("TARGET");
+const Date_ spot    = Holidays::Adjust(target, naiveSpot, BizDayConvention_("ModifiedFollowing"));
+const bool  isBizDay = Holidays::IsBusinessDay(target, spot);
+
+// Date::Increment_ is the step interface; ParseIncrement covers tenors ('3M',
+// '10Y', '2W'), business-day counts with a calendar suffix ('5BD;CN.IB'), and
+// special-day names ('IMM', 'EOM'). operator+ applies FwdFrom.
+const Handle_<Date::Increment_> tenor = Date::ParseIncrement("3M");
+const Date_ maturity                   = spot + *tenor;
+
+// DateTime_ pairs a Date_ with a sub-day fraction; the (hour, minute) ctor is
+// used for fixing timestamps.
+const DateTime_ fixingTime(spot, 11, 0);
+
+// Schedule generation and year fractions. MakeSchedule lays out an adjusted
+// strip; a DayBasis_ called as a functor returns the accrual fraction.
+const Schedule_ dates  = MakeSchedule(today, maturity, PeriodLength_("3M"), target);
+const DayBasis_ act365("ACT_365F");
+const double yearFrac = act365(dates[0], dates[1], nullptr);
+```
+
+The build-tree test binary holds the executable spec for these types — for
+example `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=DateTest.*`
+covers construction, comparison, and month arithmetic, and `--gtest_filter=...`
+also has dedicated suites for `DateIncrementTest`, `DateTimeTest`,
+`DayBasisTest`, `ChinaCalendarTest`, and `HolidayDataTest`.

--- a/docs/methodology/dupire.md
+++ b/docs/methodology/dupire.md
@@ -157,6 +157,68 @@ loop and transposed once at the end so that downstream consumers (e.g. the
 `Dupire_<T_>` model, which interpolates on log-spot against the strike axis per
 simulation step) read the strike axis as a contiguous row.
 
+## Examples
+
+The local-volatility model is driven by `DupireModelData_`, which stores the
+spot, rates, and a dense strike-by-maturity local-volatility matrix. The
+up-and-out call program builds a flat 31-by-61 surface by hand and prices the
+barrier option on a `Dupire_<T_>` model via the script Monte Carlo driver; a
+calibrated run would fill the same matrix from `DupireCalib`. See
+[`dal-cpp/examples/uoc/`](../../dal-cpp/examples/uoc/) for a runnable version;
+its model construction and pricing call are:
+
+```cpp
+// from dal-cpp/examples/uoc/uoc.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/model/blackscholes.hpp>
+#include <dal/model/dupire.hpp>
+#include <dal/script/event.hpp>
+#include <dal/script/simulation.hpp>
+#include <dal/storage/globals.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+using Dal::AAD::Dupire_;
+
+RegisterAll_::Init();
+Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
+
+const double spot = 100.0;
+const double rate = 0.0;
+const double div = 0.0;
+const double vol = 0.15;
+
+// dense strike/time grid; DupireCalib would produce this from an IVS_
+auto times = Vector::XRange(0.0, 5.0, 61);
+auto spots = Vector::XRange(50.0, 200.0, 31);
+
+Handle_<ModelData_> modelData(new DupireModelData_("dupiremodel",
+                                                   spot,
+                                                   rate,
+                                                   div,
+                                                   spots,
+                                                   times,
+                                                   Matrix_<double>(spots.size(), times.size(), vol)));
+ScriptProduct_ product(eventDates, events);
+product.PreProcess(false, false);
+SimResults_ results = MCSimulation<double>(product, modelData, numPath, String_("sobol"), false, false);
+```
+
+The same program also runs the pricing with finite-difference bumps and with
+pathwise AAD (`MCSimulation<Number_>`), so the local-volatility vega in the AAD
+output is a dense grid adjoint rather than a single scalar.
+
+Related example programs used as flat-volatility baselines against the Dupire
+pricer:
+
+- [`dal-cpp/examples/vanilla/`](../../dal-cpp/examples/vanilla/) — European call
+  priced analytically and by Monte Carlo on a `BlackScholes_<T_>` model.
+- [`dal-cpp/examples/european_mc/`](../../dal-cpp/examples/european_mc/) —
+  convergence of the quasi-Monte Carlo pricer to the Black-Scholes closed form.
+- [`dal-cpp/examples/european_fd/`](../../dal-cpp/examples/european_fd/) —
+  finite-difference European pricer that recovers the Black-Scholes closed form
+  from the PDE.
+
 ## See Also
 
 - [AAD methodology](aad.md) — the reverse-mode machinery that makes a

--- a/docs/methodology/index_parsing.md
+++ b/docs/methodology/index_parsing.md
@@ -82,3 +82,51 @@ currently matches nothing. `IndexPathHistorical_`
 (`dal-cpp/dal/indice/indexpath.hpp`) adapts a fixing time series to the
 `IndexPath_` interface used where models need path-level expectations and
 range probabilities.
+
+## Examples
+
+No dedicated example program exercises index parsing in isolation; the
+snippet below is drawn from the public headers in `dal-cpp/dal/indice/` and
+shows the parse-then-construct surface. Every symbol matches the current
+signatures in `index.hpp`, `indexparse.hpp`, `index/equity.hpp`,
+`index/fx.hpp`, and `index/ir.hpp`.
+
+```cpp
+// Inline snippet drawn from the public headers in dal-cpp/dal/indice/.
+#include <dal/currency/currency.hpp>
+#include <dal/indice/index/equity.hpp>
+#include <dal/indice/index/fx.hpp>
+#include <dal/indice/index/ir.hpp>
+#include <dal/indice/index.hpp>
+#include <dal/indice/indexparse.hpp>
+#include <dal/math/cell.hpp>
+#include <dal/protocol/couponrate.hpp>
+#include <dal/time/date.hpp>
+
+using namespace Dal;
+
+// Registered parsers: 'EQ[...]' -> Index::Equity_, 'FX[...]' -> Index::Fx_.
+// Index::Parse returns std::unique_ptr<Index_>; the prefix before ':' or '['
+// selects the parser, and an unregistered prefix throws.
+std::unique_ptr<Index_> spotEq = Index::Parse("EQ[SPX]");
+std::unique_ptr<Index_> fwdEq  = Index::Parse("EQ[SPX]>3M");
+std::unique_ptr<Index_> usdJpy = Index::Parse("FX[USD/JPY]");
+const String_ fxCanonical      = usdJpy->Name();     // "FX[USD/JPY]"
+
+// IR indices have canonical names but no registered parser; they are built
+// directly. Libor_ takes a TradedRate_ tenor; Swap_ takes a swap-tenor string.
+const Index::Libor_ libor(Ccy_("USD"), TradedRate_("LIBOR3MLCH"));
+const Index::Swap_  swap(Ccy_("USD"), "5Y");
+const Index::DF_    df(Ccy_("USD"), Cell_(Date_(2027, 6, 18)));
+const String_ liborName = libor.Name();              // "IR:USD,LIBOR_3M_LCH"
+const String_ swapName  = swap.Name();               // "IR:USD,5Y"
+
+// FxIndexName produces the canonical 'FX[fgn/dom]' name used by fixing
+// snapshots and XCCY reset conventions; it round-trips with Index::Parse.
+const String_ gbpUsd = FxIndexName(Ccy_("GBP"), Ccy_("USD"));
+```
+
+The build-tree test binary covers the parse dispatch table and canonical name
+formats: `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=IndexParseTest.*`
+exercises the registered parsers, and `--gtest_filter=IndexTest.*` covers
+`Libor_`, `Swap_`, and `DF_` name generation and fixing lookup.

--- a/docs/methodology/index_parsing.md
+++ b/docs/methodology/index_parsing.md
@@ -121,9 +121,9 @@ const Index::DF_    df(Ccy_("USD"), Cell_(Date_(2027, 6, 18)));
 const String_ liborName = libor.Name();              // "IR:USD,LIBOR_3M_LCH"
 const String_ swapName  = swap.Name();               // "IR:USD,5Y"
 
-// FxIndexName produces the canonical 'FX[fgn/dom]' name used by fixing
-// snapshots and XCCY reset conventions; it round-trips with Index::Parse.
-const String_ gbpUsd = FxIndexName(Ccy_("GBP"), Ccy_("USD"));
+// FxIndexName(domestic, foreign) produces the canonical 'FX[fgn/dom]' name used
+// by fixing snapshots and XCCY reset conventions; it round-trips with Index::Parse.
+const String_ usdGbp = FxIndexName(Ccy_("GBP"), Ccy_("USD"));  // "FX[USD/GBP]" (domestic=GBP, foreign=USD)
 ```
 
 The build-tree test binary covers the parse dispatch table and canonical name

--- a/docs/methodology/interpolation.md
+++ b/docs/methodology/interpolation.md
@@ -178,6 +178,44 @@ $(N_x, N_y)$ (`dal-cpp/dal/math/interp/interp2d.hpp`).
 - Use **bilinear** for surfaces quoted on a regular grid (e.g. option volatility by
   expiry and strike).
 
+## Examples
+
+The archive-backed factories are the public general-purpose surface. A linear
+interpolator is built and evaluated directly from its knots:
+
+```cpp
+// from dal-cpp/dal/math/interp/interplinear.hpp
+#include <dal/math/interp/interplinear.hpp>
+
+using namespace Dal;
+
+const Vector_<> x = {1.0, 2.0, 3.0, 5.0, 10.0};
+const Vector_<> f = {0.05, 0.06, 0.07, 0.09, 0.12};
+
+std::unique_ptr<Interp1_> interp(Interp::NewLinear("fwd", x, f));
+const double v = (*interp)(4.0);   // linear between the knots bracketing 4.0
+```
+
+The scalar-generic weight geometry that underpins the curve layer is exercised
+end to end by the log-discount curve calibration program, which builds the same
+curve under `LOG_LINEAR`, `LOG_CUBIC_NATURAL`, and `MIXED` schemes and compares
+the resulting node discount factors and forward rates. See
+[`dal-cpp/examples/interpolate_curve/`](../../dal-cpp/examples/interpolate_curve/)
+for a runnable version; its per-scheme calibration call is:
+
+```cpp
+// from dal-cpp/examples/interpolate_curve/interpolate_curve.cpp
+CurveCalibrationSpec_ spec;
+spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+spec.solveMode_        = CurveSolveMode_::Value_::EXACT;
+spec.logDfScheme_      = LogDfScheme_::Value_::LOG_LINEAR;   // or LOG_CUBIC_NATURAL, MIXED
+const auto result = CalibrateYieldCurve(spec);
+
+const auto* logDf = dynamic_cast<const DiscountLogDF_*>(result.curve_.get());
+const Vector_<Date_> dates = logDf->NodeDates();
+const Vector_<> nodeDf = logDf->NodeDF();          // scheme-dependent knot DFs
+```
+
 ## See Also
 
 - [Log-discount curve](log_discount_curve.md) — uses log-linear, cubic, and mixed

--- a/docs/methodology/interpolation.md
+++ b/docs/methodology/interpolation.md
@@ -212,6 +212,7 @@ spec.logDfScheme_      = LogDfScheme_::Value_::LOG_LINEAR;   // or LOG_CUBIC_NAT
 const auto result = CalibrateYieldCurve(spec);
 
 const auto* logDf = dynamic_cast<const DiscountLogDF_*>(result.curve_.get());
+REQUIRE(logDf, "calibrated curve is not a DiscountLogDF_");
 const Vector_<Date_> dates = logDf->NodeDates();
 const Vector_<> nodeDf = logDf->NodeDF();          // scheme-dependent knot DFs
 ```

--- a/docs/methodology/log_discount_curve.md
+++ b/docs/methodology/log_discount_curve.md
@@ -204,6 +204,38 @@ AAD-derived analytic residual Jacobian. ZERO_RATE maps a future node $z_i$ to
 $\ell_i=-z_i\tau_i$ before using this document's interpolation geometry. The four
 representations have different solver column units and between-node shapes.
 
+## Examples
+
+The three `LogDfScheme_` choices are compared side by side by the interpolation
+example, which calibrates the same instrument set three times — once each for
+`LOG_LINEAR`, `LOG_CUBIC_NATURAL`, and `MIXED` — and prints the solved node
+discount factors, the 1-year forward rates at each node, and the per-scheme
+repricing residuals. See
+[`dal-cpp/examples/interpolate_curve/`](../../dal-cpp/examples/interpolate_curve/)
+for a runnable version. The per-scheme calibration builds the typed curve
+through the public factory:
+
+```cpp
+// from dal-cpp/examples/interpolate_curve/interpolate_curve.cpp
+CurveCalibrationSpec_ spec;
+spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+spec.knotPolicy_       = CurveKnotPolicy_::Value_::INPUT;
+spec.solveMode_        = CurveSolveMode_::Value_::EXACT;
+spec.logDfScheme_      = scheme;   // LogDfScheme_::Value_::{LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED}
+const auto result = CalibrateYieldCurve(spec);
+
+const auto* curve = dynamic_cast<const DiscountLogDF_*>(result.curve_.get());
+const Vector_<> nodeDf = curve->NodeDF();        // P(today, nodeDate) per storage node
+```
+
+`NodeDF()` and `NodeLogDF()` return one entry per storage node — anchor first,
+then every declared future knot — so the pinned anchor ordinate is included in
+the returned vector. The staged multi-curve calibration program
+([`dal-cpp/examples/curve_calibration/`](../../dal-cpp/examples/curve_calibration/))
+exercises the same `CalibrateYieldCurve` entry point in an OIS-discounting +
+tenor-forecasting setup, with the discount and forward curves layered through
+`CurveBlock_`.
+
 ## See Also
 
 - [Interpolation](interpolation.md) — passive interpolation geometry and typed ordinate

--- a/docs/methodology/log_discount_curve.md
+++ b/docs/methodology/log_discount_curve.md
@@ -225,6 +225,7 @@ spec.logDfScheme_      = scheme;   // LogDfScheme_::Value_::{LOG_LINEAR, LOG_CUB
 const auto result = CalibrateYieldCurve(spec);
 
 const auto* curve = dynamic_cast<const DiscountLogDF_*>(result.curve_.get());
+REQUIRE(curve, "calibrated curve is not a DiscountLogDF_");
 const Vector_<> nodeDf = curve->NodeDF();        // P(today, nodeDate) per storage node
 ```
 

--- a/docs/methodology/matrix.md
+++ b/docs/methodology/matrix.md
@@ -205,8 +205,9 @@ No dedicated example program exercises the matrix layer in isolation; the
 snippets below are drawn from the public headers under `dal-cpp/dal/math/matrix/`.
 
 A band-diagonal system is built through `Sparse::NewBandDiagonal`, which returns
-the tightest available representation — a `TriDiagonal_` when both bandwidths are
-at most one, otherwise a `Banded_` — and solved through the common
+the tightest available representation — a public `TriDiagonal_` when both
+bandwidths are at most one, otherwise a wider banded matrix reached only through
+the `Sparse::Square_` interface — and solved through the common
 `SquareMatrixDecomposition_` interface:
 
 ```cpp

--- a/docs/methodology/matrix.md
+++ b/docs/methodology/matrix.md
@@ -199,6 +199,85 @@ $$
 
 and exceeding `maxIterations` without meeting the threshold throws.
 
+## Examples
+
+No dedicated example program exercises the matrix layer in isolation; the
+snippets below are drawn from the public headers under `dal-cpp/dal/math/matrix/`.
+
+A band-diagonal system is built through `Sparse::NewBandDiagonal`, which returns
+the tightest available representation — a `TriDiagonal_` when both bandwidths are
+at most one, otherwise a `Banded_` — and solved through the common
+`SquareMatrixDecomposition_` interface:
+
+```cpp
+// from dal-cpp/dal/math/matrix/banded.hpp
+#include <dal/math/matrix/banded.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+const int n = 8;
+std::unique_ptr<Sparse::Square_> a(Sparse::NewBandDiagonal(n, 1, 1));   // tri-diagonal
+for (int i = 0; i < n; ++i)
+    a->Set(i, i, 2.0);
+for (int i = 0; i < n - 1; ++i) {
+    a->Set(i, i + 1, -1.0);   // above
+    a->Set(i + 1, i, -1.0);   // below
+}
+
+const Vector_<> b(n, 1.0);
+Vector_<> x(n);
+std::unique_ptr<SquareMatrixDecomposition_> decomp(a->Decompose());
+decomp->SolveLeft(b, &x);   // solve A x = b by the Thomas algorithm
+```
+
+For a dense symmetric positive-definite system, `CholeskyDecomposition` returns a
+`SymmetricDecomposition_` whose `Solve` handles both forward and backward
+substitution, and whose `MakeCorrelated` applies the retained lower factor to
+i.i.d. deviates:
+
+```cpp
+// from dal-cpp/dal/math/matrix/cholesky.hpp
+#include <dal/math/matrix/cholesky.hpp>
+#include <dal/math/matrix/squarematrix.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+SquareMatrix_<> a(3);
+a(0, 0) = 4.0; a(1, 1) = 1.0; a(2, 2) = 9.0;
+a(0, 1) = a(1, 0) = 1.0;
+a(0, 2) = a(2, 0) = 2.0;
+a(1, 2) = a(2, 1) = 0.0;
+
+std::unique_ptr<Sparse::SymmetricDecomposition_> chol(CholeskyDecomposition(a));
+const Vector_<> b = {1.0, 2.0, 3.0};
+Vector_<> x(3);
+chol->Solve(b, &x);   // forward/backward substitution against L L^T
+```
+
+When $A$ is available only through its matrix-vector products, the Krylov solvers
+take the matrix by its `Sparse::Square_` base and converge under the combined
+tolerance of the *When to Use Which* section. `CGSolve` is the right call for a
+symmetric positive-definite $A$ such as a Gauss-Newton normal-equations Hessian:
+
+```cpp
+// from dal-cpp/dal/math/matrix/bcg.hpp
+#include <dal/math/matrix/bcg.hpp>
+#include <dal/math/matrix/banded.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+const int n = 64;
+std::unique_ptr<Sparse::Square_> a(Sparse::NewBandDiagonal(n, 1, 1));
+// ... fill a SPD band matrix ...
+const Vector_<> b(n, 1.0);
+Vector_<> x(n, 0.0);
+Sparse::CGSolve(*a, b, /*tolRel=*/1e-8, /*tolAbs=*/1e-10, /*maxIterations=*/200, &x);
+// Sparse::BCGSolve(*a, b, 1e-8, 1e-10, 200, &x);   // non-symmetric fallback
+```
+
 ## See Also
 
 - [Interpolation](interpolation.md) — the natural cubic-spline construction reduces to a

--- a/docs/methodology/matrix.md
+++ b/docs/methodology/matrix.md
@@ -58,8 +58,8 @@ The tri-diagonal case ($m_1 = m_2 = 1$) is special-cased by `Sparse::TriDiagonal
 does not use the offset array at all. Instead it stores the three diagonals directly as
 `diag_` (length $n$), `above_` (length $n-1$, the first super-diagonal), and `below_`
 (length $n-1$, the first sub-diagonal). The factory `Sparse::NewBandDiagonal(size, nAbove,
-nBelow)` returns a `TriDiagonal_` when both `nAbove` and `nBelow` are at most 1, and the
-general `Banded_` otherwise, so callers always use the tightest available representation.
+nBelow)` returns a `TriDiagonal_` when both `nAbove` and `nBelow` are at most 1, and a
+wider banded matrix otherwise, so callers always use the tightest available representation.
 
 ## Tri-Diagonal Solve (Thomas Algorithm)
 

--- a/docs/methodology/pde.md
+++ b/docs/methodology/pde.md
@@ -18,6 +18,7 @@ The framework is plain `double`; it does not use active AAD types.
 `CoordinateMap_` maps a computational coordinate `y` to a physical coordinate `x`:
 
 ```cpp
+// from dal-cpp/dal/math/pde/pde.hpp
 virtual double operator()(double y, double* dxDy, double* d2xDy2) const = 0;
 virtual double Y(double x) const = 0;
 ```
@@ -90,6 +91,7 @@ $$
 `CoordinateVector_` describes a one-dimensional computational grid:
 
 ```cpp
+// from dal-cpp/dal/math/pde/pde.hpp
 struct CoordinateVector_ {
     double yLow_;
     double yHigh_;
@@ -172,6 +174,7 @@ The factory functions return `std::unique_ptr`. Callers normally wrap the result
 Constant factories:
 
 ```cpp
+// from dal-cpp/dal/math/pde/pde.hpp
 std::unique_ptr<ScalarCoeff_> NewConstCoeff(double val);
 std::unique_ptr<VectorCoeff_> NewConstCoeff(const Vector_<>& val);
 std::unique_ptr<MatrixCoeff_> NewConstCoeff(const Matrix_<>& val);
@@ -182,6 +185,7 @@ The matrix constant must be square. Constant coefficients report all-zero depend
 Callable factories:
 
 ```cpp
+// from dal-cpp/dal/math/pde/pde.hpp
 std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(const Vector_<>&)> f, Coeff_::x_dep_t dep);
 std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<void(const Vector_<>&, Vector_<>*)> f,
                                              const Vector_<Coeff_::x_dep_t>& dep);
@@ -195,6 +199,7 @@ adapter resizes the output object to match `dep` before invoking the callable.
 The one-dimensional convenience overloads infer axis-0 dependence and length/shape 1:
 
 ```cpp
+// from dal-cpp/dal/math/pde/pde.hpp
 std::unique_ptr<ScalarCoeff_> NewScalarCoeff(std::function<double(double)> f);
 std::unique_ptr<VectorCoeff_> NewVectorCoeff(std::function<double(double)> f);
 std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<double(double)> f);
@@ -203,6 +208,7 @@ std::unique_ptr<MatrixCoeff_> NewMatrixCoeff(std::function<double(double)> f);
 These make Black-Scholes coefficients concise:
 
 ```cpp
+// from dal-cpp/examples/european_fd/european_fd.cpp
 Handle_<ScalarCoeff_> disc(NewConstCoeff(rate));
 Handle_<VectorCoeff_> mu(NewVectorCoeff([=](double s) { return (rate - div) * s; }));
 Handle_<MatrixCoeff_> var(NewMatrixCoeff([=](double s) { return vol * vol * s * s; }));
@@ -278,6 +284,7 @@ vectors.
 Whole-vector aliasing is supported:
 
 ```cpp
+// from dal-cpp/dal/math/pde/thetascheme.hpp
 scheme(dt, grids, vals, *disc, *mu, *var, &vals);
 ```
 
@@ -291,7 +298,8 @@ fresh `Cube_<>(1, 1, n)`; the implementation does not resize cubes in place.
 
 ## Example Roll Loop
 
-The European finite-difference example in `dal-cpp/examples/european_fd/` runs explicit,
+The European finite-difference example in
+[`dal-cpp/examples/european_fd/`](../../dal-cpp/examples/european_fd/) runs explicit,
 Crank-Nicolson, and fully implicit scheme configurations through the same rollback helper.
 The explicit configuration uses a finer time grid because explicit rollback is
 conditionally stable. After the base scheme comparison, the example continues the
@@ -299,6 +307,7 @@ Crank-Nicolson convergence sweep by increasing `spaceSteps` and `timeSteps` toge
 each selected run, the helper uses:
 
 ```cpp
+// from dal-cpp/examples/european_fd/european_fd.cpp
 const SchemeRun_ schemeRuns[] = {
     {"Explicit", 0.0, kBaseSteps, kExplicitTimeSteps},
     {"Crank-Nicolson", 0.5, kBaseSteps, kBaseSteps},

--- a/docs/methodology/quadrature.md
+++ b/docs/methodology/quadrature.md
@@ -202,6 +202,47 @@ Simpson on a truncated interval: it places nodes where the density has mass,
 needs no truncation, and achieves exactness for polynomial payoffs that
 Simpson matches only approximately and at far higher cost.
 
+## Examples
+
+No dedicated example program exercises the quadrature layer; the snippets below
+are drawn from `dal-cpp/dal/math/integral/quadrature.hpp`. Both rules are driven
+through the same pull-style loop on `Quad1DFixed_<T_>`.
+
+`NormalExpectation_` evaluates a standard-normal expectation with a Gauss-Hermite
+node set; $n$ nodes are exact for polynomial payoffs up to degree $2n-1$:
+
+```cpp
+// from dal-cpp/dal/math/integral/quadrature.hpp
+#include <dal/math/integral/quadrature.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+NormalExpectation_<> quad(/*n=*/8);   // 8 Gauss-Hermite nodes
+while (!quad.IsComplete()) {
+    const double z = quad.GetX();
+    const double payoff = std::max(std::exp(z) - strike, 0.0);   // f(z)
+    quad.PutY(payoff);
+}
+const double price = quad.Result();   // E[f(Z)], Z ~ N(0,1)
+```
+
+`QuadSimpson_` integrates a smooth integrand over a finite interval with the
+composite $1/3$ rule; the requested point count is forced odd internally:
+
+```cpp
+// from dal-cpp/dal/math/integral/quadrature.hpp
+QuadSimpson_<> quad(/*n=*/101, /*lo=*/0.0, /*hi=*/1.0);
+while (!quad.IsComplete()) {
+    const double x = quad.GetX();
+    quad.PutY(std::sin(x));
+}
+const double integral = quad.Result();   // int_0^1 sin(x) dx
+```
+
+`Restart()` rewinds the cursor and resets the accumulator so the same node set
+can be reused across several integrands without rebuilding the weights.
+
 ## See Also
 
 - [Black / Bachelier vanilla pricing](black_scholes.md) — the normal CDF/PDF at the

--- a/docs/methodology/random.md
+++ b/docs/methodology/random.md
@@ -325,6 +325,39 @@ over a 100K-path batch, the dominant Monte Carlo inner loop.
   rather than re-measuring the common inverse-CDF cost already covered by the
   Sobol fast/precise pair.
 
+## Examples
+
+The Sobol benchmark program drives every generator through the same
+`FillUniform` / `FillNormal` inner loop and times the `precise` / `polish`
+inverse-CDF modes separately. See
+[`dal-cpp/examples/sobol/`](../../dal-cpp/examples/sobol/) for a runnable
+version; its per-configuration construction and draw loop is:
+
+```cpp
+// from dal-cpp/examples/sobol/sobol.cpp
+#include <dal/math/random/sobol.hpp>
+#include <dal/math/random/quasirandom.hpp>
+#include <dal/math/vectors.hpp>
+
+using namespace Dal;
+
+const int numDims = 5;
+Vector_<> dst;
+
+// Acklam-only fast path (precise=false, polish=false)
+std::unique_ptr<SequenceSet_> rsg(NewSobol(numDims, 1000));
+rsg->FillUniform(&dst);
+
+// Acklam plus a Newton step using the precise CDF (precise=true, polish=true)
+rsg = NewSobol(numDims, 1000, true, true);
+rsg->FillNormal(&dst);
+```
+
+The storable wrapper `SobolRSG_` (`dal-cpp/dal/math/random/sobol.hpp`) exposes the
+same `FillUniform` / `FillNormal` / `NDim` surface and persists both flags, so a
+generator configured for the precise-polished path can be archived and rebuilt
+identically.
+
 ## See Also
 
 - [Script engine](script_engine.md) — the Monte Carlo driver that consumes these

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -506,10 +506,66 @@ contract at compile time via `HasConstVisit_` / `HasNonConstVisit_`: a non-const
 attempts to mutate through a const visitor fail to build rather than corrupt the
 tree.
 
+## Examples
+
+The script program feeds an events table to `ScriptProduct_`, which runs the
+parser and AST construction in its constructor, and then prints the debug walk
+of the processed tree. See [`dal-cpp/examples/script/`](../../dal-cpp/examples/script/)
+for a runnable version; its events table and product construction are:
+
+```cpp
+// from dal-cpp/examples/script/script.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/script/event.hpp>
+#include <dal/storage/globals.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+
+Dal::RegisterAll_::Init();
+Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
+
+Vector_<Cell_> eventDates;
+Vector_<String_> events;
+
+// Constant variables resolve in the preprocessor and become NodeConstVar_ leaves
+eventDates.emplace_back("BARRIER");
+events.emplace_back("150.00");
+eventDates.emplace_back("STRIKE");
+events.emplace_back("120.00");
+
+// Schedule directive: the preprocessor expands PeriodBegin/PeriodEnd per period
+eventDates.emplace_back(
+    "START: 2022-09-25\n"
+    "END: 2025-09-25\n"
+    "FREQ: 1W");
+events.emplace_back("IF spot() > BARRIER:0.1 THEN alive = 0 END");
+
+// Final payoff: an IF/END block followed by a PAYS clause on the same date
+eventDates.emplace_back(Date_(2025, 9, 25));
+events.emplace_back(
+    "IF spot() > BARRIER:0.1 THEN alive = 0 END "
+    "uoc pays alive * MAX(spot() - STRIKE, 0.0)");
+
+// The constructor runs the preprocessor and parser; the returned product holds
+// the dated AST that DomainProcessor_, ConstCondProcessor_, and the evaluator
+// then walk
+ScriptProduct_ product(eventDates, events);
+```
+
+The `BARRIER:0.1` suffix on each comparison sets the node's `eps_` field, which
+the fuzzy evaluator consumes as the smoothing width for that condition. Running
+`product.Debug(out)` after the constructor walks the AST and writes the dated,
+variable-indexed event listing that the visitor passes operate on; downstream
+valuation calls `IndexVariables` and `PreProcess` before evaluation or
+`Compile`. The Monte Carlo driver is the free function `MCSimulation<T_>` in
+`dal-cpp/dal/script/simulation.hpp`, templated on `double` for value-only runs
+and on `AAD::Number_` for pathwise-adjoint runs.
+
 ## See Also
 
 - [Automatic Adjoint Differentiation](aad.md) — the reverse-mode machinery that
   fuzzy evaluation feeds, enabling pathwise Greeks through discontinuous payoffs.
-- `dal-cpp/examples/script/script.cpp` — runnable example of the full pipeline:
-  events table parsing, preprocessing, domain analysis, condition folding, and
-  evaluation.
+- [`dal-cpp/examples/script/`](../../dal-cpp/examples/script/) — runnable example
+  of the full pipeline: events table parsing, preprocessing, domain analysis,
+  condition folding, and evaluation.

--- a/docs/methodology/underdetermined_search.md
+++ b/docs/methodology/underdetermined_search.md
@@ -396,6 +396,57 @@ satisfaction. The approximate mode solves a regularised normal-equation system a
 converges on residual norm. In both, the weight matrix turns the surplus degrees of
 freedom into a smoothness prior.
 
+## Examples
+
+The underdetermined solver is consumed by curve calibration rather than called
+directly. The example program constructs an instrument set and a denser knot
+grid, then calls the positional `CalibrateYieldCurve` overload from
+`dal-cpp/dal/curve/curveblock.hpp`, which assembles a `CurveCalibrationSpec_`,
+runs the residual function through `Underdetermined::Find`, and returns the
+fitted discount curve. See [`dal-cpp/examples/underdetermined/`](../../dal-cpp/examples/underdetermined/)
+for a runnable version; its calibration entry point is:
+
+```cpp
+// from dal-cpp/examples/underdetermined/underdetermined.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/curve/curveblock.hpp>
+
+using namespace Dal;
+
+const Date_ today(2024, 1, 15);
+const String_& ccy = "USD";
+const DayBasis_ basis("ACT_365F");
+
+Vector_<Handle_<YCInstrument_>> instruments;
+instruments.push_back(Handle_<YCInstrument_>(new Deposit_(today, Date::AddMonths(today, 1), 0.0450, basis)));
+instruments.push_back(Handle_<YCInstrument_>(new STIR_(today, Date::AddMonths(today, 3), Date::AddMonths(today, 6), 0.0470, basis)));
+instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 12), 0.0490, 6, basis)));
+instruments.push_back(Handle_<YCInstrument_>(new Swap_(today, Date::AddMonths(today, 60), 0.0510, 6, basis)));
+
+Vector_<Date_> knotDates = {
+    Date::AddMonths(today, 1),
+    Date::AddMonths(today, 3),
+    Date::AddMonths(today, 6),
+    Date::AddMonths(today, 12),
+    Date::AddMonths(today, 24),
+    Date::AddMonths(today, 36),
+    Date::AddMonths(today, 60),
+};
+
+// The system is underdetermined: with the default piecewise-linear-forward
+// parameterization there are two parameters per knot, so n > m and the
+// tridiagonal smoothing weight W picks the least-rough solution
+std::unique_ptr<DiscountCurve_> dc(CalibrateYieldCurve(today, ccy, instruments, knotDates));
+```
+
+The example then wraps the calibrated curve in a `CurveBlock_`, reprices each
+instrument through its `Precompute` rate, and prints the model-minus-market
+error in basis points to confirm the componentwise tolerance test converged.
+The solver controls (`maxEvaluations_`, `maxRestarts_`, line-search tolerances)
+flow in through the `CurveCalibrationSpec_` fields when the spec-form overload
+`CalibrateYieldCurve(spec)` is used instead of the positional convenience
+overload shown above.
+
 ## See Also
 
 - [Yield curve construction](yield_curve.md) — the primary consumer of this solver.

--- a/docs/methodology/xccy_calibration.md
+++ b/docs/methodology/xccy_calibration.md
@@ -198,24 +198,179 @@ valid residual system without the analytic eligibility requirement.
   matrix views; joint XCCY has options plus forward-Jacobian/range views, but no
   effective-inverse worksheet getter.
 
-## Runnable Examples
+## Examples
 
-- `xccy_curve_calibration` performs staged basis-only calibration against
-  supplied domestic and foreign curve blocks and prints fit diagnostics,
-  including the FX spot and maximum residual, plus elapsed time.
-- `xccy_reset_pricing` prices future fixed, resettable, and MTM swaps against
-  piecewise-constant discount, projection, and basis curves, validates their
-  reset and notional behavior, and prices an already-started MTM swap from an
-  immutable snapshot of historical domestic-rate, foreign-rate, and FX fixings.
-- `xccy_mtm_calibration` builds known domestic, foreign, and basis curves,
-  derives self-consistent quotes, supplies an immutable fixing snapshot for an
-  already-started MTM swap, and recovers five declaration blocks across the
-  domestic, foreign, and basis groups in one joint calibration. It prints the
-  convergence residual, Jacobian shape, block ranges, and parameter-recovery
-  errors.
-- `dal-python/examples/007.xccy_joint_calibration.py` runs joint calibration
-  through the installed Python surface and prints convergence, matrix
-  dimensions, named ranges, and FX forwards.
+The three standalone programs under `dal-cpp/examples/` exercise the staged,
+joint, and pricing surfaces declared in `dal-cpp/dal/curve/xccycalibration.hpp`
+and `dal-cpp/dal/curve/xccyjointcalibration.hpp`. The snippets below condense
+their real call sequences; class and enum names, factory functions, and
+include paths match the current source. See the citations in each example.
+
+### Staged basis-only calibration
+
+`xccy_curve_calibration` performs staged basis-only calibration against
+supplied domestic and foreign curve blocks and prints fit diagnostics,
+including the FX spot and maximum residual, plus elapsed time. See
+[`dal-cpp/examples/xccy_curve_calibration/`](../../dal-cpp/examples/xccy_curve_calibration/)
+for a runnable version.
+
+```cpp
+// from dal-cpp/examples/xccy_curve_calibration/xccy_curve_calibration.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/platform/initall.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/xccycalibration.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/storage/globals.hpp>
+#include <dal/time/date.hpp>
+#include <dal/utilities/timer.hpp>
+
+using namespace Dal;
+
+RegisterAll_::Init();
+const Date_ today(2024, 1, 15);
+XGLOBAL::SetEvaluationDate(today);
+
+// Pre-calibrated domestic and foreign CurveBlock_ objects are inputs; only the
+// basis-curve parameters are solved. The example builds them with the file-local
+// MakeXccyBlock helper on top of NewDiscountPWLF.
+CrossCurrencyCalibrationSpec_ spec;
+spec.today_              = today;
+spec.basisPair_          = CurrencyPair_(Ccy_("USD"), Ccy_("EUR"));
+spec.domesticCurveBlock_ = MakeXccyBlock("usd_ois", "USD", today, 0.02);
+spec.foreignCurveBlock_  = MakeXccyBlock("eur_ois", "EUR", today, 0.01);
+spec.fxSpot_             = 1.10;
+spec.knotDates_          = {Date::AddMonths(today, 6), Date::AddMonths(today, 12), Date::AddMonths(today, 24),
+                            Date::AddMonths(today, 60), Date::AddMonths(today, 120)};
+
+// Each CrossCurrencySwap_ carries its market-implied par spread on the foreign
+// leg; the example prototypes every swap against a quote market to derive them
+// before calibration. maturities and marketSpreads are parallel vectors.
+for (int i = 0; i < static_cast<int>(maturities.size()); ++i) {
+    spec.instruments_.push_back(
+        Handle_<CrossCurrencySwap_>(new CrossCurrencySwap_(MakeXccySwap(today, marketSpreads[i], maturities[i]))));
+}
+
+Timer_ timer;
+timer.Reset();
+const auto result = CalibrateCrossCurrencyMarket(spec);
+const auto elapsedMs = timer.Elapsed<milliseconds>();
+// result.diagnostics_ exposes residuals_, marketRates_, modelRates_, and the
+// optional effJacobianInverse_ and jacobian_ matrices described above.
+```
+
+### Joint domestic, foreign, and basis calibration
+
+`xccy_mtm_calibration` builds known domestic, foreign, and basis curves,
+derives self-consistent quotes, supplies an immutable fixing snapshot for an
+already-started MTM swap, and recovers five declaration blocks across the
+domestic, foreign, and basis groups in one joint calibration. It prints the
+convergence residual, Jacobian shape, block ranges, and parameter-recovery
+errors. See
+[`dal-cpp/examples/xccy_mtm_calibration/`](../../dal-cpp/examples/xccy_mtm_calibration/)
+for a runnable version.
+
+```cpp
+// from dal-cpp/examples/xccy_mtm_calibration/xccy_mtm_calibration.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/curve/curveblock.hpp>
+#include <dal/curve/xccyjointcalibration.hpp>
+#include <dal/indice/fixingsnapshot.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/time/datetime.hpp>
+
+using namespace Dal;
+
+const Date_ today(2025, 1, 16);
+const DateTime_ valuationTime(today, 9, 0);
+const CurrencyPair_ pair(Ccy_("USD"), Ccy_("EUR"));
+
+// Already-started MTM swap: one historical fixing each for the domestic rate,
+// foreign rate, and FX index. MarketFixingSnapshot_ is the immutable map the
+// joint solver retains on the result.
+MarketFixingSnapshot_::values_t observations;
+observations["USD-JOINT-3M"][historicalFixing] = 0.040;
+observations["EUR-JOINT-3M"][historicalFixing] = 0.030;
+observations[FxIndexName(pair)][historicalFixing] = 1.20;
+const Handle_<MarketFixingSnapshot_> fixings(new MarketFixingSnapshot_(observations));
+
+// domestic_, foreign_, and basis_ each carry declarations and instrument
+// groups; the example builds them with five knots per curve and quotes the
+// basis swaps off a known truth market.
+JointXccyCalibrationSpec_ spec;
+spec.valuationTime_      = valuationTime;
+spec.pair_               = pair;
+spec.collateralCurrency_ = pair.domestic_;
+spec.fxSpot_             = 1.10;
+spec.domestic_           = domestic.declaration_;
+spec.foreign_            = foreign.declaration_;
+spec.basis_              = basis;
+spec.fixings_            = fixings;
+spec.tolerance_          = 1.0e-10;
+spec.initialGuess_       = 0.005;
+
+const JointXccyCalibrationResult_ result = CalibrateJointXccyMarket(spec);
+// result.converged_, jointMaxAbsResidual_, jacobianAtSolution_,
+// parameterRanges_, and residualRanges_ cover every declaration block; the
+// example cross-checks recovered parameters against the known truth.
+```
+
+### Pricing fixed, resettable, and MTM swaps
+
+`xccy_reset_pricing` prices future fixed, resettable, and MTM swaps against
+piecewise-constant discount, projection, and basis curves, validates their
+reset and notional behavior, and prices an already-started MTM swap from an
+immutable snapshot of historical domestic-rate, foreign-rate, and FX fixings.
+See [`dal-cpp/examples/xccy_reset_pricing/`](../../dal-cpp/examples/xccy_reset_pricing/)
+for a runnable version.
+
+```cpp
+// from dal-cpp/examples/xccy_reset_pricing/xccy_reset_pricing.cpp
+#include <dal/platform/platform.hpp>
+#include <dal/platform/initall.hpp>
+#include <dal/curve/xccycalibration.hpp>
+#include <dal/curve/xccypricing.hpp>
+#include <dal/indice/fixingsnapshot.hpp>
+#include <dal/protocol/collateraltype.hpp>
+#include <dal/time/datetime.hpp>
+
+using namespace Dal;
+
+RegisterAll_::Init();
+const Date_ today(2025, 1, 16);
+const DateTime_ valuationTime(today, 9, 0);
+
+// Config selects one of FIXED, RESETTABLE, or MARK_TO_MARKET notional handling;
+// BuildXccyCashflowPlan returns the period and reset schedule the pricer walks.
+const CrossCurrencySwapConfig_ config = Config(XccyNotionalMode_::Value_::MARK_TO_MARKET);
+const XccyCashflowPlan_ plan = BuildXccyCashflowPlan(start, maturity, config);
+
+// XccyMarketView_ bundles discount, forward, and basis curve slots plus FX
+// spot. The example fills view.domestic_ and view.foreign_ from
+// Tape::JointCurveBlock_<double> records built out of a CrossCurrencyMarket_.
+XccyMarketView_<double> view;
+view.valuationTime_      = market.ValuationTime();
+view.pair_               = CurrencyPair_(market.DomesticCcy(), market.ForeignCcy());
+view.collateralCurrency_ = market.CollateralCurrency();
+view.fxSpot_             = market.FxSpot();
+view.domestic_           = &domestic;
+view.foreign_            = &foreign;
+view.basis_              = market.BasisCurve();
+
+// ResolveXccyNotionals fills the per-period domestic notionals and the
+// mtmDeltas_ vector that only MARK_TO_MARKET produces; PriceXccyParSpread
+// returns the par basis spread on the configured quoted leg. The example
+// asserts the direct pricer agrees with CrossCurrencySwap_::Precompute.
+const Handle_<MarketFixingSnapshot_> fixings(new MarketFixingSnapshot_());
+const XccyResolvedNotionals_<double> notionals = ResolveXccyNotionals<double>(plan, view, *fixings);
+const double parSpread = PriceXccyParSpread<double>(plan, view, *fixings);
+```
+
+### Python
+
+`dal-python/examples/007.xccy_joint_calibration.py` runs joint calibration
+through the installed Python surface and prints convergence, matrix
+dimensions, named ranges, and FX forwards.
 
 ## Performance Smoke Surface
 

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -809,6 +809,7 @@ spec.logDfScheme_      = scheme;   // one of LOG_LINEAR, LOG_CUBIC_NATURAL, MIXE
 
 const auto result = CalibrateYieldCurve(spec);
 const auto* curve = dynamic_cast<const DiscountLogDF_*>(result.curve_.get());
+REQUIRE(curve, "calibrated curve is not a DiscountLogDF_");
 const Vector_<> nodeDf = curve->NodeDF();      // P(today, nodeDate) per storage node
 ```
 

--- a/docs/methodology/yield_curve.md
+++ b/docs/methodology/yield_curve.md
@@ -528,8 +528,11 @@ This mirrors `dal-cpp/examples/euribor3m_curve/euribor3m_curve.cpp`: a classic
 single-curve Euribor 3M bootstrap that discounts and forecasts off one curve
 (no OIS data). The instrument set is deposit + STIR futures + vanilla swaps,
 assembled into a `CurveCalibrationSpec_` and solved by `CalibrateYieldCurve`.
+See [`dal-cpp/examples/euribor3m_curve/`](../../dal-cpp/examples/euribor3m_curve/)
+for a runnable version.
 
 ```cpp
+// from dal-cpp/examples/euribor3m_curve/euribor3m_curve.cpp
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/ycinstrument.hpp>
 #include <dal/protocol/collateraltype.hpp>
@@ -636,9 +639,12 @@ stages share a knot grid: stage 1 calibrates the OIS discount curve from OIS
 deposits and OIS swaps; stage 2 calibrates the 3M forecasting curve from FRAs
 and IRS, holding the discount curve fixed. Each stage quotes 20 instruments
 onto 9 knots, an overdetermined system, so both stages use the least-squares
-`APPROXIMATE` solver.
+`APPROXIMATE` solver. See
+[`dal-cpp/examples/curve_calibration/`](../../dal-cpp/examples/curve_calibration/)
+for a runnable version.
 
 ```cpp
+// from dal-cpp/examples/curve_calibration/curve_calibration.cpp
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiselinear.hpp>
@@ -702,9 +708,13 @@ API citations:
 When no market quotes are available (e.g. building a market to derive implied
 quotes), a flat forward curve is built directly with `NewDiscountPWLF`. This is
 the helper used in both `curve_calibration.cpp` and
-`xccy_curve_calibration.cpp`:
+`xccy_curve_calibration.cpp` (see
+[`dal-cpp/examples/curve_calibration/`](../../dal-cpp/examples/curve_calibration/)
+and
+[`dal-cpp/examples/xccy_curve_calibration/`](../../dal-cpp/examples/xccy_curve_calibration/)):
 
 ```cpp
+// from dal-cpp/examples/curve_calibration/curve_calibration.cpp (MakeFlatDiscountCurve)
 #include <dal/curve/piecewiselinear.hpp>
 #include <dal/curve/ycimp.hpp>
 
@@ -725,6 +735,87 @@ API citations:
 
 - `PiecewiseLinear_(knots, fLeft, fRight)` — `dal-cpp/dal/curve/piecewiselinear.hpp`.
 - `NewDiscountPWLF(name, ccy, fwds, base)` — `dal-cpp/dal/curve/ycimp.hpp`.
+
+### Joint simultaneous multi-curve calibration
+
+This mirrors `dal-cpp/examples/joint_multi_curve_calibration/joint_multi_curve_calibration.cpp`.
+The joint path solves OIS discount and IBOR-3M forward curves in one
+`CalibrateJointMultiCurve` call over a stacked parameter vector, rather than the
+two staged `CalibrateMultiCurve` calls illustrated above. See
+[`dal-cpp/examples/joint_multi_curve_calibration/`](../../dal-cpp/examples/joint_multi_curve_calibration/)
+for a runnable version. Each declaration contributes one `JointCurveDeclaration_`
+that names its collateral, tenor, and whether it calibrates a discount or forward
+slot; the spec carries the single shared `solveMode_` and `fitTolerance_`.
+
+```cpp
+// from dal-cpp/examples/joint_multi_curve_calibration/joint_multi_curve_calibration.cpp
+JointCurveDeclaration_ oisDecl;
+oisDecl.curveName_            = "joint_ois";
+oisDecl.instruments_          = market.ois;
+oisDecl.knotDates_            = knots;
+oisDecl.targetCollateral_     = CollateralType_(CollateralType_::Value_::OIS);
+oisDecl.calibrateDiscountCurve_ = true;
+
+JointCurveDeclaration_ liborDecl;
+liborDecl.curveName_            = "joint_3m";
+liborDecl.instruments_          = market.libor;
+liborDecl.knotDates_            = knots;
+liborDecl.targetCollateral_     = CollateralType_(CollateralType_::Value_::OIS);
+liborDecl.targetTenor_          = market.forecastTenor;
+liborDecl.calibrateDiscountCurve_ = false;
+// Base-layer the 3M forward over the OIS discount so the smoother acts on the
+// spread forward (matches the staged path's ApplyStageDefaults).
+liborDecl.baseLayeredOverDiscount_ = true;
+
+JointMultiCurveCalibrationSpec_ jointSpec;
+jointSpec.today_          = today;
+jointSpec.ccy_            = ccy.String();
+jointSpec.liborBasis_     = market.liborBasis;
+jointSpec.solveMode_      = CurveSolveMode_::Value_::EXACT;
+jointSpec.curves_         = {oisDecl, liborDecl};
+
+const auto jointResult = CalibrateJointMultiCurve(jointSpec);
+```
+
+API citations:
+
+- `JointCurveDeclaration_` and `CalibrateJointMultiCurve` — `dal-cpp/dal/curve/jointcalibration.hpp`.
+- See [Joint simultaneous calibration and AAD analytic Jacobian](#joint-simultaneous-calibration-and-aad-analytic-jacobian)
+  for the joint-vs-staged drift analysis and the stacked AAD Jacobian.
+
+### Log-discount curve across all three schemes
+
+This mirrors `dal-cpp/examples/interpolate_curve/interpolate_curve.cpp`. The
+program calibrates the same instrument set three times under `LOG_DISCOUNT`,
+varying only `logDfScheme_` across `LOG_LINEAR`, `LOG_CUBIC_NATURAL`, and
+`MIXED`, then compares the solved node discount factors, the 1-year forward
+rates at each node, and the per-scheme repricing residuals. See
+[`dal-cpp/examples/interpolate_curve/`](../../dal-cpp/examples/interpolate_curve/)
+for a runnable version. See [Log-Discount Curve](log_discount_curve.md) for the
+boundary, extrapolation, and column-order contracts that distinguish the three
+schemes.
+
+```cpp
+// from dal-cpp/examples/interpolate_curve/interpolate_curve.cpp
+CurveCalibrationSpec_ spec;
+spec.today_            = today;
+spec.parameterization_ = CurveParameterization_::Value_::LOG_DISCOUNT;
+spec.knotPolicy_       = CurveKnotPolicy_::Value_::INPUT;
+spec.solveMode_        = CurveSolveMode_::Value_::EXACT;
+spec.liborBasis_       = DayBasis_("ACT_365F");
+spec.knotDates_        = PtirdsKnotDates();
+spec.instruments_      = PtirdsInstruments(today);
+spec.logDfScheme_      = scheme;   // one of LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED
+
+const auto result = CalibrateYieldCurve(spec);
+const auto* curve = dynamic_cast<const DiscountLogDF_*>(result.curve_.get());
+const Vector_<> nodeDf = curve->NodeDF();      // P(today, nodeDate) per storage node
+```
+
+API citations:
+
+- `CurveCalibrationSpec_::logDfScheme_` — `dal-cpp/dal/curve/calibration.hpp`.
+- `DiscountLogDF_::NodeDates()`, `NodeDF()`, `NodeLogDF()` — `dal-cpp/dal/curve/yclogdf.hpp`.
 
 ## See Also
 

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -11,8 +11,29 @@ This note explains two operations that sit on top of a calibrated yield curve
    sensitivity vector $g$ into bucketed risk per market quote via the calibration
    inverse Jacobian `effJacobianInverse_`.
 
-The runnable demonstration of both is the example program
-`dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp`.
+The runnable demonstration of both is
+[`dal-cpp/examples/yield_curve_jacobian/`](../../dal-cpp/examples/yield_curve_jacobian/).
+The program calibrates a square LOG_DISCOUNT system once, reads the analytic
+Jacobian straight off the diagnostics struct, and cross-checks it against an
+independent central-difference bump oracle:
+
+```cpp
+// from dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp
+CurveCalibrationOptions_ options;
+options.jacobianMode_ = CurveJacobianMode_::Value_::ANALYTIC;
+const auto result = CalibrateYieldCurve(spec, options);
+
+// Arc (a): the analytic forward Jacobian captured at the solved x*.
+const Matrix_<>& jAad = result.diagnostics_.jacobian_;
+// Arc (b): the effective inverse for bucketed IR risk.
+const Matrix_<>& effJacobianInverse = result.diagnostics_.effJacobianInverse_;
+```
+
+The example seeds its own two-sided bump oracle, asserts element-wise agreement
+with `jacobian_` to a relative bar of `1e-9`, then exercises the inverse-Jacobian
+risk transform and a nonlinear re-solve sanity check. See
+[Timing: BUMPED vs ANALYTIC](#timing-bumped-vs-analytic) for the matched-pair
+calibration timing it prints.
 
 ## The Forward Jacobian, Two Ways
 
@@ -497,5 +518,5 @@ benchmarking.
   Jacobian.
 - [Single-curve AAD calibration internals](yield_curve.md#single-curve-aad-calibration-internals)
   — the `CurveJacobianMode_::{BUMPED,ANALYTIC}` selection and eligibility rules.
-- `dal-cpp/examples/yield_curve_jacobian/yield_curve_jacobian.cpp` — the
-  runnable program demonstrating both arcs end to end.
+- [`dal-cpp/examples/yield_curve_jacobian/`](../../dal-cpp/examples/yield_curve_jacobian/)
+  — the runnable program demonstrating both arcs end to end.


### PR DESCRIPTION
## Summary
- Adds an authoritative C++ examples style guide at `docs/methodology/_cpp-example-style.md` so every methodology doc uses consistent include style, naming conventions, the example-program pointer pattern (`// from dal-cpp/examples/<name>/<name>.cpp` + `../../dal-cpp/examples/<name>/` markdown link), and math-macro rules.
- Adds C++ examples to all 16 methodology docs under `docs/methodology/`. 13 previously had zero code blocks; `pde.md` and `yield_curve.md` already had partial coverage and were aligned to the style guide rather than rewritten.
- Each doc that maps to an existing `dal-cpp/examples/<name>/` program now cross-references it (link + excerpt). Docs without a dedicated example program (`dates.md`, `index_parsing.md`, `matrix.md`, `quadrature.md`) use concise inline snippets drawn directly from the real public headers.
- Two correctness fixes applied during review: `black_scholes.md` snippet reattributed to the real defining header (vanilla.cpp does not call `Distribution::BlackOpt`); `matrix.md` no longer names a non-public internal type.

## Test plan
- [x] `python3 .github/scripts/check_docs.py` passes for all 39 markdown files (the docs lint is the only CI gate for this docs-only change).
- [x] Every fenced `cpp` block's symbols were verified against real public headers / example programs during review (no invented API).
- [x] All example-program links and `// from` file pointers resolve to real paths.
