### PR TITLE
fix: Handle DAL-35 scaled alpha combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ here as the baseline rather than dated releases:
 
 ## 2026-07
 
+- `matrix`: Added exact scaled-`alpha` candidate combination for `Sparse::CGSolve`
+  and `Sparse::BCGSolve`. When the standalone binary64 coefficient is unsafe, the
+  stored quotient remains exact until each complete solution, residual, or BCG
+  shadow-residual expression is rounded once; finite cancellation and subnormal
+  candidates are accepted, while genuinely non-finite candidates still fail before
+  the atomic commit. The existing `beta/betaPrev` direction-ratio path is unchanged,
+  and solver-level FTZ validation is limited to the S3/S5 first-iteration cases.
+  Public signatures and bindings are unchanged. See `docs/methodology/matrix.md`.
+
 - `matrix`: Made `Sparse::CGSolve` and `Sparse::BCGSolve` scale-safe across the
   finite binary64 range. Norm and convergence classification no longer relies
   on overflowed or underflowed intermediates, and ambiguous signed dot products

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -17,6 +17,7 @@
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/utilities/algorithms.hpp>
 #include <dal/utilities/numerics.hpp>
+#include <dal/math/matrix/bcg_scaled_alpha.inc>
 
 namespace Dal {
     namespace {
@@ -167,6 +168,25 @@ namespace Dal {
         constexpr int EXACT_MAX_EXPONENT = 8352;
         constexpr int EXACT_LIMB_BITS = 32;
         constexpr int EXACT_LIMB_COUNT = (EXACT_MAX_EXPONENT - EXACT_MIN_EXPONENT) / EXACT_LIMB_BITS;
+
+#if defined(DAL35_PROBE_PRODUCTION_MAX_EXPONENT_DELTA)
+        constexpr int DAL35_PRODUCTION_MAX_EXPONENT_DELTA_ = DAL35_PROBE_PRODUCTION_MAX_EXPONENT_DELTA;
+#else
+        constexpr int DAL35_PRODUCTION_MAX_EXPONENT_DELTA_ = 0;
+#endif
+
+        constexpr BcgScaledAlphaPrivate_::AccumulatorBounds_ ACTUAL_ACCUMULATOR_BOUNDS_{
+            EXACT_MIN_EXPONENT, EXACT_MAX_EXPONENT + DAL35_PRODUCTION_MAX_EXPONENT_DELTA_, EXACT_LIMB_BITS, EXACT_LIMB_COUNT, 53, 1};
+
+        static_assert(BcgScaledAlphaPrivate_::REVIEWED_BOUNDS_FINGERPRINT_MATCHES_, "DAL35_PRODUCTION_REVIEWED_BOUNDS_FINGERPRINT_MISMATCH");
+        static_assert(BcgScaledAlphaPrivate_::SameAccumulatorBounds_(ACTUAL_ACCUMULATOR_BOUNDS_,
+                                                                     BcgScaledAlphaPrivate_::REVIEWED_ACCUMULATOR_BOUNDS_),
+                      "DAL35_PRODUCTION_ACCUMULATOR_INPUT_FINGERPRINT_MISMATCH");
+        static_assert(BcgScaledAlphaPrivate_::SameBoundsFingerprint_(
+                          BcgScaledAlphaPrivate_::MakeBoundsFingerprint_(ACTUAL_ACCUMULATOR_BOUNDS_,
+                                                                         BcgScaledAlphaPrivate_::DeriveCandidateBounds_(ACTUAL_ACCUMULATOR_BOUNDS_)),
+                          BcgScaledAlphaPrivate_::REVIEWED_BOUNDS_FINGERPRINT_),
+                      "DAL35_PRODUCTION_DERIVED_BOUNDS_FINGERPRINT_MISMATCH");
 
         struct ExactPositive_ {
             std::array<std::uint32_t, EXACT_LIMB_COUNT> limbs_{};
@@ -827,6 +847,46 @@ namespace Dal {
             return beta;
         }
 
+        BcgScaledAlphaPrivate_::StoredScaledBits_ CaptureStoredBits(const Scaled_& value) {
+            std::uint64_t bits = 0;
+            std::memcpy(&bits, &value.mantissa_, sizeof(bits));
+            return {bits, value.exponent_, value.normalized_};
+        }
+
+        std::uint64_t CaptureDoubleBits(double value) {
+            std::uint64_t bits = 0;
+            std::memcpy(&bits, &value, sizeof(bits));
+            return bits;
+        }
+
+        int EvaluateScaledCombination(const BcgScaledAlphaPrivate_::ExactAlpha_& alpha,
+                                      const Vector_<>& values,
+                                      const Vector_<>& base,
+                                      BcgScaledAlphaPrivate_::ExactWorkspace_* workspace,
+                                      Vector_<>* result) {
+            for (int i = 0; i < static_cast<int>(values.size()); ++i) {
+                const BcgScaledAlphaPrivate_::RoundedBinary64_ rounded =
+                    BcgScaledAlphaPrivate_::EvaluateElement_(alpha, CaptureDoubleBits(values[i]), CaptureDoubleBits(base[i]), workspace);
+                if (rounded.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::NON_FINITE)
+                    return i;
+                std::memcpy(&(*result)[i], &rounded.bits_, sizeof(rounded.bits_));
+            }
+            return -1;
+        }
+
+        void PrepareScaledCandidates(KrylovState_& s, const BcgScaledAlphaPrivate_::ExactAlpha_& alpha, const Vector_<>& x, const char* solver) {
+            BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+            if (EvaluateScaledCombination(alpha, s.pCandidate_, x, &workspace, &s.xCandidate_) >= 0)
+                ThrowFailure(solver, "numerical breakdown", "candidate x");
+
+            BcgScaledAlphaPrivate_::ExactAlpha_ negativeAlpha = alpha;
+            negativeAlpha.negative_ = !negativeAlpha.negative_;
+            if (EvaluateScaledCombination(negativeAlpha, s.rCandidate_, s.r_, &workspace, &s.rCandidate_) >= 0)
+                ThrowFailure(solver, "numerical breakdown", "candidate residual");
+            if (s.biConjugate_ && EvaluateScaledCombination(negativeAlpha, s.rrCandidate_, s.rr_, &workspace, &s.rrCandidate_) >= 0)
+                ThrowFailure(solver, "numerical breakdown", "candidate shadow residual");
+        }
+
         void PrepareCandidate(KrylovState_& s, const Scaled_& beta, const Vector_<>& x, const char* solver) {
             s.A_.MultiplyLeft(s.pCandidate_, &s.rCandidate_);
             ValidateCallbackResult(s.rCandidate_, s.A_.Size(), solver, "MultiplyLeft", false);
@@ -838,6 +898,14 @@ namespace Dal {
 
             const Vector_<>& shadowDirection = s.biConjugate_ ? rightDirection : s.pCandidate_;
             const Scaled_ alphaDenominator = ScaledDot(s.rCandidate_, shadowDirection);
+            const BcgScaledAlphaPrivate_::AlphaPlan_ alphaPlan =
+                BcgScaledAlphaPrivate_::ClassifyAlpha_(CaptureStoredBits(beta), CaptureStoredBits(alphaDenominator));
+            if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::DENOMINATOR_ZERO)
+                ThrowFailure(solver, "numerical breakdown", "alpha denominator");
+            if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::SCALED_EXACT) {
+                PrepareScaledCandidates(s, alphaPlan.exact_, x, solver);
+                return;
+            }
             const double alpha = ScaledRatio(beta, alphaDenominator, solver, "alpha denominator", "alpha ratio");
             StableBatch_ stableBatch;
             StableCombination(alpha, s.pCandidate_, x, solver, "candidate x", &s.xCandidate_);

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -888,6 +888,36 @@ namespace Dal {
                 ThrowFailure(solver, "numerical breakdown", "candidate shadow residual");
         }
 
+#if defined(__GNUC__) || defined(__clang__)
+#define DAL35_COLD_NOINLINE_ __attribute__((cold, noinline))
+#elif defined(_MSC_VER)
+#define DAL35_COLD_NOINLINE_ __declspec(noinline)
+#else
+#define DAL35_COLD_NOINLINE_
+#endif
+        DAL35_COLD_NOINLINE_ bool PrepareExceptionalAlpha(KrylovState_& s,
+                                                          const Scaled_& beta,
+                                                          const Scaled_& denominator,
+                                                          const BcgScaledAlphaPrivate_::StoredScaledBits_& numeratorBits,
+                                                          const BcgScaledAlphaPrivate_::StoredScaledBits_& denominatorBits,
+                                                          const Vector_<>& x,
+                                                          const char* solver,
+                                                          double* alpha) {
+            const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ClassifyAlphaAndInvokeLegacy_(
+                numeratorBits, denominatorBits, [&]() { *alpha = ScaledRatio(beta, denominator, solver, "alpha denominator", "alpha ratio"); });
+            if (plan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::DENOMINATOR_ZERO)
+                ThrowFailure(solver, "numerical breakdown", "alpha denominator");
+#if defined(DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION)
+            if (plan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL)
+                PrepareScaledCandidates(s, plan.exact_, x, solver);
+#endif
+            if (plan.path_ != BcgScaledAlphaPrivate_::AlphaPath_::SCALED_EXACT)
+                return false;
+            PrepareScaledCandidates(s, plan.exact_, x, solver);
+            return true;
+        }
+#undef DAL35_COLD_NOINLINE_
+
         void PrepareCandidate(KrylovState_& s, const Scaled_& beta, const Vector_<>& x, const char* solver) {
             s.A_.MultiplyLeft(s.pCandidate_, &s.rCandidate_);
             ValidateCallbackResult(s.rCandidate_, s.A_.Size(), solver, "MultiplyLeft", false);
@@ -899,21 +929,18 @@ namespace Dal {
 
             const Vector_<>& shadowDirection = s.biConjugate_ ? rightDirection : s.pCandidate_;
             const Scaled_ alphaDenominator = ScaledDot(s.rCandidate_, shadowDirection);
+            const BcgScaledAlphaPrivate_::StoredScaledBits_ numeratorBits = CaptureStoredBits(beta);
+            const BcgScaledAlphaPrivate_::StoredScaledBits_ denominatorBits = CaptureStoredBits(alphaDenominator);
             double alpha = 0.0;
-            const BcgScaledAlphaPrivate_::AlphaPlan_ alphaPlan =
-                BcgScaledAlphaPrivate_::ClassifyAlphaAndInvokeLegacy_(CaptureStoredBits(beta), CaptureStoredBits(alphaDenominator), [&]() {
-                    alpha = ScaledRatio(beta, alphaDenominator, solver, "alpha denominator", "alpha ratio");
-                });
-            if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::DENOMINATOR_ZERO)
-                ThrowFailure(solver, "numerical breakdown", "alpha denominator");
 #if defined(DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION)
-            if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL)
-                PrepareScaledCandidates(s, alphaPlan.exact_, x, solver);
-#endif
-            if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::SCALED_EXACT) {
-                PrepareScaledCandidates(s, alphaPlan.exact_, x, solver);
+            if (PrepareExceptionalAlpha(s, beta, alphaDenominator, numeratorBits, denominatorBits, x, solver, &alpha))
                 return;
-            }
+#else
+            if (BcgScaledAlphaPrivate_::CanUseLegacyRatioFast_(numeratorBits, denominatorBits))
+                alpha = ScaledRatio(beta, alphaDenominator, solver, "alpha denominator", "alpha ratio");
+            else if (PrepareExceptionalAlpha(s, beta, alphaDenominator, numeratorBits, denominatorBits, x, solver, &alpha))
+                return;
+#endif
             StableBatch_ stableBatch;
             StableCombination(alpha, s.pCandidate_, x, solver, "candidate x", &s.xCandidate_);
             StableCombination(-alpha, s.rCandidate_, s.r_, solver, "candidate residual", &s.rCandidate_);

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -19,6 +19,20 @@
 #include <dal/utilities/numerics.hpp>
 #include <dal/math/matrix/bcg_scaled_alpha.inc>
 
+#if defined(DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION) && !defined(DAL35_ENABLE_TEST_SEAM)
+#error "DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION requires DAL35_ENABLE_TEST_SEAM"
+#endif
+
+#if defined(DAL35_ENABLE_TEST_SEAM)
+#if defined(__GNUC__) || defined(__clang__)
+#define DAL35_TEST_HIDDEN_ __attribute__((visibility("hidden")))
+#else
+#define DAL35_TEST_HIDDEN_
+#endif
+extern "C" DAL35_TEST_HIDDEN_ void Dal35ObserveExactWorkspaceConstructionForTest_() noexcept;
+#undef DAL35_TEST_HIDDEN_
+#endif
+
 namespace Dal {
     namespace {
         struct XPrecondition_ {
@@ -855,6 +869,9 @@ namespace Dal {
 
         void PrepareScaledCandidates(KrylovState_& s, const BcgScaledAlphaPrivate_::ExactAlpha_& alpha, const Vector_<>& x, const char* solver) {
             BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+#if defined(DAL35_ENABLE_TEST_SEAM)
+            Dal35ObserveExactWorkspaceConstructionForTest_();
+#endif
             const BcgScaledAlphaPrivate_::CandidateGroup_ group{&s.pCandidate_,
                                                                 &x,
                                                                 &s.r_,
@@ -889,6 +906,10 @@ namespace Dal {
                 });
             if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::DENOMINATOR_ZERO)
                 ThrowFailure(solver, "numerical breakdown", "alpha denominator");
+#if defined(DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION)
+            if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL)
+                PrepareScaledCandidates(s, alphaPlan.exact_, x, solver);
+#endif
             if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::SCALED_EXACT) {
                 PrepareScaledCandidates(s, alphaPlan.exact_, x, solver);
                 return;

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -853,37 +853,21 @@ namespace Dal {
             return {bits, value.exponent_, value.normalized_};
         }
 
-        std::uint64_t CaptureDoubleBits(double value) {
-            std::uint64_t bits = 0;
-            std::memcpy(&bits, &value, sizeof(bits));
-            return bits;
-        }
-
-        int EvaluateScaledCombination(const BcgScaledAlphaPrivate_::ExactAlpha_& alpha,
-                                      const Vector_<>& values,
-                                      const Vector_<>& base,
-                                      BcgScaledAlphaPrivate_::ExactWorkspace_* workspace,
-                                      Vector_<>* result) {
-            for (int i = 0; i < static_cast<int>(values.size()); ++i) {
-                const BcgScaledAlphaPrivate_::RoundedBinary64_ rounded =
-                    BcgScaledAlphaPrivate_::EvaluateElement_(alpha, CaptureDoubleBits(values[i]), CaptureDoubleBits(base[i]), workspace);
-                if (rounded.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::NON_FINITE)
-                    return i;
-                std::memcpy(&(*result)[i], &rounded.bits_, sizeof(rounded.bits_));
-            }
-            return -1;
-        }
-
         void PrepareScaledCandidates(KrylovState_& s, const BcgScaledAlphaPrivate_::ExactAlpha_& alpha, const Vector_<>& x, const char* solver) {
             BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
-            if (EvaluateScaledCombination(alpha, s.pCandidate_, x, &workspace, &s.xCandidate_) >= 0)
+            const BcgScaledAlphaPrivate_::CandidateGroup_ group{&s.pCandidate_,
+                                                                &x,
+                                                                &s.r_,
+                                                                s.biConjugate_ ? &s.rr_ : nullptr,
+                                                                &s.xCandidate_,
+                                                                &s.rCandidate_,
+                                                                s.biConjugate_ ? &s.rrCandidate_ : nullptr};
+            const BcgScaledAlphaPrivate_::CandidateEvidence_ evidence = BcgScaledAlphaPrivate_::EvaluateCandidateGroup_(alpha, group, &workspace);
+            if (evidence.subject_ == BcgScaledAlphaPrivate_::CandidateSubject_::X)
                 ThrowFailure(solver, "numerical breakdown", "candidate x");
-
-            BcgScaledAlphaPrivate_::ExactAlpha_ negativeAlpha = alpha;
-            negativeAlpha.negative_ = !negativeAlpha.negative_;
-            if (EvaluateScaledCombination(negativeAlpha, s.rCandidate_, s.r_, &workspace, &s.rCandidate_) >= 0)
+            if (evidence.subject_ == BcgScaledAlphaPrivate_::CandidateSubject_::RESIDUAL)
                 ThrowFailure(solver, "numerical breakdown", "candidate residual");
-            if (s.biConjugate_ && EvaluateScaledCombination(negativeAlpha, s.rrCandidate_, s.rr_, &workspace, &s.rrCandidate_) >= 0)
+            if (evidence.subject_ == BcgScaledAlphaPrivate_::CandidateSubject_::SHADOW_RESIDUAL)
                 ThrowFailure(solver, "numerical breakdown", "candidate shadow residual");
         }
 
@@ -898,15 +882,17 @@ namespace Dal {
 
             const Vector_<>& shadowDirection = s.biConjugate_ ? rightDirection : s.pCandidate_;
             const Scaled_ alphaDenominator = ScaledDot(s.rCandidate_, shadowDirection);
+            double alpha = 0.0;
             const BcgScaledAlphaPrivate_::AlphaPlan_ alphaPlan =
-                BcgScaledAlphaPrivate_::ClassifyAlpha_(CaptureStoredBits(beta), CaptureStoredBits(alphaDenominator));
+                BcgScaledAlphaPrivate_::ClassifyAlphaAndInvokeLegacy_(CaptureStoredBits(beta), CaptureStoredBits(alphaDenominator), [&]() {
+                    alpha = ScaledRatio(beta, alphaDenominator, solver, "alpha denominator", "alpha ratio");
+                });
             if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::DENOMINATOR_ZERO)
                 ThrowFailure(solver, "numerical breakdown", "alpha denominator");
             if (alphaPlan.path_ == BcgScaledAlphaPrivate_::AlphaPath_::SCALED_EXACT) {
                 PrepareScaledCandidates(s, alphaPlan.exact_, x, solver);
                 return;
             }
-            const double alpha = ScaledRatio(beta, alphaDenominator, solver, "alpha denominator", "alpha ratio");
             StableBatch_ stableBatch;
             StableCombination(alpha, s.pCandidate_, x, solver, "candidate x", &s.xCandidate_);
             StableCombination(-alpha, s.rCandidate_, s.r_, solver, "candidate residual", &s.rCandidate_);

--- a/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
+++ b/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
@@ -153,6 +153,21 @@ namespace Dal {
 
             inline bool IsRawSubnormal_(std::uint64_t bits) { return (bits & BINARY64_EXPONENT_MASK_) == 0 && (bits & BINARY64_FRACTION_MASK_) != 0; }
 
+            inline bool IsLegacyInteriorExponentDifference_(int difference) { return difference >= -1020 && difference <= 1022; }
+
+            inline bool CanUseLegacyRatioFast_(const StoredScaledBits_& numerator, const StoredScaledBits_& denominator) {
+                const int numeratorExponent = static_cast<int>((numerator.mantissaBits_ & BINARY64_EXPONENT_MASK_) >> 52U);
+                const int denominatorExponent = static_cast<int>((denominator.mantissaBits_ & BINARY64_EXPONENT_MASK_) >> 52U);
+                if (numeratorExponent == 0 || numeratorExponent == 0x7ff || denominatorExponent == 0 || denominatorExponent == 0x7ff)
+                    return false;
+                const int rawDifference = numeratorExponent - denominatorExponent;
+                if (!IsLegacyInteriorExponentDifference_(rawDifference))
+                    return false;
+                const int storedDifference =
+                    rawDifference + (numerator.normalized_ ? numerator.exponent_ : 0) - (denominator.normalized_ ? denominator.exponent_ : 0);
+                return IsLegacyInteriorExponentDifference_(storedDifference);
+            }
+
             inline ExactAlpha_ ReduceRatio_(Dyadic_ numerator, Dyadic_ denominator) {
                 const std::uint64_t divisor = std::gcd(numerator.significand_, denominator.significand_);
                 return {numerator.significand_ / divisor, denominator.significand_ / divisor, numerator.binaryExponent_ - denominator.binaryExponent_,

--- a/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
+++ b/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
@@ -232,6 +232,16 @@ namespace Dal {
                 return {exact, ProveLegacyRatio_(numerator, denominator, exact) ? AlphaPath_::ORDINARY_NORMAL : AlphaPath_::SCALED_EXACT};
             }
 
+            template <class LegacyConversion_>
+            inline AlphaPlan_ ClassifyAlphaAndInvokeLegacy_(const StoredScaledBits_& numerator,
+                                                            const StoredScaledBits_& denominator,
+                                                            LegacyConversion_&& legacyConversion) {
+                const AlphaPlan_ plan = ClassifyAlpha_(numerator, denominator);
+                if (plan.path_ == AlphaPath_::LEGACY_ZERO || plan.path_ == AlphaPath_::ORDINARY_NORMAL)
+                    legacyConversion();
+                return plan;
+            }
+
             constexpr int EXACT_CANDIDATE_LIMB_COUNT_ = REVIEWED_CANDIDATE_BOUNDS_.candidateLimbCount_;
 
             struct ExactMagnitude_ {
@@ -552,6 +562,62 @@ namespace Dal {
                 if (subtrahend.last_ >= subtrahend.first_)
                     Subtract_(subtrahend, magnitude);
                 return Round_(*magnitude, alpha.denominator_, commonExponent, comparison < 0);
+            }
+
+            enum class CandidateSubject_ : std::uint8_t { NONE, X, RESIDUAL, SHADOW_RESIDUAL };
+
+            struct CandidateEvidence_ {
+                CandidateSubject_ subject_;
+                int firstNonFiniteIndex_;
+            };
+
+            struct CandidateGroup_ {
+                const Vector_<>* direction_;
+                const Vector_<>* xBase_;
+                const Vector_<>* residualBase_;
+                const Vector_<>* shadowBase_;
+                Vector_<>* xOutput_;
+                Vector_<>* residualInOut_;
+                Vector_<>* shadowInOut_;
+            };
+
+            inline std::uint64_t CandidateBits_(double value) {
+                std::uint64_t bits = 0;
+                std::memcpy(&bits, &value, sizeof(bits));
+                return bits;
+            }
+
+            inline CandidateEvidence_ EvaluateCandidateSubject_(const ExactAlpha_& alpha,
+                                                                const Vector_<>& values,
+                                                                const Vector_<>& base,
+                                                                CandidateSubject_ subject,
+                                                                ExactWorkspace_* workspace,
+                                                                Vector_<>* output) {
+                for (int i = 0; i < static_cast<int>(values.size()); ++i) {
+                    const RoundedBinary64_ rounded = EvaluateElement_(alpha, CandidateBits_(values[i]), CandidateBits_(base[i]), workspace);
+                    if (rounded.classification_ == RoundedClass_::NON_FINITE)
+                        return {subject, i};
+                    std::memcpy(&(*output)[i], &rounded.bits_, sizeof(rounded.bits_));
+                }
+                return {CandidateSubject_::NONE, -1};
+            }
+
+            inline CandidateEvidence_ EvaluateCandidateGroup_(const ExactAlpha_& alpha, const CandidateGroup_& group, ExactWorkspace_* workspace) {
+                CandidateEvidence_ evidence =
+                    EvaluateCandidateSubject_(alpha, *group.direction_, *group.xBase_, CandidateSubject_::X, workspace, group.xOutput_);
+                if (evidence.subject_ != CandidateSubject_::NONE)
+                    return evidence;
+
+                ExactAlpha_ negativeAlpha = alpha;
+                negativeAlpha.negative_ = !negativeAlpha.negative_;
+                evidence = EvaluateCandidateSubject_(negativeAlpha, *group.residualInOut_, *group.residualBase_, CandidateSubject_::RESIDUAL,
+                                                     workspace, group.residualInOut_);
+                if (evidence.subject_ != CandidateSubject_::NONE)
+                    return evidence;
+                if (group.shadowInOut_ == nullptr)
+                    return evidence;
+                return EvaluateCandidateSubject_(negativeAlpha, *group.shadowInOut_, *group.shadowBase_, CandidateSubject_::SHADOW_RESIDUAL,
+                                                 workspace, group.shadowInOut_);
             }
 
             static_assert(std::is_standard_layout<ExactMagnitude_>::value, "DAL35_EXACT_MAGNITUDE_MUST_BE_STANDARD_LAYOUT");

--- a/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
+++ b/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
@@ -1,0 +1,563 @@
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <dal/platform/platform.hpp>
+#include <limits>
+#include <numeric>
+#include <string>
+#include <type_traits>
+
+namespace Dal {
+    namespace {
+        namespace BcgScaledAlphaPrivate_ {
+            struct AccumulatorBounds_ {
+                int minExponent_;
+                int maxExponent_;
+                int limbBits_;
+                int limbCount_;
+                int storedSignificandBits_;
+                int topRoundingCarry_;
+            };
+
+            struct CandidateBounds_ {
+                int storedMinExponent_;
+                int storedMaxExponent_;
+                int alphaMinExponent_;
+                int alphaMaxExponent_;
+                int maxAlignmentDistance_;
+                int logicalMagnitudeBits_;
+                int candidateLimbCount_;
+                int maxLogicalBitIndex_;
+                int physicalMagnitudeBits_;
+            };
+
+            using BoundsFingerprint_ = std::array<int, 15>;
+
+            constexpr CandidateBounds_ DeriveCandidateBounds_(const AccumulatorBounds_& input) {
+                const int accumulatorBits = input.limbBits_ * input.limbCount_;
+                const int storedMinExponent = input.minExponent_ + 1 - input.storedSignificandBits_;
+                const int storedMaxExponent = input.maxExponent_ + input.topRoundingCarry_ - input.storedSignificandBits_;
+                const int alphaMinExponent = storedMinExponent - storedMaxExponent;
+                const int alphaMaxExponent = storedMaxExponent - storedMinExponent;
+                const int productMinExponent = alphaMinExponent - 1074;
+                const int productMaxExponent = alphaMaxExponent + 971;
+                const int maxAlignmentDistance = std::max(productMaxExponent + 1074, 971 - productMinExponent);
+                const int logicalMagnitudeBits = 2 * input.storedSignificandBits_ + maxAlignmentDistance + 1;
+                const int candidateLimbCount = (logicalMagnitudeBits + input.limbBits_ - 1) / input.limbBits_;
+                return {storedMinExponent,  storedMaxExponent,        alphaMinExponent,
+                        alphaMaxExponent,   maxAlignmentDistance,     logicalMagnitudeBits,
+                        candidateLimbCount, logicalMagnitudeBits - 1, candidateLimbCount * input.limbBits_};
+            }
+
+            constexpr BoundsFingerprint_ MakeBoundsFingerprint_(const AccumulatorBounds_& input, const CandidateBounds_& derived) {
+                return {input.minExponent_,
+                        input.maxExponent_,
+                        input.limbBits_,
+                        input.limbCount_,
+                        input.storedSignificandBits_,
+                        input.topRoundingCarry_,
+                        derived.storedMinExponent_,
+                        derived.storedMaxExponent_,
+                        derived.alphaMinExponent_,
+                        derived.alphaMaxExponent_,
+                        derived.maxAlignmentDistance_,
+                        derived.logicalMagnitudeBits_,
+                        derived.candidateLimbCount_,
+                        derived.maxLogicalBitIndex_,
+                        derived.physicalMagnitudeBits_};
+            }
+
+            constexpr bool SameBoundsFingerprint_(const BoundsFingerprint_& lhs, const BoundsFingerprint_& rhs) {
+                for (int i = 0; i < static_cast<int>(lhs.size()); ++i)
+                    if (lhs[i] != rhs[i])
+                        return false;
+                return true;
+            }
+
+            constexpr bool SameAccumulatorBounds_(const AccumulatorBounds_& lhs, const AccumulatorBounds_& rhs) {
+                return lhs.minExponent_ == rhs.minExponent_ && lhs.maxExponent_ == rhs.maxExponent_ && lhs.limbBits_ == rhs.limbBits_ &&
+                       lhs.limbCount_ == rhs.limbCount_ && lhs.storedSignificandBits_ == rhs.storedSignificandBits_ &&
+                       lhs.topRoundingCarry_ == rhs.topRoundingCarry_;
+            }
+
+            constexpr AccumulatorBounds_ WithTopRoundingCarryDelta_(const AccumulatorBounds_& input, int delta) {
+                return {input.minExponent_, input.maxExponent_,           input.limbBits_,
+                        input.limbCount_,   input.storedSignificandBits_, input.topRoundingCarry_ + delta};
+            }
+
+            constexpr AccumulatorBounds_ REVIEWED_ACCUMULATOR_BOUNDS_{-8608, 8352, 32, 530, 53, 1};
+            constexpr BoundsFingerprint_ REVIEWED_BOUNDS_FINGERPRINT_{-8608,  8352,  32,    530,   53,  1,     -8660, 8300,
+                                                                      -16960, 16960, 19005, 19112, 598, 19111, 19136};
+            constexpr CandidateBounds_ REVIEWED_CANDIDATE_BOUNDS_ = DeriveCandidateBounds_(REVIEWED_ACCUMULATOR_BOUNDS_);
+            constexpr bool REVIEWED_BOUNDS_FINGERPRINT_MATCHES_ = SameBoundsFingerprint_(
+                MakeBoundsFingerprint_(REVIEWED_ACCUMULATOR_BOUNDS_, REVIEWED_CANDIDATE_BOUNDS_), REVIEWED_BOUNDS_FINGERPRINT_);
+
+            static_assert(sizeof(double) == sizeof(std::uint64_t), "DAL35_BINARY64_SIZE_MISMATCH");
+            static_assert(std::numeric_limits<double>::is_iec559, "DAL35_BINARY64_IEC559_REQUIRED");
+            static_assert(std::numeric_limits<double>::digits == 53, "DAL35_BINARY64_SIGNIFICAND_MISMATCH");
+            static_assert(std::numeric_limits<double>::min_exponent == -1021, "DAL35_BINARY64_MIN_EXPONENT_MISMATCH");
+            static_assert(std::numeric_limits<double>::max_exponent == 1024, "DAL35_BINARY64_MAX_EXPONENT_MISMATCH");
+
+            struct StoredScaledBits_ {
+                std::uint64_t mantissaBits_;
+                int exponent_;
+                bool normalized_;
+            };
+
+            struct Dyadic_ {
+                std::uint64_t significand_;
+                int binaryExponent_;
+                bool negative_;
+            };
+
+            struct ExactAlpha_ {
+                std::uint64_t numerator_;
+                std::uint64_t denominator_;
+                int binaryExponent_;
+                bool negative_;
+            };
+
+            enum class AlphaPath_ : std::uint8_t { DENOMINATOR_ZERO, LEGACY_ZERO, ORDINARY_NORMAL, SCALED_EXACT };
+
+            struct AlphaPlan_ {
+                ExactAlpha_ exact_;
+                AlphaPath_ path_;
+            };
+
+            constexpr std::uint64_t BINARY64_FRACTION_MASK_ = (1ULL << 52U) - 1ULL;
+            constexpr std::uint64_t BINARY64_EXPONENT_MASK_ = 0x7ff0000000000000ULL;
+            constexpr std::uint64_t BINARY64_SIGN_MASK_ = 0x8000000000000000ULL;
+
+            inline int HighestBit_(std::uint64_t value) {
+                int result = -1;
+                while (value != 0) {
+                    value >>= 1U;
+                    ++result;
+                }
+                return result;
+            }
+
+            inline bool IsPowerOfTwo_(std::uint64_t value) { return value != 0 && (value & (value - 1U)) == 0; }
+
+            inline Dyadic_ DecodeFinite_(std::uint64_t bits) {
+                const std::uint64_t exponentField = (bits & BINARY64_EXPONENT_MASK_) >> 52U;
+                const std::uint64_t fraction = bits & BINARY64_FRACTION_MASK_;
+                const bool negative = (bits & BINARY64_SIGN_MASK_) != 0;
+                if (exponentField == 0)
+                    return {fraction, -1074, negative};
+                return {(1ULL << 52U) | fraction, static_cast<int>(exponentField) - 1023 - 52, negative};
+            }
+
+            inline bool IsFiniteBits_(std::uint64_t bits) { return (bits & BINARY64_EXPONENT_MASK_) != BINARY64_EXPONENT_MASK_; }
+
+            inline bool IsRawSubnormal_(std::uint64_t bits) { return (bits & BINARY64_EXPONENT_MASK_) == 0 && (bits & BINARY64_FRACTION_MASK_) != 0; }
+
+            inline ExactAlpha_ ReduceRatio_(Dyadic_ numerator, Dyadic_ denominator) {
+                const std::uint64_t divisor = std::gcd(numerator.significand_, denominator.significand_);
+                return {numerator.significand_ / divisor, denominator.significand_ / divisor, numerator.binaryExponent_ - denominator.binaryExponent_,
+                        numerator.negative_ != denominator.negative_};
+            }
+
+            inline ExactAlpha_ DecodeStoredRatio_(const StoredScaledBits_& numerator, const StoredScaledBits_& denominator) {
+                Dyadic_ decodedNumerator = DecodeFinite_(numerator.mantissaBits_);
+                Dyadic_ decodedDenominator = DecodeFinite_(denominator.mantissaBits_);
+                if (numerator.normalized_)
+                    decodedNumerator.binaryExponent_ += numerator.exponent_;
+                if (denominator.normalized_)
+                    decodedDenominator.binaryExponent_ += denominator.exponent_;
+                return ReduceRatio_(decodedNumerator, decodedDenominator);
+            }
+
+            inline int CompareScaledU64_(std::uint64_t lhs, int lhsExponent, std::uint64_t rhs, int rhsExponent) {
+                const int lhsHighest = HighestBit_(lhs) + lhsExponent;
+                const int rhsHighest = HighestBit_(rhs) + rhsExponent;
+                if (lhsHighest != rhsHighest)
+                    return lhsHighest < rhsHighest ? -1 : 1;
+                if (lhsExponent == rhsExponent)
+                    return lhs == rhs ? 0 : (lhs < rhs ? -1 : 1);
+                if (lhsExponent > rhsExponent) {
+                    const int shift = lhsExponent - rhsExponent;
+                    const std::uint64_t shifted = lhs << shift;
+                    return shifted == rhs ? 0 : (shifted < rhs ? -1 : 1);
+                }
+                const int shift = rhsExponent - lhsExponent;
+                const std::uint64_t shifted = rhs << shift;
+                return lhs == shifted ? 0 : (lhs < shifted ? -1 : 1);
+            }
+
+            inline int FloorLog2Ratio_(const ExactAlpha_& value) {
+                const int numeratorHighest = HighestBit_(value.numerator_);
+                const int denominatorHighest = HighestBit_(value.denominator_);
+                const std::uint64_t normalizedNumerator = value.numerator_ << (52 - numeratorHighest);
+                const std::uint64_t normalizedDenominator = value.denominator_ << (52 - denominatorHighest);
+                return numeratorHighest - denominatorHighest + value.binaryExponent_ + (normalizedNumerator < normalizedDenominator ? -1 : 0);
+            }
+
+            inline bool IsExactDyadicNormalFinite_(const ExactAlpha_& value, int highestExponent) {
+                if (!IsPowerOfTwo_(value.denominator_) || highestExponent < -1022 || highestExponent > 1023)
+                    return false;
+                if (highestExponent < 1023)
+                    return true;
+                const int denominatorExponent = HighestBit_(value.denominator_);
+                return CompareScaledU64_(value.numerator_, value.binaryExponent_ - denominatorExponent, (1ULL << 53U) - 1ULL, 971) <= 0;
+            }
+
+            inline bool IsLegacyStageSafe_(const ExactAlpha_& value) {
+                const int highestExponent = FloorLog2Ratio_(value);
+                if (highestExponent >= -1021 && highestExponent <= 1022)
+                    return true;
+                return IsExactDyadicNormalFinite_(value, highestExponent);
+            }
+
+            inline bool ProveLegacyRatio_(const StoredScaledBits_& numerator, const StoredScaledBits_& denominator, const ExactAlpha_& exact) {
+                if (IsRawSubnormal_(numerator.mantissaBits_) || IsRawSubnormal_(denominator.mantissaBits_))
+                    return false;
+                if (!numerator.normalized_ && !denominator.normalized_)
+                    return IsLegacyStageSafe_(exact);
+                const ExactAlpha_ raw = ReduceRatio_(DecodeFinite_(numerator.mantissaBits_), DecodeFinite_(denominator.mantissaBits_));
+                if (!IsLegacyStageSafe_(raw))
+                    return false;
+                return IsLegacyStageSafe_(exact);
+            }
+
+            inline AlphaPlan_ ClassifyAlpha_(const StoredScaledBits_& numerator, const StoredScaledBits_& denominator) {
+                const Dyadic_ decodedNumerator = DecodeFinite_(numerator.mantissaBits_);
+                const Dyadic_ decodedDenominator = DecodeFinite_(denominator.mantissaBits_);
+                if (decodedDenominator.significand_ == 0)
+                    return {{0, 0, 0, false}, AlphaPath_::DENOMINATOR_ZERO};
+                if (decodedNumerator.significand_ == 0)
+                    return {{0, 1, 0, decodedNumerator.negative_ != decodedDenominator.negative_}, AlphaPath_::LEGACY_ZERO};
+                const ExactAlpha_ exact = DecodeStoredRatio_(numerator, denominator);
+                return {exact, ProveLegacyRatio_(numerator, denominator, exact) ? AlphaPath_::ORDINARY_NORMAL : AlphaPath_::SCALED_EXACT};
+            }
+
+            constexpr int EXACT_CANDIDATE_LIMB_COUNT_ = REVIEWED_CANDIDATE_BOUNDS_.candidateLimbCount_;
+
+            struct ExactMagnitude_ {
+                std::array<std::uint32_t, EXACT_CANDIDATE_LIMB_COUNT_> limbs_{};
+                int first_ = EXACT_CANDIDATE_LIMB_COUNT_;
+                int last_ = -1;
+            };
+
+            struct ExactWorkspace_ {
+                ExactMagnitude_ positive_;
+                ExactMagnitude_ negative_;
+            };
+
+            inline void ResetMagnitude_(ExactMagnitude_* magnitude) noexcept {
+                if (magnitude->first_ == EXACT_CANDIDATE_LIMB_COUNT_ && magnitude->last_ == -1)
+                    return;
+                if (magnitude->first_ >= 0 && magnitude->first_ <= magnitude->last_ && magnitude->last_ < EXACT_CANDIDATE_LIMB_COUNT_) {
+                    for (int i = magnitude->first_; i <= magnitude->last_; ++i)
+                        magnitude->limbs_[i] = 0;
+                } else {
+                    for (std::uint32_t& limb : magnitude->limbs_)
+                        limb = 0;
+                }
+                magnitude->first_ = EXACT_CANDIDATE_LIMB_COUNT_;
+                magnitude->last_ = -1;
+            }
+
+            class WorkspaceCallReset_ {
+                ExactWorkspace_* workspace_;
+
+            public:
+                explicit WorkspaceCallReset_(ExactWorkspace_* workspace) noexcept : workspace_(workspace) {}
+                ~WorkspaceCallReset_() noexcept {
+                    ResetMagnitude_(&workspace_->positive_);
+                    ResetMagnitude_(&workspace_->negative_);
+                }
+            };
+
+            inline void CheckCanonicalMagnitude_(const ExactMagnitude_& magnitude, const char* name) {
+                if (magnitude.first_ == EXACT_CANDIDATE_LIMB_COUNT_ && magnitude.last_ == -1)
+                    return;
+                THROW(std::string("scaled candidate workspace ") + name + " is not canonical: first=" + std::to_string(magnitude.first_) +
+                      ", last=" + std::to_string(magnitude.last_) + ", expected first=" + std::to_string(EXACT_CANDIDATE_LIMB_COUNT_) + ", last=-1");
+            }
+
+            inline void CheckCanonicalWorkspace_(const ExactWorkspace_& workspace) {
+                CheckCanonicalMagnitude_(workspace.positive_, "positive");
+                CheckCanonicalMagnitude_(workspace.negative_, "negative");
+            }
+
+            inline void CheckLogicalBitRange_(int firstBit, int lastBit) {
+                if (firstBit < 0 || lastBit < firstBit || lastBit > REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_)
+                    THROW(std::string("scaled candidate exact bit range violates reviewed [0,") +
+                          std::to_string(REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_) + "] bound");
+            }
+
+            inline void TouchLimb_(int limb, ExactMagnitude_* magnitude) {
+                magnitude->first_ = std::min(magnitude->first_, limb);
+                magnitude->last_ = std::max(magnitude->last_, limb);
+            }
+
+            inline void AddBit_(int bit, ExactMagnitude_* magnitude) {
+                std::uint64_t carry = 1;
+                int currentBit = bit;
+                while (carry != 0) {
+                    CheckLogicalBitRange_(currentBit, currentBit);
+                    const int limb = currentBit / 32;
+                    const int offset = currentBit % 32;
+                    TouchLimb_(limb, magnitude);
+                    const std::uint64_t sum = static_cast<std::uint64_t>(magnitude->limbs_[limb]) + (carry << offset);
+                    magnitude->limbs_[limb] = static_cast<std::uint32_t>(sum);
+                    carry = sum >> 32U;
+                    currentBit = (limb + 1) * 32;
+                }
+            }
+
+            inline std::array<std::uint32_t, 4> Multiply53_(std::uint64_t lhs, std::uint64_t rhs) {
+                const std::array<std::uint32_t, 2> left = {static_cast<std::uint32_t>(lhs), static_cast<std::uint32_t>(lhs >> 32U)};
+                const std::array<std::uint32_t, 2> right = {static_cast<std::uint32_t>(rhs), static_cast<std::uint32_t>(rhs >> 32U)};
+                std::array<std::uint32_t, 4> result{};
+                for (int i = 0; i < 2; ++i) {
+                    std::uint64_t carry = 0;
+                    for (int j = 0; j < 2; ++j) {
+                        const std::uint64_t sum = static_cast<std::uint64_t>(result[i + j]) + static_cast<std::uint64_t>(left[i]) * right[j] + carry;
+                        result[i + j] = static_cast<std::uint32_t>(sum);
+                        carry = sum >> 32U;
+                    }
+                    int output = i + 2;
+                    while (carry != 0) {
+                        const std::uint64_t sum = static_cast<std::uint64_t>(result[output]) + carry;
+                        result[output] = static_cast<std::uint32_t>(sum);
+                        carry = sum >> 32U;
+                        ++output;
+                    }
+                }
+                return result;
+            }
+
+            inline void AddProduct_(std::uint64_t lhs, std::uint64_t rhs, int shift, ExactMagnitude_* magnitude) {
+                if (lhs == 0 || rhs == 0)
+                    return;
+                const std::array<std::uint32_t, 4> product = Multiply53_(lhs, rhs);
+                for (int word = 0; word < static_cast<int>(product.size()); ++word)
+                    for (int bit = 0; bit < 32; ++bit)
+                        if ((product[word] & (1U << bit)) != 0)
+                            AddBit_(shift + 32 * word + bit, magnitude);
+            }
+
+            inline void Trim_(ExactMagnitude_* magnitude) {
+                while (magnitude->first_ <= magnitude->last_ && magnitude->limbs_[magnitude->first_] == 0)
+                    ++magnitude->first_;
+                while (magnitude->last_ >= magnitude->first_ && magnitude->limbs_[magnitude->last_] == 0)
+                    --magnitude->last_;
+                if (magnitude->last_ < magnitude->first_) {
+                    magnitude->first_ = EXACT_CANDIDATE_LIMB_COUNT_;
+                    magnitude->last_ = -1;
+                }
+            }
+
+            inline int Compare_(const ExactMagnitude_& lhs, const ExactMagnitude_& rhs) {
+                if (lhs.last_ != rhs.last_)
+                    return lhs.last_ < rhs.last_ ? -1 : 1;
+                for (int i = lhs.last_; i >= std::min(lhs.first_, rhs.first_); --i)
+                    if (lhs.limbs_[i] != rhs.limbs_[i])
+                        return lhs.limbs_[i] < rhs.limbs_[i] ? -1 : 1;
+                return 0;
+            }
+
+            inline void Subtract_(const ExactMagnitude_& subtrahend, ExactMagnitude_* minuend) {
+                const int first = std::min(minuend->first_, subtrahend.first_);
+                const int last = minuend->last_;
+                CheckLogicalBitRange_(32 * first, std::min(REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_, 32 * last + 31));
+                minuend->first_ = first;
+                std::uint64_t borrow = 0;
+                for (int i = first; i <= last; ++i) {
+                    TouchLimb_(i, minuend);
+                    const std::uint64_t rhs = static_cast<std::uint64_t>(subtrahend.limbs_[i]) + borrow;
+                    const std::uint64_t lhs = minuend->limbs_[i];
+                    if (lhs < rhs) {
+                        minuend->limbs_[i] = static_cast<std::uint32_t>((1ULL << 32U) + lhs - rhs);
+                        borrow = 1;
+                    } else {
+                        minuend->limbs_[i] = static_cast<std::uint32_t>(lhs - rhs);
+                        borrow = 0;
+                    }
+                }
+                if (borrow != 0)
+                    THROW("scaled candidate exact subtraction underflow");
+                Trim_(minuend);
+            }
+
+            inline bool Bit_(const ExactMagnitude_& value, int bit) {
+                if (bit < 0 || bit > REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_)
+                    return false;
+                return (value.limbs_[bit / 32] & (1U << (bit % 32))) != 0;
+            }
+
+            inline bool HasBitBelow_(const ExactMagnitude_& value, int exclusiveBit) {
+                if (exclusiveBit <= 0 || value.last_ < value.first_)
+                    return false;
+                const int lastBit = std::min(exclusiveBit - 1, REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_);
+                const int lastLimb = lastBit / 32;
+                for (int i = value.first_; i < lastLimb; ++i)
+                    if (value.limbs_[i] != 0)
+                        return true;
+                if (lastLimb < value.first_)
+                    return false;
+                const int bits = lastBit % 32 + 1;
+                const std::uint32_t mask = bits == 32 ? std::numeric_limits<std::uint32_t>::max() : (1U << bits) - 1U;
+                return (value.limbs_[lastLimb] & mask) != 0;
+            }
+
+            inline int HighestBit_(const ExactMagnitude_& value) {
+                const std::uint32_t top = value.limbs_[value.last_];
+                return 32 * value.last_ + HighestBit_(static_cast<std::uint64_t>(top));
+            }
+
+            inline int CompareNormalized_(const ExactMagnitude_& numerator, std::uint64_t denominator) {
+                const int numeratorHighest = HighestBit_(numerator);
+                const int denominatorHighest = HighestBit_(denominator);
+                std::uint64_t numeratorTop = 0;
+                for (int bit = numeratorHighest; bit > numeratorHighest - 53; --bit)
+                    numeratorTop = (numeratorTop << 1U) | static_cast<std::uint64_t>(Bit_(numerator, bit));
+                const std::uint64_t denominatorTop = denominator << (52 - denominatorHighest);
+                if (numeratorTop != denominatorTop)
+                    return numeratorTop < denominatorTop ? -1 : 1;
+                return HasBitBelow_(numerator, numeratorHighest - 52) ? 1 : 0;
+            }
+
+            inline int FloorLog2Ratio_(const ExactMagnitude_& numerator, std::uint64_t denominator) {
+                return HighestBit_(numerator) - HighestBit_(denominator) + (CompareNormalized_(numerator, denominator) < 0 ? -1 : 0);
+            }
+
+            struct Division_ {
+                std::uint64_t quotient_;
+                std::uint64_t remainder_;
+                bool started_;
+            };
+
+            inline void FeedDivisionBit_(bool bit, std::uint64_t denominator, Division_* division) {
+                division->remainder_ = (division->remainder_ << 1U) | static_cast<std::uint64_t>(bit);
+                const bool quotientBit = division->remainder_ >= denominator;
+                if (quotientBit)
+                    division->remainder_ -= denominator;
+                if (!division->started_ && !quotientBit)
+                    return;
+                division->started_ = true;
+                if (division->quotient_ > (((1ULL << 53U) - 1ULL) >> 1U))
+                    THROW("scaled candidate quotient exceeds binary64 significand bound");
+                division->quotient_ = (division->quotient_ << 1U) | static_cast<std::uint64_t>(quotientBit);
+            }
+
+            inline Division_ DivideBits_(const ExactMagnitude_& numerator, int lowestBit, std::uint64_t denominator) {
+                Division_ result{0, 0, false};
+                for (int bit = HighestBit_(numerator); bit >= lowestBit; --bit)
+                    FeedDivisionBit_(Bit_(numerator, bit), denominator, &result);
+                return result;
+            }
+
+            inline int RoundingRelation_(const ExactMagnitude_& numerator, int shift, std::uint64_t denominator, Division_* division) {
+                if (shift >= 0) {
+                    *division = DivideBits_(numerator, 0, denominator);
+                    for (int i = 0; i < shift; ++i)
+                        FeedDivisionBit_(false, denominator, division);
+                    const std::uint64_t twiceRemainder = division->remainder_ << 1U;
+                    return twiceRemainder == denominator ? 0 : (twiceRemainder < denominator ? -1 : 1);
+                }
+
+                const int discardedBits = -shift;
+                if (discardedBits > HighestBit_(numerator))
+                    *division = {0, 0, false};
+                else
+                    *division = DivideBits_(numerator, discardedBits, denominator);
+                const std::int64_t comparison = static_cast<std::int64_t>(division->remainder_ << 1U) - static_cast<std::int64_t>(denominator);
+                if (comparison > 0)
+                    return 1;
+                if (comparison == 0)
+                    return HasBitBelow_(numerator, discardedBits) ? 1 : 0;
+                if (comparison <= -2)
+                    return -1;
+                if (!Bit_(numerator, discardedBits - 1))
+                    return -1;
+                return HasBitBelow_(numerator, discardedBits - 1) ? 1 : 0;
+            }
+
+            enum class RoundedClass_ : std::uint8_t { FINITE, NON_FINITE };
+
+            struct RoundedBinary64_ {
+                std::uint64_t bits_;
+                RoundedClass_ classification_;
+            };
+
+            inline RoundedBinary64_ Round_(const ExactMagnitude_& numerator, std::uint64_t denominator, int binaryExponent, bool negative) {
+                int highestExponent = FloorLog2Ratio_(numerator, denominator) + binaryExponent;
+                if (highestExponent >= 1024)
+                    return {0, RoundedClass_::NON_FINITE};
+                const int unitExponent = highestExponent <= -1023 ? -1074 : highestExponent - 52;
+                Division_ division{};
+                const int relation = RoundingRelation_(numerator, binaryExponent - unitExponent, denominator, &division);
+                std::uint64_t significand = division.quotient_;
+                if (relation > 0 || (relation == 0 && (significand & 1U) != 0))
+                    ++significand;
+                const std::uint64_t sign = negative ? BINARY64_SIGN_MASK_ : 0;
+                if (significand == 0)
+                    return {sign, RoundedClass_::FINITE};
+                if (highestExponent <= -1023) {
+                    if (significand < (1ULL << 52U))
+                        return {sign | significand, RoundedClass_::FINITE};
+                    return {sign | (1ULL << 52U), RoundedClass_::FINITE};
+                }
+                if (significand == (1ULL << 53U)) {
+                    significand >>= 1U;
+                    ++highestExponent;
+                }
+                if (highestExponent >= 1024)
+                    return {0, RoundedClass_::NON_FINITE};
+                const std::uint64_t exponent = static_cast<std::uint64_t>(highestExponent + 1023) << 52U;
+                return {sign | exponent | (significand - (1ULL << 52U)), RoundedClass_::FINITE};
+            }
+
+            inline RoundedBinary64_
+            EvaluateElement_(const ExactAlpha_& alpha, std::uint64_t valueBits, std::uint64_t baseBits, ExactWorkspace_* workspace) {
+                WorkspaceCallReset_ cleanup(workspace);
+                CheckCanonicalWorkspace_(*workspace);
+                if (alpha.numerator_ == 0 || alpha.denominator_ == 0 || alpha.binaryExponent_ < REVIEWED_CANDIDATE_BOUNDS_.alphaMinExponent_ ||
+                    alpha.binaryExponent_ > REVIEWED_CANDIDATE_BOUNDS_.alphaMaxExponent_)
+                    THROW("scaled candidate exact alpha violates reviewed bounds");
+                if (!IsFiniteBits_(valueBits) || !IsFiniteBits_(baseBits))
+                    THROW("scaled candidate evaluator requires finite binary64 inputs");
+
+                const Dyadic_ value = DecodeFinite_(valueBits);
+                const Dyadic_ base = DecodeFinite_(baseBits);
+                const bool productNegative = alpha.negative_ != value.negative_;
+                if (value.significand_ == 0 && base.significand_ == 0) {
+                    const bool negative = productNegative == base.negative_ ? productNegative : false;
+                    return {negative ? BINARY64_SIGN_MASK_ : 0, RoundedClass_::FINITE};
+                }
+
+                const int productExponent = alpha.binaryExponent_ + value.binaryExponent_;
+                int commonExponent = productExponent;
+                if (value.significand_ == 0)
+                    commonExponent = base.binaryExponent_;
+                else if (base.significand_ != 0)
+                    commonExponent = std::min(productExponent, base.binaryExponent_);
+
+                if (value.significand_ != 0)
+                    AddProduct_(alpha.numerator_, value.significand_, productExponent - commonExponent,
+                                productNegative ? &workspace->negative_ : &workspace->positive_);
+                if (base.significand_ != 0)
+                    AddProduct_(alpha.denominator_, base.significand_, base.binaryExponent_ - commonExponent,
+                                base.negative_ ? &workspace->negative_ : &workspace->positive_);
+
+                const int comparison = Compare_(workspace->positive_, workspace->negative_);
+                if (comparison == 0)
+                    return {0, RoundedClass_::FINITE};
+                ExactMagnitude_* magnitude = comparison > 0 ? &workspace->positive_ : &workspace->negative_;
+                const ExactMagnitude_& subtrahend = comparison > 0 ? workspace->negative_ : workspace->positive_;
+                if (subtrahend.last_ >= subtrahend.first_)
+                    Subtract_(subtrahend, magnitude);
+                return Round_(*magnitude, alpha.denominator_, commonExponent, comparison < 0);
+            }
+
+            static_assert(std::is_standard_layout<ExactMagnitude_>::value, "DAL35_EXACT_MAGNITUDE_MUST_BE_STANDARD_LAYOUT");
+            static_assert(std::is_trivially_copyable<ExactMagnitude_>::value, "DAL35_EXACT_MAGNITUDE_MUST_BE_TRIVIALLY_COPYABLE");
+            static_assert(std::is_standard_layout<ExactWorkspace_>::value, "DAL35_EXACT_WORKSPACE_MUST_BE_STANDARD_LAYOUT");
+            static_assert(std::is_trivially_copyable<ExactWorkspace_>::value, "DAL35_EXACT_WORKSPACE_MUST_BE_TRIVIALLY_COPYABLE");
+        } // namespace BcgScaledAlphaPrivate_
+    } // namespace
+} // namespace Dal

--- a/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
+++ b/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
@@ -242,6 +242,21 @@ namespace Dal {
                 return plan;
             }
 
+#if defined(DAL35_ENABLE_TEST_SEAM)
+            template <class LegacyConversion_, class ScaledEvaluation_>
+            inline AlphaPlan_ ObserveAlphaDispatchForTest_(const StoredScaledBits_& numerator,
+                                                          const StoredScaledBits_& denominator,
+                                                          LegacyConversion_&& legacyConversion,
+                                                          ScaledEvaluation_&& scaledEvaluation) {
+                const AlphaPlan_ plan = ClassifyAlpha_(numerator, denominator);
+                if (plan.path_ == AlphaPath_::LEGACY_ZERO || plan.path_ == AlphaPath_::ORDINARY_NORMAL)
+                    legacyConversion();
+                if (plan.path_ == AlphaPath_::SCALED_EXACT)
+                    scaledEvaluation(plan.exact_);
+                return plan;
+            }
+#endif
+
             constexpr int EXACT_CANDIDATE_LIMB_COUNT_ = REVIEWED_CANDIDATE_BOUNDS_.candidateLimbCount_;
 
             struct ExactMagnitude_ {

--- a/dal-cpp/tests/math/matrix/dal35_one_bit_oracle.hpp
+++ b/dal-cpp/tests/math/matrix/dal35_one_bit_oracle.hpp
@@ -154,12 +154,7 @@ namespace Dal35OneBitOracle_ {
         return Compare_(Shift_(numerator, -initial), denominator) < 0 ? initial - 1 : initial;
     }
 
-    inline OracleResult_ Round_(const OracleNat_& numerator, const OracleNat_& denominator, int binaryExponent, bool negative) {
-        int highestExponent = FloorLog2Ratio_(numerator, denominator) + binaryExponent;
-        if (highestExponent >= 1024)
-            return {0, OracleClass_::NON_FINITE};
-        const int unitExponent = highestExponent <= -1023 ? -1074 : highestExponent - 52;
-        const int shift = binaryExponent - unitExponent;
+    inline std::uint64_t RoundedSignificand_(const OracleNat_& numerator, const OracleNat_& denominator, int shift) {
         const OracleNat_ scaledNumerator = shift >= 0 ? Shift_(numerator, shift) : numerator;
         const OracleNat_ scaledDenominator = shift >= 0 ? denominator : Shift_(denominator, -shift);
         Division_ division = Divide_(scaledNumerator, scaledDenominator);
@@ -167,7 +162,10 @@ namespace Dal35OneBitOracle_ {
         std::uint64_t significand = ToU64_(division.quotient_);
         if (halfComparison > 0 || (halfComparison == 0 && (significand & 1U) != 0))
             ++significand;
+        return significand;
+    }
 
+    inline OracleResult_ PackRounded_(std::uint64_t significand, int highestExponent, bool negative) {
         const std::uint64_t sign = negative ? (1ULL << 63U) : 0;
         if (significand == 0)
             return {sign, OracleClass_::FINITE};
@@ -186,6 +184,53 @@ namespace Dal35OneBitOracle_ {
         return {sign | exponent | (significand - (1ULL << 52U)), OracleClass_::FINITE};
     }
 
+    inline OracleResult_ Round_(const OracleNat_& numerator, const OracleNat_& denominator, int binaryExponent, bool negative) {
+        const int highestExponent = FloorLog2Ratio_(numerator, denominator) + binaryExponent;
+        if (highestExponent >= 1024)
+            return {0, OracleClass_::NON_FINITE};
+        const int unitExponent = highestExponent <= -1023 ? -1074 : highestExponent - 52;
+        return PackRounded_(RoundedSignificand_(numerator, denominator, binaryExponent - unitExponent), highestExponent, negative);
+    }
+
+    inline int CommonExponent_(const RawFinite_& value, const RawFinite_& base, int productExponent) {
+        if (value.significand_.empty())
+            return base.binaryExponent_;
+        if (!base.significand_.empty())
+            return std::min(productExponent, base.binaryExponent_);
+        return productExponent;
+    }
+
+    inline void AccumulateProduct_(const OracleInput_& input,
+                                   const RawFinite_& value,
+                                   int productExponent,
+                                   int commonExponent,
+                                   bool productNegative,
+                                   OracleNat_* positive,
+                                   OracleNat_* negative) {
+        if (value.significand_.empty())
+            return;
+        OracleNat_ product = Shift_(Multiply_(input.alpha_.numerator_, value.significand_), productExponent - commonExponent);
+        (productNegative ? *negative : *positive) = std::move(product);
+    }
+
+    inline void AccumulateBase_(const OracleInput_& input, const RawFinite_& base, int commonExponent, OracleNat_* positive, OracleNat_* negative) {
+        if (base.significand_.empty())
+            return;
+        const OracleNat_ baseTerm = Shift_(Multiply_(input.alpha_.denominator_, base.significand_), base.binaryExponent_ - commonExponent);
+        if (base.negative_)
+            *negative = Add_(*negative, baseTerm);
+        else
+            *positive = Add_(*positive, baseTerm);
+    }
+
+    inline OracleResult_ RoundDifference_(const OracleNat_& positive, const OracleNat_& negative, const OracleInput_& input, int commonExponent) {
+        const int comparison = Compare_(positive, negative);
+        if (comparison == 0)
+            return {0, OracleClass_::FINITE};
+        const OracleNat_ magnitude = comparison > 0 ? Subtract_(positive, negative) : Subtract_(negative, positive);
+        return Round_(magnitude, input.alpha_.denominator_, commonExponent, comparison < 0);
+    }
+
     inline OracleResult_ Evaluate_(const OracleInput_& input) {
         const RawFinite_ value = Decode_(input.valueBits_);
         const RawFinite_ base = Decode_(input.baseBits_);
@@ -196,30 +241,11 @@ namespace Dal35OneBitOracle_ {
         }
 
         const int productExponent = input.alpha_.binaryExponent_ + value.binaryExponent_;
-        int commonExponent = productExponent;
-        if (value.significand_.empty())
-            commonExponent = base.binaryExponent_;
-        else if (!base.significand_.empty())
-            commonExponent = std::min(productExponent, base.binaryExponent_);
-
+        const int commonExponent = CommonExponent_(value, base, productExponent);
         OracleNat_ positive;
         OracleNat_ negative;
-        if (!value.significand_.empty()) {
-            OracleNat_ product = Shift_(Multiply_(input.alpha_.numerator_, value.significand_), productExponent - commonExponent);
-            (productNegative ? negative : positive) = std::move(product);
-        }
-        if (!base.significand_.empty()) {
-            const OracleNat_ baseTerm = Shift_(Multiply_(input.alpha_.denominator_, base.significand_), base.binaryExponent_ - commonExponent);
-            if (base.negative_)
-                negative = Add_(negative, baseTerm);
-            else
-                positive = Add_(positive, baseTerm);
-        }
-
-        const int comparison = Compare_(positive, negative);
-        if (comparison == 0)
-            return {0, OracleClass_::FINITE};
-        const OracleNat_ magnitude = comparison > 0 ? Subtract_(positive, negative) : Subtract_(negative, positive);
-        return Round_(magnitude, input.alpha_.denominator_, commonExponent, comparison < 0);
+        AccumulateProduct_(input, value, productExponent, commonExponent, productNegative, &positive, &negative);
+        AccumulateBase_(input, base, commonExponent, &positive, &negative);
+        return RoundDifference_(positive, negative, input, commonExponent);
     }
 } // namespace Dal35OneBitOracle_

--- a/dal-cpp/tests/math/matrix/dal35_one_bit_oracle.hpp
+++ b/dal-cpp/tests/math/matrix/dal35_one_bit_oracle.hpp
@@ -1,3 +1,7 @@
+//
+// Created by dal-implementer on 2026/7/29.
+//
+
 #pragma once
 
 #include <algorithm>

--- a/dal-cpp/tests/math/matrix/dal35_one_bit_oracle.hpp
+++ b/dal-cpp/tests/math/matrix/dal35_one_bit_oracle.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace Dal35OneBitOracle_ {
+    using OracleNat_ = std::vector<std::uint8_t>;
+
+    struct OracleAlpha_ {
+        OracleNat_ numerator_;
+        OracleNat_ denominator_;
+        int binaryExponent_;
+        bool negative_;
+    };
+
+    struct OracleInput_ {
+        OracleAlpha_ alpha_;
+        std::uint64_t valueBits_;
+        std::uint64_t baseBits_;
+    };
+
+    enum class OracleClass_ : std::uint8_t { FINITE, NON_FINITE };
+
+    struct OracleResult_ {
+        std::uint64_t bits_;
+        OracleClass_ classification_;
+    };
+
+    struct RawFinite_ {
+        OracleNat_ significand_;
+        int binaryExponent_;
+        bool negative_;
+    };
+
+    struct Division_ {
+        OracleNat_ quotient_;
+        OracleNat_ remainder_;
+    };
+
+    inline void Trim_(OracleNat_* value) {
+        while (!value->empty() && value->back() == 0)
+            value->pop_back();
+    }
+
+    inline OracleNat_ FromU64_(std::uint64_t value) {
+        OracleNat_ result;
+        while (value != 0) {
+            result.push_back(static_cast<std::uint8_t>(value & 1U));
+            value >>= 1U;
+        }
+        return result;
+    }
+
+    inline std::uint64_t ToU64_(const OracleNat_& value) {
+        std::uint64_t result = 0;
+        for (int bit = static_cast<int>(value.size()) - 1; bit >= 0; --bit)
+            result = (result << 1U) | value[bit];
+        return result;
+    }
+
+    inline int Compare_(const OracleNat_& lhs, const OracleNat_& rhs) {
+        if (lhs.size() != rhs.size())
+            return lhs.size() < rhs.size() ? -1 : 1;
+        for (int bit = static_cast<int>(lhs.size()) - 1; bit >= 0; --bit)
+            if (lhs[bit] != rhs[bit])
+                return lhs[bit] < rhs[bit] ? -1 : 1;
+        return 0;
+    }
+
+    inline OracleNat_ Shift_(const OracleNat_& value, int bits) {
+        if (value.empty())
+            return {};
+        OracleNat_ result(bits, 0);
+        result.insert(result.end(), value.begin(), value.end());
+        return result;
+    }
+
+    inline OracleNat_ Add_(const OracleNat_& lhs, const OracleNat_& rhs) {
+        OracleNat_ result(std::max(lhs.size(), rhs.size()) + 1, 0);
+        std::uint8_t carry = 0;
+        for (int bit = 0; bit < static_cast<int>(result.size()); ++bit) {
+            const std::uint8_t left = bit < static_cast<int>(lhs.size()) ? lhs[bit] : 0;
+            const std::uint8_t right = bit < static_cast<int>(rhs.size()) ? rhs[bit] : 0;
+            const std::uint8_t sum = left + right + carry;
+            result[bit] = sum & 1U;
+            carry = sum >> 1U;
+        }
+        Trim_(&result);
+        return result;
+    }
+
+    inline OracleNat_ Subtract_(const OracleNat_& lhs, const OracleNat_& rhs) {
+        OracleNat_ result(lhs.size(), 0);
+        int borrow = 0;
+        for (int bit = 0; bit < static_cast<int>(lhs.size()); ++bit) {
+            int difference = static_cast<int>(lhs[bit]) - borrow;
+            if (bit < static_cast<int>(rhs.size()))
+                difference -= rhs[bit];
+            if (difference < 0) {
+                difference += 2;
+                borrow = 1;
+            } else {
+                borrow = 0;
+            }
+            result[bit] = static_cast<std::uint8_t>(difference);
+        }
+        Trim_(&result);
+        return result;
+    }
+
+    inline OracleNat_ Multiply_(const OracleNat_& lhs, const OracleNat_& rhs) {
+        OracleNat_ result;
+        for (int bit = 0; bit < static_cast<int>(rhs.size()); ++bit)
+            if (rhs[bit] != 0)
+                result = Add_(result, Shift_(lhs, bit));
+        return result;
+    }
+
+    inline Division_ Divide_(const OracleNat_& numerator, const OracleNat_& denominator) {
+        Division_ result{{}, numerator};
+        if (Compare_(result.remainder_, denominator) < 0)
+            return result;
+        const int maximumShift = static_cast<int>(result.remainder_.size() - denominator.size());
+        result.quotient_.assign(maximumShift + 1, 0);
+        for (int shift = maximumShift; shift >= 0; --shift) {
+            const OracleNat_ shiftedDenominator = Shift_(denominator, shift);
+            if (Compare_(result.remainder_, shiftedDenominator) >= 0) {
+                result.remainder_ = Subtract_(result.remainder_, shiftedDenominator);
+                result.quotient_[shift] = 1;
+            }
+        }
+        Trim_(&result.quotient_);
+        return result;
+    }
+
+    inline RawFinite_ Decode_(std::uint64_t bits) {
+        const std::uint64_t exponent = (bits >> 52U) & 0x7ffU;
+        const std::uint64_t fraction = bits & ((1ULL << 52U) - 1ULL);
+        if (exponent == 0)
+            return {FromU64_(fraction), -1074, (bits >> 63U) != 0};
+        return {FromU64_((1ULL << 52U) | fraction), static_cast<int>(exponent) - 1023 - 52, (bits >> 63U) != 0};
+    }
+
+    inline int FloorLog2Ratio_(const OracleNat_& numerator, const OracleNat_& denominator) {
+        const int initial = static_cast<int>(numerator.size()) - static_cast<int>(denominator.size());
+        if (initial >= 0)
+            return Compare_(numerator, Shift_(denominator, initial)) < 0 ? initial - 1 : initial;
+        return Compare_(Shift_(numerator, -initial), denominator) < 0 ? initial - 1 : initial;
+    }
+
+    inline OracleResult_ Round_(const OracleNat_& numerator, const OracleNat_& denominator, int binaryExponent, bool negative) {
+        int highestExponent = FloorLog2Ratio_(numerator, denominator) + binaryExponent;
+        if (highestExponent >= 1024)
+            return {0, OracleClass_::NON_FINITE};
+        const int unitExponent = highestExponent <= -1023 ? -1074 : highestExponent - 52;
+        const int shift = binaryExponent - unitExponent;
+        const OracleNat_ scaledNumerator = shift >= 0 ? Shift_(numerator, shift) : numerator;
+        const OracleNat_ scaledDenominator = shift >= 0 ? denominator : Shift_(denominator, -shift);
+        Division_ division = Divide_(scaledNumerator, scaledDenominator);
+        const int halfComparison = Compare_(Shift_(division.remainder_, 1), scaledDenominator);
+        std::uint64_t significand = ToU64_(division.quotient_);
+        if (halfComparison > 0 || (halfComparison == 0 && (significand & 1U) != 0))
+            ++significand;
+
+        const std::uint64_t sign = negative ? (1ULL << 63U) : 0;
+        if (significand == 0)
+            return {sign, OracleClass_::FINITE};
+        if (highestExponent <= -1023) {
+            if (significand < (1ULL << 52U))
+                return {sign | significand, OracleClass_::FINITE};
+            return {sign | (1ULL << 52U), OracleClass_::FINITE};
+        }
+        if (significand == (1ULL << 53U)) {
+            significand >>= 1U;
+            ++highestExponent;
+        }
+        if (highestExponent >= 1024)
+            return {0, OracleClass_::NON_FINITE};
+        const std::uint64_t exponent = static_cast<std::uint64_t>(highestExponent + 1023) << 52U;
+        return {sign | exponent | (significand - (1ULL << 52U)), OracleClass_::FINITE};
+    }
+
+    inline OracleResult_ Evaluate_(const OracleInput_& input) {
+        const RawFinite_ value = Decode_(input.valueBits_);
+        const RawFinite_ base = Decode_(input.baseBits_);
+        const bool productNegative = input.alpha_.negative_ != value.negative_;
+        if (value.significand_.empty() && base.significand_.empty()) {
+            const bool negative = productNegative == base.negative_ ? productNegative : false;
+            return {negative ? (1ULL << 63U) : 0, OracleClass_::FINITE};
+        }
+
+        const int productExponent = input.alpha_.binaryExponent_ + value.binaryExponent_;
+        int commonExponent = productExponent;
+        if (value.significand_.empty())
+            commonExponent = base.binaryExponent_;
+        else if (!base.significand_.empty())
+            commonExponent = std::min(productExponent, base.binaryExponent_);
+
+        OracleNat_ positive;
+        OracleNat_ negative;
+        if (!value.significand_.empty()) {
+            OracleNat_ product = Shift_(Multiply_(input.alpha_.numerator_, value.significand_), productExponent - commonExponent);
+            (productNegative ? negative : positive) = std::move(product);
+        }
+        if (!base.significand_.empty()) {
+            const OracleNat_ baseTerm = Shift_(Multiply_(input.alpha_.denominator_, base.significand_), base.binaryExponent_ - commonExponent);
+            if (base.negative_)
+                negative = Add_(negative, baseTerm);
+            else
+                positive = Add_(positive, baseTerm);
+        }
+
+        const int comparison = Compare_(positive, negative);
+        if (comparison == 0)
+            return {0, OracleClass_::FINITE};
+        const OracleNat_ magnitude = comparison > 0 ? Subtract_(positive, negative) : Subtract_(negative, positive);
+        return Round_(magnitude, input.alpha_.denominator_, commonExponent, comparison < 0);
+    }
+} // namespace Dal35OneBitOracle_

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -24,7 +24,9 @@
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/math/matrix/bcg.hpp>
+#define DAL35_ENABLE_TEST_SEAM
 #include <dal/math/matrix/bcg_scaled_alpha.inc>
+#undef DAL35_ENABLE_TEST_SEAM
 #include "dal35_one_bit_oracle.hpp"
 
 namespace {
@@ -665,6 +667,43 @@ namespace {
     };
 #endif
 
+    struct AlphaClassifierObservation_ {
+        BcgScaledAlphaPrivate_::AlphaPlan_ plan_;
+        int legacyConversionCalls_;
+        unsigned entryMxcsr_;
+        unsigned exitMxcsr_;
+        std::array<std::uint64_t, 6> comparableBits_;
+    };
+
+    AlphaClassifierObservation_ ObserveAlphaClassification(const BcgScaledAlphaPrivate_::StoredScaledBits_& numerator,
+                                                           const BcgScaledAlphaPrivate_::StoredScaledBits_& denominator,
+                                                           bool flushToZero) {
+        AlphaClassifierObservation_ result{};
+#if defined(__SSE2__) || defined(_M_X64)
+        MxcsrRestore_ restore;
+        const unsigned configured =
+            (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+        _mm_setcsr(configured);
+        result.entryMxcsr_ = _mm_getcsr();
+#else
+        (void)flushToZero;
+#endif
+        result.plan_ =
+            BcgScaledAlphaPrivate_::ClassifyAlphaAndInvokeLegacy_(numerator, denominator, [&result]() { ++result.legacyConversionCalls_; });
+#if defined(__SSE2__) || defined(_M_X64)
+        result.exitMxcsr_ = _mm_getcsr();
+#endif
+        result.comparableBits_ = {
+            result.plan_.exact_.numerator_,
+            result.plan_.exact_.denominator_,
+            static_cast<std::uint64_t>(static_cast<std::int64_t>(result.plan_.exact_.binaryExponent_)),
+            static_cast<std::uint64_t>(result.plan_.exact_.negative_),
+            static_cast<std::uint64_t>(result.plan_.path_),
+            static_cast<std::uint64_t>(result.legacyConversionCalls_),
+        };
+        return result;
+    }
+
     void AssertBCGIdentityInitialClassification(const Vector_<>& b, const Vector_<>& requestedResidual, double tolRel, double tolAbs) {
         Vector_<> x = {b[0] - requestedResidual[0], b[1] - requestedResidual[1]};
         const Vector_<> entry = x;
@@ -702,11 +741,14 @@ namespace {
     const char* SolverName(bool biConjugate) { return biConjugate ? "BCGSolve" : "CGSolve"; }
 
     struct ScaledAlphaObservation_ {
-        std::uint64_t resultBits_;
-        std::uint64_t directResidualBits_;
-        BcgScaledAlphaPrivate_::CandidateSubject_ evidenceSubject_;
-        int evidenceIndex_;
-        int commitCount_;
+        std::uint64_t resultBits_ = 0;
+        std::uint64_t directResidualBits_ = 0;
+        BcgScaledAlphaPrivate_::CandidateSubject_ evidenceSubject_ = BcgScaledAlphaPrivate_::CandidateSubject_::NONE;
+        int evidenceIndex_ = -1;
+        int commitCount_ = 0;
+        int confirmationCount_ = 0;
+        std::uint64_t confirmationInputBits_ = 0x7ff8000000000001ULL;
+        std::uint64_t confirmationOutputBits_ = 0x7ff8000000000002ULL;
         CallbackCounts_ counts_;
         std::vector<std::uint64_t> callbackBits_;
     };
@@ -734,6 +776,11 @@ namespace {
             (*output)[0] = diagonal * input[0];
             if (call == 2)
                 operatorDirection = (*output)[0];
+            if (call == 3) {
+                ++result.confirmationCount_;
+                result.confirmationInputBits_ = DoubleBits(input[0]);
+                result.confirmationOutputBits_ = DoubleBits((*output)[0]);
+            }
             RecordCallback(1, call, input[0], (*output)[0], &result.callbackBits_);
             return true;
         });
@@ -791,6 +838,108 @@ namespace {
         result.commitCount_ = &x[0] == entryStorage ? 0 : 1;
         return result;
     }
+
+    struct OrdinaryCandidateObservation_ {
+        std::uint64_t coefficientBits_ = 0;
+        std::array<std::uint64_t, 2> directionBits_{};
+        std::array<std::uint64_t, 2> operatorDirectionBits_{};
+        std::array<std::uint64_t, 2> xCandidateBits_{};
+        std::array<std::uint64_t, 2> residualCandidateBits_{};
+        std::array<std::uint64_t, 2> shadowCandidateBits_{};
+        std::array<std::uint64_t, 2> finalBits_{};
+        CallbackCounts_ counts_;
+        int commitCount_ = 0;
+        bool callbackException_ = false;
+    };
+
+    OrdinaryCandidateObservation_ ObserveOrdinaryCandidateCommit(bool biConjugate) {
+        OrdinaryCandidateObservation_ result;
+        HookedPreconditionedDiagonal_ matrix({1.0, 2.25}, &result.counts_);
+        matrix.SetLeftHook([&result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = input[0];
+            (*output)[1] = 2.25 * input[1];
+            if (call == 2) {
+                result.directionBits_ = {DoubleBits(input[0]), DoubleBits(input[1])};
+                result.operatorDirectionBits_ = {DoubleBits((*output)[0]), DoubleBits((*output)[1])};
+            }
+            return true;
+        });
+        matrix.SetRightHook([](int, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = input[0];
+            (*output)[1] = 2.25 * input[1];
+            return true;
+        });
+        matrix.SetPreconditionerLeftHook([biConjugate, &result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = input[0];
+            (*output)[1] = input[1];
+            if (call == 2) {
+                result.residualCandidateBits_ = {DoubleBits(input[0]), DoubleBits(input[1])};
+                if (!biConjugate)
+                    throw CallbackSentinel_();
+            }
+            return true;
+        });
+        matrix.SetPreconditionerRightHook([&result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = input[0];
+            (*output)[1] = input[1];
+            if (call == 2) {
+                result.shadowCandidateBits_ = {DoubleBits(input[0]), DoubleBits(input[1])};
+                throw CallbackSentinel_();
+            }
+            return true;
+        });
+        const Vector_<> b = {1.0, 2.0};
+        Vector_<> x = {0.0, 0.0};
+        const double* const entryStorage = &x[0];
+        try {
+            RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 3, &x);
+        } catch (const CallbackSentinel_&) {
+            result.callbackException_ = true;
+        }
+        result.commitCount_ = &x[0] == entryStorage ? 0 : 1;
+        result.xCandidateBits_ = {DoubleBits(x[0]), DoubleBits(x[1])};
+        result.finalBits_ = result.xCandidateBits_;
+        result.coefficientBits_ = result.xCandidateBits_[0];
+        return result;
+    }
+
+#if defined(__SSE2__) || defined(_M_X64)
+    struct OrdinaryFpStatusObservation_ {
+        unsigned entryStatus_;
+        unsigned exitStatus_;
+        std::uint64_t resultBits_;
+        int commitCount_;
+        std::string failureMessage_;
+    };
+
+    OrdinaryFpStatusObservation_ ObserveOrdinaryFpStatus(bool biConjugate, unsigned entryStatus, bool overflowCandidate) {
+        MxcsrRestore_ restore;
+        const unsigned statusMask = _MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW;
+        _mm_setcsr((_mm_getcsr() & ~statusMask) | entryStatus);
+        OrdinaryFpStatusObservation_ result{_mm_getcsr(), 0, 0, 0, {}};
+        CallbackCounts_ counts;
+        const double diagonal = overflowCandidate ? std::ldexp(1.0, -1000) : 2.0;
+        HookedPreconditionedDiagonal_ matrix({diagonal}, &counts);
+        const auto preconditioner = [](int, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = input[0];
+            return true;
+        };
+        matrix.SetPreconditionerLeftHook(preconditioner);
+        matrix.SetPreconditionerRightHook(preconditioner);
+        const Vector_<> b = {overflowCandidate ? std::ldexp(1.0, 100) : 6.0};
+        Vector_<> x = {0.0};
+        const double* const entryStorage = &x[0];
+        try {
+            RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x);
+        } catch (const Exception_& exception) {
+            result.failureMessage_ = exception.what();
+        }
+        result.exitStatus_ = _mm_getcsr();
+        result.resultBits_ = DoubleBits(x[0]);
+        result.commitCount_ = &x[0] == entryStorage ? 0 : 1;
+        return result;
+    }
+#endif
 
     struct AllocationObservation_ {
         std::size_t count_;
@@ -1568,23 +1717,30 @@ TEST(MatrixTest, TestScaledAlphaBoundsAndClassifierMatrix) {
                 numerator.mantissaBits_ ^= 0x8000000000000000ULL;
             if (signCase == 2)
                 denominator.mantissaBits_ ^= 0x8000000000000000ULL;
+            AlphaClassifierObservation_ observations[2];
 #if defined(__SSE2__) || defined(_M_X64)
-            MxcsrRestore_ restore;
-            const unsigned before = _mm_getcsr();
+            const int modeCount = 2;
+#else
+            const int modeCount = 1;
 #endif
-            int legacyConversionCalls = 0;
-            const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ClassifyAlphaAndInvokeLegacy_(
-                numerator, denominator, [&legacyConversionCalls]() { ++legacyConversionCalls; });
+            for (int mode = 0; mode < modeCount; ++mode) {
+                const bool flushToZero = mode != 0;
+                observations[mode] = ObserveAlphaClassification(numerator, denominator, flushToZero);
 #if defined(__SSE2__) || defined(_M_X64)
-            const unsigned after = _mm_getcsr();
-            ASSERT_EQ(before, after);
+                const unsigned expectedMode = flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
+                ASSERT_EQ(expectedMode, observations[mode].entryMxcsr_ & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
+                ASSERT_EQ(observations[mode].entryMxcsr_, observations[mode].exitMxcsr_);
 #endif
-            ASSERT_EQ(row.expectedNumerator_, plan.exact_.numerator_);
-            ASSERT_EQ(row.expectedDenominator_, plan.exact_.denominator_);
-            ASSERT_EQ(row.expectedExponent_, plan.exact_.binaryExponent_);
-            ASSERT_EQ(signCase != 0, plan.exact_.negative_);
-            ASSERT_EQ(row.expectedPath_, plan.path_);
-            ASSERT_EQ(row.expectedPath_ == AlphaPath_::ORDINARY_NORMAL ? 1 : 0, legacyConversionCalls);
+                ASSERT_EQ(row.expectedNumerator_, observations[mode].plan_.exact_.numerator_);
+                ASSERT_EQ(row.expectedDenominator_, observations[mode].plan_.exact_.denominator_);
+                ASSERT_EQ(row.expectedExponent_, observations[mode].plan_.exact_.binaryExponent_);
+                ASSERT_EQ(signCase != 0, observations[mode].plan_.exact_.negative_);
+                ASSERT_EQ(row.expectedPath_, observations[mode].plan_.path_);
+                ASSERT_EQ(row.expectedPath_ == AlphaPath_::ORDINARY_NORMAL ? 1 : 0, observations[mode].legacyConversionCalls_);
+            }
+#if defined(__SSE2__) || defined(_M_X64)
+            ASSERT_EQ(observations[0].comparableBits_, observations[1].comparableBits_);
+#endif
         }
     }
 
@@ -1922,23 +2078,50 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
         double initial_;
         std::uint64_t expectedBits_;
         BcgScaledAlphaPrivate_::ExactAlpha_ exactAlpha_;
+        std::uint64_t expectedRhsBits_;
+        std::array<std::uint64_t, 16> cgCallbacks_;
+        std::array<std::uint64_t, 24> bcgCallbacks_;
     };
     const std::array<SolverFtzRow_, 3> rows = {{
-        {"S3", std::ldexp(1.0, 500), std::ldexp(1.0, 1023), std::ldexp(1.0, -574), 0.0, 0x0000000000000001ULL, {1, 1, -1523, false}},
+        {"S3",
+         std::ldexp(1.0, 500),
+         std::ldexp(1.0, 1023),
+         std::ldexp(1.0, -574),
+         0.0,
+         0x0000000000000001ULL,
+         {1, 1, -1523, false},
+         0x1c10000000000000ULL,
+         {1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x1c10000000000000ULL, 0x5c00000000000000ULL, 1, 2, 0x5c00000000000000ULL,
+          0x7b40000000000000ULL, 1, 3, 0x0000000000000001ULL, 0x1c10000000000000ULL},
+         {1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x1c10000000000000ULL, 0x5c00000000000000ULL,
+          4, 1, 0x1c10000000000000ULL, 0x5c00000000000000ULL, 1, 2, 0x5c00000000000000ULL, 0x7b40000000000000ULL,
+          2, 1, 0x5c00000000000000ULL, 0x7b40000000000000ULL, 1, 3, 0x0000000000000001ULL, 0x1c10000000000000ULL}},
         {"S5+",
          std::ldexp(1.0, 500),
          std::ldexp(1.0, 600),
          std::ldexp(1.0, -574),
          std::ldexp(1.0, -1022),
          0x0000000000000001ULL,
-         {1, 1, -1100, false}},
+         {1, 1, -1100, false},
+         0x1c10000000000000ULL,
+         {1, 1, 0x0010000000000000ULL, 0x1f50000000000000ULL, 3, 1, 0x9f4ffffffffffffeULL, 0xc4cffffffffffffeULL, 1, 2, 0xc4cffffffffffffeULL,
+          0xe40ffffffffffffeULL, 1, 3, 0x0000000000000001ULL, 0x1c10000000000000ULL},
+         {1, 1, 0x0010000000000000ULL, 0x1f50000000000000ULL, 3, 1, 0x9f4ffffffffffffeULL, 0xc4cffffffffffffeULL,
+          4, 1, 0x9f4ffffffffffffeULL, 0xc4cffffffffffffeULL, 1, 2, 0xc4cffffffffffffeULL, 0xe40ffffffffffffeULL,
+          2, 1, 0xc4cffffffffffffeULL, 0xe40ffffffffffffeULL, 1, 3, 0x0000000000000001ULL, 0x1c10000000000000ULL}},
         {"S5-",
          std::ldexp(1.0, 500),
          std::ldexp(1.0, 600),
          -std::ldexp(1.0, -574),
          -std::ldexp(1.0, -1022),
          0x8000000000000001ULL,
-         {1, 1, -1100, false}},
+         {1, 1, -1100, false},
+         0x9c10000000000000ULL,
+         {1, 1, 0x8010000000000000ULL, 0x9f50000000000000ULL, 3, 1, 0x1f4ffffffffffffeULL, 0x44cffffffffffffeULL, 1, 2, 0x44cffffffffffffeULL,
+          0x640ffffffffffffeULL, 1, 3, 0x8000000000000001ULL, 0x9c10000000000000ULL},
+         {1, 1, 0x8010000000000000ULL, 0x9f50000000000000ULL, 3, 1, 0x1f4ffffffffffffeULL, 0x44cffffffffffffeULL,
+          4, 1, 0x1f4ffffffffffffeULL, 0x44cffffffffffffeULL, 1, 2, 0x44cffffffffffffeULL, 0x640ffffffffffffeULL,
+          2, 1, 0x44cffffffffffffeULL, 0x640ffffffffffffeULL, 1, 3, 0x8000000000000001ULL, 0x9c10000000000000ULL}},
     }};
     for (const bool biConjugate : {false, true}) {
         for (const SolverFtzRow_& row : rows) {
@@ -1953,7 +2136,23 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
                 observations[flushToZero ? 1 : 0] =
                     ObserveScaledAlphaSolve(biConjugate, row.diagonal_, row.preconditioner_, row.rhs_, row.initial_, &row.exactAlpha_);
                 const unsigned after = _mm_getcsr();
+                ASSERT_EQ(flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF, before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
                 ASSERT_EQ(before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK), after & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
+                const ScaledAlphaObservation_& observation = observations[flushToZero ? 1 : 0];
+                const CallbackCounts_ expectedCounts = biConjugate ? CallbackCounts_{3, 1, 1, 1} : CallbackCounts_{3, 0, 1, 0};
+                const std::vector<std::uint64_t> expectedCallbacks =
+                    biConjugate ? std::vector<std::uint64_t>(row.bcgCallbacks_.begin(), row.bcgCallbacks_.end())
+                                : std::vector<std::uint64_t>(row.cgCallbacks_.begin(), row.cgCallbacks_.end());
+                ASSERT_EQ(row.expectedBits_, observation.resultBits_);
+                ASSERT_EQ(0x0000000000000000ULL, observation.directResidualBits_);
+                ASSERT_EQ(BcgScaledAlphaPrivate_::CandidateSubject_::NONE, observation.evidenceSubject_);
+                ASSERT_EQ(-1, observation.evidenceIndex_);
+                ASSERT_EQ(1, observation.commitCount_);
+                ASSERT_EQ(1, observation.confirmationCount_);
+                ASSERT_EQ(row.expectedBits_, observation.confirmationInputBits_);
+                ASSERT_EQ(row.expectedRhsBits_, observation.confirmationOutputBits_);
+                ASSERT_EQ(expectedCallbacks, observation.callbackBits_);
+                AssertCallbackCounts(expectedCounts, observation.counts_);
             }
             ASSERT_EQ(row.expectedBits_, observations[0].resultBits_);
             ASSERT_EQ(0x0000000000000000ULL, observations[0].directResidualBits_);
@@ -1973,13 +2172,25 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
 #endif
 
 TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
-    const BcgScaledAlphaPrivate_::AlphaPlan_ plan =
-        BcgScaledAlphaPrivate_::ClassifyAlpha_({0x4042000000000000ULL, 0, false}, {0x4052000000000000ULL, 0, false});
+    int legacyPathEntries = 0;
+    int exactPathEntries = 0;
+    int exactWorkspaceConstructions = 0;
+    const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ObserveAlphaDispatchForTest_(
+        {0x4042000000000000ULL, 0, false}, {0x4052000000000000ULL, 0, false}, [&legacyPathEntries]() { ++legacyPathEntries; },
+        [&exactPathEntries, &exactWorkspaceConstructions](const BcgScaledAlphaPrivate_::ExactAlpha_&) {
+            ++exactPathEntries;
+            BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+            ++exactWorkspaceConstructions;
+            AssertCanonicalWorkspace(workspace);
+        });
     ASSERT_EQ(BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL, plan.path_);
     ASSERT_EQ(1U, plan.exact_.numerator_);
     ASSERT_EQ(1U, plan.exact_.denominator_);
     ASSERT_EQ(-1, plan.exact_.binaryExponent_);
     ASSERT_FALSE(plan.exact_.negative_);
+    ASSERT_EQ(1, legacyPathEntries);
+    ASSERT_EQ(0, exactPathEntries);
+    ASSERT_EQ(0, exactWorkspaceConstructions);
 
     const std::vector<std::uint64_t> cgCallbacks = {
         1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x4018000000000000ULL, 0x4018000000000000ULL,
@@ -1990,6 +2201,18 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
         2, 1, 0x4018000000000000ULL, 0x4028000000000000ULL, 1, 3, 0x4008000000000000ULL, 0x4018000000000000ULL};
     for (const bool biConjugate : {false, true}) {
         SCOPED_TRACE(SolverName(biConjugate));
+        const OrdinaryCandidateObservation_ candidateObservation = ObserveOrdinaryCandidateCommit(biConjugate);
+        ASSERT_TRUE(candidateObservation.callbackException_);
+        ASSERT_EQ(1, candidateObservation.commitCount_);
+        ASSERT_EQ(0x3fe0000000000000ULL, candidateObservation.coefficientBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3ff0000000000000ULL, 0x4000000000000000ULL}), candidateObservation.directionBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3ff0000000000000ULL, 0x4012000000000000ULL}), candidateObservation.operatorDirectionBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0x3ff0000000000000ULL}), candidateObservation.xCandidateBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0xbfd0000000000000ULL}), candidateObservation.residualCandidateBits_);
+        if (biConjugate)
+            ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0xbfd0000000000000ULL}), candidateObservation.shadowCandidateBits_);
+        ASSERT_EQ(candidateObservation.xCandidateBits_, candidateObservation.finalBits_);
+        AssertCallbackCounts(biConjugate ? CallbackCounts_{2, 1, 2, 2} : CallbackCounts_{2, 0, 2, 0}, candidateObservation.counts_);
 #if defined(__SSE2__) || defined(_M_X64)
         MxcsrRestore_ restore;
         const unsigned statusMask = _MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW;
@@ -2009,6 +2232,35 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
         ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.preconditionerRight_);
     }
 }
+
+#if defined(__SSE2__) || defined(_M_X64)
+TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaFpStatus) {
+    const unsigned statusMask = _MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW;
+    for (const bool biConjugate : {false, true}) {
+        for (const unsigned entryStatus : {0U, static_cast<unsigned>(_MM_EXCEPT_INVALID), static_cast<unsigned>(_MM_EXCEPT_OVERFLOW),
+                                           static_cast<unsigned>(_MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW)}) {
+            SCOPED_TRACE(std::string(SolverName(biConjugate)) + " success status=" + std::to_string(entryStatus));
+            const OrdinaryFpStatusObservation_ observation = ObserveOrdinaryFpStatus(biConjugate, entryStatus, false);
+            ASSERT_EQ(entryStatus, observation.entryStatus_ & statusMask);
+            ASSERT_EQ(entryStatus, observation.exitStatus_ & statusMask);
+            ASSERT_EQ(0x4008000000000000ULL, observation.resultBits_);
+            ASSERT_EQ(1, observation.commitCount_);
+            ASSERT_TRUE(observation.failureMessage_.empty());
+        }
+        for (const unsigned entryStatus : {0U, static_cast<unsigned>(_MM_EXCEPT_INVALID)}) {
+            SCOPED_TRACE(std::string(SolverName(biConjugate)) + " overflow status=" + std::to_string(entryStatus));
+            const OrdinaryFpStatusObservation_ observation = ObserveOrdinaryFpStatus(biConjugate, entryStatus, true);
+            ASSERT_EQ(entryStatus, observation.entryStatus_ & statusMask);
+            ASSERT_EQ(entryStatus | static_cast<unsigned>(_MM_EXCEPT_OVERFLOW), observation.exitStatus_ & statusMask);
+            ASSERT_EQ(0x0000000000000000ULL, observation.resultBits_);
+            ASSERT_EQ(0, observation.commitCount_);
+            ASSERT_NE(std::string::npos, observation.failureMessage_.find(SolverName(biConjugate)));
+            ASSERT_NE(std::string::npos, observation.failureMessage_.find("numerical breakdown"));
+            ASSERT_NE(std::string::npos, observation.failureMessage_.find("candidate x"));
+        }
+    }
+}
+#endif
 
 TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaAddsNoHeapAllocations) {
     for (const bool biConjugate : {false, true}) {

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -1139,6 +1139,271 @@ namespace {
         AssertCallbackFaultResult(biConjugate, site, fault, solve, x);
         AssertCallbackCounts(ExpectedCallbackFaultCounts(biConjugate, site), counts);
     }
+
+    struct ClassifierRow_ {
+        const char* id_;
+        BcgScaledAlphaPrivate_::StoredScaledBits_ numerator_;
+        BcgScaledAlphaPrivate_::StoredScaledBits_ denominator_;
+        std::uint64_t expectedNumerator_;
+        std::uint64_t expectedDenominator_;
+        int expectedExponent_;
+        BcgScaledAlphaPrivate_::AlphaPath_ expectedPath_;
+    };
+
+    const std::array<ClassifierRow_, 12>& ClassifierRows() {
+        using BcgScaledAlphaPrivate_::AlphaPath_;
+        using BcgScaledAlphaPrivate_::StoredScaledBits_;
+        const StoredScaledBits_ unit{0x3fe0000000000000ULL, 1, true};
+        static const std::array<ClassifierRow_, 12> rows = {{
+            {"C1", {0x3fe0000000000000ULL, -1074, true}, unit, 1, 1, -1075, AlphaPath_::SCALED_EXACT},
+            {"C2", {0x3fe0000000000000ULL, -1073, true}, unit, 1, 1, -1074, AlphaPath_::SCALED_EXACT},
+            {"C3", {0x3feffffffffffffeULL, -1022, true}, unit, 4503599627370495ULL, 2251799813685248ULL, -1023, AlphaPath_::SCALED_EXACT},
+            {"C4", {0x3fe0000000000000ULL, -1021, true}, unit, 1, 1, -1022, AlphaPath_::ORDINARY_NORMAL},
+            {"C5", {0x3fe0000000000000ULL, 1024, true}, unit, 1, 1, 1023, AlphaPath_::ORDINARY_NORMAL},
+            {"C6", {0x3fefffffffffffffULL, 1024, true}, unit, 9007199254740991ULL, 4503599627370496ULL, 1023, AlphaPath_::ORDINARY_NORMAL},
+            {"C7",
+             {0x3fefffffffffffffULL, 1025, true},
+             {0x3feffffffffffffeULL, 1, true},
+             9007199254740991ULL,
+             9007199254740990ULL,
+             1024,
+             AlphaPath_::SCALED_EXACT},
+            {"C8", {0x0000000000000001ULL, 0, false}, {0x0000000000000001ULL, 0, false}, 1, 1, 0, AlphaPath_::SCALED_EXACT},
+            {"C9a", {0x3fe0000000000000ULL, 1025, true}, unit, 1, 1, 1024, AlphaPath_::SCALED_EXACT},
+            {"C9b", {0x3fe0000000000000ULL, 1026, true}, unit, 1, 1, 1025, AlphaPath_::SCALED_EXACT},
+            {"C10", {0x3fe0000000000000ULL, 1101, true}, unit, 1, 1, 1100, AlphaPath_::SCALED_EXACT},
+            {"C11", {0x3fe0000000000000ULL, -1099, true}, unit, 1, 1, -1100, AlphaPath_::SCALED_EXACT},
+        }};
+        return rows;
+    }
+
+    void AssertClassifierObservation(const ClassifierRow_& row,
+                                     int signCase,
+                                     const BcgScaledAlphaPrivate_::StoredScaledBits_& numerator,
+                                     const BcgScaledAlphaPrivate_::StoredScaledBits_& denominator,
+                                     bool flushToZero,
+                                     AlphaClassifierObservation_* observation) {
+        using BcgScaledAlphaPrivate_::AlphaPath_;
+        *observation = ObserveAlphaClassification(numerator, denominator, flushToZero);
+#if defined(__SSE2__) || defined(_M_X64)
+        const unsigned expectedMode = flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
+        ASSERT_EQ(expectedMode, observation->entryMxcsr_ & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
+        ASSERT_EQ(observation->entryMxcsr_, observation->exitMxcsr_);
+#endif
+        ASSERT_EQ(row.expectedNumerator_, observation->plan_.exact_.numerator_);
+        ASSERT_EQ(row.expectedDenominator_, observation->plan_.exact_.denominator_);
+        ASSERT_EQ(row.expectedExponent_, observation->plan_.exact_.binaryExponent_);
+        ASSERT_EQ(signCase != 0, observation->plan_.exact_.negative_);
+        ASSERT_EQ(row.expectedPath_, observation->plan_.path_);
+        ASSERT_EQ(row.expectedPath_ == AlphaPath_::ORDINARY_NORMAL ? 1 : 0, observation->legacyConversionCalls_);
+    }
+
+    void AssertClassifierRowSign(const ClassifierRow_& row, int signCase) {
+        BcgScaledAlphaPrivate_::StoredScaledBits_ numerator = row.numerator_;
+        BcgScaledAlphaPrivate_::StoredScaledBits_ denominator = row.denominator_;
+        if (signCase == 1)
+            numerator.mantissaBits_ ^= 0x8000000000000000ULL;
+        if (signCase == 2)
+            denominator.mantissaBits_ ^= 0x8000000000000000ULL;
+        AlphaClassifierObservation_ withoutFtz{};
+        AssertClassifierObservation(row, signCase, numerator, denominator, false, &withoutFtz);
+#if defined(__SSE2__) || defined(_M_X64)
+        AlphaClassifierObservation_ withFtz{};
+        AssertClassifierObservation(row, signCase, numerator, denominator, true, &withFtz);
+        ASSERT_EQ(withoutFtz.comparableBits_, withFtz.comparableBits_);
+#endif
+    }
+
+    void AssertClassifierMatrix() {
+        for (const ClassifierRow_& row : ClassifierRows())
+            for (const int signCase : {0, 1, 2}) {
+                SCOPED_TRACE(std::string(row.id_) + " sign=" + std::to_string(signCase));
+                AssertClassifierRowSign(row, signCase);
+            }
+    }
+
+    void AssertEvaluatorOracle(const EvaluatorRow_& row) {
+        const Dal35OneBitOracle_::OracleResult_ oracle = Dal35OneBitOracle_::Evaluate_(OracleInput(row.alpha_, row.valueBits_, row.baseBits_));
+        const Dal35OneBitOracle_::OracleClass_ expectedOracleClass = row.expectedClass_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE
+                                                                         ? Dal35OneBitOracle_::OracleClass_::FINITE
+                                                                         : Dal35OneBitOracle_::OracleClass_::NON_FINITE;
+        ASSERT_EQ(expectedOracleClass, oracle.classification_);
+        if (oracle.classification_ == Dal35OneBitOracle_::OracleClass_::FINITE)
+            ASSERT_EQ(row.expectedBits_, oracle.bits_);
+    }
+
+    void ObserveEvaluatorMode(const EvaluatorRow_& row, bool flushToZero, BcgScaledAlphaPrivate_::RoundedBinary64_* result) {
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+#if defined(__SSE2__) || defined(_M_X64)
+        MxcsrRestore_ restore;
+        const unsigned configured =
+            (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+        _mm_setcsr(configured);
+        const unsigned before = _mm_getcsr();
+#else
+        (void)flushToZero;
+#endif
+        *result = BcgScaledAlphaPrivate_::EvaluateElement_(row.alpha_, row.valueBits_, row.baseBits_, &workspace);
+#if defined(__SSE2__) || defined(_M_X64)
+        ASSERT_EQ(before, _mm_getcsr());
+#endif
+        ASSERT_EQ(row.expectedClass_, result->classification_);
+        std::uint64_t destination = 0x3fd5555555555555ULL;
+        if (result->classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
+            destination = result->bits_;
+        ASSERT_EQ(row.expectedClass_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE ? row.expectedBits_ : 0x3fd5555555555555ULL, destination);
+        AssertCanonicalWorkspace(workspace);
+    }
+
+    void AssertEvaluatorRow(const EvaluatorRow_& row) {
+        AssertEvaluatorOracle(row);
+        BcgScaledAlphaPrivate_::RoundedBinary64_ withoutFtz{};
+        ObserveEvaluatorMode(row, false, &withoutFtz);
+#if defined(__SSE2__) || defined(_M_X64)
+        BcgScaledAlphaPrivate_::RoundedBinary64_ withFtz{};
+        ObserveEvaluatorMode(row, true, &withFtz);
+        ASSERT_EQ(withoutFtz.classification_, withFtz.classification_);
+        if (withFtz.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
+            ASSERT_EQ(withoutFtz.bits_, withFtz.bits_);
+#endif
+    }
+
+    void ConfigureResidualOverflowMatrix(bool shadowFailure, HookedPreconditionedDiagonal_* matrix) {
+        const double minimumSubnormal = DoubleFromBits(0x0000000000000001ULL);
+        matrix->SetLeftHook([minimumSubnormal, shadowFailure](int call, const Vector_<>&, Vector_<>* output) {
+            if (call == 1) {
+                (*output)[0] = 0.0;
+                (*output)[1] = 0.0;
+            } else {
+                (*output)[0] = shadowFailure ? 0.0 : 1.0;
+                (*output)[1] = minimumSubnormal;
+            }
+            return true;
+        });
+        matrix->SetRightHook([minimumSubnormal](int, const Vector_<>&, Vector_<>* output) {
+            (*output)[0] = 1.0;
+            (*output)[1] = minimumSubnormal;
+            return true;
+        });
+        const auto preconditioner = [minimumSubnormal](int, const Vector_<>&, Vector_<>* output) {
+            (*output)[0] = 0.0;
+            (*output)[1] = minimumSubnormal;
+            return true;
+        };
+        matrix->SetPreconditionerLeftHook(preconditioner);
+        matrix->SetPreconditionerRightHook(preconditioner);
+    }
+
+    void AssertResidualOrShadowOverflow(bool biConjugate, bool shadowFailure) {
+        SCOPED_TRACE(std::string(SolverName(biConjugate)) + (shadowFailure ? " shadow" : " residual"));
+        const double maximumFinite = DoubleFromBits(0x7fefffffffffffffULL);
+        const Vector_<> b = {1.0, maximumFinite};
+        CallbackCounts_ counts;
+        HookedPreconditionedDiagonal_ matrix({1.0, 1.0}, &counts);
+        ConfigureResidualOverflowMatrix(shadowFailure, &matrix);
+        Vector_<> x = {0.0, 0.0};
+        const double* const entryStorage = &x[0];
+
+        AssertDalExceptionContains(
+            [&]() { RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x); },
+            {SolverName(biConjugate), "numerical breakdown", shadowFailure ? "candidate shadow residual" : "candidate residual"});
+
+        ASSERT_EQ(0, &x[0] == entryStorage ? 0 : 1);
+        ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[0]));
+        ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[1]));
+        AssertCallbackCounts(biConjugate ? CallbackCounts_{2, 1, 1, 1} : CallbackCounts_{2, 0, 1, 0}, counts);
+    }
+
+#if defined(__SSE2__) || defined(_M_X64)
+    template <class Row_> void AssertSolverFtzMode(bool biConjugate, const Row_& row, bool flushToZero, ScaledAlphaObservation_* observation) {
+        MxcsrRestore_ restore;
+        const unsigned configured =
+            (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+        _mm_setcsr(configured);
+        const unsigned before = _mm_getcsr();
+        *observation = ObserveScaledAlphaSolve(biConjugate, row.diagonal_, row.preconditioner_, row.rhs_, row.initial_, &row.exactAlpha_);
+        const unsigned after = _mm_getcsr();
+        ASSERT_EQ(flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF, before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
+        ASSERT_EQ(before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK), after & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
+        const CallbackCounts_ expectedCounts = biConjugate ? CallbackCounts_{3, 1, 1, 1} : CallbackCounts_{3, 0, 1, 0};
+        const std::vector<std::uint64_t> expectedCallbacks = biConjugate
+                                                                 ? std::vector<std::uint64_t>(row.bcgCallbacks_.begin(), row.bcgCallbacks_.end())
+                                                                 : std::vector<std::uint64_t>(row.cgCallbacks_.begin(), row.cgCallbacks_.end());
+        ASSERT_EQ(row.expectedBits_, observation->resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, observation->directResidualBits_);
+        ASSERT_EQ(BcgScaledAlphaPrivate_::CandidateSubject_::NONE, observation->evidenceSubject_);
+        ASSERT_EQ(-1, observation->evidenceIndex_);
+        ASSERT_EQ(1, observation->commitCount_);
+        ASSERT_EQ(1, observation->confirmationCount_);
+        ASSERT_EQ(row.expectedBits_, observation->confirmationInputBits_);
+        ASSERT_EQ(row.expectedRhsBits_, observation->confirmationOutputBits_);
+        ASSERT_EQ(expectedCallbacks, observation->callbackBits_);
+        AssertCallbackCounts(expectedCounts, observation->counts_);
+    }
+
+    template <class Row_> void AssertSolverFtzRow(bool biConjugate, const Row_& row) {
+        SCOPED_TRACE(std::string(SolverName(biConjugate)) + " " + row.id_);
+        ScaledAlphaObservation_ observations[2];
+        for (const bool flushToZero : {false, true})
+            AssertSolverFtzMode(biConjugate, row, flushToZero, &observations[flushToZero ? 1 : 0]);
+        ASSERT_EQ(row.expectedBits_, observations[0].resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, observations[0].directResidualBits_);
+        ASSERT_EQ(BcgScaledAlphaPrivate_::CandidateSubject_::NONE, observations[0].evidenceSubject_);
+        ASSERT_EQ(-1, observations[0].evidenceIndex_);
+        ASSERT_EQ(1, observations[0].commitCount_);
+        ASSERT_EQ(observations[0].resultBits_, observations[1].resultBits_);
+        ASSERT_EQ(observations[0].directResidualBits_, observations[1].directResidualBits_);
+        ASSERT_EQ(observations[0].evidenceSubject_, observations[1].evidenceSubject_);
+        ASSERT_EQ(observations[0].evidenceIndex_, observations[1].evidenceIndex_);
+        ASSERT_EQ(observations[0].commitCount_, observations[1].commitCount_);
+        ASSERT_EQ(observations[0].callbackBits_, observations[1].callbackBits_);
+        AssertCallbackCounts(observations[0].counts_, observations[1].counts_);
+    }
+
+    template <class Rows_> void AssertSolverFtzRows(const Rows_& rows) {
+        for (const bool biConjugate : {false, true})
+            for (const auto& row : rows)
+                AssertSolverFtzRow(biConjugate, row);
+    }
+#endif
+
+    void AssertOrdinaryCandidateCorpus(bool biConjugate) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        const OrdinaryCandidateObservation_ observation = ObserveOrdinaryCandidateCommit(biConjugate);
+        ASSERT_TRUE(observation.callbackException_);
+        ASSERT_EQ(1, observation.commitCount_);
+        ASSERT_EQ(0x3fe0000000000000ULL, observation.coefficientBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3ff0000000000000ULL, 0x4000000000000000ULL}), observation.directionBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3ff0000000000000ULL, 0x4012000000000000ULL}), observation.operatorDirectionBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0x3ff0000000000000ULL}), observation.xCandidateBits_);
+        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0xbfd0000000000000ULL}), observation.residualCandidateBits_);
+        if (biConjugate)
+            ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0xbfd0000000000000ULL}), observation.shadowCandidateBits_);
+        ASSERT_EQ(observation.xCandidateBits_, observation.finalBits_);
+        AssertCallbackCounts(biConjugate ? CallbackCounts_{2, 1, 2, 2} : CallbackCounts_{2, 0, 2, 0}, observation.counts_);
+    }
+
+    void AssertOrdinarySolveCorpus(bool biConjugate, const std::vector<std::uint64_t>& cgCallbacks, const std::vector<std::uint64_t>& bcgCallbacks) {
+#if defined(__SSE2__) || defined(_M_X64)
+        MxcsrRestore_ restore;
+        const unsigned statusMask = _MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW;
+        const unsigned configured = _mm_getcsr() | statusMask;
+        _mm_setcsr(configured);
+#endif
+        const ScaledAlphaObservation_ observation = ObserveScaledAlphaSolve(biConjugate, 2.0, 1.0, 6.0, 0.0);
+#if defined(__SSE2__) || defined(_M_X64)
+        ASSERT_EQ(configured & statusMask, _mm_getcsr() & statusMask);
+#endif
+        ASSERT_EQ(0x4008000000000000ULL, observation.resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, observation.directResidualBits_);
+        ASSERT_EQ(biConjugate ? bcgCallbacks : cgCallbacks, observation.callbackBits_);
+        AssertCallbackCounts(biConjugate ? CallbackCounts_{3, 1, 1, 1} : CallbackCounts_{3, 0, 1, 0}, observation.counts_);
+    }
+
+    void AssertOrdinaryAlphaCorpus(bool biConjugate, const std::vector<std::uint64_t>& cgCallbacks, const std::vector<std::uint64_t>& bcgCallbacks) {
+        AssertOrdinaryCandidateCorpus(biConjugate);
+        AssertOrdinarySolveCorpus(biConjugate, cgCallbacks, bcgCallbacks);
+    }
 } // namespace
 
 TEST(MatrixTest, TestCGSolveAndBCGSolveLargeFiniteRhs) {
@@ -1679,37 +1944,6 @@ TEST(MatrixTest, TestBCGSolveScaledAlphaMinimumSubnormal) {
 
 TEST(MatrixTest, TestScaledAlphaBoundsAndClassifierMatrix) {
     using BcgScaledAlphaPrivate_::AlphaPath_;
-    using BcgScaledAlphaPrivate_::StoredScaledBits_;
-    const StoredScaledBits_ unit{0x3fe0000000000000ULL, 1, true};
-    struct ClassifierRow_ {
-        const char* id_;
-        StoredScaledBits_ numerator_;
-        StoredScaledBits_ denominator_;
-        std::uint64_t expectedNumerator_;
-        std::uint64_t expectedDenominator_;
-        int expectedExponent_;
-        AlphaPath_ expectedPath_;
-    };
-    const std::array<ClassifierRow_, 12> rows = {{
-        {"C1", {0x3fe0000000000000ULL, -1074, true}, unit, 1, 1, -1075, AlphaPath_::SCALED_EXACT},
-        {"C2", {0x3fe0000000000000ULL, -1073, true}, unit, 1, 1, -1074, AlphaPath_::SCALED_EXACT},
-        {"C3", {0x3feffffffffffffeULL, -1022, true}, unit, 4503599627370495ULL, 2251799813685248ULL, -1023, AlphaPath_::SCALED_EXACT},
-        {"C4", {0x3fe0000000000000ULL, -1021, true}, unit, 1, 1, -1022, AlphaPath_::ORDINARY_NORMAL},
-        {"C5", {0x3fe0000000000000ULL, 1024, true}, unit, 1, 1, 1023, AlphaPath_::ORDINARY_NORMAL},
-        {"C6", {0x3fefffffffffffffULL, 1024, true}, unit, 9007199254740991ULL, 4503599627370496ULL, 1023, AlphaPath_::ORDINARY_NORMAL},
-        {"C7",
-         {0x3fefffffffffffffULL, 1025, true},
-         {0x3feffffffffffffeULL, 1, true},
-         9007199254740991ULL,
-         9007199254740990ULL,
-         1024,
-         AlphaPath_::SCALED_EXACT},
-        {"C8", {0x0000000000000001ULL, 0, false}, {0x0000000000000001ULL, 0, false}, 1, 1, 0, AlphaPath_::SCALED_EXACT},
-        {"C9a", {0x3fe0000000000000ULL, 1025, true}, unit, 1, 1, 1024, AlphaPath_::SCALED_EXACT},
-        {"C9b", {0x3fe0000000000000ULL, 1026, true}, unit, 1, 1, 1025, AlphaPath_::SCALED_EXACT},
-        {"C10", {0x3fe0000000000000ULL, 1101, true}, unit, 1, 1, 1100, AlphaPath_::SCALED_EXACT},
-        {"C11", {0x3fe0000000000000ULL, -1099, true}, unit, 1, 1, -1100, AlphaPath_::SCALED_EXACT},
-    }};
 
     ASSERT_EQ(-8660, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.storedMinExponent_);
     ASSERT_EQ(8300, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.storedMaxExponent_);
@@ -1719,46 +1953,34 @@ TEST(MatrixTest, TestScaledAlphaBoundsAndClassifierMatrix) {
     ASSERT_EQ(598, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.candidateLimbCount_);
     ASSERT_EQ(19111, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_);
 
-    for (const ClassifierRow_& row : rows) {
-        for (const int signCase : {0, 1, 2}) {
-            SCOPED_TRACE(std::string(row.id_) + " sign=" + std::to_string(signCase));
-            StoredScaledBits_ numerator = row.numerator_;
-            StoredScaledBits_ denominator = row.denominator_;
-            if (signCase == 1)
-                numerator.mantissaBits_ ^= 0x8000000000000000ULL;
-            if (signCase == 2)
-                denominator.mantissaBits_ ^= 0x8000000000000000ULL;
-            AlphaClassifierObservation_ observations[2];
-#if defined(__SSE2__) || defined(_M_X64)
-            const int modeCount = 2;
-#else
-            const int modeCount = 1;
-#endif
-            for (int mode = 0; mode < modeCount; ++mode) {
-                const bool flushToZero = mode != 0;
-                observations[mode] = ObserveAlphaClassification(numerator, denominator, flushToZero);
-#if defined(__SSE2__) || defined(_M_X64)
-                const unsigned expectedMode = flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
-                ASSERT_EQ(expectedMode, observations[mode].entryMxcsr_ & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
-                ASSERT_EQ(observations[mode].entryMxcsr_, observations[mode].exitMxcsr_);
-#endif
-                ASSERT_EQ(row.expectedNumerator_, observations[mode].plan_.exact_.numerator_);
-                ASSERT_EQ(row.expectedDenominator_, observations[mode].plan_.exact_.denominator_);
-                ASSERT_EQ(row.expectedExponent_, observations[mode].plan_.exact_.binaryExponent_);
-                ASSERT_EQ(signCase != 0, observations[mode].plan_.exact_.negative_);
-                ASSERT_EQ(row.expectedPath_, observations[mode].plan_.path_);
-                ASSERT_EQ(row.expectedPath_ == AlphaPath_::ORDINARY_NORMAL ? 1 : 0, observations[mode].legacyConversionCalls_);
-            }
-#if defined(__SSE2__) || defined(_M_X64)
-            ASSERT_EQ(observations[0].comparableBits_, observations[1].comparableBits_);
-#endif
-        }
-    }
-
+    AssertClassifierMatrix();
     ASSERT_EQ(AlphaPath_::DENOMINATOR_ZERO,
               BcgScaledAlphaPrivate_::ClassifyAlpha_({0x0000000000000000ULL, 0, false}, {0x8000000000000000ULL, 0, false}).path_);
     ASSERT_EQ(AlphaPath_::LEGACY_ZERO,
               BcgScaledAlphaPrivate_::ClassifyAlpha_({0x8000000000000000ULL, 0, false}, {0x3ff0000000000000ULL, 0, false}).path_);
+}
+
+TEST(MatrixTest, TestScaledAlphaFastProofIsConservative) {
+    using BcgScaledAlphaPrivate_::StoredScaledBits_;
+    struct FastProofRow_ {
+        const char* id_;
+        StoredScaledBits_ numerator_;
+        StoredScaledBits_ denominator_;
+        bool expected_;
+    };
+    const std::array<FastProofRow_, 7> rows = {{
+        {"ordinary raw", {0x4018000000000000ULL, 0, false}, {0x4028000000000000ULL, 0, false}, true},
+        {"ordinary normalized", {0x3fe0000000000000ULL, 100, true}, {0x3fe0000000000000ULL, 100, true}, true},
+        {"raw subnormal", {0x0000000000000001ULL, 0, false}, {0x3ff0000000000000ULL, 0, false}, false},
+        {"zero denominator", {0x3ff0000000000000ULL, 0, false}, {0x0000000000000000ULL, 0, false}, false},
+        {"lower exact boundary", {0x3fe0000000000000ULL, -1021, true}, {0x3fe0000000000000ULL, 1, true}, false},
+        {"upper exact boundary", {0x3fe0000000000000ULL, 1024, true}, {0x3fe0000000000000ULL, 1, true}, false},
+        {"unsafe raw stage", {0x7fe0000000000000ULL, -2044, true}, {0x0010000000000000ULL, 1, true}, false},
+    }};
+    for (const FastProofRow_& row : rows) {
+        SCOPED_TRACE(row.id_);
+        ASSERT_EQ(row.expected_, BcgScaledAlphaPrivate_::CanUseLegacyRatioFast_(row.numerator_, row.denominator_));
+    }
 }
 
 TEST(MatrixTest, TestScaledAlphaOracleBootstrap) { AssertOracleBootstrap(); }
@@ -1767,48 +1989,7 @@ TEST(MatrixTest, TestScaledAlphaEvaluatorMatrixAndFtz) {
     AssertOracleBootstrap();
     for (const EvaluatorRow_& row : EvaluatorRows()) {
         SCOPED_TRACE(row.id_);
-        const Dal35OneBitOracle_::OracleResult_ oracle = Dal35OneBitOracle_::Evaluate_(OracleInput(row.alpha_, row.valueBits_, row.baseBits_));
-        const Dal35OneBitOracle_::OracleClass_ expectedOracleClass = row.expectedClass_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE
-                                                                         ? Dal35OneBitOracle_::OracleClass_::FINITE
-                                                                         : Dal35OneBitOracle_::OracleClass_::NON_FINITE;
-        ASSERT_EQ(expectedOracleClass, oracle.classification_);
-        if (oracle.classification_ == Dal35OneBitOracle_::OracleClass_::FINITE)
-            ASSERT_EQ(row.expectedBits_, oracle.bits_);
-
-        BcgScaledAlphaPrivate_::RoundedBinary64_ priorResult{};
-        bool havePrior = false;
-        for (const bool flushToZero : {false, true}) {
-            BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
-#if defined(__SSE2__) || defined(_M_X64)
-            MxcsrRestore_ restore;
-            const unsigned configured =
-                (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
-            _mm_setcsr(configured);
-            const unsigned before = _mm_getcsr();
-#else
-            if (flushToZero)
-                continue;
-#endif
-            const BcgScaledAlphaPrivate_::RoundedBinary64_ result =
-                BcgScaledAlphaPrivate_::EvaluateElement_(row.alpha_, row.valueBits_, row.baseBits_, &workspace);
-#if defined(__SSE2__) || defined(_M_X64)
-            const unsigned after = _mm_getcsr();
-            ASSERT_EQ(before, after);
-#endif
-            ASSERT_EQ(row.expectedClass_, result.classification_);
-            std::uint64_t destination = 0x3fd5555555555555ULL;
-            if (result.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
-                destination = result.bits_;
-            ASSERT_EQ(row.expectedClass_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE ? row.expectedBits_ : 0x3fd5555555555555ULL, destination);
-            AssertCanonicalWorkspace(workspace);
-            if (havePrior) {
-                ASSERT_EQ(priorResult.classification_, result.classification_);
-                if (result.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
-                    ASSERT_EQ(priorResult.bits_, result.bits_);
-            }
-            priorResult = result;
-            havePrior = true;
-        }
+        AssertEvaluatorRow(row);
     }
 }
 
@@ -2028,53 +2209,11 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaRejectCandidateOverflow) {
 }
 
 TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaRejectResidualAndShadowOverflow) {
-    const double minimumSubnormal = DoubleFromBits(0x0000000000000001ULL);
-    const double maximumFinite = DoubleFromBits(0x7fefffffffffffffULL);
-    const Vector_<> b = {1.0, maximumFinite};
     for (const bool shadowFailure : {false, true}) {
         for (const bool biConjugate : {false, true}) {
             if (shadowFailure && !biConjugate)
                 continue;
-            SCOPED_TRACE(std::string(SolverName(biConjugate)) + (shadowFailure ? " shadow" : " residual"));
-            CallbackCounts_ counts;
-            HookedPreconditionedDiagonal_ matrix({1.0, 1.0}, &counts);
-            matrix.SetLeftHook([minimumSubnormal, shadowFailure](int call, const Vector_<>&, Vector_<>* output) {
-                if (call == 1) {
-                    (*output)[0] = 0.0;
-                    (*output)[1] = 0.0;
-                } else {
-                    (*output)[0] = shadowFailure ? 0.0 : 1.0;
-                    (*output)[1] = minimumSubnormal;
-                }
-                return true;
-            });
-            matrix.SetRightHook([minimumSubnormal](int, const Vector_<>&, Vector_<>* output) {
-                (*output)[0] = 1.0;
-                (*output)[1] = minimumSubnormal;
-                return true;
-            });
-            const auto preconditioner = [minimumSubnormal](int, const Vector_<>&, Vector_<>* output) {
-                (*output)[0] = 0.0;
-                (*output)[1] = minimumSubnormal;
-                return true;
-            };
-            matrix.SetPreconditionerLeftHook(preconditioner);
-            matrix.SetPreconditionerRightHook(preconditioner);
-            Vector_<> x = {0.0, 0.0};
-            const double* const entryStorage = &x[0];
-
-            AssertDalExceptionContains(
-                [&]() { RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x); },
-                {SolverName(biConjugate), "numerical breakdown", shadowFailure ? "candidate shadow residual" : "candidate residual"});
-
-            const int commitCount = &x[0] == entryStorage ? 0 : 1;
-            ASSERT_EQ(0, commitCount);
-            ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[0]));
-            ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[1]));
-            ASSERT_EQ(2, counts.left_);
-            ASSERT_EQ(biConjugate ? 1 : 0, counts.right_);
-            ASSERT_EQ(1, counts.preconditionerLeft_);
-            ASSERT_EQ(biConjugate ? 1 : 0, counts.preconditionerRight_);
+            AssertResidualOrShadowOverflow(biConjugate, shadowFailure);
         }
     }
 }
