### PR TITLE
test: harden CoDiPack thread-local tape guarantees

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -133,6 +133,46 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  codipack-thread-isolation:
+    name: CoDiPack thread isolation
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-14
+      CXX: g++-14
+      CXXFLAGS: -O2
+      DAL_NUM_THREADS: 8
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: recursive
+
+      - name: Setup
+        run: |
+          sudo apt install -y gcc-14 g++-14 make cmake
+
+      - name: Configure CoDiPack
+        run: |
+          cmake --preset=Release-linux -S . -B build/Release-codipack \
+            -DDAL_USE_XAD_AAD=OFF \
+            -DDAL_USE_CODIPACK_AAD=ON \
+            -DDAL_USE_ADEPT_AAD=OFF \
+            -DDAL_BUILD_PYTHON=OFF \
+            -DDAL_CPP_BUILD_EXAMPLES=OFF \
+            -DDAL_CPP_BUILD_BENCHMARKS=OFF
+
+      - name: Build CoDiPack
+        run: |
+          cmake --build build/Release-codipack --parallel 2
+
+      - name: Test CoDiPack thread isolation
+        run: |
+          ./build/Release-codipack/dal-cpp/dal_cpp_tests \
+            --gtest_filter='AADTest.TestCoDiPackTapeIsPerThreadAcrossThreadLifetimes:AADTest.TestWithCheckpointWithMultiThreading:AADTest.TestAADMutiThread'
+
+      - name: Test CoDiPack suite
+        run: |
+          ctest --test-dir build/Release-codipack --output-on-failure -LE benchmark
+
   # Extended build: dal-cpp + dal-public + dal-python.
   # Lives in a separate job so the main 16-job compiler×backend matrix
   # stays lean — the Python bindings are backend-agnostic, so testing

--- a/dal-cpp/tests/math/aad/test_concurrent_aad.cpp
+++ b/dal-cpp/tests/math/aad/test_concurrent_aad.cpp
@@ -3,24 +3,127 @@
 //
 
 #include <gtest/gtest.h>
-#include <dal/platform/platform.hpp>
-#include <dal/math/vectors.hpp>
-#include <dal/math/aad/aad.hpp>
-#include <dal/concurrency/threadpool.hpp>
 
+#include <algorithm>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <dal/concurrency/threadpool.hpp>
+#include <dal/math/aad/aad.hpp>
+#include <dal/math/vectors.hpp>
+#include <dal/platform/platform.hpp>
+
+using Dal::TaskHandle_;
 using Dal::ThreadPool_;
 using Dal::Vector_;
-using Dal::AAD::Tape_;
 using Dal::AAD::Number_;
-using Dal::TaskHandle_;
+using Dal::AAD::Tape_;
 
 struct SimpleModel_ {
     Number_ s1_;
     Number_ s2_;
-    SimpleModel_(const double s1, const double s2)
-    : s1_(s1), s2_(s2) {}
+    SimpleModel_(const double s1, const double s2) : s1_(s1), s2_(s2) {}
 };
 
