### PR TITLE
fix: DAL-14 accept tolerance-converged BCG guesses

### DIFF
--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -112,6 +112,8 @@ namespace Dal {
                 s.rr_ = s.r_;
             if (AllOf(s.r_, [](double value) { return value == 0.0; }))
                 return;
+            if (biConjugate && tNorm > 0.0 && sqrt(InnerProduct(s.r_, s.r_)) <= tNorm)
+                return;
 
             for (int ii = 0; ii < maxIterations; ++ii) {
                 const double beta = PrepareDirection(s, ii);

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -83,6 +83,19 @@ TEST(MatrixTest, TestBCGSolveAcceptsExactInitialGuess) {
     ASSERT_DOUBLE_EQ(x[1], 2.0);
 }
 
+TEST(MatrixTest, TestBCGSolveAcceptsToleranceConvergedInitialGuess) {
+    std::unique_ptr<Sparse::Square_> mat = Sparse::NewBandDiagonal(2, 1, 1);
+    mat->Set(0, 1, 1.0);
+    mat->Set(1, 0, -1.0);
+    const Vector_<> b = {1.0e-12, 0.0};
+    Vector_<> x = {0.0, 0.0};
+
+    Sparse::BCGSolve(*mat, b, 0.0, 1.0e-10, 10, &x);
+
+    ASSERT_DOUBLE_EQ(x[0], 0.0);
+    ASSERT_DOUBLE_EQ(x[1], 0.0);
+}
+
 TEST(MatrixTest, TestCGSolveDoesNotTreatUnderflowedResidualAsZero) {
     const double nonzeroResidual = 1e-170;
     ASSERT_DOUBLE_EQ(nonzeroResidual * nonzeroResidual, 0.0);


### PR DESCRIPTION
## Summary
- accept a supplied BCG initial guess when its nonzero residual already satisfies the requested tolerance
- add a regression for an invertible nonsymmetric system that otherwise reaches a zero-denominator breakdown
- preserve CG refinement behavior and the existing exact-zero/underflow protections

## Reproduction
On `origin/master` at `74194219b2a786c179066940c749c63e4761b0ae`, the focused regression

`./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='MatrixTest.TestBCGSolveAcceptsToleranceConvergedInitialGuess'`

throws `Exhausted iterations in BCGSolve` even though `||r0||₂ = 1e-12` is below `tolAbs = 1e-10`.

## Root cause
The shared Krylov solver recognized only an exactly-zero initial residual before entering BCG. A nonzero residual already within tolerance still attempted the first bi-conjugate update; for the valid nonsymmetric fixture, the search denominator is zero and the iteration breaks down instead of accepting the initial guess.

## Fix
Check BCG's documented residual threshold before its first update. The check is limited to BCG because DAL calibration callers rely on CG performing at least one refinement step. The positive-threshold guard preserves the existing nonzero-underflow behavior when the threshold is zero.

## Test plan
- [x] RED: focused BCG regression fails with `Exhausted iterations in BCGSolve`
- [x] GREEN: BCG tolerance, exact-initial, and underflow filters pass (3/3)
- [x] Representative CG/calibration compatibility filters pass (6/6)
- [x] `bash ./build_linux.sh` passes (1134/1134 tests)
- [x] `git diff --check` passes
- [x] changed-line `git clang-format --diff` reports no changes

## Risk
The behavior change is confined to BCG calls whose initial residual is nonzero and already within a positive requested tolerance. CG behavior and public API signatures are unchanged.

Closes DAL-14