@@ -2134,51 +2273,7 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
           4, 1, 0x1f4ffffffffffffeULL, 0x44cffffffffffffeULL, 1, 2, 0x44cffffffffffffeULL, 0x640ffffffffffffeULL,
           2, 1, 0x44cffffffffffffeULL, 0x640ffffffffffffeULL, 1, 3, 0x8000000000000001ULL, 0x9c10000000000000ULL}},
     }};
-    for (const bool biConjugate : {false, true}) {
-        for (const SolverFtzRow_& row : rows) {
-            SCOPED_TRACE(std::string(SolverName(biConjugate)) + " " + row.id_);
-            ScaledAlphaObservation_ observations[2];
-            for (const bool flushToZero : {false, true}) {
-                MxcsrRestore_ restore;
-                const unsigned configured =
-                    (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
-                _mm_setcsr(configured);
-                const unsigned before = _mm_getcsr();
-                observations[flushToZero ? 1 : 0] =
-                    ObserveScaledAlphaSolve(biConjugate, row.diagonal_, row.preconditioner_, row.rhs_, row.initial_, &row.exactAlpha_);
-                const unsigned after = _mm_getcsr();
-                ASSERT_EQ(flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF, before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
-                ASSERT_EQ(before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK), after & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
-                const ScaledAlphaObservation_& observation = observations[flushToZero ? 1 : 0];
-                const CallbackCounts_ expectedCounts = biConjugate ? CallbackCounts_{3, 1, 1, 1} : CallbackCounts_{3, 0, 1, 0};
-                const std::vector<std::uint64_t> expectedCallbacks =
-                    biConjugate ? std::vector<std::uint64_t>(row.bcgCallbacks_.begin(), row.bcgCallbacks_.end())
-                                : std::vector<std::uint64_t>(row.cgCallbacks_.begin(), row.cgCallbacks_.end());
-                ASSERT_EQ(row.expectedBits_, observation.resultBits_);
-                ASSERT_EQ(0x0000000000000000ULL, observation.directResidualBits_);
-                ASSERT_EQ(BcgScaledAlphaPrivate_::CandidateSubject_::NONE, observation.evidenceSubject_);
-                ASSERT_EQ(-1, observation.evidenceIndex_);
-                ASSERT_EQ(1, observation.commitCount_);
-                ASSERT_EQ(1, observation.confirmationCount_);
-                ASSERT_EQ(row.expectedBits_, observation.confirmationInputBits_);
-                ASSERT_EQ(row.expectedRhsBits_, observation.confirmationOutputBits_);
-                ASSERT_EQ(expectedCallbacks, observation.callbackBits_);
-                AssertCallbackCounts(expectedCounts, observation.counts_);
-            }
-            ASSERT_EQ(row.expectedBits_, observations[0].resultBits_);
-            ASSERT_EQ(0x0000000000000000ULL, observations[0].directResidualBits_);
-            ASSERT_EQ(BcgScaledAlphaPrivate_::CandidateSubject_::NONE, observations[0].evidenceSubject_);
-            ASSERT_EQ(-1, observations[0].evidenceIndex_);
-            ASSERT_EQ(1, observations[0].commitCount_);
-            ASSERT_EQ(observations[0].resultBits_, observations[1].resultBits_);
-            ASSERT_EQ(observations[0].directResidualBits_, observations[1].directResidualBits_);
-            ASSERT_EQ(observations[0].evidenceSubject_, observations[1].evidenceSubject_);
-            ASSERT_EQ(observations[0].evidenceIndex_, observations[1].evidenceIndex_);
-            ASSERT_EQ(observations[0].commitCount_, observations[1].commitCount_);
-            ASSERT_EQ(observations[0].callbackBits_, observations[1].callbackBits_);
-            AssertCallbackCounts(observations[0].counts_, observations[1].counts_);
-        }
-    }
+    AssertSolverFtzRows(rows);
 }
 #endif
 
@@ -2212,38 +2307,8 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
         1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x4018000000000000ULL, 0x4018000000000000ULL,
         4, 1, 0x4018000000000000ULL, 0x4018000000000000ULL, 1, 2, 0x4018000000000000ULL, 0x4028000000000000ULL,
         2, 1, 0x4018000000000000ULL, 0x4028000000000000ULL, 1, 3, 0x4008000000000000ULL, 0x4018000000000000ULL};