+#ifdef DAL_USE_CODIPACK_AAD
+namespace {
+    struct CoDiThreadResult_ {
+        const void* tape_;
+        double value_;
+        double firstAdjoint_;
+        double secondAdjoint_;
+    };
+
+    std::vector<CoDiThreadResult_> RunCoDiThreadWave(size_t nThreads) {
+        std::vector<CoDiThreadResult_> results(nThreads);
+        std::vector<std::thread> threads;
+        threads.reserve(nThreads);
+
+        std::mutex startMutex;
+        std::condition_variable startCondition;
+        size_t nReady = 0;
+        bool start = false;
+        bool tapesAreDistinct = false;
+
+        for (size_t i = 0; i < nThreads; ++i) {
+            threads.emplace_back([&, i]() {
+                results[i].tape_ = &Dal::AAD::Tape()->tape_;
+
+                {
+                    std::unique_lock<std::mutex> lock(startMutex);
+                    ++nReady;
+                    startCondition.notify_all();
+                    startCondition.wait(lock, [&]() { return start; });
+                }
+
+                if (!tapesAreDistinct)
+                    return;
+
+                Dal::AAD::Clear(*Dal::AAD::Tape());
+                Number_ first(2.0);
+                Number_ second(3.0);
+                Dal::AAD::PutOnTape(first);
+                Dal::AAD::PutOnTape(second);
+                Dal::AAD::NewRecording(*Dal::AAD::Tape());
+
+                Number_ value = first * second;
+                Dal::AAD::Adjoint(value) = 1.0;
+                Dal::AAD::PropagateToStart(*Dal::AAD::Tape());
+
+                results[i].value_ = Dal::AAD::Value(value);
+                results[i].firstAdjoint_ = Dal::AAD::Adjoint(first);
+                results[i].secondAdjoint_ = Dal::AAD::Adjoint(second);
+            });
+        }
+
+        {
+            std::unique_lock<std::mutex> lock(startMutex);
+            startCondition.wait(lock, [&]() { return nReady == nThreads; });
+            std::vector<std::uintptr_t> tapeAddresses;
+            tapeAddresses.reserve(nThreads);
+            for (const auto& result : results)
+                tapeAddresses.push_back(reinterpret_cast<std::uintptr_t>(result.tape_));
+            std::sort(tapeAddresses.begin(), tapeAddresses.end());
+            tapeAddresses.erase(std::unique(tapeAddresses.begin(), tapeAddresses.end()), tapeAddresses.end());
+            tapesAreDistinct = tapeAddresses.size() == nThreads;
+            start = true;
+        }
+        startCondition.notify_all();
+
+        for (auto& thread : threads)
+            thread.join();
+
+        return results;
+    }
+} // namespace
+
+TEST(AADTest, TestCoDiPackTapeIsPerThreadAcrossThreadLifetimes) {
+    constexpr size_t N_THREADS = 8;
+    constexpr size_t N_WAVES = 8;
+
+    for (size_t wave = 0; wave < N_WAVES; ++wave) {
+        const auto results = RunCoDiThreadWave(N_THREADS);
+        std::vector<std::uintptr_t> tapeAddresses;
+        tapeAddresses.reserve(N_THREADS);
+
+        for (const auto& result : results)
+            tapeAddresses.push_back(reinterpret_cast<std::uintptr_t>(result.tape_));
+
+        std::sort(tapeAddresses.begin(), tapeAddresses.end());
+        tapeAddresses.erase(std::unique(tapeAddresses.begin(), tapeAddresses.end()), tapeAddresses.end());
+        ASSERT_EQ(tapeAddresses.size(), N_THREADS);
+
+        for (const auto& result : results) {
+            ASSERT_NEAR(result.value_, 6.0, 1e-10);
+            ASSERT_NEAR(result.firstAdjoint_, 3.0, 1e-10);
+            ASSERT_NEAR(result.secondAdjoint_, 2.0, 1e-10);
+        }
+    }
+}
+#endif
 
 TEST(AADTest, TestAADMutiThread) {
     constexpr int batch_size = 2048;
@@ -35,7 +138,7 @@ TEST(AADTest, TestAADMutiThread) {
     futures.reserve(n_rounds / batch_size + 1);
 
     Vector_<> greeks(3, 0.0);
-    Vector_<Vector_<>> final_results(n_threads +1, greeks);
+    Vector_<Vector_<>> final_results(n_threads + 1, greeks);
 
     int first_round = 0;
     int rounds_left = n_rounds;
@@ -77,12 +180,11 @@ TEST(AADTest, TestAADMutiThread) {
     for (auto& future : futures)
         pool->ActiveWait(future);
 
-    for (const auto& res: final_results)
+    for (const auto& res : final_results)
         for (size_t i = 0; i < greeks.size(); ++i)
-        greeks[i] += res[i];
+            greeks[i] += res[i];
 
     ASSERT_NEAR(greeks[0] / n_rounds, 6.0, 1e-8);
     ASSERT_NEAR(greeks[1], 3.0, 1e-8);
     ASSERT_NEAR(greeks[2], 2.0, 1e-8);
-
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,6 +130,29 @@ with an unknown CPU baseline.
 | `DAL_USE_ADEPT_AAD`        | `OFF`        | Use Adept                                                                             |
 | `MSVC_RUNTIME`             | `dynamic`    | MSVC-only C++ runtime: `static` for `/MT` (`/MTd` in Debug), otherwise `/MD` (`/MDd`) |
 
+### Selecting an AAD backend
+
+The native AADET backend is selected when all three external-backend options
+are `OFF`. XAD, CoDiPack, and Adept are mutually exclusive; configuration
+fails if more than one is enabled. For example, configure, build, and test a
+separate CoDiPack tree with:
+
+```bash
+cmake --preset=Release-linux -S . -B build/Release-codipack \
+  -DDAL_USE_XAD_AAD=OFF \
+  -DDAL_USE_CODIPACK_AAD=ON \
+  -DDAL_USE_ADEPT_AAD=OFF
+cmake --build build/Release-codipack --parallel
+ctest --test-dir build/Release-codipack --output-on-failure
+```
+
+CoDiPack recording is isolated by native thread-local storage: each operating
+system thread owns its underlying CoDiPack tape and DAL wrapper, and that
+storage is destroyed when the thread exits. This lifecycle does not depend on
+the Python GIL. A `Number_`, `Tape_`, or tape position remains thread-affine;
+create, record, propagate, and clear it on the same thread instead of moving it
+to another thread.
+
 ## Windows C++ and Excel
 
 From a Visual Studio 2022 developer shell with Ninja available:

--- a/docs/methodology/aad.md
+++ b/docs/methodology/aad.md
@@ -340,6 +340,12 @@ The library compiles with one of four AAD backends selected at build time:
 - **XAD** (`DAL_USE_XAD_AAD`) — `xad::adj<double>` tape.
 - **CoDiPack** (`DAL_USE_CODIPACK_AAD`) — `codi::RealReverseUnchecked` tape.
 
+CoDiPack gives each operating system thread its own underlying tape and DAL
+wrapper through native thread-local storage. Recording and reverse propagation
+therefore run independently of the Python GIL, and the tape is destroyed when
+its owning thread exits. Active values and tape positions are thread-affine and
+must not be transferred between threads.
+
 All four expose the same `Number_` / `Tape_` surface through facade functions in
 `dal-cpp/dal/math/aad/aad.hpp`, so caller code is backend-neutral. The
 differences that matter at the call site are the recording contract and the


### PR DESCRIPTION
## Summary

- add a deterministic CoDiPack-only regression test that holds worker threads alive together, verifies eight distinct underlying tape addresses, and repeats recording/propagation across eight thread-lifetime waves
- add a dedicated Linux CI gate that explicitly configures and builds the CoDiPack backend, runs the focused concurrency tests, and then runs the complete non-benchmark CTest suite
- document backend selection, the native AADET default, external-backend mutual exclusion, CoDiPack thread-local lifetime guarantees, and thread-affinity constraints

## Audit correction and pinned evidence

The earlier review suspected that CoDiPack used one process-wide static tape and could crash under concurrent DAL use. That conclusion came from a stale or incorrectly synchronized submodule working tree, not from the repository's pinned dependency state.

`master` pins `dal-cpp/externals/CodiPack` at gitlink:

```text
86b94d3f3c3b6659a36f8e640945a7ebe1884a4a
```

At that exact commit, `include/codi/expressions/activeType.hpp` declares `static thread_local Tape tape` and defines the template storage with `thread_local`. DAL's wrapper is also thread-local. This follow-up therefore does not change production tape ownership; it adds deterministic regression coverage, CI enforcement, and user documentation around the already-correct pinned behavior.

## Validation

- mutation check: temporarily replacing both pinned CoDiPack `thread_local` declarations with shared static storage made `AADTest.TestCoDiPackTapeIsPerThreadAcrossThreadLifetimes` fail deterministically (`1` unique address vs expected `8`); restoring the pinned source returned the focused suite to 3/3 passing
- CoDiPack configure/build: passed with `DAL_USE_CODIPACK_AAD=ON` and the other external backends off
- CoDiPack full suite: 1168/1168 passed
- default native AADET configure/build: passed with all external backends off
- default native AADET full suite: 1171/1171 passed
- `clang-format --dry-run --Werror dal-cpp/tests/math/aad/test_concurrent_aad.cpp`: passed
- `git diff --check`: passed

This PR intentionally leaves the three historical review threads on PR #34 unchanged and does not merge itself.
