### PR TITLE
fix: DAL-55 initialize Black-Scholes clone state

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -365,7 +365,7 @@ jobs:
             slug: asan-ubsan
             sanitizers: address;undefined
             flags: -O2 -g -fno-sanitize-recover=all
-            core-filter: ConcurrencyTest.*:DistributionTest.*:MatrixTest.TestLowerBandAccumulator:StackTest.*:UnderdeterminedTest.TestFindUsesQuadraticBacktrackMinimum:ScriptTest.Test*Batch*:StorageTest.TestEvaluationDate*
+            core-filter: ConcurrencyTest.*:DistributionTest.*:MatrixTest.TestLowerBandAccumulator:ModelTest.TestBlackScholesModelCloneHasDefinedPreAllocationState:StackTest.*:UnderdeterminedTest.TestFindUsesQuadraticBacktrackMinimum:ScriptTest.Test*Batch*:StorageTest.TestEvaluationDate*
             public-filter: PublicApiTest.TestMonteCarlo*
           - label: TSan concurrency tests
             slug: tsan

--- a/dal-cpp/dal/model/blackscholes.hpp
+++ b/dal-cpp/dal/model/blackscholes.hpp
@@ -30,8 +30,8 @@ namespace Dal {
             T_ vol_;
 
             Vector_<> timeLine_;
-            bool todayOnTimeLine_;
-            const Vector_<SampleDef_>* defLine_;
+            bool todayOnTimeLine_ = false;
+            const Vector_<SampleDef_>* defLine_ = nullptr;
 
             Vector_<T_> stds_;
             Vector_<T_> drifts_;

--- a/dal-cpp/tests/model/test_blackscholes.cpp
+++ b/dal-cpp/tests/model/test_blackscholes.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstring>
+#include <new>
 
 #include <dal/platform/platform.hpp>
 #include <dal/math/aad/sample.hpp>
@@ -95,6 +97,23 @@ TEST(ModelTest, TestBlackScholesModelCloneIsIndependent) {
     ASSERT_NEAR(bs_clone->Vol(), 0.20, 1e-10);
     ASSERT_NEAR(bs_clone->Rate(), 0.05, 1e-10);
     ASSERT_NEAR(bs_clone->Div(), 0.01, 1e-10);
+}
+
+TEST(ModelTest, TestBlackScholesModelCloneHasDefinedPreAllocationState) {
+    using model_t = AAD::BlackScholes_<>;
+    alignas(model_t) unsigned char storage[sizeof(model_t)];
+    std::memset(storage, 0xc0, sizeof(storage));
+    auto* model = new (storage) model_t(100.0, 0.20, 0.05, 0.01);
+
+    std::unique_ptr<AAD::Model_<>> cloned(model->Clone());
+    model->~model_t();
+
+    auto* blackScholesClone = dynamic_cast<const model_t*>(cloned.get());
+    ASSERT_TRUE(blackScholesClone != nullptr);
+    ASSERT_NEAR(blackScholesClone->Spot(), 100.0, 1e-10);
+    ASSERT_NEAR(blackScholesClone->Vol(), 0.20, 1e-10);
+    ASSERT_NEAR(blackScholesClone->Rate(), 0.05, 1e-10);
+    ASSERT_NEAR(blackScholesClone->Div(), 0.01, 1e-10);
 }
 
 TEST(ModelTest, TestBlackScholesAllocateRejectsEmptyTimeline) {


### PR DESCRIPTION
## Summary

- Initialize the Black-Scholes model's transient timeline flag and sample-definition pointer to inert values.
- Add a deterministic regression for cloning before `Allocate()`.
- Include that regression in the focused ASan/UBSan GitHub Actions filter.

## Reproduction

Cloning a freshly constructed `BlackScholes_` before `Allocate()` invokes the implicit copy constructor. Under UBSan with poisoned object storage, the baseline deterministically reports an invalid `bool` load while copying the model.

## Root cause

`todayOnTimeLine_` and `defLine_` had no constructor-state initialization, so `Clone()` copied indeterminate transient members before `Allocate()` assigned them.

## Fix

Default-initialize the transient members to `false` and `nullptr`, retain all existing allocation and clone behavior, and continuously exercise the pre-allocation clone regression in the ASan/UBSan CI job.

## Test plan

- [x] Focused ASan/UBSan RED on the baseline/test-only state and GREEN at the final head.
- [x] CI-equivalent ASan/UBSan core filter: 38/38 passed; public filter: 3/3 passed.
- [x] Full Linux matrix: 1194/1194 passed.
- [x] Full CoDiPack matrix: 1191/1191 passed.
- [x] Documentation checks passed; independent tester and reviewer gates passed.

## Risks

The production change only defines private transient constructor state; no public API, numerical method, binding, parameter/default, or documented contract changes. DAL-57 remains a separate pre-existing sanitizer issue outside this PR's focused sanitizer filter and does not affect the DAL-55 result.

Closes DAL-55