-    for (const bool biConjugate : {false, true}) {
-        SCOPED_TRACE(SolverName(biConjugate));
-        const OrdinaryCandidateObservation_ candidateObservation = ObserveOrdinaryCandidateCommit(biConjugate);
-        ASSERT_TRUE(candidateObservation.callbackException_);
-        ASSERT_EQ(1, candidateObservation.commitCount_);
-        ASSERT_EQ(0x3fe0000000000000ULL, candidateObservation.coefficientBits_);
-        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3ff0000000000000ULL, 0x4000000000000000ULL}), candidateObservation.directionBits_);
-        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3ff0000000000000ULL, 0x4012000000000000ULL}), candidateObservation.operatorDirectionBits_);
-        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0x3ff0000000000000ULL}), candidateObservation.xCandidateBits_);
-        ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0xbfd0000000000000ULL}), candidateObservation.residualCandidateBits_);
-        if (biConjugate)
-            ASSERT_EQ((std::array<std::uint64_t, 2>{0x3fe0000000000000ULL, 0xbfd0000000000000ULL}), candidateObservation.shadowCandidateBits_);
-        ASSERT_EQ(candidateObservation.xCandidateBits_, candidateObservation.finalBits_);
-        AssertCallbackCounts(biConjugate ? CallbackCounts_{2, 1, 2, 2} : CallbackCounts_{2, 0, 2, 0}, candidateObservation.counts_);
-#if defined(__SSE2__) || defined(_M_X64)
-        MxcsrRestore_ restore;
-        const unsigned statusMask = _MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW;
-        const unsigned configured = _mm_getcsr() | statusMask;
-        _mm_setcsr(configured);
-#endif
-        const ScaledAlphaObservation_ observation = ObserveScaledAlphaSolve(biConjugate, 2.0, 1.0, 6.0, 0.0);
-#if defined(__SSE2__) || defined(_M_X64)
-        ASSERT_EQ(configured & statusMask, _mm_getcsr() & statusMask);
-#endif
-        ASSERT_EQ(0x4008000000000000ULL, observation.resultBits_);
-        ASSERT_EQ(0x0000000000000000ULL, observation.directResidualBits_);
-        ASSERT_EQ(biConjugate ? bcgCallbacks : cgCallbacks, observation.callbackBits_);
-        ASSERT_EQ(3, observation.counts_.left_);
-        ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.right_);
-        ASSERT_EQ(1, observation.counts_.preconditionerLeft_);
-        ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.preconditionerRight_);
-    }
+    AssertOrdinaryAlphaCorpus(false, cgCallbacks, bcgCallbacks);
+    AssertOrdinaryAlphaCorpus(true, cgCallbacks, bcgCallbacks);
 }
 
 #if defined(__SSE2__) || defined(_M_X64)

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -704,6 +704,9 @@ namespace {
     struct ScaledAlphaObservation_ {
         std::uint64_t resultBits_;
         std::uint64_t directResidualBits_;
+        BcgScaledAlphaPrivate_::CandidateSubject_ evidenceSubject_;
+        int evidenceIndex_;
+        int commitCount_;
         CallbackCounts_ counts_;
         std::vector<std::uint64_t> callbackBits_;
     };
@@ -715,21 +718,36 @@ namespace {
         callbackBits->push_back(DoubleBits(output));
     }
 
-    ScaledAlphaObservation_ ObserveScaledAlphaSolve(bool biConjugate, double diagonal, double preconditionerScale, double rhs, double initial) {
+    ScaledAlphaObservation_ ObserveScaledAlphaSolve(bool biConjugate,
+                                                    double diagonal,
+                                                    double preconditionerScale,
+                                                    double rhs,
+                                                    double initial,
+                                                    const BcgScaledAlphaPrivate_::ExactAlpha_* exactAlpha = nullptr) {
         ScaledAlphaObservation_ result;
+        double direction = 0.0;
+        double residualBase = 0.0;
+        double operatorDirection = 0.0;
+        double shadowOperatorDirection = 0.0;
         HookedPreconditionedDiagonal_ matrix({diagonal}, &result.counts_);
-        matrix.SetLeftHook([diagonal, &result](int call, const Vector_<>& input, Vector_<>* output) {
+        matrix.SetLeftHook([diagonal, &result, &operatorDirection](int call, const Vector_<>& input, Vector_<>* output) {
             (*output)[0] = diagonal * input[0];
+            if (call == 2)
+                operatorDirection = (*output)[0];
             RecordCallback(1, call, input[0], (*output)[0], &result.callbackBits_);
             return true;
         });
-        matrix.SetRightHook([diagonal, &result](int call, const Vector_<>& input, Vector_<>* output) {
+        matrix.SetRightHook([diagonal, &result, &shadowOperatorDirection](int call, const Vector_<>& input, Vector_<>* output) {
             (*output)[0] = diagonal * input[0];
+            if (call == 1)
+                shadowOperatorDirection = (*output)[0];
             RecordCallback(2, call, input[0], (*output)[0], &result.callbackBits_);
             return true;
         });
-        const auto preconditioner = [preconditionerScale, &result](int call, const Vector_<>& input, Vector_<>* output) {
+        const auto preconditioner = [preconditionerScale, &result, &direction, &residualBase](int call, const Vector_<>& input, Vector_<>* output) {
             (*output)[0] = preconditionerScale * input[0];
+            direction = (*output)[0];
+            residualBase = input[0];
             RecordCallback(3, call, input[0], (*output)[0], &result.callbackBits_);
             return true;
         };
@@ -742,11 +760,35 @@ namespace {
         matrix.SetPreconditionerRightHook(shadowPreconditioner);
         const Vector_<> b = {rhs};
         Vector_<> x = {initial};
+        const double* const entryStorage = &x[0];
 
         RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x);
 
         result.resultBits_ = DoubleBits(x[0]);
         result.directResidualBits_ = DoubleBits(DiagonalResidual({diagonal}, x, b)[0]);
+        BcgScaledAlphaPrivate_::CandidateEvidence_ evidence{BcgScaledAlphaPrivate_::CandidateSubject_::NONE, -1};
+        if (exactAlpha != nullptr) {
+            const Vector_<> directionVector = {direction};
+            const Vector_<> xBase = {initial};
+            const Vector_<> residualBaseVector = {residualBase};
+            const Vector_<> shadowBase = {residualBase};
+            Vector_<> xOutput(1);
+            Vector_<> residual = {operatorDirection};
+            Vector_<> shadow = {shadowOperatorDirection};
+            BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+            const BcgScaledAlphaPrivate_::CandidateGroup_ group{&directionVector,
+                                                                &xBase,
+                                                                &residualBaseVector,
+                                                                biConjugate ? &shadowBase : nullptr,
+                                                                &xOutput,
+                                                                &residual,
+                                                                biConjugate ? &shadow : nullptr};
+            evidence = BcgScaledAlphaPrivate_::EvaluateCandidateGroup_(*exactAlpha, group, &workspace);
+            AssertCanonicalWorkspace(workspace);
+        }
+        result.evidenceSubject_ = evidence.subject_;
+        result.evidenceIndex_ = evidence.firstNonFiniteIndex_;
+        result.commitCount_ = &x[0] == entryStorage ? 0 : 1;
         return result;
     }
 
@@ -1530,7 +1572,9 @@ TEST(MatrixTest, TestScaledAlphaBoundsAndClassifierMatrix) {
             MxcsrRestore_ restore;
             const unsigned before = _mm_getcsr();
 #endif
-            const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ClassifyAlpha_(numerator, denominator);
+            int legacyConversionCalls = 0;
+            const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ClassifyAlphaAndInvokeLegacy_(
+                numerator, denominator, [&legacyConversionCalls]() { ++legacyConversionCalls; });
 #if defined(__SSE2__) || defined(_M_X64)
             const unsigned after = _mm_getcsr();
             ASSERT_EQ(before, after);
@@ -1540,7 +1584,6 @@ TEST(MatrixTest, TestScaledAlphaBoundsAndClassifierMatrix) {
             ASSERT_EQ(row.expectedExponent_, plan.exact_.binaryExponent_);
             ASSERT_EQ(signCase != 0, plan.exact_.negative_);
             ASSERT_EQ(row.expectedPath_, plan.path_);
-            const int legacyConversionCalls = plan.path_ == AlphaPath_::ORDINARY_NORMAL || plan.path_ == AlphaPath_::LEGACY_ZERO ? 1 : 0;
             ASSERT_EQ(row.expectedPath_ == AlphaPath_::ORDINARY_NORMAL ? 1 : 0, legacyConversionCalls);
         }
     }
@@ -1675,6 +1718,86 @@ TEST(MatrixTest, TestScaledAlphaReviewedExponentAndTopCarryBounds) {
     }
 }
 
+TEST(MatrixTest, TestScaledAlphaCandidateEvidencePriorityAndAscendingIndex) {
+    using BcgScaledAlphaPrivate_::CandidateEvidence_;
+    using BcgScaledAlphaPrivate_::CandidateGroup_;
+    using BcgScaledAlphaPrivate_::CandidateSubject_;
+    const BcgScaledAlphaPrivate_::ExactAlpha_ alpha{1, 1, 1100, false};
+    const Vector_<> zeroBase = {0.0, 0.0, 0.0};
+    {
+        const Vector_<> direction = {0.0, 1.0, 1.0};
+        Vector_<> residual = {3.0, 5.0, 7.0};
+        const Vector_<> residualBase = {11.0, 13.0, 17.0};
+        Vector_<> shadow = {19.0, 23.0, 29.0};
+        const Vector_<> shadowBase = {31.0, 37.0, 41.0};
+        Vector_<> xOutput = {43.0, 47.0, 53.0};
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+        const CandidateGroup_ group{
+            &direction, &zeroBase, &residualBase, &shadowBase, &xOutput, &residual, &shadow,
+        };
+
+        const CandidateEvidence_ evidence = BcgScaledAlphaPrivate_::EvaluateCandidateGroup_(alpha, group, &workspace);
+
+        ASSERT_EQ(CandidateSubject_::X, evidence.subject_);
+        ASSERT_EQ(1, evidence.firstNonFiniteIndex_);
+        ASSERT_EQ(0x0000000000000000ULL, DoubleBits(xOutput[0]));
+        ASSERT_EQ(0x4047800000000000ULL, DoubleBits(xOutput[1]));
+        ASSERT_EQ(0x404a800000000000ULL, DoubleBits(xOutput[2]));
+        ASSERT_EQ(0x4008000000000000ULL, DoubleBits(residual[0]));
+        ASSERT_EQ(0x4014000000000000ULL, DoubleBits(residual[1]));
+        ASSERT_EQ(0x401c000000000000ULL, DoubleBits(residual[2]));
+        ASSERT_EQ(0x4033000000000000ULL, DoubleBits(shadow[0]));
+        ASSERT_EQ(0x4037000000000000ULL, DoubleBits(shadow[1]));
+        ASSERT_EQ(0x403d000000000000ULL, DoubleBits(shadow[2]));
+        AssertCanonicalWorkspace(workspace);
+    }
+    {
+        const Vector_<> direction = {0.0, 0.0, 0.0};
+        Vector_<> residual = {0.0, 1.0, 1.0};
+        const Vector_<> residualBase = {0.0, 0.0, 0.0};
+        Vector_<> shadow = {19.0, 23.0, 29.0};
+        const Vector_<> shadowBase = {31.0, 37.0, 41.0};
+        Vector_<> xOutput = {43.0, 47.0, 53.0};
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+        const CandidateGroup_ group{
+            &direction, &zeroBase, &residualBase, &shadowBase, &xOutput, &residual, &shadow,
+        };
+
+        const CandidateEvidence_ evidence = BcgScaledAlphaPrivate_::EvaluateCandidateGroup_(alpha, group, &workspace);
+
+        ASSERT_EQ(CandidateSubject_::RESIDUAL, evidence.subject_);
+        ASSERT_EQ(1, evidence.firstNonFiniteIndex_);
+        ASSERT_EQ(0x0000000000000000ULL, DoubleBits(residual[0]));
+        ASSERT_EQ(0x3ff0000000000000ULL, DoubleBits(residual[1]));
+        ASSERT_EQ(0x3ff0000000000000ULL, DoubleBits(residual[2]));
+        ASSERT_EQ(0x4033000000000000ULL, DoubleBits(shadow[0]));
+        ASSERT_EQ(0x4037000000000000ULL, DoubleBits(shadow[1]));
+        ASSERT_EQ(0x403d000000000000ULL, DoubleBits(shadow[2]));
+        AssertCanonicalWorkspace(workspace);
+    }
+    {
+        const Vector_<> direction = {0.0, 0.0, 0.0};
+        Vector_<> residual = {0.0, 0.0, 0.0};
+        const Vector_<> residualBase = {0.0, 0.0, 0.0};
+        Vector_<> shadow = {0.0, 1.0, 1.0};
+        const Vector_<> shadowBase = {0.0, 0.0, 0.0};
+        Vector_<> xOutput = {43.0, 47.0, 53.0};
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+        const CandidateGroup_ group{
+            &direction, &zeroBase, &residualBase, &shadowBase, &xOutput, &residual, &shadow,
+        };
+
+        const CandidateEvidence_ evidence = BcgScaledAlphaPrivate_::EvaluateCandidateGroup_(alpha, group, &workspace);
+
+        ASSERT_EQ(CandidateSubject_::SHADOW_RESIDUAL, evidence.subject_);
+        ASSERT_EQ(1, evidence.firstNonFiniteIndex_);
+        ASSERT_EQ(0x0000000000000000ULL, DoubleBits(shadow[0]));
+        ASSERT_EQ(0x3ff0000000000000ULL, DoubleBits(shadow[1]));
+        ASSERT_EQ(0x3ff0000000000000ULL, DoubleBits(shadow[2]));
+        AssertCanonicalWorkspace(workspace);
+    }
+}
+
 TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaOverflowCancellation) {
     const double diagonal = std::ldexp(1.0, -500);
     const double preconditioner = std::ldexp(1.0, -600);
@@ -1722,15 +1845,70 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaRejectCandidateOverflow) {
         matrix.SetPreconditionerLeftHook(preconditioner);
         matrix.SetPreconditionerRightHook(preconditioner);
         Vector_<> x = {0.0};
+        const double* const entryStorage = &x[0];
 
         AssertDalExceptionContains([&]() { RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x); },
                                    {SolverName(biConjugate), "numerical breakdown", "candidate x"});
 
+        const int commitCount = &x[0] == entryStorage ? 0 : 1;
+        ASSERT_EQ(0, commitCount);
         ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[0]));
         ASSERT_EQ(2, counts.left_);
         ASSERT_EQ(biConjugate ? 1 : 0, counts.right_);
         ASSERT_EQ(1, counts.preconditionerLeft_);
         ASSERT_EQ(biConjugate ? 1 : 0, counts.preconditionerRight_);
+    }
+}
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaRejectResidualAndShadowOverflow) {
+    const double minimumSubnormal = DoubleFromBits(0x0000000000000001ULL);
+    const double maximumFinite = DoubleFromBits(0x7fefffffffffffffULL);
+    const Vector_<> b = {1.0, maximumFinite};
+    for (const bool shadowFailure : {false, true}) {
+        for (const bool biConjugate : {false, true}) {
+            if (shadowFailure && !biConjugate)
+                continue;
+            SCOPED_TRACE(std::string(SolverName(biConjugate)) + (shadowFailure ? " shadow" : " residual"));
+            CallbackCounts_ counts;
+            HookedPreconditionedDiagonal_ matrix({1.0, 1.0}, &counts);
+            matrix.SetLeftHook([minimumSubnormal, shadowFailure](int call, const Vector_<>&, Vector_<>* output) {
+                if (call == 1) {
+                    (*output)[0] = 0.0;
+                    (*output)[1] = 0.0;
+                } else {
+                    (*output)[0] = shadowFailure ? 0.0 : 1.0;
+                    (*output)[1] = minimumSubnormal;
+                }
+                return true;
+            });
+            matrix.SetRightHook([minimumSubnormal](int, const Vector_<>&, Vector_<>* output) {
+                (*output)[0] = 1.0;
+                (*output)[1] = minimumSubnormal;
+                return true;
+            });
+            const auto preconditioner = [minimumSubnormal](int, const Vector_<>&, Vector_<>* output) {
+                (*output)[0] = 0.0;
+                (*output)[1] = minimumSubnormal;
+                return true;
+            };
+            matrix.SetPreconditionerLeftHook(preconditioner);
+            matrix.SetPreconditionerRightHook(preconditioner);
+            Vector_<> x = {0.0, 0.0};
+            const double* const entryStorage = &x[0];
+
+            AssertDalExceptionContains(
+                [&]() { RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x); },
+                {SolverName(biConjugate), "numerical breakdown", shadowFailure ? "candidate shadow residual" : "candidate residual"});
+
+            const int commitCount = &x[0] == entryStorage ? 0 : 1;
+            ASSERT_EQ(0, commitCount);
+            ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[0]));
+            ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[1]));
+            ASSERT_EQ(2, counts.left_);
+            ASSERT_EQ(biConjugate ? 1 : 0, counts.right_);
+            ASSERT_EQ(1, counts.preconditionerLeft_);
+            ASSERT_EQ(biConjugate ? 1 : 0, counts.preconditionerRight_);
+        }
     }
 }
 
