### PR TITLE
feat: expose DAL-6 staged XCCY sensitivities

### DIFF
--- a/.codex/artifacts/plans/p1-staged-xccy-sensitivity.md
+++ b/.codex/artifacts/plans/p1-staged-xccy-sensitivity.md
@@ -1,0 +1,60 @@
+# P1 Staged XCCY Sensitivity Implementation Plan
+
+## Baseline and scope
+
+- Base: `master` at `1d90f66036bbc84a322eb26ffbca2bbe1abba89b`.
+- Deliver only the reviewed P1 implementation across core, public C++, Python, and Excel.
+- Preserve staged matrix ownership in `CrossCurrencyCalibrationDiagnostics_`, joint matrix ownership on `JointXccyCalibrationResult_`, all existing axes and solver scaling, and every legacy one-argument/default entry point.
+- Defer current-state documentation prose to the later doc-writer stage. Excel Machinist function metadata changes with the implementation because it defines the worksheet contract.
+
+## Design
+
+1. Extend staged diagnostics in place with:
+   - `parameterKnotDates_` in `spec.knotDates_` order;
+   - `residualTolerance_`;
+   - `jacobianScaling_ = "unscaled"`;
+   - `effJacobianInverseScaling_ = "solver_scaled"`;
+   - independent `jacobianAvailability_` and `effJacobianInverseAvailability_` values from `available`, `not_requested`, and `not_available_for_mode`.
+2. Derive availability from the requested compute flag first, then solve/matrix mode. Keep empty matrices as the numeric carrier for unavailable data; never infer the reason from emptiness and never recompute in a getter.
+3. Validate every market quote, positive solver scalar, initial guess, residual, and returned matrix entry as finite before exposing the result. Preserve the existing rejection rules for empty instruments and non-increasing knots.
+4. Add public facade overload/accessors:
+   - `CalibrateXccyMarket(spec, options)`;
+   - staged diagnostics/Jacobian/effective-inverse read-only accessors;
+   - `JointXccyResultEffJacobianInverse`.
+5. Bind staged options and diagnostics aliases in Python. Keep matrices under `result.diagnostics` and reserve `jacobian_at_solution` for joint results.
+6. Parse staged Excel `jacobianMode`, `computeForwardJacobian`, and `computeEffJacobianInverse` settings with strict types for these new keys only. Add staged selectors for matrices, axes, availability, tolerance, and scaling, plus the joint effective-inverse selector.
+
+The effective inverse remains the solver-scaled pseudoinverse. A raw decimal quote bump is mapped only as:
+
+```text
+dx = eff_jacobian_inverse * dq / residual_tolerance
+```
+
+Instrument names are labels and may repeat; integer row order is authoritative. Parameter columns follow the PWC knot/right-forward order.
+
+## TDD stages
+
+1. Core RED:
+   - add focused tests for axes, shapes, duplicate labels, metadata, the full availability truth table, default-overload parity, finite-input rejection, central-difference parity, and scaled inverse re-solve predictions;
+   - include small-bump negative scaling evidence and fixed 5/10/16-instrument 1bp ladders.
+2. Core GREEN:
+   - implement diagnostics metadata, availability derivation, and finite checks with the minimum calibration changes;
+   - rerun the focused core filter and refactor only while green.
+3. Public/Python RED then GREEN:
+   - add facade overload/accessor tests and Python overload/legacy/snake-case cross-surface tests;
+   - implement facade and bindings without moving diagnostics data.
+4. Excel RED then GREEN:
+   - add portable Excel tests for strict new-setting types, settings propagation, all staged selectors, joint inverse, and unknown-key/view messages;
+   - implement adapters, update Machinist markup, regenerate checked-in public stubs, and rerun the focused Excel target.
+5. Verification:
+   - run formatting and generated-file drift checks;
+   - run targeted C++, public, Python, and portable Excel tests;
+   - run `bash ./build_linux.sh` and `ctest --test-dir build/Release-linux --output-on-failure`;
+   - record Windows Excel and sanitizer/AAD-backend coverage as CI-only residual risk unless available locally.
+
+## Delivery
+
+- Use branch `feature/dal-6-staged-xccy-sensitivity`.
+- Commit one focused implementation unit with an imperative subject.
+- Push and open a `master` PR whose title or branch routes to `DAL-6` without close intent.
+- Report the exact branch, commit, PR, RED/GREEN commands and outcomes, full local verification, and remaining platform/CI risks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ here as the baseline rather than dated releases:
 
 ## 2026-07
 
+- `curve`: Added staged XCCY sensitivity diagnostics across public C++, Python,
+  and Excel. The additive options overload selects analytic or bumped
+  Jacobians and independently controls the forward and effective-inverse
+  matrices while preserving the one-argument defaults. Diagnostics retain the
+  instrument and basis-knot axes plus explicit availability, tolerance, and
+  scaling metadata; the effective inverse is `solver_scaled`, so raw decimal
+  quote bumps map as `dx = E * dq / tolerance`. Public C++ and Excel also expose
+  the retained joint XCCY effective inverse. See
+  `docs/methodology/xccy_calibration.md`,
+  `docs/methodology/yield_curve_jacobian.md`, and `docs/public-api.md`.
+
 - `curve`: Made calibration settings dictionaries strict on the Python and Excel
   surfaces. `dal.calibrate_curve` raises `ValueError` on an unknown settings key,
   and the Excel single-curve, staged-XCCY, and joint-XCCY settings parsers throw

--- a/dal-cpp/dal/curve/calibration_internal.hpp
+++ b/dal-cpp/dal/curve/calibration_internal.hpp
@@ -89,8 +89,8 @@ namespace Dal {
         return retval;
     }
 
