### PR TITLE
fix: DAL-7 handle exact Krylov residuals

### DIFF
--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -110,6 +110,8 @@ namespace Dal {
             Transform(b, s.r_, std::minus<>(), &s.r_); // r = b - Ax
             if (biConjugate)
                 s.rr_ = s.r_;
+            if (InnerProduct(s.r_, s.r_) == 0.0)
+                return;
 
             for (int ii = 0; ii < maxIterations; ++ii) {
                 const double beta = PrepareDirection(s, ii);

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -110,7 +110,7 @@ namespace Dal {
             Transform(b, s.r_, std::minus<>(), &s.r_); // r = b - Ax
             if (biConjugate)
                 s.rr_ = s.r_;
-            if (InnerProduct(s.r_, s.r_) == 0.0)
+            if (AllOf(s.r_, [](double value) { return value == 0.0; }))
                 return;
 
             for (int ii = 0; ii < maxIterations; ++ii) {

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -45,6 +45,33 @@ TEST(MatrixTest, TestBCGSolve) {
     ASSERT_NEAR(result[9], 0.07446809, 1e-8);
 }
 
+TEST(MatrixTest, TestCGSolveAcceptsExactInitialGuess) {
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(2, 0, 0);
+    mat->Set(0, 0, 2.0);
+    mat->Set(1, 1, 3.0);
+    const Vector_<> b = {2.0, 6.0};
+    Vector_<> x = {1.0, 2.0};
+
+    Sparse::CGSolve(*mat, b, 1e-12, 1e-14, 10, &x);
+
+    ASSERT_DOUBLE_EQ(x[0], 1.0);
+    ASSERT_DOUBLE_EQ(x[1], 2.0);
+}
+
+TEST(MatrixTest, TestBCGSolveAcceptsExactInitialGuess) {
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(2, 1, 1);
+    mat->Set(0, 0, 2.0);
+    mat->Set(0, 1, 1.0);
+    mat->Set(1, 1, 3.0);
+    const Vector_<> b = {4.0, 6.0};
+    Vector_<> x = {1.0, 2.0};
+
+    Sparse::BCGSolve(*mat, b, 1e-12, 1e-14, 10, &x);
+
+    ASSERT_DOUBLE_EQ(x[0], 1.0);
+    ASSERT_DOUBLE_EQ(x[1], 2.0);
+}
+
 // Tri-diagonal systems with distinct band values exercise every branch of the
 // fused Krylov sweeps. CG requires a symmetric positive-definite matrix, so it
 // gets a symmetric system; BCG handles the asymmetric case (and its shadow path).
@@ -108,4 +135,3 @@ TEST(MatrixTest, TestBCGSolveAsymmetricLowResidual) {
     Sparse::BCGSolve(*mat, b, 1e-12, 1e-14, 500, &x);
     ASSERT_LT(ResidualInfNorm(*mat, x, b), 1e-8);
 }
-

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -11,6 +11,17 @@
 
 using namespace Dal;
 
+namespace {
+    class RescaledIdentity_ : public Sparse::TriDiagonal_, public HasPreConditioner_ {
+        static void Rescale(const Vector_<>& b, Vector_<>* x) { (*x)[0] = 1e170 * b[0]; }
+
+    public:
+        RescaledIdentity_() : Sparse::TriDiagonal_(1) { Set(0, 0, 1.0); }
+        void PreConditionerSolveLeft(const Vector_<>& b, Vector_<>* x) const override { Rescale(b, x); }
+        void PreConditionerSolveRight(const Vector_<>& b, Vector_<>* x) const override { Rescale(b, x); }
+    };
+} // namespace
+
 TEST(MatrixTest, TestCGSolve) {
     const int n = 10;
     std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(n, 1, 1);
@@ -70,6 +81,30 @@ TEST(MatrixTest, TestBCGSolveAcceptsExactInitialGuess) {
 
     ASSERT_DOUBLE_EQ(x[0], 1.0);
     ASSERT_DOUBLE_EQ(x[1], 2.0);
+}
+
+TEST(MatrixTest, TestCGSolveDoesNotTreatUnderflowedResidualAsZero) {
+    const double nonzeroResidual = 1e-170;
+    ASSERT_DOUBLE_EQ(nonzeroResidual * nonzeroResidual, 0.0);
+    const RescaledIdentity_ mat;
+    const Vector_<> b = {0.0};
+    Vector_<> x = {nonzeroResidual};
+
+    Sparse::CGSolve(mat, b, EPSILON, 0.0, 10, &x);
+
+    ASSERT_DOUBLE_EQ(x[0], 0.0);
+}
+
+TEST(MatrixTest, TestBCGSolveDoesNotTreatUnderflowedResidualAsZero) {
+    const double nonzeroResidual = 1e-170;
+    ASSERT_DOUBLE_EQ(nonzeroResidual * nonzeroResidual, 0.0);
+    const RescaledIdentity_ mat;
+    const Vector_<> b = {0.0};
+    Vector_<> x = {nonzeroResidual};
+
+    Sparse::BCGSolve(mat, b, EPSILON, 0.0, 10, &x);
+
+    ASSERT_DOUBLE_EQ(x[0], 0.0);
 }
 
 // Tri-diagonal systems with distinct band values exercise every branch of the


### PR DESCRIPTION
Closes DAL-7

## Summary

- Accept an exact initial CG/BCG solution without entering a zero-over-zero Krylov update.
- Restrict the shortcut to residual vectors whose components are all exactly zero.
- Cover exact-zero and squared-norm-underflow residuals for both CG and BCG.

## Reproduction

An exact initial guess produces `r = b - Ax = 0`, but the solver previously entered its first iteration and eventually threw `Exhausted iterations`. A first attempt to detect this with `InnerProduct(r, r) == 0.0` also misclassified representable residual components such as `1e-170`, because their squared norm underflows to zero.

## Root cause

The shared Krylov path did not distinguish an exactly zero residual vector from a nonzero vector whose squared norm rounded to zero.

## Fix

Return before the first CG/BCG update only when every stored residual component equals `0.0`. Nonzero residuals continue through the existing iteration and tolerance logic.

## Test plan

- [x] Exact-initial-guess CG/BCG regressions: 2/2 passed.
- [x] Squared-norm-underflow CG/BCG regressions: 2/2 passed.
- [x] `MatrixTest.*`: 58/58 passed.
- [x] `UnderdeterminedTest.*`: 16/16 passed.
- [x] `NUM_CORES=2 bash ./build_linux.sh`: 1124/1124 passed at `73f89a7e703ec748ef770f617fab20c55350a844`.
- [x] Independent tester gate passed; reviewer verdict: Approve.

## Risk

The initialization path gains one short-circuit O(n) residual scan. Public signatures, defaults, tolerance semantics, bindings, and documentation contracts are unchanged. Unscaled extreme-subnormal Krylov inner products can still underflow during iteration; this existing numerical-scale limitation is outside this exact-zero guard fix.