@@ -1743,11 +1921,24 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
         double rhs_;
         double initial_;
         std::uint64_t expectedBits_;
+        BcgScaledAlphaPrivate_::ExactAlpha_ exactAlpha_;
     };
     const std::array<SolverFtzRow_, 3> rows = {{
-        {"S3", std::ldexp(1.0, 500), std::ldexp(1.0, 1023), std::ldexp(1.0, -574), 0.0, 0x0000000000000001ULL},
-        {"S5+", std::ldexp(1.0, 500), std::ldexp(1.0, 600), std::ldexp(1.0, -574), std::ldexp(1.0, -1022), 0x0000000000000001ULL},
-        {"S5-", std::ldexp(1.0, 500), std::ldexp(1.0, 600), -std::ldexp(1.0, -574), -std::ldexp(1.0, -1022), 0x8000000000000001ULL},
+        {"S3", std::ldexp(1.0, 500), std::ldexp(1.0, 1023), std::ldexp(1.0, -574), 0.0, 0x0000000000000001ULL, {1, 1, -1523, false}},
+        {"S5+",
+         std::ldexp(1.0, 500),
+         std::ldexp(1.0, 600),
+         std::ldexp(1.0, -574),
+         std::ldexp(1.0, -1022),
+         0x0000000000000001ULL,
+         {1, 1, -1100, false}},
+        {"S5-",
+         std::ldexp(1.0, 500),
+         std::ldexp(1.0, 600),
+         -std::ldexp(1.0, -574),
+         -std::ldexp(1.0, -1022),
+         0x8000000000000001ULL,
+         {1, 1, -1100, false}},
     }};
     for (const bool biConjugate : {false, true}) {
         for (const SolverFtzRow_& row : rows) {
@@ -1759,12 +1950,21 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
                     (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
                 _mm_setcsr(configured);
                 const unsigned before = _mm_getcsr();
-                observations[flushToZero ? 1 : 0] = ObserveScaledAlphaSolve(biConjugate, row.diagonal_, row.preconditioner_, row.rhs_, row.initial_);
+                observations[flushToZero ? 1 : 0] =
+                    ObserveScaledAlphaSolve(biConjugate, row.diagonal_, row.preconditioner_, row.rhs_, row.initial_, &row.exactAlpha_);
                 const unsigned after = _mm_getcsr();
                 ASSERT_EQ(before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK), after & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
             }
             ASSERT_EQ(row.expectedBits_, observations[0].resultBits_);
+            ASSERT_EQ(0x0000000000000000ULL, observations[0].directResidualBits_);
+            ASSERT_EQ(BcgScaledAlphaPrivate_::CandidateSubject_::NONE, observations[0].evidenceSubject_);
+            ASSERT_EQ(-1, observations[0].evidenceIndex_);
+            ASSERT_EQ(1, observations[0].commitCount_);
             ASSERT_EQ(observations[0].resultBits_, observations[1].resultBits_);
+            ASSERT_EQ(observations[0].directResidualBits_, observations[1].directResidualBits_);
+            ASSERT_EQ(observations[0].evidenceSubject_, observations[1].evidenceSubject_);
+            ASSERT_EQ(observations[0].evidenceIndex_, observations[1].evidenceIndex_);
+            ASSERT_EQ(observations[0].commitCount_, observations[1].commitCount_);
             ASSERT_EQ(observations[0].callbackBits_, observations[1].callbackBits_);
             AssertCallbackCounts(observations[0].counts_, observations[1].counts_);
         }

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -5,23 +5,111 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <limits>
 #include <map>
+#include <new>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
+#if defined(__SSE2__) || defined(_M_X64)
+#include <immintrin.h>
+#endif
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/math/matrix/bcg.hpp>
+#include <dal/math/matrix/bcg_scaled_alpha.inc>
+#include "dal35_one_bit_oracle.hpp"
+
+namespace {
+    std::atomic<bool> dal35TrackAllocations_{false};
+    std::atomic<std::size_t> dal35AllocationCount_{0};
+
+    void* Dal35Allocate_(std::size_t size) {
+        if (dal35TrackAllocations_.load(std::memory_order_relaxed))
+            dal35AllocationCount_.fetch_add(1, std::memory_order_relaxed);
+        if (void* result = std::malloc(size == 0 ? 1 : size))
+            return result;
+        throw std::bad_alloc();
+    }
+} // namespace
+
+void* operator new(std::size_t size) { return Dal35Allocate_(size); }
+
+void* operator new[](std::size_t size) { return Dal35Allocate_(size); }
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+    try {
+        return Dal35Allocate_(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+    try {
+        return Dal35Allocate_(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void operator delete(void* address) noexcept { std::free(address); }
+
+void operator delete[](void* address) noexcept { std::free(address); }
+
+void operator delete(void* address, std::size_t) noexcept { std::free(address); }
+
+void operator delete[](void* address, std::size_t) noexcept { std::free(address); }
+
+void operator delete(void* address, const std::nothrow_t&) noexcept { std::free(address); }
+
+void operator delete[](void* address, const std::nothrow_t&) noexcept { std::free(address); }
 
 using namespace Dal;
 
 namespace {
+    class AllocationScope_ {
+        bool active_ = true;
+
+    public:
+        AllocationScope_() noexcept {
+            dal35AllocationCount_.store(0, std::memory_order_relaxed);
+            dal35TrackAllocations_.store(true, std::memory_order_relaxed);
+        }
+        ~AllocationScope_() noexcept {
+            if (active_)
+                dal35TrackAllocations_.store(false, std::memory_order_relaxed);
+        }
+        std::size_t Finish() noexcept {
+            dal35TrackAllocations_.store(false, std::memory_order_relaxed);
+            active_ = false;
+            return dal35AllocationCount_.load(std::memory_order_relaxed);
+        }
+    };
+
+#if defined(DAL35_PROBE_TEST_TOP_CARRY_DELTA)
+    constexpr int DAL35_TEST_TOP_CARRY_DELTA_ = DAL35_PROBE_TEST_TOP_CARRY_DELTA;
+#else
+    constexpr int DAL35_TEST_TOP_CARRY_DELTA_ = 0;
+#endif
+
+    constexpr BcgScaledAlphaPrivate_::AccumulatorBounds_ DAL35_TEST_PROBE_INPUT_ =
+        BcgScaledAlphaPrivate_::WithTopRoundingCarryDelta_(BcgScaledAlphaPrivate_::REVIEWED_ACCUMULATOR_BOUNDS_, DAL35_TEST_TOP_CARRY_DELTA_);
+
+    static_assert(BcgScaledAlphaPrivate_::REVIEWED_BOUNDS_FINGERPRINT_MATCHES_, "DAL35_TEST_SEAM_BOUNDS_FINGERPRINT_MISMATCH");
+    static_assert(BcgScaledAlphaPrivate_::SameBoundsFingerprint_(
+                      BcgScaledAlphaPrivate_::MakeBoundsFingerprint_(DAL35_TEST_PROBE_INPUT_,
+                                                                     BcgScaledAlphaPrivate_::DeriveCandidateBounds_(DAL35_TEST_PROBE_INPUT_)),
+                      BcgScaledAlphaPrivate_::REVIEWED_BOUNDS_FINGERPRINT_),
+                  "DAL35_TEST_SEAM_BOUNDS_FINGERPRINT_MISMATCH");
+
     class RescaledIdentity_ : public Sparse::TriDiagonal_, public HasPreConditioner_ {
         static void Rescale(const Vector_<>& b, Vector_<>* x) { (*x)[0] = 1e170 * b[0]; }
 
@@ -449,6 +537,134 @@ namespace {
         return result;
     }
 
+    std::uint64_t DoubleBits(double value) {
+        std::uint64_t result = 0;
+        std::memcpy(&result, &value, sizeof(result));
+        return result;
+    }
+
+    struct OracleBootstrapRow_ {
+        const char* id_;
+        Dal35OneBitOracle_::OracleInput_ input_;
+        std::uint64_t expectedBits_;
+        Dal35OneBitOracle_::OracleClass_ expectedClass_;
+    };
+
+    const std::array<OracleBootstrapRow_, 10>& OracleBootstrapRows() {
+        static const std::array<OracleBootstrapRow_, 10> rows = {{
+            {"O1",
+             {{{1}, {1}, 0, false}, 0x0000000000000000ULL, 0x0000000000000000ULL},
+             0x0000000000000000ULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O2",
+             {{{1}, {1}, -1075, true}, 0x3ff0000000000000ULL, 0x0000000000000000ULL},
+             0x8000000000000000ULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O3",
+             {{{1}, {1}, -1074, false}, 0x3ff0000000000000ULL, 0x0000000000000000ULL},
+             0x0000000000000001ULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O4",
+             {{{1}, {1}, -1022, false}, 0x3ff0000000000000ULL, 0x0000000000000000ULL},
+             0x0010000000000000ULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O5",
+             {{{1}, {1}, 0, false}, 0x7fefffffffffffffULL, 0x0000000000000000ULL},
+             0x7fefffffffffffffULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O6", {{{1}, {1}, 1100, false}, 0x37d0000000000000ULL, 0x7fefffffffffffffULL}, 0, Dal35OneBitOracle_::OracleClass_::NON_FINITE},
+            {"O7",
+             {{{1}, {1}, 1100, false}, 0x37cfffffffffffffULL, 0x7fefffffffffffffULL},
+             0x7fefffffffffffffULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O8", {{{1}, {1}, 1100, false}, 0x37d0000000000001ULL, 0x7fefffffffffffffULL}, 0, Dal35OneBitOracle_::OracleClass_::NON_FINITE},
+            {"O9",
+             {{{1, 0, 1}, {1, 1}, 1050, false}, 0x0000000003000000ULL, 0xc012000000000000ULL},
+             0x3fe0000000000000ULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+            {"O10",
+             {{{1, 0, 1}, {1, 1}, 1050, true}, 0x0000000003000000ULL, 0x4012000000000000ULL},
+             0xbfe0000000000000ULL,
+             Dal35OneBitOracle_::OracleClass_::FINITE},
+        }};
+        return rows;
+    }
+
+    void AssertOracleBootstrap() {
+        for (const OracleBootstrapRow_& row : OracleBootstrapRows()) {
+            SCOPED_TRACE(row.id_);
+            const Dal35OneBitOracle_::OracleResult_ result = Dal35OneBitOracle_::Evaluate_(row.input_);
+            ASSERT_EQ(row.expectedClass_, result.classification_);
+            if (result.classification_ == Dal35OneBitOracle_::OracleClass_::FINITE)
+                ASSERT_EQ(row.expectedBits_, result.bits_);
+        }
+    }
+
+    Dal35OneBitOracle_::OracleInput_ OracleInput(const BcgScaledAlphaPrivate_::ExactAlpha_& alpha, std::uint64_t valueBits, std::uint64_t baseBits) {
+        return {{Dal35OneBitOracle_::FromU64_(alpha.numerator_), Dal35OneBitOracle_::FromU64_(alpha.denominator_), alpha.binaryExponent_,
+                 alpha.negative_},
+                valueBits,
+                baseBits};
+    }
+
+    struct EvaluatorRow_ {
+        const char* id_;
+        BcgScaledAlphaPrivate_::ExactAlpha_ alpha_;
+        std::uint64_t valueBits_;
+        std::uint64_t baseBits_;
+        std::uint64_t expectedBits_;
+        BcgScaledAlphaPrivate_::RoundedClass_ expectedClass_;
+    };
+
+    const std::array<EvaluatorRow_, 21>& EvaluatorRows() {
+        using BcgScaledAlphaPrivate_::RoundedClass_;
+        static const std::array<EvaluatorRow_, 21> rows = {{
+            {"E1", {1, 1, -1100, false}, 0x4180000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, RoundedClass_::FINITE},
+            {"E2", {1, 1, -1100, false}, 0x4180000000000001ULL, 0x0000000000000000ULL, 0x0000000000000001ULL, RoundedClass_::FINITE},
+            {"E3", {1, 1, -1100, false}, 0x417fffffffffffffULL, 0x0000000000000000ULL, 0x0000000000000000ULL, RoundedClass_::FINITE},
+            {"E4", {1, 1, -1100, true}, 0x4180000000000000ULL, 0x0000000000000000ULL, 0x8000000000000000ULL, RoundedClass_::FINITE},
+            {"E5", {1, 1, -1523, false}, 0x5c00000000000000ULL, 0x0000000000000000ULL, 0x0000000000000001ULL, RoundedClass_::FINITE},
+            {"E6", {1, 3, 1026, false}, 0x0000000000000003ULL, 0x4040000000000000ULL, 0x4040000000000000ULL, RoundedClass_::FINITE},
+            {"E7", {1, 3, 1026, false}, 0x0000000000000003ULL, 0x4040000000000001ULL, 0x4040000000000002ULL, RoundedClass_::FINITE},
+            {"E8", {5, 3, 1050, false}, 0x0000000003000000ULL, 0xc012000000000000ULL, 0x3fe0000000000000ULL, RoundedClass_::FINITE},
+            {"E9", {5, 3, 1050, true}, 0x0000000003000000ULL, 0x4012000000000000ULL, 0xbfe0000000000000ULL, RoundedClass_::FINITE},
+            {"E10", {1, 1, 1100, false}, 0x3b30000000000000ULL, 0xffe0000000000000ULL, 0x7fe0000000000000ULL, RoundedClass_::FINITE},
+            {"E11", {1, 1, 1100, false}, 0xbb30000000000000ULL, 0x7fe0000000000000ULL, 0xffe0000000000000ULL, RoundedClass_::FINITE},
+            {"E12", {1, 1, -1100, false}, 0xc4cffffffffffffeULL, 0x0010000000000000ULL, 0x0000000000000001ULL, RoundedClass_::FINITE},
+            {"E13", {1, 1, -1100, false}, 0x44cffffffffffffeULL, 0x8010000000000000ULL, 0x8000000000000001ULL, RoundedClass_::FINITE},
+            {"E14", {1, 1, 1100, false}, 0x39b0000000000000ULL, 0xfe70000000000000ULL, 0x0000000000000000ULL, RoundedClass_::FINITE},
+            {"E15", {1, 1, 1100, false}, 0x3ff0000000000000ULL, 0x0000000000000000ULL, 0, RoundedClass_::NON_FINITE},
+            {"E16", {1, 1, 1100, false}, 0x37cfffffffffffffULL, 0x7fefffffffffffffULL, 0x7fefffffffffffffULL, RoundedClass_::FINITE},
+            {"E17", {1, 1, 1100, false}, 0x37d0000000000000ULL, 0x7fefffffffffffffULL, 0, RoundedClass_::NON_FINITE},
+            {"E18", {1, 1, 1100, false}, 0x37d0000000000001ULL, 0x7fefffffffffffffULL, 0, RoundedClass_::NON_FINITE},
+            {"E19", {1, 1, 1100, false}, 0xb7cfffffffffffffULL, 0xffefffffffffffffULL, 0xffefffffffffffffULL, RoundedClass_::FINITE},
+            {"E20", {1, 1, 1100, false}, 0xb7d0000000000000ULL, 0xffefffffffffffffULL, 0, RoundedClass_::NON_FINITE},
+            {"E21", {1, 1, 1100, false}, 0xb7d0000000000001ULL, 0xffefffffffffffffULL, 0, RoundedClass_::NON_FINITE},
+        }};
+        return rows;
+    }
+
+    void AssertCanonicalWorkspace(const BcgScaledAlphaPrivate_::ExactWorkspace_& workspace) {
+        const auto assertMagnitude = [](const BcgScaledAlphaPrivate_::ExactMagnitude_& magnitude) {
+            ASSERT_EQ(BcgScaledAlphaPrivate_::EXACT_CANDIDATE_LIMB_COUNT_, magnitude.first_);
+            ASSERT_EQ(-1, magnitude.last_);
+            for (const std::uint32_t limb : magnitude.limbs_)
+                ASSERT_EQ(0U, limb);
+        };
+        assertMagnitude(workspace.positive_);
+        assertMagnitude(workspace.negative_);
+    }
+
+#if defined(__SSE2__) || defined(_M_X64)
+    class MxcsrRestore_ {
+        unsigned prior_;
+
+    public:
+        MxcsrRestore_() noexcept : prior_(_mm_getcsr()) {}
+        ~MxcsrRestore_() noexcept { _mm_setcsr(prior_); }
+    };
+#endif
+
     void AssertBCGIdentityInitialClassification(const Vector_<>& b, const Vector_<>& requestedResidual, double tolRel, double tolAbs) {
         Vector_<> x = {b[0] - requestedResidual[0], b[1] - requestedResidual[1]};
         const Vector_<> entry = x;
@@ -484,6 +700,88 @@ namespace {
     }
 
     const char* SolverName(bool biConjugate) { return biConjugate ? "BCGSolve" : "CGSolve"; }
+
+    struct ScaledAlphaObservation_ {
+        std::uint64_t resultBits_;
+        std::uint64_t directResidualBits_;
+        CallbackCounts_ counts_;
+        std::vector<std::uint64_t> callbackBits_;
+    };
+
+    void RecordCallback(std::uint64_t tag, int call, double input, double output, std::vector<std::uint64_t>* callbackBits) {
+        callbackBits->push_back(tag);
+        callbackBits->push_back(static_cast<std::uint64_t>(call));
+        callbackBits->push_back(DoubleBits(input));
+        callbackBits->push_back(DoubleBits(output));
+    }
+
+    ScaledAlphaObservation_ ObserveScaledAlphaSolve(bool biConjugate, double diagonal, double preconditionerScale, double rhs, double initial) {
+        ScaledAlphaObservation_ result;
+        HookedPreconditionedDiagonal_ matrix({diagonal}, &result.counts_);
+        matrix.SetLeftHook([diagonal, &result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = diagonal * input[0];
+            RecordCallback(1, call, input[0], (*output)[0], &result.callbackBits_);
+            return true;
+        });
+        matrix.SetRightHook([diagonal, &result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = diagonal * input[0];
+            RecordCallback(2, call, input[0], (*output)[0], &result.callbackBits_);
+            return true;
+        });
+        const auto preconditioner = [preconditionerScale, &result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = preconditionerScale * input[0];
+            RecordCallback(3, call, input[0], (*output)[0], &result.callbackBits_);
+            return true;
+        };
+        const auto shadowPreconditioner = [preconditionerScale, &result](int call, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = preconditionerScale * input[0];
+            RecordCallback(4, call, input[0], (*output)[0], &result.callbackBits_);
+            return true;
+        };
+        matrix.SetPreconditionerLeftHook(preconditioner);
+        matrix.SetPreconditionerRightHook(shadowPreconditioner);
+        const Vector_<> b = {rhs};
+        Vector_<> x = {initial};
+
+        RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x);
+
+        result.resultBits_ = DoubleBits(x[0]);
+        result.directResidualBits_ = DoubleBits(DiagonalResidual({diagonal}, x, b)[0]);
+        return result;
+    }
+
+    struct AllocationObservation_ {
+        std::size_t count_;
+        std::uint64_t resultBits_;
+    };
+
+    AllocationObservation_ ObserveSolveAllocations(bool biConjugate, double diagonal, double preconditionerScale, double rhs) {
+        CallbackCounts_ counts;
+        HookedPreconditionedDiagonal_ matrix({diagonal}, &counts);
+        const auto preconditioner = [preconditionerScale](int, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = preconditionerScale * input[0];
+            return true;
+        };
+        matrix.SetPreconditionerLeftHook(preconditioner);
+        matrix.SetPreconditionerRightHook(preconditioner);
+        const Vector_<> b = {rhs};
+        Vector_<> x = {0.0};
+
+        AllocationScope_ allocations;
+        RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x);
+        const std::size_t count = allocations.Finish();
+        return {count, DoubleBits(x[0])};
+    }
+
+    void AssertScaledAlphaSolve(bool biConjugate, double diagonal, double preconditionerScale, double rhs, std::uint64_t expectedBits) {
+        const ScaledAlphaObservation_ observation = ObserveScaledAlphaSolve(biConjugate, diagonal, preconditionerScale, rhs, 0.0);
+        ASSERT_EQ(expectedBits, observation.resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, observation.directResidualBits_);
+        ASSERT_EQ(3, observation.counts_.left_);
+        ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.right_);
+        ASSERT_EQ(1, observation.counts_.preconditionerLeft_);
+        ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.preconditionerRight_);
+    }
 
     void AssertDalExceptionContains(const std::function<void()>& call, std::initializer_list<const char*> tokens) {
         bool caught = false;
@@ -1151,4 +1449,376 @@ TEST(MatrixTest, TestCGSolveAndBCGSolvePublicSignaturesRemainExact) {
     SolveFunction_ bcg = &Sparse::BCGSolve;
     ASSERT_NE(nullptr, cg);
     ASSERT_NE(nullptr, bcg);
+}
+
+TEST(MatrixTest, TestCGSolveScaledAlphaOverflow) {
+    AssertScaledAlphaSolve(false, std::ldexp(1.0, -500), std::ldexp(1.0, -600), std::ldexp(1.0, 100), 0x6570000000000000ULL);
+}
+
+TEST(MatrixTest, TestBCGSolveScaledAlphaOverflow) {
+    AssertScaledAlphaSolve(true, std::ldexp(1.0, -500), std::ldexp(1.0, -600), std::ldexp(1.0, 100), 0x6570000000000000ULL);
+}
+
+TEST(MatrixTest, TestCGSolveScaledAlphaUnderflow) {
+    AssertScaledAlphaSolve(false, std::ldexp(1.0, 500), std::ldexp(1.0, 600), std::ldexp(1.0, -100), 0x1a70000000000000ULL);
+}
+
+TEST(MatrixTest, TestBCGSolveScaledAlphaUnderflow) {
+    AssertScaledAlphaSolve(true, std::ldexp(1.0, 500), std::ldexp(1.0, 600), std::ldexp(1.0, -100), 0x1a70000000000000ULL);
+}
+
+TEST(MatrixTest, TestCGSolveScaledAlphaMinimumSubnormal) {
+    AssertScaledAlphaSolve(false, std::ldexp(1.0, 500), std::ldexp(1.0, 1023), std::ldexp(1.0, -574), 0x0000000000000001ULL);
+}
+
+TEST(MatrixTest, TestBCGSolveScaledAlphaMinimumSubnormal) {
+    AssertScaledAlphaSolve(true, std::ldexp(1.0, 500), std::ldexp(1.0, 1023), std::ldexp(1.0, -574), 0x0000000000000001ULL);
+}
+
+TEST(MatrixTest, TestScaledAlphaBoundsAndClassifierMatrix) {
+    using BcgScaledAlphaPrivate_::AlphaPath_;
+    using BcgScaledAlphaPrivate_::StoredScaledBits_;
+    const StoredScaledBits_ unit{0x3fe0000000000000ULL, 1, true};
+    struct ClassifierRow_ {
+        const char* id_;
+        StoredScaledBits_ numerator_;
+        StoredScaledBits_ denominator_;
+        std::uint64_t expectedNumerator_;
+        std::uint64_t expectedDenominator_;
+        int expectedExponent_;
+        AlphaPath_ expectedPath_;
+    };
+    const std::array<ClassifierRow_, 12> rows = {{
+        {"C1", {0x3fe0000000000000ULL, -1074, true}, unit, 1, 1, -1075, AlphaPath_::SCALED_EXACT},
+        {"C2", {0x3fe0000000000000ULL, -1073, true}, unit, 1, 1, -1074, AlphaPath_::SCALED_EXACT},
+        {"C3", {0x3feffffffffffffeULL, -1022, true}, unit, 4503599627370495ULL, 2251799813685248ULL, -1023, AlphaPath_::SCALED_EXACT},
+        {"C4", {0x3fe0000000000000ULL, -1021, true}, unit, 1, 1, -1022, AlphaPath_::ORDINARY_NORMAL},
+        {"C5", {0x3fe0000000000000ULL, 1024, true}, unit, 1, 1, 1023, AlphaPath_::ORDINARY_NORMAL},
+        {"C6", {0x3fefffffffffffffULL, 1024, true}, unit, 9007199254740991ULL, 4503599627370496ULL, 1023, AlphaPath_::ORDINARY_NORMAL},
+        {"C7",
+         {0x3fefffffffffffffULL, 1025, true},
+         {0x3feffffffffffffeULL, 1, true},
+         9007199254740991ULL,
+         9007199254740990ULL,
+         1024,
+         AlphaPath_::SCALED_EXACT},
+        {"C8", {0x0000000000000001ULL, 0, false}, {0x0000000000000001ULL, 0, false}, 1, 1, 0, AlphaPath_::SCALED_EXACT},
+        {"C9a", {0x3fe0000000000000ULL, 1025, true}, unit, 1, 1, 1024, AlphaPath_::SCALED_EXACT},
+        {"C9b", {0x3fe0000000000000ULL, 1026, true}, unit, 1, 1, 1025, AlphaPath_::SCALED_EXACT},
+        {"C10", {0x3fe0000000000000ULL, 1101, true}, unit, 1, 1, 1100, AlphaPath_::SCALED_EXACT},
+        {"C11", {0x3fe0000000000000ULL, -1099, true}, unit, 1, 1, -1100, AlphaPath_::SCALED_EXACT},
+    }};
+
+    ASSERT_EQ(-8660, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.storedMinExponent_);
+    ASSERT_EQ(8300, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.storedMaxExponent_);
+    ASSERT_EQ(-16960, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.alphaMinExponent_);
+    ASSERT_EQ(16960, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.alphaMaxExponent_);
+    ASSERT_EQ(19112, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.logicalMagnitudeBits_);
+    ASSERT_EQ(598, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.candidateLimbCount_);
+    ASSERT_EQ(19111, BcgScaledAlphaPrivate_::REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_);
+
+    for (const ClassifierRow_& row : rows) {
+        for (const int signCase : {0, 1, 2}) {
+            SCOPED_TRACE(std::string(row.id_) + " sign=" + std::to_string(signCase));
+            StoredScaledBits_ numerator = row.numerator_;
+            StoredScaledBits_ denominator = row.denominator_;
+            if (signCase == 1)
+                numerator.mantissaBits_ ^= 0x8000000000000000ULL;
+            if (signCase == 2)
+                denominator.mantissaBits_ ^= 0x8000000000000000ULL;
+#if defined(__SSE2__) || defined(_M_X64)
+            MxcsrRestore_ restore;
+            const unsigned before = _mm_getcsr();
+#endif
+            const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ClassifyAlpha_(numerator, denominator);
+#if defined(__SSE2__) || defined(_M_X64)
+            const unsigned after = _mm_getcsr();
+            ASSERT_EQ(before, after);
+#endif
+            ASSERT_EQ(row.expectedNumerator_, plan.exact_.numerator_);
+            ASSERT_EQ(row.expectedDenominator_, plan.exact_.denominator_);
+            ASSERT_EQ(row.expectedExponent_, plan.exact_.binaryExponent_);
+            ASSERT_EQ(signCase != 0, plan.exact_.negative_);
+            ASSERT_EQ(row.expectedPath_, plan.path_);
+            const int legacyConversionCalls = plan.path_ == AlphaPath_::ORDINARY_NORMAL || plan.path_ == AlphaPath_::LEGACY_ZERO ? 1 : 0;
+            ASSERT_EQ(row.expectedPath_ == AlphaPath_::ORDINARY_NORMAL ? 1 : 0, legacyConversionCalls);
+        }
+    }
+
+    ASSERT_EQ(AlphaPath_::DENOMINATOR_ZERO,
+              BcgScaledAlphaPrivate_::ClassifyAlpha_({0x0000000000000000ULL, 0, false}, {0x8000000000000000ULL, 0, false}).path_);
+    ASSERT_EQ(AlphaPath_::LEGACY_ZERO,
+              BcgScaledAlphaPrivate_::ClassifyAlpha_({0x8000000000000000ULL, 0, false}, {0x3ff0000000000000ULL, 0, false}).path_);
+}
+
+TEST(MatrixTest, TestScaledAlphaOracleBootstrap) { AssertOracleBootstrap(); }
+
+TEST(MatrixTest, TestScaledAlphaEvaluatorMatrixAndFtz) {
+    AssertOracleBootstrap();
+    for (const EvaluatorRow_& row : EvaluatorRows()) {
+        SCOPED_TRACE(row.id_);
+        const Dal35OneBitOracle_::OracleResult_ oracle = Dal35OneBitOracle_::Evaluate_(OracleInput(row.alpha_, row.valueBits_, row.baseBits_));
+        const Dal35OneBitOracle_::OracleClass_ expectedOracleClass = row.expectedClass_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE
+                                                                         ? Dal35OneBitOracle_::OracleClass_::FINITE
+                                                                         : Dal35OneBitOracle_::OracleClass_::NON_FINITE;
+        ASSERT_EQ(expectedOracleClass, oracle.classification_);
+        if (oracle.classification_ == Dal35OneBitOracle_::OracleClass_::FINITE)
+            ASSERT_EQ(row.expectedBits_, oracle.bits_);
+
+        BcgScaledAlphaPrivate_::RoundedBinary64_ priorResult{};
+        bool havePrior = false;
+        for (const bool flushToZero : {false, true}) {
+            BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+#if defined(__SSE2__) || defined(_M_X64)
+            MxcsrRestore_ restore;
+            const unsigned configured =
+                (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+            _mm_setcsr(configured);
+            const unsigned before = _mm_getcsr();
+#else
+            if (flushToZero)
+                continue;
+#endif
+            const BcgScaledAlphaPrivate_::RoundedBinary64_ result =
+                BcgScaledAlphaPrivate_::EvaluateElement_(row.alpha_, row.valueBits_, row.baseBits_, &workspace);
+#if defined(__SSE2__) || defined(_M_X64)
+            const unsigned after = _mm_getcsr();
+            ASSERT_EQ(before, after);
+#endif
+            ASSERT_EQ(row.expectedClass_, result.classification_);
+            std::uint64_t destination = 0x3fd5555555555555ULL;
+            if (result.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
+                destination = result.bits_;
+            ASSERT_EQ(row.expectedClass_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE ? row.expectedBits_ : 0x3fd5555555555555ULL, destination);
+            AssertCanonicalWorkspace(workspace);
+            if (havePrior) {
+                ASSERT_EQ(priorResult.classification_, result.classification_);
+                if (result.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
+                    ASSERT_EQ(priorResult.bits_, result.bits_);
+            }
+            priorResult = result;
+            havePrior = true;
+        }
+    }
+}
+
+TEST(MatrixTest, TestScaledAlphaWorkspaceCleanupInjection) {
+    const BcgScaledAlphaPrivate_::ExactAlpha_ alpha{1, 1, 0, false};
+    {
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+        workspace.positive_.first_ = 7;
+        workspace.positive_.last_ = 9;
+        workspace.positive_.limbs_[7] = 1;
+        workspace.positive_.limbs_[9] = 3;
+        ASSERT_THROW(BcgScaledAlphaPrivate_::EvaluateElement_(alpha, 0x3ff0000000000000ULL, 0x0000000000000000ULL, &workspace), Exception_);
+        AssertCanonicalWorkspace(workspace);
+    }
+    {
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+        workspace.negative_.first_ = -1;
+        workspace.negative_.last_ = BcgScaledAlphaPrivate_::EXACT_CANDIDATE_LIMB_COUNT_;
+        workspace.negative_.limbs_[0] = 5;
+        workspace.negative_.limbs_.back() = 7;
+        ASSERT_THROW(BcgScaledAlphaPrivate_::EvaluateElement_(alpha, 0x3ff0000000000000ULL, 0x0000000000000000ULL, &workspace), Exception_);
+        AssertCanonicalWorkspace(workspace);
+    }
+}
+
+TEST(MatrixTest, TestScaledAlphaWorkspaceForwardReverseReuse) {
+    AssertOracleBootstrap();
+    const std::array<int, 4> order = {9, 4, 13, 14};
+    BcgScaledAlphaPrivate_::ExactWorkspace_ reused;
+    for (const bool reverse : {false, true}) {
+        for (int position = 0; position < static_cast<int>(order.size()); ++position) {
+            const int index = order[reverse ? static_cast<int>(order.size()) - 1 - position : position];
+            const EvaluatorRow_& row = EvaluatorRows()[index];
+            SCOPED_TRACE(std::string(row.id_) + (reverse ? " reverse" : " forward"));
+            const BcgScaledAlphaPrivate_::RoundedBinary64_ actual =
+                BcgScaledAlphaPrivate_::EvaluateElement_(row.alpha_, row.valueBits_, row.baseBits_, &reused);
+            BcgScaledAlphaPrivate_::ExactWorkspace_ fresh;
+            const BcgScaledAlphaPrivate_::RoundedBinary64_ expected =
+                BcgScaledAlphaPrivate_::EvaluateElement_(row.alpha_, row.valueBits_, row.baseBits_, &fresh);
+            ASSERT_EQ(expected.classification_, actual.classification_);
+            if (actual.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
+                ASSERT_EQ(expected.bits_, actual.bits_);
+            AssertCanonicalWorkspace(reused);
+            AssertCanonicalWorkspace(fresh);
+        }
+    }
+}
+
+TEST(MatrixTest, TestScaledAlphaReviewedExponentAndTopCarryBounds) {
+    const std::uint64_t maximumSignificand = (1ULL << 53U) - 1ULL;
+    BcgScaledAlphaPrivate_::ExactMagnitude_ topCarry;
+    BcgScaledAlphaPrivate_::AddProduct_(maximumSignificand, maximumSignificand, 19005, &topCarry);
+    BcgScaledAlphaPrivate_::AddProduct_(maximumSignificand, maximumSignificand, 19005, &topCarry);
+    ASSERT_EQ(19111, BcgScaledAlphaPrivate_::HighestBit_(topCarry));
+    BcgScaledAlphaPrivate_::ResetMagnitude_(&topCarry);
+    ASSERT_EQ(BcgScaledAlphaPrivate_::EXACT_CANDIDATE_LIMB_COUNT_, topCarry.first_);
+    ASSERT_EQ(-1, topCarry.last_);
+
+    const std::array<BcgScaledAlphaPrivate_::ExactAlpha_, 2> alphas = {
+        BcgScaledAlphaPrivate_::ExactAlpha_{maximumSignificand, maximumSignificand, -16960, false},
+        BcgScaledAlphaPrivate_::ExactAlpha_{maximumSignificand, maximumSignificand, 16960, false}};
+    const std::array<std::uint64_t, 2> values = {0x0000000000000001ULL, 0x7fefffffffffffffULL};
+    const std::array<std::uint64_t, 2> bases = {0x7fefffffffffffffULL, 0x0000000000000001ULL};
+    for (int i = 0; i < 2; ++i) {
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+        const BcgScaledAlphaPrivate_::RoundedBinary64_ actual = BcgScaledAlphaPrivate_::EvaluateElement_(alphas[i], values[i], bases[i], &workspace);
+        const Dal35OneBitOracle_::OracleResult_ expected = Dal35OneBitOracle_::Evaluate_(OracleInput(alphas[i], values[i], bases[i]));
+        ASSERT_EQ(expected.classification_ == Dal35OneBitOracle_::OracleClass_::FINITE ? BcgScaledAlphaPrivate_::RoundedClass_::FINITE
+                                                                                       : BcgScaledAlphaPrivate_::RoundedClass_::NON_FINITE,
+                  actual.classification_);
+        if (actual.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE)
+            ASSERT_EQ(expected.bits_, actual.bits_);
+        AssertCanonicalWorkspace(workspace);
+    }
+}
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaOverflowCancellation) {
+    const double diagonal = std::ldexp(1.0, -500);
+    const double preconditioner = std::ldexp(1.0, -600);
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        const ScaledAlphaObservation_ positive =
+            ObserveScaledAlphaSolve(biConjugate, diagonal, preconditioner, std::ldexp(1.0, 523), -std::ldexp(1.0, 1023));
+        const ScaledAlphaObservation_ negative =
+            ObserveScaledAlphaSolve(biConjugate, diagonal, preconditioner, -std::ldexp(1.0, 523), std::ldexp(1.0, 1023));
+        ASSERT_EQ(0x7fe0000000000000ULL, positive.resultBits_);
+        ASSERT_EQ(0xffe0000000000000ULL, negative.resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, positive.directResidualBits_);
+        ASSERT_EQ(0x0000000000000000ULL, negative.directResidualBits_);
+    }
+}
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaMinimumSubnormalCancellation) {
+    const double diagonal = std::ldexp(1.0, 500);
+    const double preconditioner = std::ldexp(1.0, 600);
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        const ScaledAlphaObservation_ positive =
+            ObserveScaledAlphaSolve(biConjugate, diagonal, preconditioner, std::ldexp(1.0, -574), std::ldexp(1.0, -1022));
+        const ScaledAlphaObservation_ negative =
+            ObserveScaledAlphaSolve(biConjugate, diagonal, preconditioner, -std::ldexp(1.0, -574), -std::ldexp(1.0, -1022));
+        ASSERT_EQ(0x0000000000000001ULL, positive.resultBits_);
+        ASSERT_EQ(0x8000000000000001ULL, negative.resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, positive.directResidualBits_);
+        ASSERT_EQ(0x0000000000000000ULL, negative.directResidualBits_);
+    }
+}
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaRejectCandidateOverflow) {
+    const double diagonal = std::ldexp(1.0, -500);
+    const double preconditionerScale = std::ldexp(1.0, -600);
+    const Vector_<> b = {std::ldexp(1.0, 600)};
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        CallbackCounts_ counts;
+        HookedPreconditionedDiagonal_ matrix({diagonal}, &counts);
+        const auto preconditioner = [preconditionerScale](int, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = preconditionerScale * input[0];
+            return true;
+        };
+        matrix.SetPreconditionerLeftHook(preconditioner);
+        matrix.SetPreconditionerRightHook(preconditioner);
+        Vector_<> x = {0.0};
+
+        AssertDalExceptionContains([&]() { RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x); },
+                                   {SolverName(biConjugate), "numerical breakdown", "candidate x"});
+
+        ASSERT_EQ(0x0000000000000000ULL, DoubleBits(x[0]));
+        ASSERT_EQ(2, counts.left_);
+        ASSERT_EQ(biConjugate ? 1 : 0, counts.right_);
+        ASSERT_EQ(1, counts.preconditionerLeft_);
+        ASSERT_EQ(biConjugate ? 1 : 0, counts.preconditionerRight_);
+    }
+}
+
+#if defined(__SSE2__) || defined(_M_X64)
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
+    struct SolverFtzRow_ {
+        const char* id_;
+        double diagonal_;
+        double preconditioner_;
+        double rhs_;
+        double initial_;
+        std::uint64_t expectedBits_;
+    };
+    const std::array<SolverFtzRow_, 3> rows = {{
+        {"S3", std::ldexp(1.0, 500), std::ldexp(1.0, 1023), std::ldexp(1.0, -574), 0.0, 0x0000000000000001ULL},
+        {"S5+", std::ldexp(1.0, 500), std::ldexp(1.0, 600), std::ldexp(1.0, -574), std::ldexp(1.0, -1022), 0x0000000000000001ULL},
+        {"S5-", std::ldexp(1.0, 500), std::ldexp(1.0, 600), -std::ldexp(1.0, -574), -std::ldexp(1.0, -1022), 0x8000000000000001ULL},
+    }};
+    for (const bool biConjugate : {false, true}) {
+        for (const SolverFtzRow_& row : rows) {
+            SCOPED_TRACE(std::string(SolverName(biConjugate)) + " " + row.id_);
+            ScaledAlphaObservation_ observations[2];
+            for (const bool flushToZero : {false, true}) {
+                MxcsrRestore_ restore;
+                const unsigned configured =
+                    (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+                _mm_setcsr(configured);
+                const unsigned before = _mm_getcsr();
+                observations[flushToZero ? 1 : 0] = ObserveScaledAlphaSolve(biConjugate, row.diagonal_, row.preconditioner_, row.rhs_, row.initial_);
+                const unsigned after = _mm_getcsr();
+                ASSERT_EQ(before & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK), after & static_cast<unsigned>(_MM_FLUSH_ZERO_MASK));
+            }
+            ASSERT_EQ(row.expectedBits_, observations[0].resultBits_);
+            ASSERT_EQ(observations[0].resultBits_, observations[1].resultBits_);
+            ASSERT_EQ(observations[0].callbackBits_, observations[1].callbackBits_);
+            AssertCallbackCounts(observations[0].counts_, observations[1].counts_);
+        }
+    }
+}
+#endif
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
+    const BcgScaledAlphaPrivate_::AlphaPlan_ plan =
+        BcgScaledAlphaPrivate_::ClassifyAlpha_({0x4042000000000000ULL, 0, false}, {0x4052000000000000ULL, 0, false});
+    ASSERT_EQ(BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL, plan.path_);
+    ASSERT_EQ(1U, plan.exact_.numerator_);
+    ASSERT_EQ(1U, plan.exact_.denominator_);
+    ASSERT_EQ(-1, plan.exact_.binaryExponent_);
+    ASSERT_FALSE(plan.exact_.negative_);
+
+    const std::vector<std::uint64_t> cgCallbacks = {
+        1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x4018000000000000ULL, 0x4018000000000000ULL,
+        1, 2, 0x4018000000000000ULL, 0x4028000000000000ULL, 1, 3, 0x4008000000000000ULL, 0x4018000000000000ULL};
+    const std::vector<std::uint64_t> bcgCallbacks = {
+        1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x4018000000000000ULL, 0x4018000000000000ULL,
+        4, 1, 0x4018000000000000ULL, 0x4018000000000000ULL, 1, 2, 0x4018000000000000ULL, 0x4028000000000000ULL,
+        2, 1, 0x4018000000000000ULL, 0x4028000000000000ULL, 1, 3, 0x4008000000000000ULL, 0x4018000000000000ULL};
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+#if defined(__SSE2__) || defined(_M_X64)
+        MxcsrRestore_ restore;
+        const unsigned statusMask = _MM_EXCEPT_INVALID | _MM_EXCEPT_OVERFLOW;
+        const unsigned configured = _mm_getcsr() | statusMask;
+        _mm_setcsr(configured);
+#endif
+        const ScaledAlphaObservation_ observation = ObserveScaledAlphaSolve(biConjugate, 2.0, 1.0, 6.0, 0.0);
+#if defined(__SSE2__) || defined(_M_X64)
+        ASSERT_EQ(configured & statusMask, _mm_getcsr() & statusMask);
+#endif
+        ASSERT_EQ(0x4008000000000000ULL, observation.resultBits_);
+        ASSERT_EQ(0x0000000000000000ULL, observation.directResidualBits_);
+        ASSERT_EQ(biConjugate ? bcgCallbacks : cgCallbacks, observation.callbackBits_);
+        ASSERT_EQ(3, observation.counts_.left_);
+        ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.right_);
+        ASSERT_EQ(1, observation.counts_.preconditionerLeft_);
+        ASSERT_EQ(biConjugate ? 1 : 0, observation.counts_.preconditionerRight_);
+    }
+}
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaAddsNoHeapAllocations) {
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        const AllocationObservation_ ordinary = ObserveSolveAllocations(biConjugate, 2.0, 1.0, 6.0);
+        const AllocationObservation_ scaled =
+            ObserveSolveAllocations(biConjugate, std::ldexp(1.0, -500), std::ldexp(1.0, -600), std::ldexp(1.0, 100));
+        ASSERT_GT(ordinary.count_, 0U);
+        ASSERT_LE(scaled.count_, ordinary.count_);
+        ASSERT_EQ(0x4008000000000000ULL, ordinary.resultBits_);
+        ASSERT_EQ(0x6570000000000000ULL, scaled.resultBits_);
+    }
 }

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -24,14 +24,15 @@
 #include <dal/math/matrix/banded.hpp>
 #include <dal/math/matrix/sparse.hpp>
 #include <dal/math/matrix/bcg.hpp>