-    // maxAbs and RMS of a residual sequence, single-pass. Fixed accumulation order keeps the
-    // floating-point output stable across call sites.
+    // maxAbs and RMS of a residual sequence, single-pass. Scaled accumulation avoids overflow
+    // when finite residuals are too large to square directly.
     struct ResidualStats_ {
         double maxAbsResidual_ = 0.0;
         double rmsResidual_ = 0.0;
@@ -98,12 +98,31 @@ namespace Dal {
 
     template <class E_> ResidualStats_ ResidualStats(const Vector_<E_>& residuals) {
         double maxAbs = 0.0;
-        double sq = 0.0;
+        double scale = 0.0;
+        double scaledSquares = 0.0;
         for (const E_ r : residuals) {
-            maxAbs = std::max(maxAbs, std::fabs(r));
-            sq += r * r;
+            const double absResidual = std::fabs(r);
+            if (!std::isfinite(absResidual))
+                return ResidualStats_{absResidual, absResidual};
+            maxAbs = std::max(maxAbs, absResidual);
+            if (absResidual == 0.0)
+                continue;
+            if (scale < absResidual) {
+                const double ratio = scale / absResidual;
+                scaledSquares = 1.0 + scaledSquares * ratio * ratio;
+                scale = absResidual;
+            } else {
+                const double ratio = absResidual / scale;
+                scaledSquares += ratio * ratio;
+            }
         }
-        return ResidualStats_{maxAbs, residuals.empty() ? 0.0 : std::sqrt(sq / residuals.size())};
+        const double meanScaledSquares = residuals.empty() ? 0.0 : std::min(1.0, scaledSquares / static_cast<double>(residuals.size()));
+        return ResidualStats_{maxAbs, scale * std::sqrt(meanScaledSquares)};
+    }
+
+    inline void RequireFiniteResidualStats(const ResidualStats_& stats, const String_& context) {
+        REQUIRE(std::isfinite(stats.maxAbsResidual_), context + " maximum absolute residual must be finite");
+        REQUIRE(std::isfinite(stats.rmsResidual_), context + " RMS residual must be finite");
     }
 
     // Resolve the coupon-months count for a single-period instrument's day-count context.

--- a/dal-cpp/dal/curve/xccybasiscalibration.cpp
+++ b/dal-cpp/dal/curve/xccybasiscalibration.cpp
@@ -312,6 +312,8 @@ namespace Dal {
             RequireFiniteValues(diagnostics.marketRates_, "Cross-currency calibration market rates");
             RequireFiniteValues(diagnostics.modelRates_, "Cross-currency calibration model rates");
             RequireFiniteValues(diagnostics.residuals_, "Cross-currency calibration residuals");
+            RequireFiniteResidualStats(ResidualStats_{diagnostics.maxAbsResidual_, diagnostics.rmsResidual_},
+                                       "Cross-currency calibration diagnostics");
             RequireFiniteValues(diagnostics.jacobian_, "Cross-currency calibration forward Jacobian");
             RequireFiniteValues(diagnostics.effJacobianInverse_, "Cross-currency calibration effective inverse Jacobian");
             RequireFiniteValues(fxForwardCurve.forwards_, "Cross-currency calibration FX forwards");

--- a/dal-cpp/dal/curve/xccybasiscalibration.cpp
+++ b/dal-cpp/dal/curve/xccybasiscalibration.cpp
@@ -38,6 +38,18 @@ namespace Dal {
             return spec.collateralCurrency_.Switch() == Ccy_::Value_::_NOT_SET ? spec.basisPair_.domestic_ : spec.collateralCurrency_;
         }
 
+        void RequireFiniteValues(const Vector_<>& values, const String_& context) {
+            for (int i = 0; i < static_cast<int>(values.size()); ++i)
+                REQUIRE(std::isfinite(values[i]), context + " has a non-finite value at index " + String::FromInt(i));
+        }
+
+        void RequireFiniteValues(const Matrix_<>& values, const String_& context) {
+            for (int row = 0; row < values.Rows(); ++row)
+                for (int column = 0; column < values.Cols(); ++column)
+                    REQUIRE(std::isfinite(values(row, column)),
+                            context + " has a non-finite value at row " + String::FromInt(row) + ", column " + String::FromInt(column));
+        }
+
         Vector_<XccyCashflowPlan_> BuildInstrumentPlans(const CrossCurrencyCalibrationSpec_& spec) {
             Vector_<XccyCashflowPlan_> result;
             result.reserve(spec.instruments_.size());
@@ -78,12 +90,17 @@ namespace Dal {
                     "Cross-currency calibration basis pair foreign currency must match the foreign curve block");
             REQUIRE(collateralCurrency == spec.basisPair_.domestic_, "Cross-currency calibration supports domestic-currency collateral only");
             REQUIRE(!spec.instruments_.empty(), "Cross-currency calibration requires at least one instrument");
-            for (int i = 0; i < static_cast<int>(spec.instruments_.size()); ++i)
+            for (int i = 0; i < static_cast<int>(spec.instruments_.size()); ++i) {
                 REQUIRE(spec.instruments_[i], "Cross-currency calibration has an empty XCCY instrument at index " + String::FromInt(i));
+                REQUIRE(std::isfinite(spec.instruments_[i]->MarketRate()),
+                        "Cross-currency calibration instrument market rate at index " + String::FromInt(i) + " must be finite");
+            }
             REQUIRE(!spec.knotDates_.empty(), "Cross-currency calibration requires at least one basis knot date");
-            REQUIRE(spec.smoothingWeight_ > 0.0, "Cross-currency calibration smoothing weight must be positive");
-            REQUIRE(spec.tolerance_ > 0.0, "Cross-currency calibration tolerance must be positive");
-            REQUIRE(spec.fitTolerance_ > 0.0, "Cross-currency calibration fit tolerance must be positive");
+            REQUIRE(std::isfinite(spec.smoothingWeight_) && spec.smoothingWeight_ > 0.0,
+                    "Cross-currency calibration smoothing weight must be finite and positive");
+            REQUIRE(std::isfinite(spec.tolerance_) && spec.tolerance_ > 0.0, "Cross-currency calibration tolerance must be finite and positive");
+            REQUIRE(std::isfinite(spec.fitTolerance_) && spec.fitTolerance_ > 0.0,
+                    "Cross-currency calibration fit tolerance must be finite and positive");
             REQUIRE(spec.maxEvaluations_ > 0, "Cross-currency calibration max evaluations must be positive");
             REQUIRE(spec.maxRestarts_ > 0, "Cross-currency calibration max restarts must be positive");
             REQUIRE(std::isfinite(spec.initialGuess_), "Cross-currency calibration initial guess must be finite");
@@ -229,12 +246,24 @@ namespace Dal {
         }
 
         CrossCurrencyCalibrationDiagnostics_ BuildDiagnostics(const CrossCurrencyCalibrationSpec_& spec,
+                                                              const CrossCurrencyCalibrationOptions_& options,
                                                               const XccyBasisCalibrationFunc_& func,
                                                               const Vector_<>& parameters,
                                                               bool usedApproximateFit,
                                                               const Matrix_<>* effJacobianInverse) {
             CrossCurrencyCalibrationDiagnostics_ result;
             result.usedApproximateFit_ = usedApproximateFit;
+            result.parameterKnotDates_ = spec.knotDates_;
+            result.residualTolerance_ = spec.tolerance_;
+            result.jacobianScaling_ = "unscaled";
+            result.effJacobianInverseScaling_ = "solver_scaled";
+            result.jacobianAvailability_ =
+                !options.computeForwardJacobian_
+                    ? String_("not_requested")
+                    : String_(usedApproximateFit || options.jacobianMode_ != CurveJacobianMode_::Value_::ANALYTIC ? "not_available_for_mode"
+                                                                                                                  : "available");
+            result.effJacobianInverseAvailability_ =
+                !options.computeEffJacobianInverse_ ? String_("not_requested") : String_(usedApproximateFit ? "not_available_for_mode" : "available");
             result.residuals_ = func.F(parameters);
             for (int i = 0; i < static_cast<int>(spec.instruments_.size()); ++i) {
                 result.instrumentNames_.push_back(spec.instruments_[i]->Name());
@@ -267,6 +296,7 @@ namespace Dal {
                                                                   const Handle_<MarketFixingSnapshot_>& fixings,
                                                                   const CurveDefinition_& basisDefinition,
                                                                   const XccyBasisCalibrationFunc_& func,
+                                                                  const CrossCurrencyCalibrationOptions_& options,
                                                                   XccyBasisSolveResult_* solve) {
             Handle_<DiscountCurve_> basisCurve(BuildDiscountCurveUniqueT<double>(basisDefinition, solve->parameters_).release());
             CrossCurrencyMarket_ market(spec.domesticCurveBlock_, spec.foreignCurveBlock_, spec.fxSpot_, valuationTime, collateralCurrency, fixings);
@@ -277,8 +307,14 @@ namespace Dal {
             CrossCurrencyFxForwardCurve_ fxForwardCurve = BuildFxForwardCurve(spec.basisPair_, spec.knotDates_, market, spec.fxForwardCollateral_);
             const Matrix_<>* effJacobianInverse = solve->hasEffJacobianInverse_ ? &solve->effJacobianInverse_ : nullptr;
             CrossCurrencyCalibrationDiagnostics_ diagnostics =
-                BuildDiagnostics(spec, func, solve->parameters_, solve->approximate_, effJacobianInverse);
+                BuildDiagnostics(spec, options, func, solve->parameters_, solve->approximate_, effJacobianInverse);
             diagnostics.jacobian_ = std::move(solve->forwardJacobian_);
+            RequireFiniteValues(diagnostics.marketRates_, "Cross-currency calibration market rates");
+            RequireFiniteValues(diagnostics.modelRates_, "Cross-currency calibration model rates");
+            RequireFiniteValues(diagnostics.residuals_, "Cross-currency calibration residuals");
+            RequireFiniteValues(diagnostics.jacobian_, "Cross-currency calibration forward Jacobian");
+            RequireFiniteValues(diagnostics.effJacobianInverse_, "Cross-currency calibration effective inverse Jacobian");
+            RequireFiniteValues(fxForwardCurve.forwards_, "Cross-currency calibration FX forwards");
             return CrossCurrencyCalibrationResult_(market, basisCurves, fxForwardCurve, diagnostics);
         }
     } // namespace
@@ -315,6 +351,6 @@ namespace Dal {
 
         XccyBasisCalibrationFunc_ func(spec, valuationTime, collateralCurrency, fixings, plans, basisDefinition, options.jacobianMode_);
         XccyBasisSolveResult_ solve = SolveXccyBasis(spec, options, func, guess, tolerance, *weights, controls);
-        return AssembleCalibrationResult(spec, valuationTime, collateralCurrency, fixings, basisDefinition, func, &solve);
+        return AssembleCalibrationResult(spec, valuationTime, collateralCurrency, fixings, basisDefinition, func, options, &solve);
     }
 } // namespace Dal

--- a/dal-cpp/dal/curve/xccycalibration.hpp
+++ b/dal-cpp/dal/curve/xccycalibration.hpp
@@ -61,12 +61,18 @@ namespace Dal {
 
     struct CrossCurrencyCalibrationDiagnostics_ {
         Vector_<String_> instrumentNames_;
+        Vector_<Date_> parameterKnotDates_;
         Vector_<> marketRates_;
         Vector_<> modelRates_;
         Vector_<> residuals_;
         Matrix_<> effJacobianInverse_;
         // Unscaled at-solution forward Jacobian; empty for bumped or approximate solves.
         Matrix_<> jacobian_;
+        double residualTolerance_ = 0.0;
+        String_ jacobianScaling_;
+        String_ effJacobianInverseScaling_;
+        String_ jacobianAvailability_;
+        String_ effJacobianInverseAvailability_;
         double maxAbsResidual_ = 0.0;
         double rmsResidual_ = 0.0;
         bool usedApproximateFit_ = false;

--- a/dal-cpp/tests/curve/test_xccybasisjacobian.cpp
+++ b/dal-cpp/tests/curve/test_xccybasisjacobian.cpp
@@ -4,21 +4,23 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
-#include <limits>
-#include <string>
-#include <dal/platform/platform.hpp>
+#include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
 #include <dal/curve/piecewiselinear.hpp>
 #include <dal/curve/xccycalibration.hpp>
 #include <dal/curve/ycconst.hpp>
 #include <dal/curve/ycimp.hpp>
+#include <dal/platform/platform.hpp>
 #include <dal/protocol/collateraltype.hpp>
 #include <dal/storage/_repository.hpp>
 #include <dal/storage/globals.hpp>
 #include <dal/time/daybasis.hpp>
 #include <dal/time/periodlength.hpp>
+#include <limits>
+#include <string>
 
 using namespace Dal;
 
@@ -465,6 +467,110 @@ TEST(XccyBasisJacobianTest, TestAvailabilityDistinguishesModeAndRequestFlags) {
     const auto approximateWithoutMatrices = CalibrateCrossCurrencyMarket(fixture.spec_, options);
     ASSERT_EQ(approximateWithoutMatrices.diagnostics_.jacobianAvailability_, String_("not_requested"));
     ASSERT_EQ(approximateWithoutMatrices.diagnostics_.effJacobianInverseAvailability_, String_("not_requested"));
+}
+
+TEST(XccyBasisJacobianTest, TestAvailabilityTruthTableCoversEveryModeAndFlagCombination) {
+    struct Case_ {
+        CurveSolveMode_::Value_ solveMode_;
+        CurveJacobianMode_::Value_ jacobianMode_;
+        bool computeForwardJacobian_;
+        bool computeEffJacobianInverse_;
+        const char* expectedForwardAvailability_;
+        const char* expectedInverseAvailability_;
+        bool expectedForwardValues_;
+        bool expectedInverseValues_;
+    };
+    const std::array<Case_, 16> cases = {{
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::ANALYTIC, false, false, "not_requested", "not_requested", false, false},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::ANALYTIC, false, true, "not_requested", "available", false, true},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::ANALYTIC, true, false, "available", "not_requested", true, false},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::ANALYTIC, true, true, "available", "available", true, true},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::BUMPED, false, false, "not_requested", "not_requested", false, false},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::BUMPED, false, true, "not_requested", "available", false, true},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::BUMPED, true, false, "not_available_for_mode", "not_requested", false, false},
+        {CurveSolveMode_::Value_::EXACT, CurveJacobianMode_::Value_::BUMPED, true, true, "not_available_for_mode", "available", false, true},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::ANALYTIC, false, false, "not_requested", "not_requested", false, false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::ANALYTIC, false, true, "not_requested", "not_available_for_mode", false,
+         false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::ANALYTIC, true, false, "not_available_for_mode", "not_requested", false,
+         false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::ANALYTIC, true, true, "not_available_for_mode", "not_available_for_mode",
+         false, false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::BUMPED, false, false, "not_requested", "not_requested", false, false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::BUMPED, false, true, "not_requested", "not_available_for_mode", false,
+         false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::BUMPED, true, false, "not_available_for_mode", "not_requested", false,
+         false},
+        {CurveSolveMode_::Value_::APPROXIMATE, CurveJacobianMode_::Value_::BUMPED, true, true, "not_available_for_mode", "not_available_for_mode",
+         false, false},
+    }};
+
+    for (int i = 0; i < static_cast<int>(cases.size()); ++i) {
+        SCOPED_TRACE("case=" + std::to_string(i));
+        auto fixture = MakeFixture();
+        fixture.spec_.solveMode_ = cases[i].solveMode_;
+        CrossCurrencyCalibrationOptions_ options;
+        options.jacobianMode_ = cases[i].jacobianMode_;
+        options.computeForwardJacobian_ = cases[i].computeForwardJacobian_;
+        options.computeEffJacobianInverse_ = cases[i].computeEffJacobianInverse_;
+
+        const auto& diagnostics = CalibrateCrossCurrencyMarket(fixture.spec_, options).diagnostics_;
+        ASSERT_EQ(diagnostics.jacobianAvailability_, String_(cases[i].expectedForwardAvailability_));
+        ASSERT_EQ(diagnostics.effJacobianInverseAvailability_, String_(cases[i].expectedInverseAvailability_));
+        ASSERT_EQ(!diagnostics.jacobian_.Empty(), cases[i].expectedForwardValues_);
+        ASSERT_EQ(!diagnostics.effJacobianInverse_.Empty(), cases[i].expectedInverseValues_);
+    }
+}
+
+TEST(XccyBasisJacobianTest, TestResidualStatsRemainFiniteForLargeFiniteResiduals) {
+    constexpr double largeResidual = 1.0e200;
+    const ResidualStats_ stats = ResidualStats(Vector_<>{largeResidual, -largeResidual});
+
+    ASSERT_TRUE(std::isfinite(stats.maxAbsResidual_));
+    ASSERT_TRUE(std::isfinite(stats.rmsResidual_));
+    ASSERT_DOUBLE_EQ(stats.maxAbsResidual_, largeResidual);
+    ASSERT_DOUBLE_EQ(stats.rmsResidual_, largeResidual);
+}
+
+TEST(XccyBasisJacobianTest, TestPublicDiagnosticsRemainFiniteForLargeFiniteResiduals) {
+    constexpr double largeResidual = 1.0e200;
+    auto fixture = MakeFixture();
+    for (int i = 0; i < static_cast<int>(fixture.spec_.instruments_.size()); ++i)
+        fixture.spec_ = BumpQuote(fixture.spec_, i, largeResidual - fixture.spec_.instruments_[i]->MarketRate());
+    fixture.spec_.solveMode_ = CurveSolveMode_::Value_::APPROXIMATE;
+    fixture.spec_.tolerance_ = largeResidual;
+    fixture.spec_.fitTolerance_ = 2.0;
+    CrossCurrencyCalibrationOptions_ options;
+    options.computeForwardJacobian_ = false;
+    options.computeEffJacobianInverse_ = false;
+
+    const auto& diagnostics = CalibrateCrossCurrencyMarket(fixture.spec_, options).diagnostics_;
+    ASSERT_TRUE(diagnostics.usedApproximateFit_);
+    for (const double residual : diagnostics.residuals_) {
+        ASSERT_TRUE(std::isfinite(residual));
+        ASSERT_GT(std::fabs(residual), 0.5 * largeResidual);
+    }
+    ASSERT_TRUE(std::isfinite(diagnostics.maxAbsResidual_));
+    ASSERT_TRUE(std::isfinite(diagnostics.rmsResidual_));
+    ASSERT_LE(diagnostics.rmsResidual_, diagnostics.maxAbsResidual_);
+    ASSERT_GT(diagnostics.rmsResidual_, 0.5 * largeResidual);
+}
+
+TEST(XccyBasisJacobianTest, TestResidualStatsOutputValidationRejectsNonFiniteScalars) {
+    const double infinity = std::numeric_limits<double>::infinity();
+    const std::array<std::pair<ResidualStats_, const char*>, 2> cases = {{
+        {ResidualStats_{infinity, 0.0}, "maximum absolute residual"},
+        {ResidualStats_{0.0, infinity}, "RMS residual"},
+    }};
+
+    for (const auto& testCase : cases) {
+        try {
+            RequireFiniteResidualStats(testCase.first, "Cross-currency calibration");
+            FAIL() << "Expected non-finite residual statistics to fail validation";
+        } catch (const Dal::Exception_& exception) {
+            ASSERT_NE(std::string(exception.what()).find(testCase.second), std::string::npos) << exception.what();
+        }
+    }
 }
 
 TEST(XccyBasisJacobianTest, TestValidationRejectsNonFiniteSolverInputsBeforeSolving) {

--- a/dal-cpp/tests/curve/test_xccybasisjacobian.cpp
+++ b/dal-cpp/tests/curve/test_xccybasisjacobian.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
+#include <string>
 #include <dal/platform/platform.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
@@ -186,6 +188,60 @@ namespace {
         return result;
     }
 
+    Fixture_ MakeLadderFixture(int instrumentCount, int maturityOffsetMonths = 0) {
+        Fixture_ result;
+        const Date_ valuationDate(2025, 1, 16);
+        const DateTime_ valuationTime(valuationDate, 9, 0);
+        const Ccy_ collateral("USD");
+        const auto domestic = MakeBlock("usd_ladder", "USD", valuationDate, 0.02);
+        const auto foreign = MakeBlock("eur_ladder", "EUR", valuationDate, 0.01);
+        const auto config = MtmConfig();
+        const Handle_<MarketFixingSnapshot_> fixings(new MarketFixingSnapshot_());
+
+        result.trueParameters_.reserve(instrumentCount);
+        result.spec_.knotDates_.reserve(instrumentCount);
+        for (int i = 0; i < instrumentCount; ++i) {
+            result.spec_.knotDates_.push_back(Date::AddMonths(valuationDate, 24 * (i + 1)));
+            result.trueParameters_.push_back(0.0020);
+        }
+
+        CrossCurrencyMarket_ quoteMarket(domestic, foreign, 1.10, valuationTime, collateral, fixings);
+        quoteMarket.SetBasisCurve(Handle_<DiscountCurve_>(
+            NewDiscountPWC("known_ladder_basis", "USD", PiecewiseConstant_(result.spec_.knotDates_, result.trueParameters_))));
+
+        result.spec_.today_ = valuationDate;
+        result.spec_.valuationTime_ = valuationTime;
+        result.spec_.collateralCurrency_ = collateral;
+        result.spec_.fixings_ = fixings;
+        result.spec_.basisPair_ = config.pair_;
+        result.spec_.domesticCurveBlock_ = domestic;
+        result.spec_.foreignCurveBlock_ = foreign;
+        result.spec_.fxSpot_ = 1.10;
+        result.spec_.initialGuess_ = result.trueParameters_.front();
+        result.spec_.tolerance_ = 1.0e-10;
+        result.spec_.maxEvaluations_ = 500;
+        for (int i = 0; i < instrumentCount; ++i) {
+            const Date_ maturity = Date::AddMonths(valuationDate, 24 * (i + 1) + maturityOffsetMonths);
+            result.spec_.instruments_.push_back(QuoteSwap(valuationDate, valuationDate, maturity, config, quoteMarket));
+        }
+        return result;
+    }
+
+    Vector_<> Parameters(const CrossCurrencyCalibrationResult_& result, const CurrencyPair_& pair) {
+        const auto* basis = dynamic_cast<const Tape::DiscountPWC_<double>*>(result.basisCurves_.at(pair).get());
+        REQUIRE(basis, "Expected a PWC basis curve in staged XCCY sensitivity fixture");
+        return basis->FRight();
+    }
+
+    CrossCurrencyCalibrationSpec_ BumpQuote(const CrossCurrencyCalibrationSpec_& spec, int instrumentIndex, double bump) {
+        CrossCurrencyCalibrationSpec_ result = spec;
+        const auto& original = spec.instruments_[instrumentIndex];
+        const auto span = original->TimeSpan();
+        result.instruments_[instrumentIndex] = Handle_<CrossCurrencySwap_>(
+            new CrossCurrencySwap_(span.first, span.first, span.second, original->MarketRate() + bump, original->Config()));
+        return result;
+    }
+
     Vector_<> Residuals(const CrossCurrencyCalibrationSpec_& spec, const Vector_<>& parameters) {
         CrossCurrencyMarket_ market(spec.domesticCurveBlock_, spec.foreignCurveBlock_, spec.fxSpot_, spec.valuationTime_, spec.collateralCurrency_,
                                     spec.fixings_);
@@ -212,6 +268,15 @@ namespace {
         }
         return result;
     }
+
+    void AssertCalibrationFailsWith(const CrossCurrencyCalibrationSpec_& spec, const std::string& expected) {
+        try {
+            static_cast<void>(CalibrateCrossCurrencyMarket(spec));
+            FAIL() << "Expected staged XCCY calibration to fail with " << expected;
+        } catch (const Dal::Exception_& exception) {
+            ASSERT_NE(std::string(exception.what()).find(expected), std::string::npos) << exception.what();
+        }
+    }
 } // namespace
 
 TEST(XccyBasisJacobianTest, TestAnalyticMatchesCentralDifferenceIncludingHistoricalResetRow) {
@@ -233,6 +298,92 @@ TEST(XccyBasisJacobianTest, TestAnalyticMatchesCentralDifferenceIncludingHistori
     for (int row = 0; row < analytic.Rows(); ++row)
         for (int column = 0; column < analytic.Cols(); ++column)
             ASSERT_NEAR(analytic(row, column), central(row, column), 1.0e-7) << "row=" << row << " column=" << column;
+}
+
+TEST(XccyBasisJacobianTest, TestDiagnosticsExposeStableAxesScalingAndAvailability) {
+    const auto fixture = MakeFixture();
+    const auto calibrated = CalibrateCrossCurrencyMarket(fixture.spec_);
+    const auto& diagnostics = calibrated.diagnostics_;
+
+    ASSERT_EQ(diagnostics.instrumentNames_.size(), fixture.spec_.instruments_.size());
+    ASSERT_EQ(diagnostics.instrumentNames_[0], diagnostics.instrumentNames_[1]);
+    ASSERT_EQ(diagnostics.parameterKnotDates_, fixture.spec_.knotDates_);
+    ASSERT_EQ(diagnostics.jacobian_.Rows(), static_cast<int>(diagnostics.instrumentNames_.size()));
+    ASSERT_EQ(diagnostics.jacobian_.Cols(), static_cast<int>(diagnostics.parameterKnotDates_.size()));
+    ASSERT_EQ(diagnostics.effJacobianInverse_.Rows(), static_cast<int>(diagnostics.parameterKnotDates_.size()));
+    ASSERT_EQ(diagnostics.effJacobianInverse_.Cols(), static_cast<int>(diagnostics.instrumentNames_.size()));
+    ASSERT_NEAR(diagnostics.residualTolerance_, fixture.spec_.tolerance_, 1.0e-20);
+    ASSERT_EQ(diagnostics.jacobianScaling_, String_("unscaled"));
+    ASSERT_EQ(diagnostics.effJacobianInverseScaling_, String_("solver_scaled"));
+    ASSERT_EQ(diagnostics.jacobianAvailability_, String_("available"));
+    ASSERT_EQ(diagnostics.effJacobianInverseAvailability_, String_("available"));
+}
+
+TEST(XccyBasisJacobianTest, TestEffectiveInverseRequiresToleranceScalingForSmallQuoteBumps) {
+    auto fixture = MakeLadderFixture(3, 12);
+    fixture.spec_.tolerance_ = 1.0e-8;
+    const auto base = CalibrateCrossCurrencyMarket(fixture.spec_);
+    const Vector_<> baseParameters = Parameters(base, fixture.spec_.basisPair_);
+    constexpr double bump = 1.0e-6;
+
+    for (int instrument = 0; instrument < static_cast<int>(fixture.spec_.instruments_.size()); ++instrument) {
+        SCOPED_TRACE("instrument=" + std::to_string(instrument));
+        Vector_<> predictedMoves(baseParameters.size());
+        for (int parameter = 0; parameter < static_cast<int>(baseParameters.size()); ++parameter)
+            predictedMoves[parameter] = base.diagnostics_.effJacobianInverse_(parameter, instrument) * bump / fixture.spec_.tolerance_;
+        auto bumpedSpec = BumpQuote(fixture.spec_, instrument, bump);
+        bumpedSpec.initialGuess_ = baseParameters.front() + predictedMoves.front();
+        CrossCurrencyCalibrationOptions_ reSolveOptions;
+        reSolveOptions.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+        reSolveOptions.computeEffJacobianInverse_ = false;
+        reSolveOptions.computeForwardJacobian_ = false;
+        Vector_<> bumpedParameters;
+        try {
+            bumpedParameters = Parameters(CalibrateCrossCurrencyMarket(bumpedSpec, reSolveOptions), fixture.spec_.basisPair_);
+        } catch (const Dal::Exception_& exception) {
+            FAIL() << "instrument=" << instrument << " " << exception.what();
+        }
+        double observedNorm = 0.0;
+        double unscaledError = 0.0;
+        Vector_<> observedMoves(baseParameters.size());
+        for (int parameter = 0; parameter < static_cast<int>(baseParameters.size()); ++parameter) {
+            observedMoves[parameter] = bumpedParameters[parameter] - baseParameters[parameter];
+            const double incorrectlyUnscaled = base.diagnostics_.effJacobianInverse_(parameter, instrument) * bump;
+            observedNorm = std::max(observedNorm, std::fabs(observedMoves[parameter]));
+            unscaledError = std::max(unscaledError, std::fabs(incorrectlyUnscaled - observedMoves[parameter]));
+        }
+        ASSERT_GT(observedNorm, 1.0e-8) << "instrument=" << instrument;
+        for (int parameter = 0; parameter < static_cast<int>(baseParameters.size()); ++parameter)
+            ASSERT_NEAR(predictedMoves[parameter], observedMoves[parameter], 0.03 * observedNorm + 1.0e-10)
+                << "instrument=" << instrument << " parameter=" << parameter;
+        ASSERT_GT(unscaledError, 0.5 * observedNorm) << "instrument=" << instrument;
+    }
+}
+
+TEST(XccyBasisJacobianTest, TestEffectiveInversePredictsOneBasisPointAcrossFixedLadders) {
+    constexpr double bump = 1.0e-4;
+    for (const int instrumentCount : {5, 10, 16}) {
+        const auto fixture = MakeLadderFixture(instrumentCount);
+        const auto base = CalibrateCrossCurrencyMarket(fixture.spec_);
+        const Vector_<> baseParameters = Parameters(base, fixture.spec_.basisPair_);
+        const int instrument = instrumentCount - 1;
+        const Vector_<> bumpedParameters =
+            Parameters(CalibrateCrossCurrencyMarket(BumpQuote(fixture.spec_, instrument, bump)), fixture.spec_.basisPair_);
+
+        double observedNorm = 0.0;
+        Vector_<> observedMoves(baseParameters.size());
+        Vector_<> predictedMoves(baseParameters.size());
+        for (int parameter = 0; parameter < static_cast<int>(baseParameters.size()); ++parameter) {
+            observedMoves[parameter] = bumpedParameters[parameter] - baseParameters[parameter];
+            predictedMoves[parameter] = base.diagnostics_.effJacobianInverse_(parameter, instrument) * bump / base.diagnostics_.residualTolerance_;
+            observedNorm = std::max(observedNorm, std::fabs(observedMoves[parameter]));
+        }
+
+        ASSERT_GT(observedNorm, 1.0e-8) << "instrumentCount=" << instrumentCount;
+        for (int parameter = 0; parameter < static_cast<int>(baseParameters.size()); ++parameter)
+            ASSERT_NEAR(predictedMoves[parameter], observedMoves[parameter], 0.03 * observedNorm + 1.0e-10)
+                << "instrumentCount=" << instrumentCount << " parameter=" << parameter;
+    }
 }
 
 TEST(XccyBasisJacobianTest, TestOmittedSnapshotCapturesRequiredGlobalFixingsOnce) {
@@ -283,18 +434,67 @@ TEST(XccyBasisJacobianTest, TestBumpedModeKeepsOnlyEffectiveInverse) {
     ASSERT_LE(calibrated.diagnostics_.maxAbsResidual_, 1.0e-8);
 }
 
-TEST(XccyBasisJacobianTest, TestDiagnosticFlagsAndApproximateModeLeaveMatricesEmpty) {
+TEST(XccyBasisJacobianTest, TestAvailabilityDistinguishesModeAndRequestFlags) {
     auto fixture = MakeFixture();
+
+    CrossCurrencyCalibrationOptions_ bumpedOptions;
+    bumpedOptions.jacobianMode_ = CurveJacobianMode_::Value_::BUMPED;
+    const auto bumped = CalibrateCrossCurrencyMarket(fixture.spec_, bumpedOptions);
+    ASSERT_EQ(bumped.diagnostics_.jacobianAvailability_, String_("not_available_for_mode"));
+    ASSERT_EQ(bumped.diagnostics_.effJacobianInverseAvailability_, String_("available"));
+    ASSERT_TRUE(bumped.diagnostics_.jacobian_.Empty());
+    ASSERT_FALSE(bumped.diagnostics_.effJacobianInverse_.Empty());
+
     CrossCurrencyCalibrationOptions_ options;
     options.computeEffJacobianInverse_ = false;
     options.computeForwardJacobian_ = false;
     const auto withoutMatrices = CalibrateCrossCurrencyMarket(fixture.spec_, options);
+    ASSERT_EQ(withoutMatrices.diagnostics_.jacobianAvailability_, String_("not_requested"));
+    ASSERT_EQ(withoutMatrices.diagnostics_.effJacobianInverseAvailability_, String_("not_requested"));
     ASSERT_TRUE(withoutMatrices.diagnostics_.jacobian_.Empty());
     ASSERT_TRUE(withoutMatrices.diagnostics_.effJacobianInverse_.Empty());
 
     fixture.spec_.solveMode_ = CurveSolveMode_::Value_::APPROXIMATE;
     const auto approximate = CalibrateCrossCurrencyMarket(fixture.spec_, CrossCurrencyCalibrationOptions_());
     ASSERT_TRUE(approximate.diagnostics_.usedApproximateFit_);
+    ASSERT_EQ(approximate.diagnostics_.jacobianAvailability_, String_("not_available_for_mode"));
+    ASSERT_EQ(approximate.diagnostics_.effJacobianInverseAvailability_, String_("not_available_for_mode"));
     ASSERT_TRUE(approximate.diagnostics_.jacobian_.Empty());
     ASSERT_TRUE(approximate.diagnostics_.effJacobianInverse_.Empty());
+
+    const auto approximateWithoutMatrices = CalibrateCrossCurrencyMarket(fixture.spec_, options);
+    ASSERT_EQ(approximateWithoutMatrices.diagnostics_.jacobianAvailability_, String_("not_requested"));
+    ASSERT_EQ(approximateWithoutMatrices.diagnostics_.effJacobianInverseAvailability_, String_("not_requested"));
+}
+
+TEST(XccyBasisJacobianTest, TestValidationRejectsNonFiniteSolverInputsBeforeSolving) {
+    for (const auto& invalid : {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity()}) {
+        auto fixture = MakeFixture();
+        fixture.spec_.smoothingWeight_ = invalid;
+        AssertCalibrationFailsWith(fixture.spec_, "smoothing weight must be finite and positive");
+
+        fixture = MakeFixture();
+        fixture.spec_.tolerance_ = invalid;
+        AssertCalibrationFailsWith(fixture.spec_, "tolerance must be finite and positive");
+
+        fixture = MakeFixture();
+        fixture.spec_.fitTolerance_ = invalid;
+        AssertCalibrationFailsWith(fixture.spec_, "fit tolerance must be finite and positive");
+
+        fixture = MakeFixture();
+        fixture.spec_.initialGuess_ = invalid;
+        AssertCalibrationFailsWith(fixture.spec_, "initial guess must be finite");
+    }
+}
+
+TEST(XccyBasisJacobianTest, TestInstrumentConstructionRejectsNonFiniteMarketRates) {
+    const auto fixture = MakeFixture();
+    for (const auto& invalid : {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity()}) {
+        try {
+            static_cast<void>(BumpQuote(fixture.spec_, 0, invalid - fixture.spec_.instruments_[0]->MarketRate()));
+            FAIL() << "Expected a non-finite XCCY market rate to fail";
+        } catch (const Dal::Exception_& exception) {
+            ASSERT_NE(std::string(exception.what()).find("requires a finite market rate"), std::string::npos) << exception.what();
+        }
+    }
 }

--- a/dal-excel/README.md
+++ b/dal-excel/README.md
@@ -57,9 +57,23 @@ present at one timestamp, their product must differ from one by no more than
 `1e-10`.
 
 Staged `CALIBRATE.XCCYMARKET` returns a basis-curve handle plus fit diagnostics.
+Its optional settings range accepts `jacobianMode` (`ANALYTIC` or `BUMPED`),
+`computeForwardJacobian`, and `computeEffJacobianInverse`. Omitting these keys
+selects `ANALYTIC`, `TRUE`, and `TRUE`.
+
 `XCCYCALIBRATIONRESULT.GET` exposes `marketRates`, `modelRates`, `residuals`,
-`maxAbsResidual`, and `rmsResidual`; neither the staged forward Jacobian nor the
-staged effective inverse is worksheet-visible.
+`maxAbsResidual`, `rmsResidual`, `instrumentNames`, `parameterKnotDates`,
+`jacobian`, `effJacobianInverse`, `residualTolerance`, `jacobianScaling`,
+`effJacobianInverseScaling`, `jacobianAvailability`, and
+`effJacobianInverseAvailability`. The Jacobian rows follow instrument input
+order; names are labels and may repeat. Its columns follow the basis-knot
+right-forward parameter order. The effective inverse has the reversed axes.
+
+The forward scaling label is `unscaled`; the effective-inverse scaling label is
+`solver_scaled`. A raw decimal quote-bump vector therefore maps as
+`dx = E * dq / residualTolerance`, where `E` is the retrieved effective
+inverse. Availability is `available`, `not_requested`, or
+`not_available_for_mode`; an unavailable matrix is returned empty.
 
 `CALIBRATE.JOINTXCCY` performs one domestic/foreign/basis solve. Its result
 supports dedicated handle getters:
@@ -71,10 +85,9 @@ supports dedicated handle getters:
 Joint settings can request both forward-Jacobian and effective-inverse
 computation. `JOINTXCCYCALIBRATIONRESULT.GET` returns views selected by
 `fxForwards`, `marketRates`, `modelRates`, `residuals`, `jacobian`,
-`parameterRanges`, or `residualRanges`; `jacobian` is the worksheet-visible
-forward matrix and the range selectors publish its named layout. No worksheet
-selector exposes the retained joint effective inverse. The generated HTML
-under `auto/` is the exact argument and settings-key reference.
+`effJacobianInverse`, `parameterRanges`, or `residualRanges`; the range
+selectors publish the matrices' named layout. The generated HTML under `auto/`
+is the exact argument and settings-key reference.
 
 ## Layout and Generated Registration
 

--- a/dal-excel/auto/MG_Calibrate_XccyMarket_public.htm
+++ b/dal-excel/auto/MG_Calibrate_XccyMarket_public.htm
@@ -22,7 +22,7 @@ Calibrate a cross-currency basis market from instruments and settings. Returns a
 <tr><td>foreignBlock</td><td>handle of type StorableCurveBlock</td><td></td><td>The pre-calibrated foreign curve block</td></tr>
 <tr><td>instruments</td><td>vector of handles</td><td></td><td>Array of cross-currency swap instrument handles (created with CROSSCURRENCYSWAP.NEW)</td></tr>
 <tr><td>knotDates</td><td>vector of dates</td><td></td><td>Knot dates for the basis curve</td></tr>
-<tr><td>settings</td><td>matrix of cells</td><td>yes</td><td>Optional two-column (key,value) settings. Keys: fxSpot, fxForwardCollateral, smoothingWeight, tolerance, fitTolerance, initialGuess, maxEvaluations, maxRestarts, solveMode (EXACT|APPROXIMATE)</td></tr>
+<tr><td>settings</td><td>matrix of cells</td><td>yes</td><td>Optional two-column (key,value) settings. Keys: fxSpot, fxForwardCollateral, smoothingWeight, tolerance, fitTolerance, initialGuess, maxEvaluations, maxRestarts, solveMode (EXACT|APPROXIMATE), jacobianMode (ANALYTIC|BUMPED), computeEffJacobianInverse, computeForwardJacobian</td></tr>
 
 </table>
 

--- a/dal-excel/auto/MG_Calibrate_XccyMarket_public.inc
+++ b/dal-excel/auto/MG_Calibrate_XccyMarket_public.inc
@@ -55,7 +55,7 @@ struct XlRegister_Calibrate_XccyMarket_
         argHelp.push_back("The pre-calibrated foreign curve block");
         argHelp.push_back("Array of cross-currency swap instrument handles (created with CROSSCURRENCYSWAP.NEW)");
         argHelp.push_back("Knot dates for the basis curve");
-        argHelp.push_back("Optional two-column (key,value) settings. Keys: fxSpot, fxForwardCollateral, smoothingWeight, tolerance, fitTolerance, initialGuess, maxEvaluations, maxRestarts, solveMode (EXACT|APPROXIMATE)");
+        argHelp.push_back("Optional two-column (key,value) settings. Keys: fxSpot, fxForwardCollateral, smoothingWeight, tolerance, fitTolerance, initialGuess, maxEvaluations, maxRestarts, solveMode (EXACT|APPROXIMATE), jacobianMode (ANALYTIC|BUMPED), computeEffJacobianInverse, computeForwardJacobian");
         Excel::Register("Base", "xl_Calibrate_XccyMarket", "CALIBRATE.XCCYMARKET", "Calibrate a cross-currency basis market from instruments and settings. Returns a result handle bundling the basis curve and the fit diagnostics.", "QQQQQQQQQ", "today,domesticCcy,foreignCcy,domesticBlock,foreignBlock,instruments,knotDates,[settings]", argHelp, false);
     }
 };

--- a/dal-excel/auto/MG_JointXccyCalibrationResult_Get_public.htm
+++ b/dal-excel/auto/MG_JointXccyCalibrationResult_Get_public.htm
@@ -16,7 +16,7 @@ Extract a matrix-valued view from a joint XCCY calibration result. Use the dedic
 <tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
 
 <tr><td>result</td><td>handle of type StorableJointXccyCalibrationResult</td><td></td><td>The joint calibration result</td></tr>
-<tr><td>attribute</td><td>string</td><td></td><td>Attribute: fxForwards, marketRates, modelRates, residuals, jacobian, parameterRanges, or residualRanges. Handle views domesticBlock, foreignBlock, and basisCurve use their dedicated getter functions.</td></tr>
+<tr><td>attribute</td><td>string</td><td></td><td>Attribute: fxForwards, marketRates, modelRates, residuals, jacobian, effJacobianInverse, parameterRanges, or residualRanges. Handle views domesticBlock, foreignBlock, and basisCurve use their dedicated getter functions.</td></tr>
 
 </table>
 

--- a/dal-excel/auto/MG_JointXccyCalibrationResult_Get_public.inc
+++ b/dal-excel/auto/MG_JointXccyCalibrationResult_Get_public.inc
@@ -36,7 +36,7 @@ struct XlRegister_JointXccyCalibrationResult_Get_
     {
         Vector_<String_> argHelp;        
         argHelp.push_back("The joint calibration result");
-        argHelp.push_back("Attribute: fxForwards, marketRates, modelRates, residuals, jacobian, parameterRanges, or residualRanges. Handle views domesticBlock, foreignBlock, and basisCurve use their dedicated getter functions.");
+        argHelp.push_back("Attribute: fxForwards, marketRates, modelRates, residuals, jacobian, effJacobianInverse, parameterRanges, or residualRanges. Handle views domesticBlock, foreignBlock, and basisCurve use their dedicated getter functions.");
         Excel::Register("Base", "xl_JointXccyCalibrationResult_Get", "JOINTXCCYCALIBRATIONRESULT.GET", "Extract a matrix-valued view from a joint XCCY calibration result. Use the dedicated getter functions for curve handles.", "QQQ", "result,attribute", argHelp, false);
     }
 };

--- a/dal-excel/auto/MG_XccyCalibrationResult_Get_public.htm
+++ b/dal-excel/auto/MG_XccyCalibrationResult_Get_public.htm
@@ -16,7 +16,7 @@ Extract a diagnostic attribute from a cross-currency calibration result. Use XCC
 <tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
 
 <tr><td>result</td><td>handle of type StorableCrossCurrencyCalibrationResult</td><td></td><td>The cross-currency calibration result handle (from CALIBRATE.XCCYMARKET)</td></tr>
-<tr><td>attribute</td><td>string</td><td></td><td>Attribute name: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual</td></tr>
+<tr><td>attribute</td><td>string</td><td></td><td>Attribute name: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, instrumentNames, parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, effJacobianInverseScaling, jacobianAvailability, effJacobianInverseAvailability</td></tr>
 
 </table>
 
@@ -28,7 +28,7 @@ Extract a diagnostic attribute from a cross-currency calibration result. Use XCC
 <table border="1" cellpadding="3">
 <tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
 
-<tr><td>value</td><td>matrix of cells</td><td>The requested diagnostic. Rate vectors (marketRates/modelRates/residuals) return as an Nx1 column; scalar stats (maxAbsResidual/rmsResidual) return as 1x1.</td></tr>
+<tr><td>value</td><td>matrix of cells</td><td>The requested diagnostic. Rate vectors (marketRates/modelRates/residuals) return as an Nx1 column; matrices retain their diagnostic axes; scalar and metadata values return as 1x1.</td></tr>
 </table>
 
 