-#define DAL35_ENABLE_TEST_SEAM
 #include <dal/math/matrix/bcg_scaled_alpha.inc>
-#undef DAL35_ENABLE_TEST_SEAM
 #include "dal35_one_bit_oracle.hpp"
 
 namespace {
     std::atomic<bool> dal35TrackAllocations_{false};
     std::atomic<std::size_t> dal35AllocationCount_{0};
+#if defined(DAL35_ENABLE_TEST_SEAM)
+    int dal35ExactWorkspaceConstructionCount_ = 0;
+#endif
 
     void* Dal35Allocate_(std::size_t size) {
         if (dal35TrackAllocations_.load(std::memory_order_relaxed))
@@ -41,6 +42,16 @@ namespace {
         throw std::bad_alloc();
     }
 } // namespace
+
+#if defined(DAL35_ENABLE_TEST_SEAM)
+#if defined(__GNUC__) || defined(__clang__)
+#define DAL35_TEST_HIDDEN_ __attribute__((visibility("hidden")))
+#else
+#define DAL35_TEST_HIDDEN_
+#endif
+extern "C" DAL35_TEST_HIDDEN_ void Dal35ObserveExactWorkspaceConstructionForTest_() noexcept { ++dal35ExactWorkspaceConstructionCount_; }
+#undef DAL35_TEST_HIDDEN_
+#endif
 
 void* operator new(std::size_t size) { return Dal35Allocate_(size); }
 
@@ -2171,27 +2182,29 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaNamedFtzFixtures) {
 }
 #endif
 
-TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
-    int legacyPathEntries = 0;
-    int exactPathEntries = 0;
-    int exactWorkspaceConstructions = 0;
-    const BcgScaledAlphaPrivate_::AlphaPlan_ plan = BcgScaledAlphaPrivate_::ObserveAlphaDispatchForTest_(
-        {0x4042000000000000ULL, 0, false}, {0x4052000000000000ULL, 0, false}, [&legacyPathEntries]() { ++legacyPathEntries; },
-        [&exactPathEntries, &exactWorkspaceConstructions](const BcgScaledAlphaPrivate_::ExactAlpha_&) {
-            ++exactPathEntries;
-            BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
-            ++exactWorkspaceConstructions;
-            AssertCanonicalWorkspace(workspace);
-        });
-    ASSERT_EQ(BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL, plan.path_);
-    ASSERT_EQ(1U, plan.exact_.numerator_);
-    ASSERT_EQ(1U, plan.exact_.denominator_);
-    ASSERT_EQ(-1, plan.exact_.binaryExponent_);
-    ASSERT_FALSE(plan.exact_.negative_);
-    ASSERT_EQ(1, legacyPathEntries);
-    ASSERT_EQ(0, exactPathEntries);
-    ASSERT_EQ(0, exactWorkspaceConstructions);
+#if defined(DAL35_ENABLE_TEST_SEAM)
+TEST(MatrixTest, TestCGSolveAndBCGSolveProductionExactWorkspaceConstructionBoundary) {
+    const double diagonal = std::ldexp(1.0, -500);
+    const double preconditioner = std::ldexp(1.0, -600);
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        dal35ExactWorkspaceConstructionCount_ = 0;
+        const OrdinaryCandidateObservation_ ordinary = ObserveOrdinaryCandidateCommit(biConjugate);
+        ASSERT_TRUE(ordinary.callbackException_);
+        ASSERT_EQ(1, ordinary.commitCount_);
+        ASSERT_EQ(0, dal35ExactWorkspaceConstructionCount_);
 
+        dal35ExactWorkspaceConstructionCount_ = 0;
+        const ScaledAlphaObservation_ scaled =
+            ObserveScaledAlphaSolve(biConjugate, diagonal, preconditioner, std::ldexp(1.0, 523), -std::ldexp(1.0, 1023));
+        ASSERT_EQ(0x7fe0000000000000ULL, scaled.resultBits_);
+        ASSERT_EQ(1, scaled.commitCount_);
+        ASSERT_EQ(1, dal35ExactWorkspaceConstructionCount_);
+    }
+}
+#endif
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaBitwiseCorpus) {
     const std::vector<std::uint64_t> cgCallbacks = {
         1, 1, 0x0000000000000000ULL, 0x0000000000000000ULL, 3, 1, 0x4018000000000000ULL, 0x4018000000000000ULL,
         1, 2, 0x4018000000000000ULL, 0x4028000000000000ULL, 1, 3, 0x4008000000000000ULL, 0x4018000000000000ULL};

--- a/docs/methodology/matrix.md
+++ b/docs/methodology/matrix.md
@@ -201,22 +201,39 @@ and exceeding `maxIterations` without meeting the threshold throws. An exact-zer
 residual returns immediately for either method. BCG also accepts a non-zero initial residual
 that already meets the tolerance; CG enters the iteration loop in that case.
 
-The implementation evaluates norms, tolerance bounds, recurrence ratios, and potentially
-canceling dot products without relying on an overflowing or underflowing intermediate
-`double`. Ordinary dot-product reduction remains the fast path when a conservative error
-bound proves its sign and non-zero classification reliable. Ambiguous cases use an
-order-independent exact accumulation of the binary64 products followed by one
-round-to-nearest, ties-to-even conversion. Borderline convergence comparisons likewise use
-the exact squared binary64 quantities, so the inclusive boundary above is preserved across
-the full finite input range.
+The implementation evaluates norms, tolerance bounds, and potentially canceling dot
+products without relying on an overflowing or underflowing intermediate `double`. Ordinary
+dot-product reduction remains the fast path when a conservative error bound proves its sign
+and non-zero classification reliable. Ambiguous cases use an order-independent exact
+accumulation of the binary64 products followed by one round-to-nearest, ties-to-even
+conversion. Borderline convergence comparisons likewise use the exact squared binary64
+quantities, so the inclusive boundary above is preserved across the full finite input range.
+
+Scale-aware recurrence handling is deliberately limited to the `alpha` candidate
+combinations. Before materializing `alpha` as binary64, an integer classifier proves that
+the existing division and exponent placement are safe. Otherwise the stored numerator and
+denominator remain an exact rational while each complete `alpha * value + base` expression
+for the solution, residual, and BCG shadow residual is combined and rounded once to
+binary64. This admits finite cancellation and subnormal results even when standalone
+`alpha` would overflow or underflow. A complete expression that rounds to a non-finite
+candidate still fails closed.
+
+The later `beta/betaPrev` direction ratio remains on the existing binary64 `ScaledRatio`
+and fused-combination path; the exact `alpha` evaluator does not change or cover it. For
+fixed input bits, that evaluator is independent of flush-to-zero (FTZ) and preserves the
+caller's FP mode. Solver-level FTZ validation is limited to the S3/S5 first-iteration
+acceptance cases (minimum-subnormal formation and cancellation to $\pm 2^{-1074}$);
+it does not extend to other iterations, arbitrary callbacks, convergence or
+direct-residual arithmetic, or the `beta/betaPrev` path.
 
 Inputs and every matrix or preconditioner result must have the expected size and contain
-only finite values. Each update is assembled in private candidate buffers; if its recursive
-residual appears converged, the solver recomputes $b-Ax$ from the candidate and publishes
-the candidate only when that direct residual independently meets the same tolerance.
-Malformed callback results, non-finite arithmetic, recurrence breakdown, or failed direct
-confirmation throw without exposing a partial candidate, leaving `x` at the entry state or
-the last fully committed finite iterate.
+only finite values. Each update is assembled in private candidate buffers; a genuine
+non-finite candidate fails before publication. If the recursive residual appears converged,
+the solver recomputes $b-Ax$ from the candidate and publishes the candidate atomically only
+when that direct residual independently meets the same tolerance. Malformed callback
+results, non-finite arithmetic, recurrence breakdown, or failed direct confirmation throw
+without exposing a partial candidate, leaving `x` at the entry state or the last fully
+committed finite iterate.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Reproduce DAL-35 with a finite CG/BCG solution whose standalone binary64 alpha overflows or underflows before it is combined with a vector.
- Fix the root cause by classifying the legacy `ScaledRatio` result and evaluating only scaled candidate products through an exact dyadic workspace; ordinary coefficients retain the legacy path and bitwise behavior.
- Preserve callback, confirmation, commit, AAD, binding, public ABI, `beta`, and `betaPrev` behavior; reject true non-finite candidate/residual/shadow results atomically.
- Document the scaled-alpha candidate semantics and verification method.

Closes DAL-35

## Reproduction and root cause

For the overflow case, a 1x1 system with `A = 2^-500`, `M^-1 = 2^-600`, and `b = 2^100` has the finite solution `x = 2^600`, but the old path first materialized `alpha = 2^1100` as binary64 and failed before computing `alpha * p`. The mirrored underflow case lost a non-zero update for the same reason. The defect was the eager standalone binary64 conversion of a scaled ratio before its candidate combination.

## Fix and RED/GREEN evidence

- Baseline RED: the controlled overflow/underflow CG and BCG fixtures failed at the legacy alpha-ratio conversion before any valid candidate commit.
- GREEN: C1-C11, E1-E21, S1-S6, and O1-O10 pass in native and forced-scalar configurations, including FTZ off/on observations, exact callback/confirmation sequences, one-commit semantics, ordered non-finite failures, drift probes, cleanup/reuse, and ordinary bitwise parity.
- A private, TU-local test seam observes the real production conversion/workspace boundary. Ordinary public CG/BCG solves record zero workspace constructions, scaled public solves record the expected positive count, and the disposable negative probe first demonstrated RED by forcing ordinary construction.

## Test plan

- [x] `bash ./build_linux.sh` — Release build/install and CTest: 1192/1192 passed.
- [x] `build/Release-linux/dal-cpp/dal_cpp_tests --gtest_brief=1` — 1131/1131 passed.
- [x] DAL-35 narrow/native filters — 5/5 and 53/53 passed.
- [x] Forced-scalar DAL-35 filters (`-U__AVX2__ -U__FMA__ -U__SSE2__`) — 2/2 and 51/51 passed.
- [x] Release ASan/UBSan with leak detection — 53/53 passed with no sanitizer report.
- [x] Ordinary/allocation/public-signature filters — 4/4 passed; instrumented production-boundary test — 1/1 passed.
- [x] `python3 .github/scripts/check_docs.py` and `python3 .github/scripts/tests/test_check_docs.py` — 39 Markdown files and 18/18 tests passed.
- [x] Diff/public ABI/bindings/AAD/install/internal-linkage gates — unchanged public surfaces, no installed `.inc`, one installed `bcg.hpp`, and no production seam symbol/string.

Independent paired performance evidence remains applicable because `e55ee3c..6c652864` is docs-only: CG was +2.82%; BCG was +3.38% overall and +3.53% in the slowest round. BCG therefore remains below the +4% gate but has only 0.47 percentage points of margin, which is the residual performance risk.