--- a/dal-excel/auto/MG_XccyCalibrationResult_Get_public.inc
+++ b/dal-excel/auto/MG_XccyCalibrationResult_Get_public.inc
@@ -36,7 +36,7 @@ struct XlRegister_XccyCalibrationResult_Get_
     {
         Vector_<String_> argHelp;        
         argHelp.push_back("The cross-currency calibration result handle (from CALIBRATE.XCCYMARKET)");
-        argHelp.push_back("Attribute name: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual");
+        argHelp.push_back("Attribute name: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, instrumentNames, parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, effJacobianInverseScaling, jacobianAvailability, effJacobianInverseAvailability");
         Excel::Register("Base", "xl_XccyCalibrationResult_Get", "XCCYCALIBRATIONRESULT.GET", "Extract a diagnostic attribute from a cross-currency calibration result. Use XCCYCALIBRATIONRESULT.GET.BASISCURVE for the basis curve itself.", "QQQ", "result,attribute", argHelp, false);
     }
 };

--- a/dal-excel/src/__xccy_test_api.hpp
+++ b/dal-excel/src/__xccy_test_api.hpp
@@ -51,6 +51,22 @@ namespace Dal {
                                                          const Handle_<StorableCrossCurrencySwapConfig_>& config,
                                                          Handle_<StorableCrossCurrencySwap_>* instrument);
 
+    DAL_EXCEL_TEST_API void Calibrate_XccyMarket(const Date_& today,
+                                                 const String_& domesticCcy,
+                                                 const String_& foreignCcy,
+                                                 const Handle_<StorableCurveBlock_>& domesticBlock,
+                                                 const Handle_<StorableCurveBlock_>& foreignBlock,
+                                                 const Vector_<Handle_<Storable_>>& instrumentWrappers,
+                                                 const Vector_<Date_>& knotDates,
+                                                 const Matrix_<Cell_>& settings,
+                                                 Handle_<StorableCrossCurrencyCalibrationResult_>* result);
+
+    DAL_EXCEL_TEST_API void XccyCalibrationResult_Get_BasisCurve(const Handle_<StorableCrossCurrencyCalibrationResult_>& result,
+                                                                 Handle_<StorableDiscountCurve_>* curve);
+
+    DAL_EXCEL_TEST_API void
+    XccyCalibrationResult_Get(const Handle_<StorableCrossCurrencyCalibrationResult_>& result, const String_& attribute, Matrix_<Cell_>* value);
+
     DAL_EXCEL_TEST_API void Calibrate_JointXccy(const Cell_& valuationTime,
                                                 const Handle_<StorableCurrencyPair_>& currencies,
                                                 const String_& collateralCurrency,

--- a/dal-excel/src/__xccycalibration.cpp
+++ b/dal-excel/src/__xccycalibration.cpp
@@ -444,6 +444,52 @@ namespace Dal {
             }
             return result;
         }
+
+        using XccyResultViewGetter_ = Matrix_<Cell_> (*)(const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_&);
+
+        struct XccyResultView_ {
+            const char* name_;
+            XccyResultViewGetter_ getter_;
+        };
+
+        const XccyResultView_ XCCY_RESULT_VIEWS[] = {
+            {"marketRates", [](const CrossCurrencyCalibrationResult_&,
+                               const CrossCurrencyCalibrationDiagnostics_& diag) { return AsCellColumn(diag.marketRates_); }},
+            {"modelRates",
+             [](const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_& diag) { return AsCellColumn(diag.modelRates_); }},
+            {"residuals",
+             [](const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_& diag) { return AsCellColumn(diag.residuals_); }},
+            {"maxAbsResidual", [](const CrossCurrencyCalibrationResult_&,
+                                  const CrossCurrencyCalibrationDiagnostics_& diag) { return Matrix_<Cell_>(1, 1, Cell_(diag.maxAbsResidual_)); }},
+            {"rmsResidual", [](const CrossCurrencyCalibrationResult_&,
+                               const CrossCurrencyCalibrationDiagnostics_& diag) { return Matrix_<Cell_>(1, 1, Cell_(diag.rmsResidual_)); }},
+            {"instrumentNames", [](const CrossCurrencyCalibrationResult_&,
+                                   const CrossCurrencyCalibrationDiagnostics_& diag) { return StringsAsCells(diag.instrumentNames_); }},
+            {"parameterKnotDates", [](const CrossCurrencyCalibrationResult_&,
+                                      const CrossCurrencyCalibrationDiagnostics_& diag) { return DatesAsCells(diag.parameterKnotDates_); }},
+            {"jacobian", [](const CrossCurrencyCalibrationResult_& result,
+                            const CrossCurrencyCalibrationDiagnostics_&) { return AsCellMatrix(XccyResultJacobian(result)); }},
+            {"effJacobianInverse", [](const CrossCurrencyCalibrationResult_& result,
+                                      const CrossCurrencyCalibrationDiagnostics_&) { return AsCellMatrix(XccyResultEffJacobianInverse(result)); }},
+            {"residualTolerance",
+             [](const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_& diag) {
+                 return Matrix_<Cell_>(1, 1, Cell_(diag.residualTolerance_));
+             }},
+            {"jacobianScaling", [](const CrossCurrencyCalibrationResult_&,
+                                   const CrossCurrencyCalibrationDiagnostics_& diag) { return Matrix_<Cell_>(1, 1, Cell_(diag.jacobianScaling_)); }},
+            {"effJacobianInverseScaling",
+             [](const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_& diag) {
+                 return Matrix_<Cell_>(1, 1, Cell_(diag.effJacobianInverseScaling_));
+             }},
+            {"jacobianAvailability",
+             [](const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_& diag) {
+                 return Matrix_<Cell_>(1, 1, Cell_(diag.jacobianAvailability_));
+             }},
+            {"effJacobianInverseAvailability",
+             [](const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_& diag) {
+                 return Matrix_<Cell_>(1, 1, Cell_(diag.effJacobianInverseAvailability_));
+             }},
+        };
     } // namespace
 
     void Calibrate_XccyMarket(const Date_& today,
@@ -505,40 +551,18 @@ namespace Dal {
 
     void XccyCalibrationResult_Get(const Handle_<StorableCrossCurrencyCalibrationResult_>& result, const String_& attribute, Matrix_<Cell_>* value) {
         REQUIRE(result, "Invalid XCCY calibration result handle");
-        const auto& diag = XccyResultDiagnostics(result->val_);
-        if (attribute == "marketRates")
-            *value = AsCellColumn(diag.marketRates_);
-        else if (attribute == "modelRates")
-            *value = AsCellColumn(diag.modelRates_);
-        else if (attribute == "residuals")
-            *value = AsCellColumn(diag.residuals_);
-        else if (attribute == "maxAbsResidual")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.maxAbsResidual_));
-        else if (attribute == "rmsResidual")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.rmsResidual_));
-        else if (attribute == "instrumentNames")
-            *value = StringsAsCells(diag.instrumentNames_);
-        else if (attribute == "parameterKnotDates")
-            *value = DatesAsCells(diag.parameterKnotDates_);
-        else if (attribute == "jacobian")
-            *value = AsCellMatrix(XccyResultJacobian(result->val_));
-        else if (attribute == "effJacobianInverse")
-            *value = AsCellMatrix(XccyResultEffJacobianInverse(result->val_));
-        else if (attribute == "residualTolerance")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.residualTolerance_));
-        else if (attribute == "jacobianScaling")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.jacobianScaling_));
-        else if (attribute == "effJacobianInverseScaling")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.effJacobianInverseScaling_));
-        else if (attribute == "jacobianAvailability")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.jacobianAvailability_));
-        else if (attribute == "effJacobianInverseAvailability")
-            *value = Matrix_<Cell_>(1, 1, Cell_(diag.effJacobianInverseAvailability_));
-        else
-            THROW("Unknown XCCY calibration attribute: " + attribute +
-                  " (accepted views: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, instrumentNames, "
-                  "parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, effJacobianInverseScaling, "
-                  "jacobianAvailability, effJacobianInverseAvailability)");
+        const auto& calibration = result->val_;
+        const auto& diag = XccyResultDiagnostics(calibration);
+        for (const auto& view : XCCY_RESULT_VIEWS) {
+            if (attribute == view.name_) {
+                *value = view.getter_(calibration, diag);
+                return;
+            }
+        }
+        THROW("Unknown XCCY calibration attribute: " + attribute +
+              " (accepted views: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, instrumentNames, "
+              "parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, effJacobianInverseScaling, "
+              "jacobianAvailability, effJacobianInverseAvailability)");
     }
 
     void Calibrate_JointXccy(const Cell_& valuationTime,

--- a/dal-excel/src/__xccycalibration.cpp
+++ b/dal-excel/src/__xccycalibration.cpp
@@ -36,7 +36,7 @@ knotDates is date[]
 &optional
 settings is cell[][]
     &$.Cols() == 2 || $.Empty()\must have two columns (key, value)
-    Optional two-column (key,value) settings. Keys: fxSpot, fxForwardCollateral, smoothingWeight, tolerance, fitTolerance, initialGuess, maxEvaluations, maxRestarts, solveMode (EXACT|APPROXIMATE)
+    Optional two-column (key,value) settings. Keys: fxSpot, fxForwardCollateral, smoothingWeight, tolerance, fitTolerance, initialGuess, maxEvaluations, maxRestarts, solveMode (EXACT|APPROXIMATE), jacobianMode (ANALYTIC|BUMPED), computeEffJacobianInverse, computeForwardJacobian
 &outputs
 result is handle StorableCrossCurrencyCalibrationResult
     The cross-currency calibration result (basis curve + diagnostics)
@@ -61,11 +61,11 @@ public XccyCalibrationResult_Get
 result is handle StorableCrossCurrencyCalibrationResult
     The cross-currency calibration result handle (from CALIBRATE.XCCYMARKET)
 attribute is string
-    Attribute name: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual
+    Attribute name: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, instrumentNames, parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, effJacobianInverseScaling, jacobianAvailability, effJacobianInverseAvailability
 &outputs
 value is cell[][]
     The requested diagnostic. Rate vectors (marketRates/modelRates/residuals) return
-    as an Nx1 column; scalar stats (maxAbsResidual/rmsResidual) return as 1x1.
+    as an Nx1 column; matrices retain their diagnostic axes; scalar and metadata values return as 1x1.
 -IF-------------------------------------------------------------------------*/
 
 /*IF--------------------------------------------------------------------------
@@ -143,7 +143,7 @@ public JointXccyCalibrationResult_Get
 result is handle StorableJointXccyCalibrationResult
     The joint calibration result
 attribute is string
-    Attribute: fxForwards, marketRates, modelRates, residuals, jacobian, parameterRanges, or residualRanges. Handle views domesticBlock, foreignBlock, and basisCurve use their dedicated getter functions.
+    Attribute: fxForwards, marketRates, modelRates, residuals, jacobian, effJacobianInverse, parameterRanges, or residualRanges. Handle views domesticBlock, foreignBlock, and basisCurve use their dedicated getter functions.
 &outputs
 value is cell[][]
     The requested joint result view
@@ -185,9 +185,46 @@ namespace Dal {
                 b.maxRestarts_ = i;
         }
 
-        void ApplyXccySettings(const Dictionary_& settings, CrossCurrencyCalibrationSpecBuilder_& b) {
-            static const Vector_<String_> validKeys = {"fxSpot",       "fxForwardCollateral", "smoothingWeight", "tolerance", "fitTolerance",
-                                                       "initialGuess", "maxEvaluations",      "maxRestarts",     "solveMode"};
+        String_ CellTypeName(const Cell_& value) {
+            if (Cell::IsBool(value))
+                return "boolean";
+            if (Cell::IsDouble(value))
+                return "number";
+            if (Cell::IsDate(value))
+                return "date";
+            if (Cell::IsDateTime(value))
+                return "date-time";
+            if (Cell::IsString(value))
+                return "string";
+            return "empty";
+        }
+
+        void ApplyXccyOptionSetting(const String_& key, const Cell_& value, CrossCurrencyCalibrationOptions_& options) {
+            if (key == "jacobianMode") {
+                REQUIRE(Cell::IsString(value), "XCCY setting '" + key + "' received " + CellTypeName(value) + "; expected string ANALYTIC or BUMPED");
+                options.jacobianMode_ = CurveJacobianMode_(Cell::ToString(value));
+            } else if (key == "computeEffJacobianInverse") {
+                REQUIRE(Cell::IsBool(value), "XCCY setting '" + key + "' received " + CellTypeName(value) + "; expected boolean true or false");
+                options.computeEffJacobianInverse_ = Cell::ToBool(value);
+            } else if (key == "computeForwardJacobian") {
+                REQUIRE(Cell::IsBool(value), "XCCY setting '" + key + "' received " + CellTypeName(value) + "; expected boolean true or false");
+                options.computeForwardJacobian_ = Cell::ToBool(value);
+            }
+        }
+
+        void ApplyXccySettings(const Dictionary_& settings, CrossCurrencyCalibrationSpecBuilder_& b, CrossCurrencyCalibrationOptions_& options) {
+            static const Vector_<String_> validKeys = {"fxSpot",
+                                                       "fxForwardCollateral",
+                                                       "smoothingWeight",
+                                                       "tolerance",
+                                                       "fitTolerance",
+                                                       "initialGuess",
+                                                       "maxEvaluations",
+                                                       "maxRestarts",
+                                                       "solveMode",
+                                                       "jacobianMode",
+                                                       "computeEffJacobianInverse",
+                                                       "computeForwardJacobian"};
             for (const auto& kv : settings) {
                 const String_& key = kv.first;
                 const Cell_& val = kv.second;
@@ -195,6 +232,7 @@ namespace Dal {
                 ApplyXccyStringSettings(key, val, b);
                 ApplyXccyDoubleSettings(key, val, b);
                 ApplyXccyIntSettings(key, val, b);
+                ApplyXccyOptionSetting(key, val, options);
             }
         }
 
@@ -373,6 +411,20 @@ namespace Dal {
             return result;
         }
 
+        Matrix_<Cell_> StringsAsCells(const Vector_<String_>& source) {
+            Matrix_<Cell_> result(source.size(), 1);
+            for (int row = 0; row < source.size(); ++row)
+                result(row, 0) = Cell_(source[row]);
+            return result;
+        }
+
+        Matrix_<Cell_> DatesAsCells(const Vector_<Date_>& source) {
+            Matrix_<Cell_> result(source.size(), 1);
+            for (int row = 0; row < source.size(); ++row)
+                result(row, 0) = Cell_(source[row]);
+            return result;
+        }
+
         Matrix_<Cell_> FxForwardsAsCells(const CrossCurrencyFxForwardCurve_& forwards) {
             REQUIRE(forwards.dates_.size() == forwards.forwards_.size(), "Joint XCCY FX-forward dates and values have inconsistent lengths");
             Matrix_<Cell_> result(forwards.dates_.size(), 2);
@@ -392,82 +444,102 @@ namespace Dal {
             }
             return result;
         }
-
-        void Calibrate_XccyMarket(const Date_& today,
-                                  const String_& domesticCcy,
-                                  const String_& foreignCcy,
-                                  const Handle_<StorableCurveBlock_>& domesticBlock,
-                                  const Handle_<StorableCurveBlock_>& foreignBlock,
-                                  const Vector_<Handle_<Storable_>>& instrumentWrappers,
-                                  const Vector_<Date_>& knotDates,
-                                  const Matrix_<Cell_>& settings,
-                                  Handle_<StorableCrossCurrencyCalibrationResult_>* result) {
-            REQUIRE(domesticBlock, "Invalid domestic curve block handle");
-            REQUIRE(foreignBlock, "Invalid foreign curve block handle");
-
-            CrossCurrencyCalibrationSpecBuilder_ builder;
-            builder.today_ = today;
-            builder.basisPair_ = CurrencyPair_New(domesticCcy, foreignCcy);
-            builder.domesticCurveBlock_ = domesticBlock->val_;
-            builder.foreignCurveBlock_ = foreignBlock->val_;
-
-            // Convert instrument wrappers to raw handles
-            for (const auto& w : instrumentWrappers) {
-                REQUIRE(w, "Invalid instrument handle");
-                auto xccyInst = handle_cast<StorableCrossCurrencySwap_>(w);
-                REQUIRE(xccyInst, "Instrument must be a cross-currency swap");
-                builder.instruments_.push_back(xccyInst->val_);
-            }
-
-            builder.knotDates_ = knotDates;
-
-            // Convert Matrix_<Cell_> to Dictionary_ and apply optional settings
-            if (!settings.Empty()) {
-                Dictionary_ dict;
-                for (int i = 0; i < settings.Rows(); ++i) {
-                    if (Cell::IsEmpty(settings(i, 0)))
-                        break;
-                    dict.Insert(Cell::ToString(settings(i, 0)), settings(i, 1));
-                }
-                ApplyXccySettings(dict, builder);
-            }
-
-            const CurrencyPair_ pair = builder.basisPair_;
-            REQUIRE(builder.fxSpot_ > 0.0, "Cross-currency calibration requires an fxSpot setting (e.g. fxSpot=1.10)");
-            auto spec = builder.Build();
-            auto calibrated = Dal::CalibrateXccyMarket(spec);
-
-            // Resolve the basis curve for the calibrated currency pair
-            auto it = calibrated.basisCurves_.find(pair);
-            REQUIRE(it != calibrated.basisCurves_.end(), "Basis curve not found for requested currency pair");
-            result->reset(new StorableCrossCurrencyCalibrationResult_(calibrated, it->second));
-        }
-
-        void XccyCalibrationResult_Get_BasisCurve(const Handle_<StorableCrossCurrencyCalibrationResult_>& result,
-                                                  Handle_<StorableDiscountCurve_>* curve) {
-            REQUIRE(result, "Invalid XCCY calibration result handle");
-            curve->reset(new StorableDiscountCurve_(result->basisCurve_));
-        }
-
-        void
-        XccyCalibrationResult_Get(const Handle_<StorableCrossCurrencyCalibrationResult_>& result, const String_& attribute, Matrix_<Cell_>* value) {
-            REQUIRE(result, "Invalid XCCY calibration result handle");
-            const auto& diag = result->val_.diagnostics_;
-            if (attribute == "marketRates")
-                *value = AsCellColumn(diag.marketRates_);
-            else if (attribute == "modelRates")
-                *value = AsCellColumn(diag.modelRates_);
-            else if (attribute == "residuals")
-                *value = AsCellColumn(diag.residuals_);
-            else if (attribute == "maxAbsResidual")
-                *value = Matrix_<Cell_>(1, 1, Cell_(diag.maxAbsResidual_));
-            else if (attribute == "rmsResidual")
-                *value = Matrix_<Cell_>(1, 1, Cell_(diag.rmsResidual_));
-            else
-                THROW("Unknown XCCY calibration attribute: " + attribute +
-                      " (expected marketRates, modelRates, residuals, maxAbsResidual, or rmsResidual)");
-        }
     } // namespace
+
+    void Calibrate_XccyMarket(const Date_& today,
+                              const String_& domesticCcy,
+                              const String_& foreignCcy,
+                              const Handle_<StorableCurveBlock_>& domesticBlock,
+                              const Handle_<StorableCurveBlock_>& foreignBlock,
+                              const Vector_<Handle_<Storable_>>& instrumentWrappers,
+                              const Vector_<Date_>& knotDates,
+                              const Matrix_<Cell_>& settings,
+                              Handle_<StorableCrossCurrencyCalibrationResult_>* result) {
+        REQUIRE(domesticBlock, "Invalid domestic curve block handle");
+        REQUIRE(foreignBlock, "Invalid foreign curve block handle");
+
+        CrossCurrencyCalibrationSpecBuilder_ builder;
+        builder.today_ = today;
+        builder.basisPair_ = CurrencyPair_New(domesticCcy, foreignCcy);
+        builder.domesticCurveBlock_ = domesticBlock->val_;
+        builder.foreignCurveBlock_ = foreignBlock->val_;
+
+        // Convert instrument wrappers to raw handles
+        for (const auto& w : instrumentWrappers) {
+            REQUIRE(w, "Invalid instrument handle");
+            auto xccyInst = handle_cast<StorableCrossCurrencySwap_>(w);
+            REQUIRE(xccyInst, "Instrument must be a cross-currency swap");
+            builder.instruments_.push_back(xccyInst->val_);
+        }
+
+        builder.knotDates_ = knotDates;
+
+        CrossCurrencyCalibrationOptions_ options;
+        // Convert Matrix_<Cell_> to Dictionary_ and apply optional settings
+        if (!settings.Empty()) {
+            Dictionary_ dict;
+            for (int i = 0; i < settings.Rows(); ++i) {
+                if (Cell::IsEmpty(settings(i, 0)))
+                    break;
+                dict.Insert(Cell::ToString(settings(i, 0)), settings(i, 1));
+            }
+            ApplyXccySettings(dict, builder, options);
+        }
+
+        const CurrencyPair_ pair = builder.basisPair_;
+        REQUIRE(builder.fxSpot_ > 0.0, "Cross-currency calibration requires an fxSpot setting (e.g. fxSpot=1.10)");
+        auto spec = builder.Build();
+        auto calibrated = Dal::CalibrateXccyMarket(spec, options);
+
+        // Resolve the basis curve for the calibrated currency pair
+        auto it = calibrated.basisCurves_.find(pair);
+        REQUIRE(it != calibrated.basisCurves_.end(), "Basis curve not found for requested currency pair");
+        result->reset(new StorableCrossCurrencyCalibrationResult_(calibrated, it->second));
+    }
+
+    void XccyCalibrationResult_Get_BasisCurve(const Handle_<StorableCrossCurrencyCalibrationResult_>& result,
+                                              Handle_<StorableDiscountCurve_>* curve) {
+        REQUIRE(result, "Invalid XCCY calibration result handle");
+        curve->reset(new StorableDiscountCurve_(result->basisCurve_));
+    }
+
+    void XccyCalibrationResult_Get(const Handle_<StorableCrossCurrencyCalibrationResult_>& result, const String_& attribute, Matrix_<Cell_>* value) {
+        REQUIRE(result, "Invalid XCCY calibration result handle");
+        const auto& diag = XccyResultDiagnostics(result->val_);
+        if (attribute == "marketRates")
+            *value = AsCellColumn(diag.marketRates_);
+        else if (attribute == "modelRates")
+            *value = AsCellColumn(diag.modelRates_);
+        else if (attribute == "residuals")
+            *value = AsCellColumn(diag.residuals_);
+        else if (attribute == "maxAbsResidual")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.maxAbsResidual_));
+        else if (attribute == "rmsResidual")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.rmsResidual_));
+        else if (attribute == "instrumentNames")
+            *value = StringsAsCells(diag.instrumentNames_);
+        else if (attribute == "parameterKnotDates")
+            *value = DatesAsCells(diag.parameterKnotDates_);
+        else if (attribute == "jacobian")
+            *value = AsCellMatrix(XccyResultJacobian(result->val_));
+        else if (attribute == "effJacobianInverse")
+            *value = AsCellMatrix(XccyResultEffJacobianInverse(result->val_));
+        else if (attribute == "residualTolerance")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.residualTolerance_));
+        else if (attribute == "jacobianScaling")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.jacobianScaling_));
+        else if (attribute == "effJacobianInverseScaling")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.effJacobianInverseScaling_));
+        else if (attribute == "jacobianAvailability")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.jacobianAvailability_));
+        else if (attribute == "effJacobianInverseAvailability")
+            *value = Matrix_<Cell_>(1, 1, Cell_(diag.effJacobianInverseAvailability_));
+        else
+            THROW("Unknown XCCY calibration attribute: " + attribute +
+                  " (accepted views: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, instrumentNames, "
+                  "parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, effJacobianInverseScaling, "
+                  "jacobianAvailability, effJacobianInverseAvailability)");
+    }
 
     void Calibrate_JointXccy(const Cell_& valuationTime,
                              const Handle_<StorableCurrencyPair_>& currencies,
@@ -551,15 +623,17 @@ namespace Dal {
             *value = AsCellColumn(JointXccyResultResiduals(result->val_));
         else if (attribute == "jacobian")
             *value = AsCellMatrix(JointXccyResultJacobian(result->val_));
+        else if (attribute == "effJacobianInverse")
+            *value = AsCellMatrix(JointXccyResultEffJacobianInverse(result->val_));
         else if (attribute == "parameterRanges")
             *value = RangesAsCells(JointXccyResultParameterRanges(result->val_));
         else if (attribute == "residualRanges")
             *value = RangesAsCells(JointXccyResultResidualRanges(result->val_));
         else
-            THROW(
-                "Unknown joint XCCY calibration attribute: " + attribute +
-                " (accepted views: domesticBlock, foreignBlock, basisCurve, fxForwards, marketRates, modelRates, residuals, jacobian, "
-                "parameterRanges, residualRanges; use the dedicated DOMESTICBLOCK, FOREIGNBLOCK, and BASISCURVE getter functions for handle views)");
+            THROW("Unknown joint XCCY calibration attribute: " + attribute +
+                  " (accepted views: domesticBlock, foreignBlock, basisCurve, fxForwards, marketRates, modelRates, residuals, jacobian, "
+                  "effJacobianInverse, parameterRanges, residualRanges; use the dedicated DOMESTICBLOCK, FOREIGNBLOCK, and BASISCURVE getter "
+                  "functions for handle views)");
     }
     // clang-format off
 #ifdef _WIN32

--- a/dal-excel/tests/test_excel_api.cpp
+++ b/dal-excel/tests/test_excel_api.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include <dal-excel/src/__curve_storable.hpp>
 #include <dal-excel/src/__xccy_test_api.hpp>
 #include <dal-public/src/curvedata.hpp>
@@ -191,14 +193,42 @@ TEST(ExcelApiTest, TestStagedCalibrationExposesFrozenSensitivityViews) {
     const auto result = StagedResult();
     ASSERT_TRUE(result);
 
+    Matrix_<Cell_> marketRates;
+    Matrix_<Cell_> modelRates;
+    Matrix_<Cell_> residuals;
+    Matrix_<Cell_> maxAbsResidual;
+    Matrix_<Cell_> rmsResidual;
     Matrix_<Cell_> instrumentNames;
     Matrix_<Cell_> knotDates;
     Matrix_<Cell_> jacobian;
     Matrix_<Cell_> inverse;
+    XccyCalibrationResult_Get(result, "marketRates", &marketRates);
+    XccyCalibrationResult_Get(result, "modelRates", &modelRates);
+    XccyCalibrationResult_Get(result, "residuals", &residuals);
+    XccyCalibrationResult_Get(result, "maxAbsResidual", &maxAbsResidual);
+    XccyCalibrationResult_Get(result, "rmsResidual", &rmsResidual);
     XccyCalibrationResult_Get(result, "instrumentNames", &instrumentNames);
     XccyCalibrationResult_Get(result, "parameterKnotDates", &knotDates);
     XccyCalibrationResult_Get(result, "jacobian", &jacobian);
     XccyCalibrationResult_Get(result, "effJacobianInverse", &inverse);
+    ASSERT_EQ(marketRates.Rows(), 1);
+    ASSERT_EQ(marketRates.Cols(), 1);
+    ASSERT_EQ(modelRates.Rows(), 1);
+    ASSERT_EQ(modelRates.Cols(), 1);
+    ASSERT_EQ(residuals.Rows(), 1);
+    ASSERT_EQ(residuals.Cols(), 1);
+    ASSERT_DOUBLE_EQ(Cell::ToDouble(marketRates(0, 0)), 0.01);
+    const double modelRate = Cell::ToDouble(modelRates(0, 0));
+    const double residual = Cell::ToDouble(residuals(0, 0));
+    ASSERT_TRUE(std::isfinite(modelRate));
+    ASSERT_TRUE(std::isfinite(residual));
+    ASSERT_NEAR(modelRate - Cell::ToDouble(marketRates(0, 0)), residual, 1.0e-15);
+    ASSERT_EQ(maxAbsResidual.Rows(), 1);
+    ASSERT_EQ(maxAbsResidual.Cols(), 1);
+    ASSERT_EQ(rmsResidual.Rows(), 1);
+    ASSERT_EQ(rmsResidual.Cols(), 1);
+    ASSERT_DOUBLE_EQ(Cell::ToDouble(maxAbsResidual(0, 0)), std::abs(residual));
+    ASSERT_DOUBLE_EQ(Cell::ToDouble(rmsResidual(0, 0)), std::abs(residual));
     ASSERT_EQ(instrumentNames.Rows(), 1);
     ASSERT_EQ(instrumentNames.Cols(), 1);
     ASSERT_TRUE(Cell::IsString(instrumentNames(0, 0)));
@@ -294,6 +324,12 @@ TEST(ExcelApiTest, TestUnknownStagedSettingsAndViewsListNewContractSurface) {
         FAIL() << "Expected an unknown staged result view to fail";
     } catch (const Exception_& exception) {
         const std::string message(exception.what());
+        const std::string expected =
+            "Unknown XCCY calibration attribute: unknown (accepted views: marketRates, modelRates, residuals, maxAbsResidual, rmsResidual, "
+            "instrumentNames, parameterKnotDates, jacobian, effJacobianInverse, residualTolerance, jacobianScaling, "
+            "effJacobianInverseScaling, jacobianAvailability, effJacobianInverseAvailability)";
+        ASSERT_GE(message.size(), expected.size());
+        ASSERT_EQ(message.substr(message.size() - expected.size()), expected);
         for (const char* attribute : {"instrumentNames", "parameterKnotDates", "jacobian", "effJacobianInverse", "jacobianAvailability",
                                       "effJacobianInverseAvailability", "residualTolerance", "jacobianScaling", "effJacobianInverseScaling"})
             ASSERT_NE(message.find(attribute), std::string::npos) << attribute << ": " << message;

--- a/dal-excel/tests/test_excel_api.cpp
+++ b/dal-excel/tests/test_excel_api.cpp
@@ -8,6 +8,7 @@
 
 #include <dal-excel/src/__curve_storable.hpp>
 #include <dal-excel/src/__xccy_test_api.hpp>
+#include <dal-public/src/curvedata.hpp>
 #include <dal-public/src/curveinstrument.hpp>
 #include <dal-public/src/curveprotocol.hpp>
 
@@ -70,6 +71,46 @@ namespace {
         settings(2, 1) = Cell_(400.0);
         return JointResult(settings);
     }
+
+    Matrix_<Cell_> StagedSettings(const Vector_<std::pair<String_, Cell_>>& additions = {}) {
+        Matrix_<Cell_> settings(3 + additions.size(), 2);
+        settings(0, 0) = Cell_("fxSpot");
+        settings(0, 1) = Cell_(1.10);
+        settings(1, 0) = Cell_("initialGuess");
+        settings(1, 1) = Cell_(0.01);
+        settings(2, 0) = Cell_("tolerance");
+        settings(2, 1) = Cell_(1.0e-8);
+        for (int i = 0; i < additions.size(); ++i) {
+            settings(3 + i, 0) = Cell_(additions[i].first);
+            settings(3 + i, 1) = additions[i].second;
+        }
+        return settings;
+    }
+
+    Handle_<StorableCrossCurrencyCalibrationResult_> StagedResult(const Matrix_<Cell_>& settings) {
+        const Date_ maturity = Today().AddDays(2 * 365);
+        const Vector_<Date_> curveKnots{Today(), maturity};
+        const Vector_<> flatRates{0.04, 0.04};
+        const auto domesticCurve = DiscountPWLFNew("usd_ois", "USD", curveKnots, flatRates);
+        const auto foreignCurve = DiscountPWLFNew("eur_ois", "EUR", curveKnots, flatRates);
+        const Handle_<StorableCurveBlock_> domestic(new StorableCurveBlock_(CurveBlockNew(domesticCurve, DayBasis_New("ACT_365F"))));
+        const Handle_<StorableCurveBlock_> foreign(new StorableCurveBlock_(CurveBlockNew(foreignCurve, DayBasis_New("ACT_360"))));
+
+        const auto instrument = CrossCurrencySwapNew(Today(), Today(), maturity, 0.01, Pair()->val_, 100.0, 100.0 / 1.10,
+                                                     RateLegConvention_New(PeriodLength_New("6M"), DayBasis_New("ACT_365F")),
+                                                     RateIndexConvention_New(PeriodLength_New("3M"), DayBasis_New("ACT_360"), CollateralType_OIS()),
+                                                     RateLegConvention_New(PeriodLength_New("6M"), DayBasis_New("ACT_360")),
+                                                     RateIndexConvention_New(PeriodLength_New("6M"), DayBasis_New("ACT_360"), CollateralType_OIS()));
+        Vector_<Handle_<Storable_>> instruments{
+            Handle_<Storable_>(new StorableCrossCurrencySwap_(instrument)),
+        };
+
+        Handle_<StorableCrossCurrencyCalibrationResult_> result;
+        Calibrate_XccyMarket(Today(), "USD", "EUR", domestic, foreign, instruments, {maturity}, settings, &result);
+        return result;
+    }
+
+    Handle_<StorableCrossCurrencyCalibrationResult_> StagedResult() { return StagedResult(StagedSettings()); }
 } // namespace
 
 TEST(ExcelApiTest, TestConfiguredCrossCurrencySwapConstruction) {
@@ -108,7 +149,8 @@ TEST(ExcelApiTest, TestJointCalibrationAndEveryResultView) {
     ASSERT_TRUE(foreign);
     ASSERT_TRUE(basis);
 
-    for (const char* attribute : {"fxForwards", "marketRates", "modelRates", "residuals", "jacobian", "parameterRanges", "residualRanges"}) {
+    for (const char* attribute :
+         {"fxForwards", "marketRates", "modelRates", "residuals", "jacobian", "effJacobianInverse", "parameterRanges", "residualRanges"}) {
         Dal::Matrix_<Dal::Cell_> value;
         JointXccyCalibrationResult_Get(result, attribute, &value);
         ASSERT_FALSE(value.Empty()) << attribute;
@@ -124,7 +166,7 @@ TEST(ExcelApiTest, TestUnknownJointResultViewListsEveryAcceptedAttribute) {
     } catch (const Dal::Exception_& exception) {
         const std::string message(exception.what());
         for (const char* attribute : {"domesticBlock", "foreignBlock", "basisCurve", "fxForwards", "marketRates", "modelRates", "residuals",
-                                      "jacobian", "parameterRanges", "residualRanges"})
+                                      "jacobian", "effJacobianInverse", "parameterRanges", "residualRanges"})
             ASSERT_NE(message.find(attribute), std::string::npos) << attribute << ": " << message;
     }
 }
@@ -142,6 +184,119 @@ TEST(ExcelApiTest, TestUnknownJointSettingsKeyListsEveryAcceptedKey) {
         ASSERT_NE(message.find("BOGUSKEY"), std::string::npos) << message;
         for (const char* key : {"domesticCurveName", "basisSmoothingWeight", "solveMode", "jacobianMode", "computeForwardJacobian"})
             ASSERT_NE(message.find(key), std::string::npos) << key << ": " << message;
+    }
+}
+
+TEST(ExcelApiTest, TestStagedCalibrationExposesFrozenSensitivityViews) {
+    const auto result = StagedResult();
+    ASSERT_TRUE(result);
+
+    Matrix_<Cell_> instrumentNames;
+    Matrix_<Cell_> knotDates;
+    Matrix_<Cell_> jacobian;
+    Matrix_<Cell_> inverse;
+    XccyCalibrationResult_Get(result, "instrumentNames", &instrumentNames);
+    XccyCalibrationResult_Get(result, "parameterKnotDates", &knotDates);
+    XccyCalibrationResult_Get(result, "jacobian", &jacobian);
+    XccyCalibrationResult_Get(result, "effJacobianInverse", &inverse);
+    ASSERT_EQ(instrumentNames.Rows(), 1);
+    ASSERT_EQ(instrumentNames.Cols(), 1);
+    ASSERT_TRUE(Cell::IsString(instrumentNames(0, 0)));
+    ASSERT_EQ(knotDates.Rows(), 1);
+    ASSERT_EQ(Cell::ToDate(knotDates(0, 0)), Today().AddDays(2 * 365));
+    ASSERT_EQ(jacobian.Rows(), instrumentNames.Rows());
+    ASSERT_EQ(jacobian.Cols(), knotDates.Rows());
+    ASSERT_EQ(inverse.Rows(), knotDates.Rows());
+    ASSERT_EQ(inverse.Cols(), instrumentNames.Rows());
+
+    const std::pair<const char*, const char*> textViews[] = {
+        {"jacobianAvailability", "available"},
+        {"effJacobianInverseAvailability", "available"},
+        {"jacobianScaling", "unscaled"},
+        {"effJacobianInverseScaling", "solver_scaled"},
+    };
+    for (const auto& view : textViews) {
+        Matrix_<Cell_> value;
+        XccyCalibrationResult_Get(result, view.first, &value);
+        ASSERT_EQ(value.Rows(), 1);
+        ASSERT_EQ(value.Cols(), 1);
+        ASSERT_EQ(Cell::ToString(value(0, 0)), String_(view.second));
+    }
+
+    Matrix_<Cell_> tolerance;
+    XccyCalibrationResult_Get(result, "residualTolerance", &tolerance);
+    ASSERT_DOUBLE_EQ(Cell::ToDouble(tolerance(0, 0)), 1.0e-8);
+}
+
+TEST(ExcelApiTest, TestStagedAvailabilitySeparatesRequestFlagsAndMode) {
+    const auto disabled = StagedResult(StagedSettings({
+        {"computeForwardJacobian", Cell_(false)},
+        {"computeEffJacobianInverse", Cell_(false)},
+    }));
+    for (const char* attribute : {"jacobianAvailability", "effJacobianInverseAvailability"}) {
+        Matrix_<Cell_> value;
+        XccyCalibrationResult_Get(disabled, attribute, &value);
+        ASSERT_EQ(Cell::ToString(value(0, 0)), String_("not_requested"));
+    }
+
+    Matrix_<Cell_> matrix;
+    XccyCalibrationResult_Get(disabled, "jacobian", &matrix);
+    ASSERT_TRUE(matrix.Empty());
+    XccyCalibrationResult_Get(disabled, "effJacobianInverse", &matrix);
+    ASSERT_TRUE(matrix.Empty());
+
+    const auto bumped = StagedResult(StagedSettings({{"jacobianMode", Cell_("BUMPED")}}));
+    Matrix_<Cell_> forwardAvailability;
+    Matrix_<Cell_> inverseAvailability;
+    XccyCalibrationResult_Get(bumped, "jacobianAvailability", &forwardAvailability);
+    XccyCalibrationResult_Get(bumped, "effJacobianInverseAvailability", &inverseAvailability);
+    ASSERT_EQ(Cell::ToString(forwardAvailability(0, 0)), String_("not_available_for_mode"));
+    ASSERT_EQ(Cell::ToString(inverseAvailability(0, 0)), String_("available"));
+}
+
+TEST(ExcelApiTest, TestNewStagedSettingsRejectWrongTypesWithoutChangingLegacyLooseKeys) {
+    ASSERT_NO_THROW(StagedResult(StagedSettings({{"maxEvaluations", Cell_("ignored-as-before")}})));
+
+    for (const auto& setting : Vector_<std::pair<String_, Cell_>>{
+             {"jacobianMode", Cell_(1.0)},
+             {"computeForwardJacobian", Cell_("false")},
+             {"computeEffJacobianInverse", Cell_("false")},
+         }) {
+        try {
+            StagedResult(StagedSettings({setting}));
+            FAIL() << "Expected wrong-typed staged setting to fail: " << setting.first;
+        } catch (const Exception_& exception) {
+            const std::string message(exception.what());
+            const char* normalizedKey = setting.first == "jacobianMode"
+                                            ? "JACOBIANMODE"
+                                            : (setting.first == "computeForwardJacobian" ? "COMPUTEFORWARDJACOBIAN" : "COMPUTEEFFJACOBIANINVERSE");
+            ASSERT_NE(message.find(normalizedKey), std::string::npos) << message;
+            ASSERT_NE(message.find("received"), std::string::npos) << message;
+            ASSERT_NE(message.find(setting.first == "jacobianMode" ? "number" : "string"), std::string::npos) << message;
+            ASSERT_NE(message.find(setting.first == "jacobianMode" ? "string" : "boolean"), std::string::npos) << message;
+        }
+    }
+}
+
+TEST(ExcelApiTest, TestUnknownStagedSettingsAndViewsListNewContractSurface) {
+    try {
+        StagedResult(StagedSettings({{"bogusKey", Cell_(1.0)}}));
+        FAIL() << "Expected an unknown staged setting to fail";
+    } catch (const Exception_& exception) {
+        const std::string message(exception.what());
+        for (const char* key : {"jacobianMode", "computeForwardJacobian", "computeEffJacobianInverse"})
+            ASSERT_NE(message.find(key), std::string::npos) << key << ": " << message;
+    }
+
+    try {
+        Matrix_<Cell_> value;
+        XccyCalibrationResult_Get(StagedResult(), "unknown", &value);
+        FAIL() << "Expected an unknown staged result view to fail";
+    } catch (const Exception_& exception) {
+        const std::string message(exception.what());
+        for (const char* attribute : {"instrumentNames", "parameterKnotDates", "jacobian", "effJacobianInverse", "jacobianAvailability",
+                                      "effJacobianInverseAvailability", "residualTolerance", "jacobianScaling", "effJacobianInverseScaling"})
+            ASSERT_NE(message.find(attribute), std::string::npos) << attribute << ": " << message;
     }
 }
 

--- a/dal-public/src/xccycalibration.cpp
+++ b/dal-public/src/xccycalibration.cpp
@@ -66,12 +66,24 @@ namespace Dal {
 
     const Matrix_<>& JointXccyResultJacobian(const JointXccyCalibrationResult_& result) { return result.jacobianAtSolution_; }
 
+    const Matrix_<>& JointXccyResultEffJacobianInverse(const JointXccyCalibrationResult_& result) { return result.effJacobianInverse_; }
+
     const Vector_<CalibrationBlockRange_>& JointXccyResultParameterRanges(const JointXccyCalibrationResult_& result) {
         return result.parameterRanges_;
     }
 
     const Vector_<CalibrationBlockRange_>& JointXccyResultResidualRanges(const JointXccyCalibrationResult_& result) { return result.residualRanges_; }
 
+    const CrossCurrencyCalibrationDiagnostics_& XccyResultDiagnostics(const CrossCurrencyCalibrationResult_& result) { return result.diagnostics_; }
+
+    const Matrix_<>& XccyResultJacobian(const CrossCurrencyCalibrationResult_& result) { return result.diagnostics_.jacobian_; }
+
+    const Matrix_<>& XccyResultEffJacobianInverse(const CrossCurrencyCalibrationResult_& result) { return result.diagnostics_.effJacobianInverse_; }
+
     CrossCurrencyCalibrationResult_ CalibrateXccyMarket(const CrossCurrencyCalibrationSpec_& spec) { return CalibrateCrossCurrencyMarket(spec); }
+
+    CrossCurrencyCalibrationResult_ CalibrateXccyMarket(const CrossCurrencyCalibrationSpec_& spec, const CrossCurrencyCalibrationOptions_& options) {
+        return CalibrateCrossCurrencyMarket(spec, options);
+    }
 
 } // namespace Dal

--- a/dal-public/src/xccycalibration.hpp
+++ b/dal-public/src/xccycalibration.hpp
@@ -59,9 +59,16 @@ namespace Dal {
     [[nodiscard]] const Vector_<>& JointXccyResultModelRates(const JointXccyCalibrationResult_& result);
     [[nodiscard]] const Vector_<>& JointXccyResultResiduals(const JointXccyCalibrationResult_& result);
     [[nodiscard]] const Matrix_<>& JointXccyResultJacobian(const JointXccyCalibrationResult_& result);
+    [[nodiscard]] const Matrix_<>& JointXccyResultEffJacobianInverse(const JointXccyCalibrationResult_& result);
     [[nodiscard]] const Vector_<CalibrationBlockRange_>& JointXccyResultParameterRanges(const JointXccyCalibrationResult_& result);
     [[nodiscard]] const Vector_<CalibrationBlockRange_>& JointXccyResultResidualRanges(const JointXccyCalibrationResult_& result);
 
-    CrossCurrencyCalibrationResult_ CalibrateXccyMarket(const CrossCurrencyCalibrationSpec_& spec);
+    [[nodiscard]] const CrossCurrencyCalibrationDiagnostics_& XccyResultDiagnostics(const CrossCurrencyCalibrationResult_& result);
+    [[nodiscard]] const Matrix_<>& XccyResultJacobian(const CrossCurrencyCalibrationResult_& result);
+    [[nodiscard]] const Matrix_<>& XccyResultEffJacobianInverse(const CrossCurrencyCalibrationResult_& result);
+
+    [[nodiscard]] CrossCurrencyCalibrationResult_ CalibrateXccyMarket(const CrossCurrencyCalibrationSpec_& spec);
+    [[nodiscard]] CrossCurrencyCalibrationResult_ CalibrateXccyMarket(const CrossCurrencyCalibrationSpec_& spec,
+                                                                      const CrossCurrencyCalibrationOptions_& options);
 
 } // namespace Dal

--- a/dal-public/tests/test_xccy_calibration.cpp
+++ b/dal-public/tests/test_xccy_calibration.cpp
@@ -11,6 +11,7 @@
 
 using Dal::CalibrateXccyMarket;
 using Dal::CollateralType_OIS;
+using Dal::CrossCurrencyCalibrationOptions_;
 using Dal::CrossCurrencyCalibrationSpecBuilder_;
 using Dal::CrossCurrencySwapNew;
 using Dal::CurrencyPair_New;
@@ -141,6 +142,8 @@ TEST(XccyCalibrationTest, TestCalibrateXccyMarket) {
 
     auto spec = builder.Build();
     auto result = CalibrateXccyMarket(spec);
+    CrossCurrencyCalibrationOptions_ options;
+    auto explicitDefaults = CalibrateXccyMarket(spec, options);
 
     ASSERT_GT(result.diagnostics_.marketRates_.size(), static_cast<size_t>(0));
     ASSERT_EQ(result.diagnostics_.marketRates_.size(), result.diagnostics_.modelRates_.size());
@@ -150,6 +153,19 @@ TEST(XccyCalibrationTest, TestCalibrateXccyMarket) {
     // Verify FX forward curve is populated
     ASSERT_GT(result.fxForwardCurve_.dates_.size(), static_cast<size_t>(0));
     ASSERT_EQ(result.fxForwardCurve_.dates_.size(), result.fxForwardCurve_.forwards_.size());
+
+    ASSERT_EQ(&Dal::XccyResultDiagnostics(result), &result.diagnostics_);
+    ASSERT_EQ(&Dal::XccyResultJacobian(result), &result.diagnostics_.jacobian_);
+    ASSERT_EQ(&Dal::XccyResultEffJacobianInverse(result), &result.diagnostics_.effJacobianInverse_);
+    ASSERT_EQ(result.diagnostics_.marketRates_.size(), explicitDefaults.diagnostics_.marketRates_.size());
+    for (int i = 0; i < static_cast<int>(result.diagnostics_.marketRates_.size()); ++i) {
+        ASSERT_NEAR(result.diagnostics_.marketRates_[i], explicitDefaults.diagnostics_.marketRates_[i], 1.0e-12);
+        ASSERT_NEAR(result.diagnostics_.modelRates_[i], explicitDefaults.diagnostics_.modelRates_[i], 1.0e-12);
+        ASSERT_NEAR(result.diagnostics_.residuals_[i], explicitDefaults.diagnostics_.residuals_[i], 1.0e-12);
+    }
+    ASSERT_EQ(result.fxForwardCurve_.forwards_.size(), explicitDefaults.fxForwardCurve_.forwards_.size());
+    for (int i = 0; i < static_cast<int>(result.fxForwardCurve_.forwards_.size()); ++i)
+        ASSERT_NEAR(result.fxForwardCurve_.forwards_[i], explicitDefaults.fxForwardCurve_.forwards_[i], 1.0e-12);
 }
 
 // Round-trip every builder field through Build() to guard against brace-init
@@ -350,6 +366,7 @@ TEST(XccyCalibrationTest, TestJointResultAccessorsReferenceEveryPlannedView) {
     ASSERT_EQ(&Dal::JointXccyResultModelRates(result), &result.modelRates_);
     ASSERT_EQ(&Dal::JointXccyResultResiduals(result), &result.residuals_);
     ASSERT_EQ(&Dal::JointXccyResultJacobian(result), &result.jacobianAtSolution_);
+    ASSERT_EQ(&Dal::JointXccyResultEffJacobianInverse(result), &result.effJacobianInverse_);
     ASSERT_EQ(&Dal::JointXccyResultParameterRanges(result), &result.parameterRanges_);
     ASSERT_EQ(&Dal::JointXccyResultResidualRanges(result), &result.residualRanges_);
 }

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -314,7 +314,7 @@ Tests are located in `tests/` and cover:
 - AAD Greek computation and validation
 - Random number generator properties
 - Curve construction plus single and staged multi-curve calibration
-- Staged XCCY basis calibration and fit diagnostics
+- Staged XCCY basis calibration, sensitivity matrices, axes, and availability metadata
 - Resettable/MTM XCCY construction with immutable fixing snapshots
 - Joint domestic/foreign/basis XCCY calibration, including matrix and named-range contracts
 
@@ -427,10 +427,28 @@ result = dal.calibrate_curve(
 Python exposes single, staged multi-curve, staged XCCY basis, and simultaneous
 joint XCCY calibration. A base curve is multiplied into the calibrated component;
 it is not a replacement for the pricing discount curve required by a forward-curve stage.
-The staged `CalibrateXccyMarket(spec)` binding is the one-argument default solve:
-it returns the calibrated market, FX forwards, and scalar/vector fit diagnostics
-only. Staged matrix options and matrix fields remain available only through the
-C++ surface.
+Staged XCCY supports both the backward-compatible
+`CalibrateXccyMarket(spec)` call and `CalibrateXccyMarket(spec, options)`.
+`CrossCurrencyCalibrationOptions_` defaults to `ANALYTIC` with
+`compute_forward_jacobian = True` and
+`compute_eff_jacobian_inverse = True`; trailing-underscore property names are
+available alongside the snake-case names.
+
+The matrices remain on `result.diagnostics`. `diagnostics.jacobian` has
+instrument rows and basis-parameter columns;
+`diagnostics.eff_jacobian_inverse` has the reversed axes.
+`instrument_names` follows input order and may contain duplicate labels.
+`parameter_knot_dates` follows the spec's knot order and labels the
+piecewise-constant basis curve's right-forward parameters. The diagnostics also
+publish `residual_tolerance`, `jacobian_scaling == "unscaled"`,
+`eff_jacobian_inverse_scaling == "solver_scaled"`, and independent
+`jacobian_availability` / `eff_jacobian_inverse_availability` values:
+`available`, `not_requested`, or `not_available_for_mode`.
+
+For a raw decimal quote-bump vector `dq`, the solver-scaled effective inverse
+`E` maps parameters as `dx = E * dq / residual_tolerance`. An unavailable
+matrix is empty; inspect its availability property to distinguish an explicit
+opt-out from a mode limitation.
 
 ### Resettable and Joint XCCY Calibration
 

--- a/dal-python/src/bindings/curve.cpp
+++ b/dal-python/src/bindings/curve.cpp
@@ -749,8 +749,36 @@ namespace {
             [](CrossCurrencyCalibrationSpecBuilder_& value, const py::iterable& dates) { SetDates(&value.knotDates_, dates); });
         xccyBuilder.def("Build", &CrossCurrencyCalibrationSpecBuilder_::Build).def("build", &CrossCurrencyCalibrationSpecBuilder_::Build);
 
+        auto xccyOptions = py::class_<CrossCurrencyCalibrationOptions_>(m, "CrossCurrencyCalibrationOptions_");
+        xccyOptions.def(py::init<>());
+        DefPropertyAliases(
+            xccyOptions, "jacobianMode_", "jacobian_mode", [](const CrossCurrencyCalibrationOptions_& value) { return value.jacobianMode_.Switch(); },
+            [](CrossCurrencyCalibrationOptions_& value, CurveJacobianMode_::Value_ mode) { value.jacobianMode_ = CurveJacobianMode_(mode); });
+        DefReadWriteAliases(xccyOptions, "computeEffJacobianInverse_", "compute_eff_jacobian_inverse",
+                            &CrossCurrencyCalibrationOptions_::computeEffJacobianInverse_);
+        DefReadWriteAliases(xccyOptions, "computeForwardJacobian_", "compute_forward_jacobian",
+                            &CrossCurrencyCalibrationOptions_::computeForwardJacobian_);
+
         auto xccyDiagnostics = py::class_<CrossCurrencyCalibrationDiagnostics_>(m, "CrossCurrencyCalibrationDiagnostics_");
+        const auto instrumentNames = [](const CrossCurrencyCalibrationDiagnostics_& value) {
+            py::list result;
+            for (const auto& name : value.instrumentNames_)
+                result.append(std::string(name.c_str()));
+            return result;
+        };
+        const auto jacobian = py::cpp_function(
+            [](const CrossCurrencyCalibrationDiagnostics_& value) -> const Matrix_<>& { return value.jacobian_; },
+            py::return_value_policy::reference_internal);
+        const auto effJacobianInverse = py::cpp_function(
+            [](const CrossCurrencyCalibrationDiagnostics_& value) -> const Matrix_<>& { return value.effJacobianInverse_; },
+            py::return_value_policy::reference_internal);
         xccyDiagnostics
+            .def_property_readonly("instrumentNames_", instrumentNames)
+            .def_property_readonly("instrument_names", instrumentNames)
+            .def_property_readonly("parameterKnotDates_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) { return DatesToList(value.parameterKnotDates_); })
+            .def_property_readonly("parameter_knot_dates",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) { return DatesToList(value.parameterKnotDates_); })
             .def_property_readonly("marketRates_",
                                    [](const CrossCurrencyCalibrationDiagnostics_& value) { return DoublesToList(value.marketRates_); })
             .def_property_readonly("market_rates",
@@ -762,7 +790,51 @@ namespace {
             .def_property_readonly("maxAbsResidual_", [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.maxAbsResidual_; })
             .def_property_readonly("max_abs_residual", [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.maxAbsResidual_; })
             .def_property_readonly("rmsResidual_", [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.rmsResidual_; })
-            .def_property_readonly("rms_residual", [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.rmsResidual_; });
+            .def_property_readonly("rms_residual", [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.rmsResidual_; })
+            .def_property_readonly("jacobian_", jacobian)
+            .def_property_readonly("jacobian", jacobian)
+            .def_property_readonly("effJacobianInverse_", effJacobianInverse)
+            .def_property_readonly("eff_jacobian_inverse", effJacobianInverse)
+            .def_property_readonly("residualTolerance_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.residualTolerance_; })
+            .def_property_readonly("residual_tolerance",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.residualTolerance_; })
+            .def_property_readonly("jacobianScaling_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.jacobianScaling_.c_str());
+                                   })
+            .def_property_readonly("jacobian_scaling",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.jacobianScaling_.c_str());
+                                   })
+            .def_property_readonly("effJacobianInverseScaling_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.effJacobianInverseScaling_.c_str());
+                                   })
+            .def_property_readonly("eff_jacobian_inverse_scaling",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.effJacobianInverseScaling_.c_str());
+                                   })
+            .def_property_readonly("jacobianAvailability_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.jacobianAvailability_.c_str());
+                                   })
+            .def_property_readonly("jacobian_availability",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.jacobianAvailability_.c_str());
+                                   })
+            .def_property_readonly("effJacobianInverseAvailability_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.effJacobianInverseAvailability_.c_str());
+                                   })
+            .def_property_readonly("eff_jacobian_inverse_availability",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) {
+                                       return std::string(value.effJacobianInverseAvailability_.c_str());
+                                   })
+            .def_property_readonly("usedApproximateFit_",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.usedApproximateFit_; })
+            .def_property_readonly("used_approximate_fit",
+                                   [](const CrossCurrencyCalibrationDiagnostics_& value) { return value.usedApproximateFit_; });
 
         auto fxForwardCurve = py::class_<CrossCurrencyFxForwardCurve_>(m, "CrossCurrencyFxForwardCurve_");
         fxForwardCurve.def_property_readonly("pair_", [](const CrossCurrencyFxForwardCurve_& value) { return value.pair_; })
@@ -946,7 +1018,9 @@ namespace {
             py::cpp_function([](const JointXccyCalibrationResult_& value) -> const Matrix_<>& { return JointXccyResultJacobian(value); },
                              py::return_value_policy::reference_internal);
         const auto inverseMatrix =
-            py::cpp_function([](const JointXccyCalibrationResult_& value) -> const Matrix_<>& { return value.effJacobianInverse_; },
+            py::cpp_function([](const JointXccyCalibrationResult_& value) -> const Matrix_<>& {
+                return JointXccyResultEffJacobianInverse(value);
+            },
                              py::return_value_policy::reference_internal);
         jointResult.def_property_readonly("domesticCurveBlock_", domesticBlock).def_property_readonly("domestic_curve_block", domesticBlock);
         jointResult.def_property_readonly("foreignCurveBlock_", foreignBlock).def_property_readonly("foreign_curve_block", foreignBlock);
@@ -1002,7 +1076,11 @@ namespace {
             .def_property_readonly("solverEvaluations_", [](const JointXccyCalibrationResult_& value) { return value.solverEvaluations_; })
             .def_property_readonly("solver_evaluations", [](const JointXccyCalibrationResult_& value) { return value.solverEvaluations_; });
 
-        m.def("CalibrateXccyMarket", &CalibrateXccyMarket, py::arg("spec"), py::call_guard<py::gil_scoped_release>());
+        m.def("CalibrateXccyMarket", py::overload_cast<const CrossCurrencyCalibrationSpec_&>(&CalibrateXccyMarket), py::arg("spec"),
+              py::call_guard<py::gil_scoped_release>());
+        m.def("CalibrateXccyMarket",
+              py::overload_cast<const CrossCurrencyCalibrationSpec_&, const CrossCurrencyCalibrationOptions_&>(&CalibrateXccyMarket),
+              py::arg("spec"), py::arg("options"), py::call_guard<py::gil_scoped_release>());
         m.def("CalibrateJointXccyMarket", py::overload_cast<const JointXccyCalibrationSpec_&>(&CalibrateJointXccyMarket), py::arg("spec"), py::call_guard<py::gil_scoped_release>());
         m.def("CalibrateJointXccyMarket",
               py::overload_cast<const JointXccyCalibrationSpec_&, const JointXccyCalibrationOptions_&>(&CalibrateJointXccyMarket), py::arg("spec"),

--- a/dal-python/tests/test_xccy_calibration.py
+++ b/dal-python/tests/test_xccy_calibration.py
@@ -98,7 +98,7 @@ def test_legacy_xccy_constructor_accepts_every_original_positional_argument():
 
 # ---- Cross-currency calibration ----
 
-def _make_xccy_instruments(fx_spot):
+def _make_xccy_instruments(fx_spot, years=(2, 5, 10)):
     """Build cross-currency swap instruments for calibration."""
     currencies = dal.CurrencyPair_New("USD", "EUR")
     usd_leg = dal.RateLegConvention_New(dal.PeriodLength_New("6M"), dal.DayBasis_New("ACT_365F"))
@@ -112,7 +112,7 @@ def _make_xccy_instruments(fx_spot):
 
     instruments = []
     knot_dates = []
-    for y in [2, 5, 10]:
+    for y in years:
         maturity = _spot().AddDays(y * 365)
         knot_dates.append(maturity)
         inst = dal.CrossCurrencySwap_New(
@@ -123,6 +123,24 @@ def _make_xccy_instruments(fx_spot):
         )
         instruments.append(inst)
     return instruments, knot_dates
+
+
+def _make_xccy_spec(solve_mode, years=(2, 5, 10)):
+    usd_block, eur_block = _make_baseline_curves()
+    instruments, knot_dates = _make_xccy_instruments(fx_spot=1.10, years=years)
+
+    builder = dal.CrossCurrencyCalibrationSpecBuilder_()
+    builder.today_ = _today()
+    builder.basisPair_ = dal.CurrencyPair_New("USD", "EUR")
+    builder.domesticCurveBlock_ = usd_block
+    builder.foreignCurveBlock_ = eur_block
+    builder.fxSpot_ = 1.10
+    builder.tolerance_ = 1.0e-8
+    builder.solveMode_ = solve_mode
+    builder.initialGuess_ = 0.01
+    builder.instruments_ = instruments
+    builder.knotDates_ = knot_dates
+    return builder.Build(), knot_dates
 
 
 def test_calibrate_xccy_market():
@@ -180,3 +198,53 @@ def test_calibrate_xccy_market_result_has_market():
     assert result.market_ is not None  # nosec B101 - pytest assertions are intentional
     assert result.fxForwardCurve_ is not None  # nosec B101 - pytest assertions are intentional
     assert result.diagnostics_ is not None  # nosec B101 - pytest assertions are intentional
+
+
+def test_staged_xccy_options_overload_preserves_default_results_and_aliases():
+    """The additive overload retains the legacy call and exposes both naming styles."""
+    spec, knot_dates = _make_xccy_spec(dal.CurveSolveMode.APPROXIMATE)
+    legacy = dal.CalibrateXccyMarket(spec)
+    options = dal.CrossCurrencyCalibrationOptions_()
+    explicit = dal.CalibrateXccyMarket(spec, options)
+
+    assert options.jacobianMode_ == dal.CurveJacobianMode.ANALYTIC  # nosec B101
+    options.jacobian_mode = dal.CurveJacobianMode.BUMPED
+    options.computeEffJacobianInverse_ = False
+    options.compute_forward_jacobian = False
+    assert options.jacobianMode_ == dal.CurveJacobianMode.BUMPED  # nosec B101
+    assert not options.compute_eff_jacobian_inverse  # nosec B101
+    assert not options.computeForwardJacobian_  # nosec B101
+
+    assert legacy.diagnostics.market_rates == explicit.diagnostics_.marketRates_  # nosec B101
+    assert legacy.diagnostics.model_rates == explicit.diagnostics_.modelRates_  # nosec B101
+    assert legacy.diagnostics.residuals == explicit.diagnostics_.residuals_  # nosec B101
+    assert legacy.fx_forward_curve.forwards == explicit.fxForwardCurve_.forwards_  # nosec B101
+    assert explicit.diagnostics.parameter_knot_dates == knot_dates  # nosec B101
+    assert explicit.diagnostics.parameterKnotDates_ == explicit.diagnostics.parameter_knot_dates  # nosec B101
+    assert explicit.diagnostics.instrumentNames_ == explicit.diagnostics.instrument_names  # nosec B101
+    assert explicit.diagnostics.residualTolerance_ == explicit.diagnostics.residual_tolerance  # nosec B101
+    assert explicit.diagnostics.jacobianScaling_ == "unscaled"  # nosec B101
+    assert explicit.diagnostics.jacobian_scaling == "unscaled"  # nosec B101
+    assert explicit.diagnostics.effJacobianInverseScaling_ == "solver_scaled"  # nosec B101
+    assert explicit.diagnostics.eff_jacobian_inverse_scaling == "solver_scaled"  # nosec B101
+    assert explicit.diagnostics.jacobianAvailability_ == "not_available_for_mode"  # nosec B101
+    assert explicit.diagnostics.eff_jacobian_inverse_availability == "not_available_for_mode"  # nosec B101
+    assert explicit.diagnostics.jacobian_.rows() == 0  # nosec B101
+    assert explicit.diagnostics.jacobian.cols() == 0  # nosec B101
+    assert explicit.diagnostics.effJacobianInverse_.rows() == 0  # nosec B101
+    assert explicit.diagnostics.eff_jacobian_inverse.cols() == 0  # nosec B101
+
+
+def test_staged_xccy_exact_matrices_keep_diagnostics_ownership_and_axes():
+    """Exact analytic matrices remain on staged diagnostics with reversed axes."""
+    spec, knot_dates = _make_xccy_spec(dal.CurveSolveMode.EXACT, years=(2,))
+    result = dal.CalibrateXccyMarket(spec, dal.CrossCurrencyCalibrationOptions_())
+    diagnostics = result.diagnostics
+
+    assert diagnostics.jacobian_availability == "available"  # nosec B101
+    assert diagnostics.effJacobianInverseAvailability_ == "available"  # nosec B101
+    assert diagnostics.jacobian.rows() == len(diagnostics.instrument_names)  # nosec B101
+    assert diagnostics.jacobian_.cols() == len(knot_dates)  # nosec B101
+    assert diagnostics.eff_jacobian_inverse.rows() == len(knot_dates)  # nosec B101
+    assert diagnostics.effJacobianInverse_.cols() == len(diagnostics.instrumentNames_)  # nosec B101
+    assert not hasattr(result, "jacobian_at_solution")  # nosec B101

--- a/docs/methodology/xccy_calibration.md
+++ b/docs/methodology/xccy_calibration.md
@@ -129,6 +129,12 @@ basis knots, fit diagnostics, and optional matrices.
 For `nInstruments` quotes and `nBasisParameters` basis parameters, the staged
 forward Jacobian has shape `nInstruments x nBasisParameters`; the effective
 inverse has shape `nBasisParameters x nInstruments`.
+Both matrices belong to `CrossCurrencyCalibrationDiagnostics_` on the staged
+result. `instrumentNames_` labels forward-Jacobian rows and effective-inverse
+columns in instrument input order. Names are labels only and may repeat; the
+integer position is authoritative. `parameterKnotDates_` labels
+forward-Jacobian columns and effective-inverse rows in `spec.knotDates_` order,
+which is the piecewise-constant basis curve's right-forward parameter order.
 
 ## Joint Domestic, Foreign, and Basis Calibration
 
@@ -163,20 +169,39 @@ foreign, or XCCY group diagnostics.
 
 ## Analytic and Bumped Jacobians
 
-Both staged and joint calibration accept `ANALYTIC` and `BUMPED`. At the
-accepted exact solution, the exposed forward matrix is the unscaled analytic
-residual Jacobian. The effective inverse is the weighted pseudoinverse formed
-from the solver's tolerance-scaled Jacobian at that same solved state; it is not
-the literal inverse of the exposed forward matrix. For a raw decimal quote
-perturbation $\Delta q$, the parameter move is
+Both staged and joint calibration accept `ANALYTIC` and `BUMPED`. A
+default-constructed staged `CrossCurrencyCalibrationOptions_` selects
+`ANALYTIC` and requests both matrices. The one-argument staged overload is
+equivalent to passing those defaults. At the accepted exact solution, the
+exposed forward matrix is the unscaled analytic residual Jacobian. Staged
+diagnostics record this as `jacobianScaling_ = "unscaled"`.
+
+The effective inverse is the weighted pseudoinverse formed from the solver's
+tolerance-scaled Jacobian at that same solved state; it is not the literal
+inverse of the exposed forward matrix. Staged diagnostics record
+`effJacobianInverseScaling_ = "solver_scaled"` and
+`residualTolerance_ = spec.tolerance_`. For a raw decimal quote perturbation
+$\Delta q$, write $E$ for the effective inverse. The parameter move is
 
 $$
-\Delta x = \mathrm{effJacobianInverse}\,\Delta q / \mathrm{tolerance}.
+\Delta x = E\,\Delta q / \mathrm{residualTolerance}.
 $$
 
 Exact analytic calibration may produce both matrices. Exact bumped calibration
 produces only the effective inverse. Approximate calibration produces neither,
 and the forward/inverse options can suppress their computations independently.
+The staged availability fields describe that outcome without requiring callers
+to infer intent from an empty matrix:
+
+| Solve mode    | Jacobian mode | Requested forward Jacobian | Requested effective inverse |
+|---------------|---------------|----------------------------|-----------------------------|
+| `EXACT`       | `ANALYTIC`    | `available`                | `available`                 |
+| `EXACT`       | `BUMPED`      | `not_available_for_mode`   | `available`                 |
+| `APPROXIMATE` | `ANALYTIC`    | `not_available_for_mode`   | `not_available_for_mode`    |
+| `APPROXIMATE` | `BUMPED`      | `not_available_for_mode`   | `not_available_for_mode`    |
+
+For either matrix, a false compute flag takes precedence and reports
+`not_requested`. Unavailable matrices use an empty numeric carrier.
 
 Joint XCCY analytic calibration is fail-fast. Every domestic and foreign
 declaration must satisfy the joint curve AAD gates, including `ACT_365F`, a
@@ -189,14 +214,17 @@ valid residual system without the analytic eligibility requirement.
 
 ## Surface Availability
 
-- **Core/public C++:** staged XCCY has full options, a forward Jacobian, and an
-  effective inverse; joint XCCY has full options and both top-level matrices.
-- **Python:** staged XCCY has the default solve, market/FX-forward output, and
-  fit diagnostics, but no staged matrix bindings; joint XCCY has options, named
-  ranges, a forward Jacobian, and an effective inverse.
-- **Excel:** staged XCCY has a basis handle and fit diagnostics, but no staged
-  matrix views; joint XCCY has options plus forward-Jacobian/range views, but no
-  effective-inverse worksheet getter.
+- **Core/public C++:** staged XCCY has full options and both matrices on
+  `CrossCurrencyCalibrationDiagnostics_`; joint XCCY has full options and both
+  top-level matrices. The public facade has read-only helpers for each.
+- **Python:** staged XCCY has both overloads, options, matrices, axes, scaling,
+  and availability metadata under `result.diagnostics`, with
+  trailing-underscore and snake-case aliases. Joint XCCY has options, named
+  ranges, a forward Jacobian, and an effective inverse at the result top level.
+- **Excel:** staged settings select the Jacobian mode and independent compute
+  flags; `XCCYCALIBRATIONRESULT.GET` exposes both matrices, both axes,
+  tolerance, scaling, and availability. Joint settings expose both matrices
+  through `JOINTXCCYCALIBRATIONRESULT.GET`.
 
 ## Examples
 

--- a/docs/methodology/yield_curve_jacobian.md
+++ b/docs/methodology/yield_curve_jacobian.md
@@ -360,6 +360,44 @@ smoother. The exact structural zeros the AAD sweep produces sit at parameters
 no residual touches by any route — the block-diagonal smoother simply ensures
 the smoothing pass does not smear those zeros into small non-zero entries.
 
+## Staged XCCY Jacobian Layout
+
+`CalibrateCrossCurrencyMarket` and the public `CalibrateXccyMarket` facade solve
+only the piecewise-constant basis curve over pre-calibrated domestic and
+foreign curve blocks. Both staged matrices are owned by
+`CrossCurrencyCalibrationDiagnostics_`, not by the result top level. The
+forward `jacobian_` has shape `nInstruments x nBasisParameters`;
+`effJacobianInverse_` has the complementary shape
+`nBasisParameters x nInstruments`.
+
+Rows follow instrument input order. `instrumentNames_` contains display labels
+for those rows, but labels may repeat and do not define identity. Columns follow
+`parameterKnotDates_` in `spec.knotDates_` order, matching the basis curve's
+right-forward parameter coordinates.
+
+A default `CrossCurrencyCalibrationOptions_` selects `ANALYTIC` and requests
+both matrices. Exact analytic mode can publish both; exact bumped mode cannot
+publish the analytic forward matrix but can publish the effective inverse;
+approximate mode publishes neither. Each false compute flag overrides the mode
+and reports `not_requested`. Otherwise an unsupported combination reports
+`not_available_for_mode`, while a populated matrix reports `available`.
+Callers should use `jacobianAvailability_` and
+`effJacobianInverseAvailability_` rather than interpret an empty matrix.
+
+The staged forward matrix is explicitly `unscaled`. The effective inverse is
+explicitly `solver_scaled`, because it is formed from residual rows divided by
+the calibration tolerance. With $E=\texttt{effJacobianInverse\_}$ and a raw
+decimal quote bump $\Delta q$,
+
+$$
+\Delta x = E\,\Delta q / \mathrm{residualTolerance}.
+$$
+
+`residualTolerance_` is the spec's `tolerance_`. Public C++, Python, and Excel
+expose the same matrices, axes, scaling labels, and availability states; Python
+keeps them under `result.diagnostics`, and Excel retrieves them through
+`XCCYCALIBRATIONRESULT.GET`.
+
 ## Joint XCCY Jacobian Layout
 
 `CalibrateJointXccyMarket` extends the same stacked-curve machinery with a final
@@ -405,8 +443,8 @@ remains available for every otherwise-valid spec. In exact bumped mode,
 requested. Exact analytic mode may retain both matrices; approximate mode
 exposes neither. `JointXccyCalibrationOptions_` can suppress the two matrix
 computations independently. Core/public C++ and joint Python expose both
-top-level matrices. The Excel joint worksheet surface exposes the forward
-Jacobian and named ranges but has no effective-inverse getter.
+top-level matrices. The Excel joint worksheet surface exposes both matrices and
+the named ranges through `JOINTXCCYCALIBRATIONRESULT.GET`.
 
 The regression suite compares the full analytic stack against two-sided central
 differences and verifies that the published parameter and residual ranges

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -159,26 +159,39 @@ For staged calibration, assemble `MultiCurveCalibrationSpec_` and call
 in-progress swaps.
 
 The public XCCY header includes the core staged and joint result types. Staged
-C++ callers that need `CrossCurrencyCalibrationOptions_` use the core
-`CalibrateCrossCurrencyMarket(spec, options)` entry point; there is no
-`CalibrateXccyMarket(spec, options)` public-facade overload. The returned
-`CrossCurrencyCalibrationDiagnostics_` owns the optional forward Jacobian and
-effective inverse. Joint results similarly own both matrices at the top level.
-The `JointXccyResult*` facade helpers expose the three solved curve handles, FX
-forwards, market/model/residual vectors, the forward Jacobian, and named
-parameter/residual ranges. There is no dedicated effective-inverse facade
-helper; C++ consumers read
-`JointXccyCalibrationResult_::effJacobianInverse_` directly.
+C++ callers can use either the backward-compatible
+`CalibrateXccyMarket(spec)` entry point or
+`CalibrateXccyMarket(spec, options)`. A default
+`CrossCurrencyCalibrationOptions_` selects `ANALYTIC` and requests both the
+forward Jacobian and effective inverse. Both matrices remain owned by
+`CrossCurrencyCalibrationResult_::diagnostics_`;
+`XccyResultDiagnostics`, `XccyResultJacobian`, and
+`XccyResultEffJacobianInverse` are read-only facade accessors.
+
+Joint results own their two matrices at the top level. The `JointXccyResult*`
+facade helpers expose the three solved curve handles, FX forwards,
+market/model/residual vectors, both the forward Jacobian and effective inverse,
+and named parameter/residual ranges.
 
 For staged XCCY, the forward/inverse shapes are
 `nInstruments x nBasisParameters` and
 `nBasisParameters x nInstruments`. For joint XCCY they are
 `totalResiduals x totalParameters` and
-`totalParameters x totalResiduals`. The effective inverse is based on the
-solver's tolerance-scaled Jacobian, so a raw decimal quote-risk transform also
-divides by the calibration `tolerance_`. See
+`totalParameters x totalResiduals`. Staged rows follow instrument input order;
+`instrumentNames_` contains row labels that may repeat. Staged columns follow
+`parameterKnotDates_` in `spec.knotDates_` order, which is the
+piecewise-constant basis curve's right-forward parameter order.
+
+Staged diagnostics publish `jacobianScaling_ = "unscaled"`,
+`effJacobianInverseScaling_ = "solver_scaled"`, and
+`residualTolerance_ = spec.tolerance_`. The availability fields distinguish
+`available`, `not_requested`, and `not_available_for_mode`; an unavailable
+matrix is empty, so callers should inspect the availability field rather than
+infer the reason from its numeric carrier. For the solver-scaled effective
+inverse $E$, a raw decimal quote bump maps as
+$\Delta x = E\,\Delta q/\mathrm{residualTolerance}$. See
 [cross-currency pricing and calibration](methodology/xccy_calibration.md) and
-the [Jacobian methodology](methodology/yield_curve_jacobian.md#joint-xccy-jacobian-layout).
+the [Jacobian methodology](methodology/yield_curve_jacobian.md#staged-xccy-jacobian-layout).
 
 Set `parameterization_ = CurveParameterization_::Value_::ZERO_RATE` to calibrate future
 zero-rate nodes. `initialGuess_` and `initialGuessPerNode_` are decimal continuously
@@ -284,10 +297,15 @@ curve = dal.DiscountZeroRate_New(
 The returned `DiscountZeroRate_` exposes read-only `anchor_date`, `node_dates`,
 `zero_rates`, `day_count`, and `log_df_scheme` properties.
 
-Python staged XCCY exposes only the one-argument default
-`CalibrateXccyMarket(spec)` solve. Its result provides the calibrated market,
-FX forwards, and scalar/vector fit diagnostics; staged matrix options and
-matrix fields remain C++-only.
+Python staged XCCY exposes both `CalibrateXccyMarket(spec)` and
+`CalibrateXccyMarket(spec, options)`. `CrossCurrencyCalibrationOptions_`
+provides trailing-underscore and snake-case properties for the Jacobian mode
+and the two independent compute flags; its defaults are `ANALYTIC`, `True`, and
+`True`. The result keeps matrices under `result.diagnostics`, not at the result
+top level. That diagnostics object exposes the forward `jacobian`, the
+`eff_jacobian_inverse`, instrument-name and parameter-knot axes, residual
+tolerance, scaling labels, and availability states, with matching
+trailing-underscore aliases.
 
 Python joint XCCY exposes the declarations, builder,
 `JointXccyCalibrationOptions_`, calibration entry point, and result surface
@@ -349,18 +367,24 @@ scheme, smoothing/tolerances, scalar initial guess, and evaluation budgets. Its 
 `baseCurve` input is the curve multiplied under the calibrated curve; it is distinct from
 the `discountCurve` used to price a forward-curve calibration.
 
+`CALIBRATE.XCCYMARKET` accepts `jacobianMode`,
+`computeForwardJacobian`, and `computeEffJacobianInverse` in its optional
+two-column settings range. Omitting them preserves the `ANALYTIC`, `TRUE`,
+`TRUE` defaults. `XCCYCALIBRATIONRESULT.GET` exposes `instrumentNames`,
+`parameterKnotDates`, `jacobian`, `effJacobianInverse`,
+`residualTolerance`, both scaling labels, and both availability states in
+addition to the fit vectors and scalars. The staged matrix axes and scaling
+contract match C++ and Python.
+
 `CALIBRATE.JOINTXCCY` accepts one domestic discount-instrument/knot group, one
 foreign discount-instrument/knot group, configured XCCY instruments, basis
 knots, an optional immutable snapshot handle, and two-column settings. Dedicated
 result functions return the domestic block, foreign block, and basis curve
 handles.
-Staged `XCCYCALIBRATIONRESULT.GET` exposes fit vectors and scalars but neither
-the staged forward Jacobian nor the staged effective inverse.
 `JOINTXCCYCALIBRATIONRESULT.GET` returns `fxForwards`, `marketRates`,
-`modelRates`, `residuals`, `jacobian`, `parameterRanges`, or `residualRanges`.
-Joint settings can request both matrix computations, but `jacobian` is the only
-matrix available through a worksheet selector; there is no
-`effJacobianInverse` worksheet getter.
+`modelRates`, `residuals`, `jacobian`, `effJacobianInverse`,
+`parameterRanges`, or `residualRanges`. Joint settings can request both matrix
+computations independently.
 Generated function help under `dal-excel/auto/*.htm` is the argument-level
 catalog used by Excel registration.
 


### PR DESCRIPTION
## Summary

- expose the frozen staged XCCY diagnostics metadata and matrices through public C++, Python, and Excel
- preserve diagnostics ownership, axes, availability/scaling semantics, and legacy API defaults
- commit all 16 availability mode/flag combinations as a regression gate
- keep RMS diagnostics finite for large finite residuals and validate both public residual statistics before return
- retain finite guards and sensitivity prediction coverage for small bumps and fixed 5/10/16-instrument ladders

Related: DAL-6

## Test plan

- [x] `NUM_CORES=2 bash ./build_linux.sh --full` (1130/1130)
- [x] focused core XCCY Jacobian suite (14/14)
- [x] public C++ API suite (included in full verification)
- [x] Python suite (included in full verification)
- [x] portable Excel API suite (9/9; Excel adapter unchanged by the follow-up)
- [x] `dal_check_generated` (`Wrote 0 files`)
