### PR TITLE
refactor: deduplicate DAL-58 Curve Lab runtime paths

### DIFF
--- a/dal-web/backend/app/schemas/curve_lab.py
+++ b/dal-web/backend/app/schemas/curve_lab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import date, datetime
+from types import MappingProxyType
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
@@ -75,6 +76,25 @@ CURVE_LAB_V1_SUCCESS_REGISTRY: tuple[CurveLabSuccessRegistryEntry, ...] = (
 )
 CURVE_LAB_V1_SUCCESS_FAMILIES: tuple[CurveLabV1SuccessFamily, ...] = tuple(
     row.instrument_type for row in CURVE_LAB_V1_SUCCESS_REGISTRY
+)
+CURVE_LAB_RISK_LIMITS = MappingProxyType(
+    {
+        "trades": 1_000,
+        "parameters": 500,
+        "quotes": 500,
+        "price_evaluations": 100_000,
+        "calibration_solves": 1_002,
+        "aad_recordings": 1_000,
+        "estimated_wall_millis": 900_000,
+    }
+)
+CURVE_LAB_RISK_COST_COEFFICIENTS = MappingProxyType(
+    {
+        "context_build_millis": 1,
+        "price_evaluation_millis": 1,
+        "calibration_solve_millis": 10,
+        "aad_recording_overhead_millis": 1,
+    }
 )
 CurveLabSuccessFamilyInput = Annotated[
     str,
@@ -167,24 +187,9 @@ class CurveLabCapabilitiesResponse(CurveLabWireModel):
         "PRICE_POINTS",
     )
     max_quote_bytes: Literal[512] = 512
-    risk_limits: dict[str, int] = Field(
-        default_factory=lambda: {
-            "trades": 1_000,
-            "parameters": 500,
-            "quotes": 500,
-            "price_evaluations": 100_000,
-            "calibration_solves": 1_002,
-            "aad_recordings": 1_000,
-            "estimated_wall_millis": 900_000,
-        }
-    )
+    risk_limits: dict[str, int] = Field(default_factory=lambda: dict(CURVE_LAB_RISK_LIMITS))
     risk_cost_coefficients: dict[str, int] = Field(
-        default_factory=lambda: {
-            "context_build_millis": 1,
-            "price_evaluation_millis": 1,
-            "calibration_solve_millis": 10,
-            "aad_recording_overhead_millis": 1,
-        }
+        default_factory=lambda: dict(CURVE_LAB_RISK_COST_COEFFICIENTS)
     )
 
 

--- a/dal-web/backend/app/services/canonical_json.py
+++ b/dal-web/backend/app/services/canonical_json.py
@@ -1,0 +1,20 @@
+"""Canonical JSON bytes shared by Curve Lab persisted evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+
+
+def canonical_json_hash(value: object) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()

--- a/dal-web/backend/app/services/curve_lab_lifecycle.py
+++ b/dal-web/backend/app/services/curve_lab_lifecycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from datetime import UTC, datetime
 from threading import Lock
 from typing import TYPE_CHECKING
@@ -15,7 +14,12 @@ from app.schemas.curve_lab import (
     CurveRuntimeManifestV1,
     CurveVersionCreateRequest,
 )
-from app.services.archive_preflight import ArchivePreflightError, preflight_archive
+from app.services.archive_preflight import (
+    ArchivePreflightError,
+    ArchivePreflightResult,
+    preflight_archive,
+)
+from app.services.canonical_json import canonical_json_hash
 from app.services.curve_lab_jobs import (
     CURVE_LAB_JOBS,
     CurveLabQueueFullError,
@@ -94,18 +98,28 @@ def _reserve_job():
         ) from exc
 
 
-def _canonical_bytes(value: object) -> bytes:
-    return json.dumps(
-        value,
-        ensure_ascii=True,
-        allow_nan=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("ascii")
+def _project_import_preflight_error(
+    error: ArchivePreflightError,
+    *,
+    job_id: str,
+    payload_length: int,
+) -> tuple[dict[str, object], int, int]:
+    return (
+        {
+            "code": error.code,
+            "message": error.message,
+            "field": error.field,
+            "value": error.value,
+            "resource_id": job_id,
+            "details": error.details,
+        },
+        error.wire_length if error.wire_length is not None else payload_length,
+        error.expanded_length if error.expanded_length is not None else 0,
+    )
 
 
 def _hash(value: object) -> str:
-    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+    return canonical_json_hash(value)
 
 
 def _audit(
@@ -305,9 +319,7 @@ def create_build_run(store: StoreProtocol, gateway: DalGateway, draft_id: str) -
     resolved_plan = {
         "schema_version": 1,
         "mode": document["mode"],
-        "component_order": [
-            declaration["component_key"] for declaration in ordered_declarations
-        ],
+        "component_order": [declaration["component_key"] for declaration in ordered_declarations],
         "stages": [
             {
                 "stage_id": stage_id(document, index),
@@ -351,9 +363,7 @@ def create_build_run(store: StoreProtocol, gateway: DalGateway, draft_id: str) -
         },
         "error": None,
         "created_at": now,
-        "deadline_at": new_deadline(
-            datetime.fromisoformat(now.replace("Z", "+00:00"))
-        ),
+        "deadline_at": new_deadline(datetime.fromisoformat(now.replace("Z", "+00:00"))),
         "finished_at": None,
     }
     try:
@@ -710,59 +720,6 @@ def quote_axis(document: dict) -> list[dict]:
     return result
 
 
-def parameter_axis(document: dict) -> list[dict]:
-    included = [item for item in document["instruments"] if item["included"]]
-    declarations = resolved_declaration_order(document)
-    default_component = declarations[0]["component_key"]
-    result: list[dict] = []
-    stage_local_index = 0
-    for declaration in declarations:
-        component_key = declaration["component_key"]
-        dates = sorted(
-            {
-                item["maturity_date"]
-                for item in included
-                if item["terms"].get("component_key", default_component) == component_key
-            }
-        )
-        representation = declaration["parameterization"]
-        coordinates: list[tuple[str, str | None]] = []
-        if representation == "PIECEWISE_LINEAR_FWD":
-            coordinates = [(date_value, side) for date_value in dates for side in ("LEFT", "RIGHT")]
-        elif representation == "PIECEWISE_CONSTANT_FWD":
-            coordinates = [(date_value, "RIGHT") for date_value in dates]
-        elif representation == "LOG_DISCOUNT":
-            coordinates = [(date_value, None) for date_value in dates[1:]]
-        else:
-            coordinates = [(date_value, None) for date_value in dates]
-        for component_local_index, (node_date, side) in enumerate(coordinates):
-            side_token = side or "SINGLE"
-            display_suffix = component_key.rsplit("/", 1)[-1]
-            result.append(
-                {
-                    "global_parameter_index": len(result),
-                    "parameter_id": (f"{component_key}:{representation}:{node_date}:{side_token}"),
-                    "component_key": component_key,
-                    "stage_id": "stage-0",
-                    "stage_local_parameter_index": stage_local_index,
-                    "component_local_parameter_index": component_local_index,
-                    "coordinate_kind": representation,
-                    "node_date": node_date,
-                    "side": side,
-                    "native_parameter_unit": (
-                        "LOG_DISCOUNT_FACTOR"
-                        if representation == "LOG_DISCOUNT"
-                        else "DECIMAL_RATE"
-                    ),
-                    "display_label": (
-                        f"{declaration['currency']} {display_suffix} {node_date} {side_token}"
-                    ),
-                }
-            )
-            stage_local_index += 1
-    return result
-
-
 def _build_public(store: StoreProtocol, record: dict) -> dict:
     current = get_draft(store, record["draft_id"])
     return {
@@ -1058,31 +1015,22 @@ def import_native_json(
             content_encoding=content_encoding,
         )
     except ArchivePreflightError as exc:
-        error = {
-            "code": exc.code,
-            "message": exc.message,
-            "field": exc.field,
-            "value": exc.value,
-            "resource_id": job_id,
-            "details": exc.details,
-        }
+        error, wire_length, expanded_length = _project_import_preflight_error(
+            exc,
+            job_id=job_id,
+            payload_length=len(payload),
+        )
         failed = {
             "id": job_id,
             "request_hash": request_hash,
-            "compressed_payload_length": (
-                exc.wire_length if exc.wire_length is not None else len(payload)
-            ),
-            "expanded_payload_length": (
-                exc.expanded_length if exc.expanded_length is not None else 0
-            ),
+            "compressed_payload_length": wire_length,
+            "expanded_payload_length": expanded_length,
             "state": "FAILED",
             "phase": "PREFLIGHT",
             "error": error,
             "resulting_version_id": None,
             "created_at": now,
-            "deadline_at": new_deadline(
-                datetime.fromisoformat(now.replace("Z", "+00:00"))
-            ),
+            "deadline_at": new_deadline(datetime.fromisoformat(now.replace("Z", "+00:00"))),
             "finished_at": now,
         }
         store.add_curve_lab_import_job(failed)
@@ -1105,9 +1053,7 @@ def import_native_json(
         "error": None,
         "resulting_version_id": None,
         "created_at": now,
-        "deadline_at": new_deadline(
-            datetime.fromisoformat(now.replace("Z", "+00:00"))
-        ),
+        "deadline_at": new_deadline(datetime.fromisoformat(now.replace("Z", "+00:00"))),
         "finished_at": None,
     }
     reservation = _reserve_job()
@@ -1118,8 +1064,7 @@ def import_native_json(
             store,
             gateway,
             queued,
-            payload,
-            content_encoding,
+            admitted,
             runtime_manifest,
         )
     except Exception:
@@ -1132,8 +1077,7 @@ def _execute_import_job(
     store: StoreProtocol,
     gateway: DalGateway,
     queued: dict,
-    payload: bytes,
-    content_encoding: str | None,
+    preflight: ArchivePreflightResult,
     runtime_manifest: CurveRuntimeManifestV1 | None,
 ) -> None:
     job_id = queued["id"]
@@ -1151,44 +1095,9 @@ def _execute_import_job(
         "phase": "PREFLIGHT",
     }
     store.update_curve_lab_import_job(job_id, running)
-    try:
-        preflight = preflight_archive(
-            payload,
-            content_encoding=content_encoding,
-        )
-    except ArchivePreflightError as exc:
-        error = {
-            "code": exc.code,
-            "message": exc.message,
-            "field": exc.field,
-            "value": exc.value,
-            "resource_id": job_id,
-            "details": exc.details,
-        }
-        store.update_curve_lab_import_job(
-            job_id,
-            {
-                **running,
-                "id": job_id,
-                "request_hash": request_hash,
-                "compressed_payload_length": (
-                    exc.wire_length if exc.wire_length is not None else len(payload)
-                ),
-                "expanded_payload_length": (
-                    exc.expanded_length if exc.expanded_length is not None else 0
-                ),
-                "state": "FAILED",
-                "phase": "PREFLIGHT",
-                "error": error,
-                "resulting_version_id": None,
-                "created_at": now,
-                "finished_at": now,
-            },
-        )
-        return
     native_running = {
         **running,
-        "compressed_payload_length": len(payload),
+        "compressed_payload_length": preflight.wire_length,
         "expanded_payload_length": preflight.expanded_length,
         "phase": "NATIVE_RECONSTRUCTION",
     }
@@ -1216,7 +1125,7 @@ def _execute_import_job(
                 **native_running,
                 "id": job_id,
                 "request_hash": request_hash,
-                "compressed_payload_length": len(payload),
+                "compressed_payload_length": preflight.wire_length,
                 "expanded_payload_length": preflight.expanded_length,
                 "state": "FAILED",
                 "phase": "NATIVE_RECONSTRUCTION",
@@ -1375,7 +1284,7 @@ def _execute_import_job(
     job = {
         "id": job_id,
         "request_hash": request_hash,
-        "compressed_payload_length": len(payload),
+        "compressed_payload_length": preflight.wire_length,
         "expanded_payload_length": preflight.expanded_length,
         "state": "SUCCEEDED",
         "phase": "PUBLISHED",

--- a/dal-web/backend/app/services/curve_lab_plan.py
+++ b/dal-web/backend/app/services/curve_lab_plan.py
@@ -19,8 +19,7 @@ def _xccy_pair(document: Mapping[str, Any]) -> tuple[str, str]:
         for item in document["instruments"]
         if item.get("included", True)
         and item["instrument_type"] == "XCCY"
-        and str(item.get("terms", {}).get("component_key", default_component))
-        in basis_keys
+        and str(item.get("terms", {}).get("component_key", default_component)) in basis_keys
     ]
     if not instruments:
         raise ValueError("XCCY component order requires an included basis instrument")
@@ -55,9 +54,7 @@ def resolved_declaration_order(
             return 0, index
         if currency == foreign:
             return 1, index
-        raise ValueError(
-            f"XCCY declaration currency {currency!r} is outside {domestic}-{foreign}"
-        )
+        raise ValueError(f"XCCY declaration currency {currency!r} is outside {domestic}-{foreign}")
 
     return [declaration for _, declaration in sorted(indexed, key=group)]
 

--- a/dal-web/backend/app/services/curve_risk.py
+++ b/dal-web/backend/app/services/curve_risk.py
@@ -759,8 +759,6 @@ def _admit_risk_run(
     request: RiskRunRequestV2,
     *,
     run_id: str,
-    created_at: str,
-    deadline_at: str,
     request_json: dict,
     request_bytes: bytes,
 ) -> _AdmittedRiskSnapshot:
@@ -916,6 +914,8 @@ def _admit_risk_run(
         sensitivity_layers=request.sensitivity_layers,
     )
     _admit_work(estimate)
+    created_at = _now()
+    deadline_at = new_deadline(datetime.fromisoformat(created_at.replace("Z", "+00:00")))
     return _AdmittedRiskSnapshot(
         run_id=run_id,
         created_at=created_at,
@@ -945,16 +945,12 @@ def create_risk_run(
 ) -> dict:
     request_json = request.model_dump(mode="json", exclude_none=True)
     request_bytes = canonical_json_bytes(request_json)
-    now = _now()
     run_id = uuid4().hex
-    deadline_at = new_deadline(datetime.fromisoformat(now.replace("Z", "+00:00")))
     admitted = _admit_risk_run(
         store,
         gateway,
         request,
         run_id=run_id,
-        created_at=now,
-        deadline_at=deadline_at,
         request_json=request_json,
         request_bytes=request_bytes,
     )
@@ -980,8 +976,8 @@ def create_risk_run(
         "state": "QUEUED",
         "result": None,
         "error": None,
-        "created_at": now,
-        "deadline_at": deadline_at,
+        "created_at": admitted.created_at,
+        "deadline_at": admitted.deadline_at,
         "finished_at": None,
     }
     try:

--- a/dal-web/backend/app/services/curve_risk.py
+++ b/dal-web/backend/app/services/curve_risk.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import hashlib
-import json
-from collections.abc import Callable
+import math
+from collections.abc import Callable, Mapping
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from app.schemas.curve_lab import FixingSnapshotCreateV1, RiskRunRequestV2
+from app.schemas.curve_lab import (
+    CURVE_LAB_RISK_COST_COEFFICIENTS,
+    CURVE_LAB_RISK_LIMITS,
+    FixingSnapshotCreateV1,
+    RiskRunRequestV2,
+)
+from app.services.canonical_json import canonical_json_bytes, canonical_json_hash
 from app.services.curve_lab_fixings import (
     canonical_utc_datetime,
     canonical_utc_timestamp,
@@ -29,7 +36,10 @@ from app.services.curve_lab_lifecycle import (
     get_version,
 )
 from app.services.curve_lab_plan import resolved_declaration_order
-from app.services.quote_canonicalization import canonicalize_quote
+from app.services.quote_canonicalization import (
+    apply_exact_decimal_bump,
+    canonicalize_quote,
+)
 from app.services.store import ConflictError, NotFoundError
 
 if TYPE_CHECKING:
@@ -37,25 +47,98 @@ if TYPE_CHECKING:
     from app.services.store import StoreProtocol
 
 _UINT64_MAX = (1 << 64) - 1
-_LIMITS = {
-    "T": 1_000,
-    "P": 500,
-    "Q": 500,
-    "price_evaluations": 100_000,
-    "calibration_solves": 1_002,
-    "aad_recordings": 1_000,
-    "estimated_wall_millis": 900_000,
+_ESTIMATE_LIMIT_FIELDS = {
+    "T": "trades",
+    "P": "parameters",
+    "Q": "quotes",
+    "price_evaluations": "price_evaluations",
+    "calibration_solves": "calibration_solves",
+    "aad_recordings": "aad_recordings",
+    "estimated_wall_millis": "estimated_wall_millis",
 }
-_COSTS = {
-    "context_build_millis": 1,
-    "price_evaluation_millis": 1,
-    "calibration_solve_millis": 10,
-    "aad_recording_overhead_millis": 1,
-}
+
+type _FrozenJsonScalar = bool | int | float | str | bytes | None
+
+
+@dataclass(frozen=True, slots=True)
+class _FrozenJsonArray:
+    items: tuple[_FrozenJsonValue, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _FrozenJsonObject:
+    entries: tuple[tuple[str, _FrozenJsonValue], ...]
+
+
+type _FrozenJsonValue = _FrozenJsonScalar | _FrozenJsonArray | _FrozenJsonObject
+
+
+@dataclass(frozen=True, slots=True)
+class _AdmittedRiskSnapshot:
+    run_id: str
+    created_at: str
+    deadline_at: str
+    request_bytes: bytes
+    request_projection: _FrozenJsonObject
+    curve_version: _FrozenJsonObject
+    dependencies: tuple[_FrozenJsonObject, ...]
+    document: _FrozenJsonObject
+    runtime_quote_axis: tuple[_FrozenJsonObject, ...]
+    persisted_quote_axis: tuple[_FrozenJsonObject, ...] | None
+    parameter_axis: tuple[_FrozenJsonObject, ...]
+    fixing_snapshot: _FrozenJsonObject
+    estimated_work: _FrozenJsonObject
+    aad_eligible_trade_count: int
+    aad_fallback_allowed: bool
+    target_fingerprint: str
 
 
 class _CurveLabDeadlineExceededError(RuntimeError):
     pass
+
+
+def _freeze_json(value: object) -> _FrozenJsonValue:
+    if value is None or isinstance(value, (bool, int, str, bytes)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("admission snapshot contains a non-finite float")
+        return value
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("admission snapshot object keys must be strings")
+        return _FrozenJsonObject(
+            tuple((key, _freeze_json(value[key])) for key in sorted(value) if isinstance(key, str))
+        )
+    if isinstance(value, (list, tuple)):
+        return _FrozenJsonArray(tuple(_freeze_json(item) for item in value))
+    raise TypeError(f"admission snapshot contains unsupported {type(value).__name__}")
+
+
+def _freeze_json_object(value: Mapping[str, object]) -> _FrozenJsonObject:
+    frozen = _freeze_json(value)
+    if not isinstance(frozen, _FrozenJsonObject):
+        raise TypeError("admission snapshot value must be an object")
+    return frozen
+
+
+def _thaw_json(value: _FrozenJsonValue) -> object:
+    if isinstance(value, _FrozenJsonArray):
+        return [_thaw_json(item) for item in value.items]
+    if isinstance(value, _FrozenJsonObject):
+        return {key: _thaw_json(item) for key, item in value.entries}
+    return value
+
+
+def _thaw_json_object(value: _FrozenJsonObject) -> dict:
+    thawed = _thaw_json(value)
+    if not isinstance(thawed, dict):
+        raise TypeError("admission snapshot value must thaw to an object")
+    return thawed
+
+
+def _thaw_json_objects(values: tuple[_FrozenJsonObject, ...]) -> list[dict]:
+    return [_thaw_json_object(value) for value in values]
 
 
 def _timeout_risk_run(store: StoreProtocol, record: dict) -> dict:
@@ -87,7 +170,7 @@ def create_fixing_snapshot(
     }
     record = {
         **document,
-        "content_hash": hashlib.sha256(_canonical_bytes(document)).hexdigest(),
+        "content_hash": canonical_json_hash(document),
         "created_at": _now(),
     }
     try:
@@ -125,18 +208,8 @@ def get_fixing_snapshot(store: StoreProtocol, snapshot_id: str) -> dict:
         ) from exc
 
 
-def _canonical_bytes(value: object) -> bytes:
-    return json.dumps(
-        value,
-        ensure_ascii=True,
-        allow_nan=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("ascii")
-
-
 def _hash(value: object) -> str:
-    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+    return canonical_json_hash(value)
 
 
 def _decimal_text(value: Decimal | str | int | float) -> str:
@@ -169,7 +242,6 @@ def estimate_work(
     quotes: int,
     measures: tuple[str, ...],
     sensitivity_layers: tuple[str, ...],
-    allow_aad_fallback: bool = True,
 ) -> dict[str, int | bool]:
     node = int(
         bool(
@@ -226,10 +298,16 @@ def estimate_work(
 
     contributions = []
     for count, coefficient in (
-        (contexts, _COSTS["context_build_millis"]),
-        (price_evaluations, _COSTS["price_evaluation_millis"]),
-        (calibration_solves, _COSTS["calibration_solve_millis"]),
-        (n_aad, _COSTS["aad_recording_overhead_millis"]),
+        (contexts, CURVE_LAB_RISK_COST_COEFFICIENTS["context_build_millis"]),
+        (
+            price_evaluations,
+            CURVE_LAB_RISK_COST_COEFFICIENTS["price_evaluation_millis"],
+        ),
+        (
+            calibration_solves,
+            CURVE_LAB_RISK_COST_COEFFICIENTS["calibration_solve_millis"],
+        ),
+        (n_aad, CURVE_LAB_RISK_COST_COEFFICIENTS["aad_recording_overhead_millis"]),
     ):
         contribution, term_overflow = _checked_multiply(count, coefficient)
         overflow |= term_overflow
@@ -262,17 +340,10 @@ def estimate_work(
 
 
 def _admit_work(estimate: dict[str, int | bool]) -> None:
-    for field in (
-        "T",
-        "P",
-        "Q",
-        "price_evaluations",
-        "calibration_solves",
-        "aad_recordings",
-        "estimated_wall_millis",
-    ):
+    for field, limit_field in _ESTIMATE_LIMIT_FIELDS.items():
         value = int(estimate[field])
-        if not estimate["overflow"] and value <= _LIMITS[field]:
+        limit = CURVE_LAB_RISK_LIMITS[limit_field]
+        if not estimate["overflow"] and value <= limit:
             continue
         code = (
             "RISK_DEADLINE_BUDGET_EXCEEDED"
@@ -285,7 +356,7 @@ def _admit_work(estimate: dict[str, int | bool]) -> None:
             "Curve Lab risk work exceeds the configured admission budget.",
             f"estimated_work.{field}",
             value,
-            constraint=f"must be <= configured limit {_LIMITS[field]}",
+            constraint=f"must be <= configured limit {limit}",
             overflow=estimate["overflow"],
             estimate=estimate,
         )
@@ -302,10 +373,13 @@ def _bumped_document(
     selected = quote_axis if quote_index is None else [quote_axis[quote_index]]
     for axis in selected:
         instrument = by_id[axis["instrument_id"]]
-        raw = Decimal(axis["raw_quote"]) + (Decimal(axis["exact_risk_raw_bump"]) * direction)
+        bump = str(axis["exact_risk_raw_bump"])
+        if direction == -1:
+            bump = bump[1:] if bump.startswith("-") else f"-{bump}"
+        raw = apply_exact_decimal_bump(str(axis["raw_quote"]), bump)
         canonical = canonicalize_quote(
             instrument["instrument_type"],
-            _decimal_text(raw),
+            raw,
             axis["canonical_raw_unit"],
         )
         instrument.update(
@@ -489,8 +563,7 @@ def _aad_parity(
     passed = all(
         discrepancy
         <= _AAD_PARITY_ABSOLUTE_TOLERANCE
-        + _AAD_PARITY_RELATIVE_TOLERANCE
-        * max(abs(Decimal(aad)), abs(Decimal(central)))
+        + _AAD_PARITY_RELATIVE_TOLERANCE * max(abs(Decimal(aad)), abs(Decimal(central)))
         for aad, central, discrepancy in zip(
             aad_values,
             central_values,
@@ -684,7 +757,13 @@ def _admit_risk_run(
     store: StoreProtocol,
     gateway: DalGateway,
     request: RiskRunRequestV2,
-) -> dict[str, object]:
+    *,
+    run_id: str,
+    created_at: str,
+    deadline_at: str,
+    request_json: dict,
+    request_bytes: bytes,
+) -> _AdmittedRiskSnapshot:
     fixing_snapshot = get_fixing_snapshot(store, request.fixing_snapshot_id)
     version = get_version(store, request.curve_version_id)
     quote_risk = bool({"DV01", "KEY_RATE_DV01"} & set(request.measures))
@@ -727,7 +806,7 @@ def _admit_risk_run(
             "curve_version_id",
             request.curve_version_id,
         )
-    _runtime_dependencies(store, build, version)
+    dependencies = _runtime_dependencies(store, build, version)
     quote_axis = (
         list(build["quote_axis"])
         if build is not None
@@ -739,9 +818,7 @@ def _admit_risk_run(
         else list(version["verification"].get("parameter_axis", []))
     )
     trades = list(request.target.model_dump(mode="json")["trades"])
-    default_component_key = str(
-        resolved_declaration_order(document)[0]["component_key"]
-    )
+    default_component_key = str(resolved_declaration_order(document)[0]["component_key"])
     required_fixings = gateway.curve_lab_required_historical_fixings(
         trades,
         request.evaluation_time.isoformat(),
@@ -764,10 +841,7 @@ def _admit_risk_run(
         expected = expected_by_key.get(key)
         if expected is None:
             continue
-        if (
-            observation["kind"] != expected["kind"]
-            or observation["units"] != expected["units"]
-        ):
+        if observation["kind"] != expected["kind"] or observation["units"] != expected["units"]:
             raise CurveLabLifecycleError(
                 422,
                 "FIXING_SNAPSHOT_INCOMPATIBLE",
@@ -784,11 +858,7 @@ def _admit_risk_run(
                 expected_units=expected["units"],
             )
     missing = next(
-        (
-            item
-            for key, item in expected_by_key.items()
-            if key not in supplied_by_key
-        ),
+        (item for key, item in expected_by_key.items() if key not in supplied_by_key),
         None,
     )
     if missing is not None:
@@ -844,17 +914,28 @@ def _admit_risk_run(
         quotes=len(quote_axis),
         measures=request.measures,
         sensitivity_layers=request.sensitivity_layers,
-        allow_aad_fallback=request.options.aad_fallback == "ALLOW",
     )
     _admit_work(estimate)
-    return {
-        "version": version,
-        "build": build,
-        "quote_axis": quote_axis,
-        "parameter_axis": parameter_axis,
-        "estimate": estimate,
-        "fixing_snapshot": fixing_snapshot,
-    }
+    return _AdmittedRiskSnapshot(
+        run_id=run_id,
+        created_at=created_at,
+        deadline_at=deadline_at,
+        request_bytes=request_bytes,
+        request_projection=_freeze_json_object(request_json),
+        curve_version=_freeze_json_object(version),
+        dependencies=tuple(_freeze_json_object(item) for item in dependencies),
+        document=_freeze_json_object(document),
+        runtime_quote_axis=tuple(_freeze_json_object(item) for item in quote_axis),
+        persisted_quote_axis=(
+            tuple(_freeze_json_object(item) for item in quote_axis) if build is not None else None
+        ),
+        parameter_axis=tuple(_freeze_json_object(item) for item in parameter_axis),
+        fixing_snapshot=_freeze_json_object(fixing_snapshot),
+        estimated_work=_freeze_json_object(estimate),
+        aad_eligible_trade_count=len(aad_eligible),
+        aad_fallback_allowed=request.options.aad_fallback == "ALLOW",
+        target_fingerprint=_hash(request_json["target"]),
+    )
 
 
 def create_risk_run(
@@ -862,13 +943,24 @@ def create_risk_run(
     gateway: DalGateway,
     request: RiskRunRequestV2,
 ) -> dict:
-    admitted = _admit_risk_run(store, gateway, request)
-    version = admitted["version"]
-    build = admitted["build"]
     request_json = request.model_dump(mode="json", exclude_none=True)
+    request_bytes = canonical_json_bytes(request_json)
     now = _now()
-    reservation = _reserve_job()
     run_id = uuid4().hex
+    deadline_at = new_deadline(datetime.fromisoformat(now.replace("Z", "+00:00")))
+    admitted = _admit_risk_run(
+        store,
+        gateway,
+        request,
+        run_id=run_id,
+        created_at=now,
+        deadline_at=deadline_at,
+        request_json=request_json,
+        request_bytes=request_bytes,
+    )
+    version = _thaw_json_object(admitted.curve_version)
+    fixing_snapshot = _thaw_json_object(admitted.fixing_snapshot)
+    reservation = _reserve_job()
     queued = {
         "id": run_id,
         "curve_version_id": request.curve_version_id,
@@ -876,18 +968,20 @@ def create_risk_run(
         "import_job_id": version.get("import_job_id"),
         "source_kind": ("BUILD_VERSION" if version["source_kind"] == "BUILD" else "IMPORT_VERSION"),
         "request": request_json,
-        "fixing_snapshot_hash": admitted["fixing_snapshot"]["content_hash"],
-        "target_fingerprint": _hash(request_json["target"]),
-        "quote_axis": admitted["quote_axis"] if build is not None else None,
-        "parameter_axis": admitted["parameter_axis"],
-        "estimated_work": admitted["estimate"],
+        "fixing_snapshot_hash": fixing_snapshot["content_hash"],
+        "target_fingerprint": admitted.target_fingerprint,
+        "quote_axis": (
+            _thaw_json_objects(admitted.persisted_quote_axis)
+            if admitted.persisted_quote_axis is not None
+            else None
+        ),
+        "parameter_axis": _thaw_json_objects(admitted.parameter_axis),
+        "estimated_work": _thaw_json_object(admitted.estimated_work),
         "state": "QUEUED",
         "result": None,
         "error": None,
         "created_at": now,
-        "deadline_at": new_deadline(
-            datetime.fromisoformat(now.replace("Z", "+00:00"))
-        ),
+        "deadline_at": deadline_at,
         "finished_at": None,
     }
     try:
@@ -896,10 +990,7 @@ def create_risk_run(
             _execute_risk_run_guarded,
             store,
             gateway,
-            request,
-            run_id,
-            now,
-            deepcopy(admitted["fixing_snapshot"]),
+            admitted,
         )
     except Exception:
         reservation.cancel()
@@ -910,24 +1001,14 @@ def create_risk_run(
 def _execute_risk_run_guarded(
     store: StoreProtocol,
     gateway: DalGateway,
-    request: RiskRunRequestV2,
-    run_id: str,
-    created_at: str,
-    fixing_snapshot: dict,
+    snapshot: _AdmittedRiskSnapshot,
 ) -> None:
     try:
-        _execute_risk_run(
-            store,
-            gateway,
-            request,
-            run_id=run_id,
-            created_at=created_at,
-            fixing_snapshot=fixing_snapshot,
-        )
+        _execute_risk_run(store, gateway, snapshot)
     except _CurveLabDeadlineExceededError:
-        _timeout_risk_run(store, store.get_curve_lab_risk_run(run_id))
+        _timeout_risk_run(store, store.get_curve_lab_risk_run(snapshot.run_id))
     except Exception:  # noqa: BLE001 - worker failure is persisted and sanitized
-        queued = store.get_curve_lab_risk_run(run_id)
+        queued = store.get_curve_lab_risk_run(snapshot.run_id)
         store.publish_curve_lab_risk_run(
             {
                 **queued,
@@ -937,8 +1018,8 @@ def _execute_risk_run_guarded(
                     "code": "RISK_EXECUTION_FAILED",
                     "message": "Curve risk execution failed.",
                     "field": "risk_run_id",
-                    "value": run_id,
-                    "resource_id": run_id,
+                    "value": snapshot.run_id,
+                    "resource_id": snapshot.run_id,
                     "details": {},
                 },
                 "finished_at": _now(),
@@ -950,63 +1031,22 @@ def _execute_risk_run_guarded(
 def _execute_risk_run(
     store: StoreProtocol,
     gateway: DalGateway,
-    request: RiskRunRequestV2,
-    *,
-    run_id: str,
-    created_at: str,
-    fixing_snapshot: dict,
+    snapshot: _AdmittedRiskSnapshot,
 ) -> dict:
-    version = get_version(store, request.curve_version_id)
+    request = RiskRunRequestV2.model_validate_json(snapshot.request_bytes)
+    request_json = _thaw_json_object(snapshot.request_projection)
+    version = _thaw_json_object(snapshot.curve_version)
+    dependencies = _thaw_json_objects(snapshot.dependencies)
+    document = _thaw_json_object(snapshot.document)
+    quote_axis = _thaw_json_objects(snapshot.runtime_quote_axis)
+    parameter_axis = _thaw_json_objects(snapshot.parameter_axis)
+    fixing_snapshot = _thaw_json_object(snapshot.fixing_snapshot)
     fixing_observations = list(fixing_snapshot["observations"])
     quote_risk = bool({"DV01", "KEY_RATE_DV01"} & set(request.measures))
-    build = (
-        store.get_curve_lab_build_run(version["build_run_id"])
-        if version["source_kind"] == "BUILD"
-        else None
-    )
-    document = (
-        deepcopy(build["request"])
-        if build is not None
-        else deepcopy(version["verification"].get("document"))
-    )
-    if not isinstance(document, dict):
-        raise CurveLabLifecycleError(
-            409,
-            "RISK_RUNTIME_CONTEXT_REQUIRED",
-            "Curve version does not carry reconstructable runtime context.",
-            "curve_version_id",
-            request.curve_version_id,
-        )
-    dependencies = _runtime_dependencies(store, build, version)
-    quote_axis = (
-        list(build["quote_axis"])
-        if build is not None
-        else list(version["verification"].get("quote_axis", []))
-    )
-    parameter_axis = (
-        list(build["parameter_axis"])
-        if build is not None
-        else list(version["verification"].get("parameter_axis", []))
-    )
     trades = list(request.target.model_dump(mode="json")["trades"])
     requested_layers = set(request.sensitivity_layers)
-    parameter_components = {axis["component_key"] for axis in parameter_axis}
-    aad_eligible_trades = sum(
-        trade["instrument_type"] == "DEPOSIT"
-        and trade["terms"].get("discount_component_key") in parameter_components
-        for trade in trades
-    )
-    estimate = estimate_work(
-        trades=len(trades),
-        aad_eligible_trades=aad_eligible_trades,
-        parameters=len(parameter_axis),
-        quotes=len(quote_axis),
-        measures=request.measures,
-        sensitivity_layers=request.sensitivity_layers,
-        allow_aad_fallback=request.options.aad_fallback == "ALLOW",
-    )
-    request_json = request.model_dump(mode="json", exclude_none=True)
-    queued = store.get_curve_lab_risk_run(run_id)
+    estimate = _thaw_json_object(snapshot.estimated_work)
+    queued = store.get_curve_lab_risk_run(snapshot.run_id)
 
     def check_deadline() -> None:
         if deadline_expired(queued["deadline_at"]):
@@ -1097,9 +1137,7 @@ def _execute_risk_run(
             else:
                 forbidden_failure = True
                 trade_methods.append(
-                    "FAILED_AAD_PARITY"
-                    if aad is not None
-                    else "FAILED_AAD_EXECUTION"
+                    "FAILED_AAD_PARITY" if aad is not None else "FAILED_AAD_EXECUTION"
                 )
         if not forbidden_failure:
             trade_to_node = selected_rows
@@ -1136,19 +1174,19 @@ def _execute_risk_run(
             )
         else:
             failed = _failed_matrix(
-                    matrix_id="trade-to-node",
-                    mathematical_name="trade_to_node_pv_gradient",
-                    orientation="TRADE_X_PARAMETER",
-                    row_axis_ref="request.target.trades",
-                    column_axis_ref="parameter_axis",
-                    rows=len(trades),
-                    columns=len(parameter_axis),
-                    method="CENTRAL_NATIVE_PARAMETER_BUMP",
-                    reason_code="PARAMETER_BUMP_FAILED",
-                    reason="A required native parameter bump failed.",
-                    input_unit="NATIVE_PARAMETER_UNIT",
-                    output_unit=(f"{request.base_currency}_PV_PER_PARAMETER_UNIT"),
-                )
+                matrix_id="trade-to-node",
+                mathematical_name="trade_to_node_pv_gradient",
+                orientation="TRADE_X_PARAMETER",
+                row_axis_ref="request.target.trades",
+                column_axis_ref="parameter_axis",
+                rows=len(trades),
+                columns=len(parameter_axis),
+                method="CENTRAL_NATIVE_PARAMETER_BUMP",
+                reason_code="PARAMETER_BUMP_FAILED",
+                reason="A required native parameter bump failed.",
+                input_unit="NATIVE_PARAMETER_UNIT",
+                output_unit=(f"{request.base_currency}_PV_PER_PARAMETER_UNIT"),
+            )
             failed["trade_methods"] = trade_methods
             failed["aad_parity"] = parity
             matrices.append(failed)
@@ -1435,21 +1473,25 @@ def _execute_risk_run(
 
     now = _now()
     record = {
-        "id": run_id,
+        "id": snapshot.run_id,
         "curve_version_id": request.curve_version_id,
         "calibration_run_id": version.get("build_run_id"),
         "import_job_id": version.get("import_job_id"),
         "source_kind": ("BUILD_VERSION" if version["source_kind"] == "BUILD" else "IMPORT_VERSION"),
         "request": request_json,
         "fixing_snapshot_hash": fixing_snapshot["content_hash"],
-        "target_fingerprint": _hash(request_json["target"]),
-        "quote_axis": quote_axis if build is not None else None,
+        "target_fingerprint": snapshot.target_fingerprint,
+        "quote_axis": (
+            _thaw_json_objects(snapshot.persisted_quote_axis)
+            if snapshot.persisted_quote_axis is not None
+            else None
+        ),
         "parameter_axis": parameter_axis,
         "estimated_work": estimate,
         "state": "SUCCEEDED",
         "result": result,
         "error": None,
-        "created_at": created_at,
+        "created_at": snapshot.created_at,
         "deadline_at": queued["deadline_at"],
         "finished_at": now,
     }

--- a/dal-web/backend/app/services/dal_gateway.py
+++ b/dal-web/backend/app/services/dal_gateway.py
@@ -1656,19 +1656,13 @@ class DalGateway:
 
         def native_leg(terms: Mapping[str, Any], prefix: str) -> Any:
             return self._dal.RateLegConvention_New(
-                self._dal.PeriodLength_New(
-                    str(terms.get(f"{prefix}_payment_frequency", "12M"))
-                ),
-                self._dal.DayBasis_New(
-                    str(terms.get(f"{prefix}_day_basis", "ACT_365F"))
-                ),
+                self._dal.PeriodLength_New(str(terms.get(f"{prefix}_payment_frequency", "12M"))),
+                self._dal.DayBasis_New(str(terms.get(f"{prefix}_day_basis", "ACT_365F"))),
             )
 
         def fixing(terms: Mapping[str, Any], prefix: str = "") -> Any:
             result = self._dal.FixingIdentity_()
-            result.index_name = str(
-                terms.get(f"{prefix}index_name", terms.get("index_name", ""))
-            )
+            result.index_name = str(terms.get(f"{prefix}index_name", terms.get("index_name", "")))
             result.fixing_hour = int(
                 terms.get(f"{prefix}fixing_hour", terms.get("fixing_hour", 11))
             )
@@ -1688,9 +1682,7 @@ class DalGateway:
             convention.initial_notional_exchange = bool(
                 terms.get("initial_notional_exchange", True)
             )
-            convention.final_notional_exchange = bool(
-                terms.get("final_notional_exchange", True)
-            )
+            convention.final_notional_exchange = bool(terms.get("final_notional_exchange", True))
             convention.spread_on_foreign_leg = spread_on_foreign
             convention.domestic_index = native_index(terms, "domestic_")
             convention.domestic_leg = native_leg(terms, "domestic")
@@ -1710,9 +1702,7 @@ class DalGateway:
         for trade in trades:
             family = str(trade["instrument_type"])
             terms = trade["terms"]
-            discount_key = str(
-                terms.get("discount_component_key", default_component_key)
-            )
+            discount_key = str(terms.get("discount_component_key", default_component_key))
             forecast_key = str(terms.get("forecast_component_key", discount_key))
             if family == "DEPOSIT":
                 native_terms = self._dal.DepositTradeTerms_(
@@ -1741,9 +1731,7 @@ class DalGateway:
                     contract_count=float(terms["contract_count"]),
                     long_position=str(terms["side"]) == "LONG",
                     reference_price=float(terms["reference_price"]),
-                    contract_value_per_price_point=float(
-                        terms["contract_value_per_price_point"]
-                    ),
+                    contract_value_per_price_point=float(terms["contract_value_per_price_point"]),
                     convexity_adjustment=float(terms.get("convexity_adjustment", 0)),
                     index=native_index(terms),
                     fixing_identity=fixing(terms),
@@ -1791,9 +1779,7 @@ class DalGateway:
                 native_terms = self._dal.XccyTradeTerms_(
                     position_count=float(terms["position_count"]),
                     contract_spread=float(terms["contract_spread"]),
-                    spread_on_foreign_leg=(
-                        str(terms.get("spread_leg", "FOREIGN")) == "FOREIGN"
-                    ),
+                    spread_on_foreign_leg=(str(terms.get("spread_leg", "FOREIGN")) == "FOREIGN"),
                     receive_non_spread_pay_spread=(
                         str(terms["side"]) == "RECEIVE_NON_SPREAD_PAY_SPREAD"
                     ),
@@ -1805,12 +1791,8 @@ class DalGateway:
                 self._dal.RateTradeDefinition_(
                     instrument_id=str(trade["trade_id"]),
                     instrument_type=getattr(self._dal.RateInstrumentType, family),
-                    trade_date=self._native_date(
-                        date.fromisoformat(str(trade["trade_date"]))
-                    ),
-                    start_date=self._native_date(
-                        date.fromisoformat(str(trade["start_date"]))
-                    ),
+                    trade_date=self._native_date(date.fromisoformat(str(trade["trade_date"]))),
+                    start_date=self._native_date(date.fromisoformat(str(trade["start_date"]))),
                     maturity_date=self._native_date(
                         date.fromisoformat(str(trade["maturity_date"]))
                     ),
@@ -1847,15 +1829,9 @@ class DalGateway:
                 "trade_index": int(trade_index),
                 "index_name": str(index_name),
                 "fixing_time": datetime.fromisoformat(repr(fixing_time)).isoformat(),
-                "kind": (
-                    "FX"
-                    if str(index_name).startswith("FX[")
-                    else "RATE"
-                ),
+                "kind": ("FX" if str(index_name).startswith("FX[") else "RATE"),
                 "units": (
-                    "DOMESTIC_PER_FOREIGN"
-                    if str(index_name).startswith("FX[")
-                    else "DECIMAL_RATE"
+                    "DOMESTIC_PER_FOREIGN" if str(index_name).startswith("FX[") else "DECIMAL_RATE"
                 ),
             }
             for trade_index, index_name, fixing_time in rows
@@ -1886,9 +1862,7 @@ class DalGateway:
                 str(
                     trade["start_date"]
                     if family == "FRA"
-                    and str(
-                        terms.get("settlement_style", "AT_START_DISCOUNTED")
-                    )
+                    and str(terms.get("settlement_style", "AT_START_DISCOUNTED"))
                     == "AT_START_DISCOUNTED"
                     else trade["maturity_date"]
                 )
@@ -1922,61 +1896,6 @@ class DalGateway:
         check_deadline: Callable[[], None] | None = None,
     ) -> list[dict[str, Any]]:
         """Adapt normalized Curve Lab trades to the native pricing kernel."""
-
-        def native_index(terms: Mapping[str, Any], prefix: str = "") -> Any:
-            def field(name: str, default: Any) -> Any:
-                return terms.get(f"{prefix}{name}", terms.get(name, default))
-
-            return self._dal.RateIndexConvention_New(
-                self._dal.PeriodLength_New(str(field("forecast_tenor", "3M"))),
-                self._dal.DayBasis_New(str(field("day_basis", "ACT_365F"))),
-                self._dal.CollateralType_(str(field("collateral", "OIS"))),
-                bool(field("use_projection_curve", False)),
-            )
-
-        def native_leg(terms: Mapping[str, Any], prefix: str) -> Any:
-            return self._dal.RateLegConvention_New(
-                self._dal.PeriodLength_New(str(terms.get(f"{prefix}_payment_frequency", "12M"))),
-                self._dal.DayBasis_New(str(terms.get(f"{prefix}_day_basis", "ACT_365F"))),
-            )
-
-        def fixing(terms: Mapping[str, Any], prefix: str = "") -> Any:
-            result = self._dal.FixingIdentity_()
-            result.index_name = str(terms.get(f"{prefix}index_name", terms.get("index_name", "")))
-            result.fixing_hour = int(
-                terms.get(f"{prefix}fixing_hour", terms.get("fixing_hour", 11))
-            )
-            result.fixing_minute = int(
-                terms.get(
-                    f"{prefix}fixing_minute",
-                    terms.get("fixing_minute", 0),
-                )
-            )
-            return result
-
-        def xccy_config(trade: Mapping[str, Any], terms: Mapping[str, Any]) -> Any:
-            pair_token = str(trade["currency_or_pair"]).replace("/", "-")
-            domestic, foreign = pair_token.split("-", 1)
-            spread_on_foreign = str(terms.get("spread_leg", "FOREIGN")) == "FOREIGN"
-            convention = self._dal.CrossCurrencyConvention_()
-            convention.initial_notional_exchange = bool(
-                terms.get("initial_notional_exchange", True)
-            )
-            convention.final_notional_exchange = bool(terms.get("final_notional_exchange", True))
-            convention.spread_on_foreign_leg = spread_on_foreign
-            convention.domestic_index = native_index(terms, "domestic_")
-            convention.domestic_leg = native_leg(terms, "domestic")
-            convention.foreign_index = native_index(terms, "foreign_")
-            convention.foreign_leg = native_leg(terms, "foreign")
-            builder = self._dal.CrossCurrencySwapConfigBuilder_()
-            builder.pair = self._dal.CurrencyPair_New(domestic, foreign)
-            builder.domestic_notional = float(terms["domestic_notional"])
-            builder.foreign_notional = float(terms["foreign_notional"])
-            builder.convention = convention
-            builder.notional_mode = self._dal.XccyNotionalMode.FIXED
-            builder.domestic_rate_fixing = fixing(terms, "domestic_")
-            builder.foreign_rate_fixing = fixing(terms, "foreign_")
-            return builder.Build()
 
         with self._calibration_lock:
             if curve_version is None:
@@ -2075,121 +1994,12 @@ class DalGateway:
                 xccy_market=native_xccy_market,
                 fixings=fixing_snapshot,
             )
-            native_trades: list[Any] = []
-            native_positions: list[int] = []
+            native_trades = self._curve_lab_native_trade_definitions(
+                trades,
+                default_key,
+            )
+            native_positions = list(range(len(trades)))
             result: list[dict[str, Any] | None] = [None] * len(trades)
-            for position, trade in enumerate(trades):
-                family = str(trade["instrument_type"])
-                terms = trade["terms"]
-                discount_key = str(terms.get("discount_component_key", default_key))
-                forecast_key = str(terms.get("forecast_component_key", discount_key))
-                if family == "DEPOSIT":
-                    native_terms = self._dal.DepositTradeTerms_(
-                        notional=float(terms["notional"]),
-                        contract_rate=float(terms["contract_rate"]),
-                        lend=str(terms["side"]) == "LEND",
-                        index=native_index(terms),
-                        discount_component_key=discount_key,
-                    )
-                elif family == "FRA":
-                    native_terms = self._dal.FraTradeTerms_(
-                        notional=float(terms["notional"]),
-                        contract_rate=float(terms["contract_rate"]),
-                        receive_floating=(str(terms["side"]) == "RECEIVE_FLOATING"),
-                        settle_at_start=(
-                            str(terms.get("settlement_style", "AT_START_DISCOUNTED"))
-                            == "AT_START_DISCOUNTED"
-                        ),
-                        index=native_index(terms),
-                        fixing_identity=fixing(terms),
-                        forecast_component_key=forecast_key,
-                        discount_component_key=discount_key,
-                    )
-                elif family == "FUTURE":
-                    native_terms = self._dal.FutureTradeTerms_(
-                        contract_count=float(terms["contract_count"]),
-                        long_position=str(terms["side"]) == "LONG",
-                        reference_price=float(terms["reference_price"]),
-                        contract_value_per_price_point=float(
-                            terms["contract_value_per_price_point"]
-                        ),
-                        convexity_adjustment=float(terms.get("convexity_adjustment", 0)),
-                        index=native_index(terms),
-                        fixing_identity=fixing(terms),
-                        forecast_component_key=forecast_key,
-                    )
-                elif family in {"OIS", "IRS"}:
-                    fixed_float = self._dal.FixedFloatTradeTerms_(
-                        notional=float(terms["notional"]),
-                        contract_rate=float(terms["contract_rate"]),
-                        pay_fixed=str(terms["side"]) == "PAY_FIXED",
-                        fixed_leg=native_leg(terms, "fixed"),
-                        float_leg=native_leg(terms, "float"),
-                        float_index=native_index(terms, "float_"),
-                        fixing_identity=fixing(terms, "float_"),
-                        forecast_component_key=forecast_key,
-                        discount_component_key=discount_key,
-                    )
-                    native_terms = (
-                        self._dal.OisTradeTerms_(value=fixed_float)
-                        if family == "OIS"
-                        else self._dal.IrsTradeTerms_(value=fixed_float)
-                    )
-                elif family == "BASIS_SWAP":
-                    native_terms = self._dal.BasisTradeTerms_(
-                        notional=float(terms["notional"]),
-                        contract_spread=float(terms["contract_spread"]),
-                        receive_reference_pay_spread=(
-                            str(terms["side"]) == "RECEIVE_REFERENCE_PAY_SPREAD"
-                        ),
-                        spread_leg=native_leg(terms, "spread"),
-                        reference_leg=native_leg(terms, "reference"),
-                        spread_index=native_index(terms, "spread_"),
-                        reference_index=native_index(terms, "reference_"),
-                        spread_fixing_identity=fixing(terms, "spread_"),
-                        reference_fixing_identity=fixing(terms, "reference_"),
-                        spread_forecast_component_key=str(
-                            terms.get("spread_forecast_component_key", forecast_key)
-                        ),
-                        reference_forecast_component_key=str(
-                            terms.get(
-                                "reference_forecast_component_key",
-                                forecast_key,
-                            )
-                        ),
-                        discount_component_key=discount_key,
-                    )
-                elif family == "XCCY":
-                    config = xccy_config(trade, terms)
-                    spread_on_foreign = str(terms.get("spread_leg", "FOREIGN")) == "FOREIGN"
-                    native_terms = self._dal.XccyTradeTerms_(
-                        position_count=float(terms["position_count"]),
-                        contract_spread=float(terms["contract_spread"]),
-                        spread_on_foreign_leg=spread_on_foreign,
-                        receive_non_spread_pay_spread=(
-                            str(terms["side"]) == "RECEIVE_NON_SPREAD_PAY_SPREAD"
-                        ),
-                        config=config,
-                    )
-                else:
-                    raise ValueError(f"unsupported Curve Lab pricing family {family!r}")
-                native_trades.append(
-                    self._dal.RateTradeDefinition_(
-                        instrument_id=str(trade["trade_id"]),
-                        instrument_type=getattr(
-                            self._dal.RateInstrumentType,
-                            family,
-                        ),
-                        trade_date=self._native_date(date.fromisoformat(str(trade["trade_date"]))),
-                        start_date=self._native_date(date.fromisoformat(str(trade["start_date"]))),
-                        maturity_date=self._native_date(
-                            date.fromisoformat(str(trade["maturity_date"]))
-                        ),
-                        currency=str(trade["currency_or_pair"]).split("-")[0],
-                        terms=native_terms,
-                    )
-                )
-                native_positions.append(position)
 
             if check_deadline is not None:
                 check_deadline()

--- a/dal-web/backend/app/services/db/store_db.py
+++ b/dal-web/backend/app/services/db/store_db.py
@@ -1031,9 +1031,7 @@ class DbStore:
     def reconcile_curve_lab_inflight(self, finished_at: str) -> int:
         with self._session() as session:
             reconciled = 0
-            restart_time = datetime.fromisoformat(
-                finished_at.replace("Z", "+00:00")
-            )
+            restart_time = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
             for model, states in (
                 (
                     CurveLabBuildRunRow,

--- a/dal-web/backend/app/services/store.py
+++ b/dal-web/backend/app/services/store.py
@@ -789,9 +789,7 @@ class Store:
     def reconcile_curve_lab_inflight(self, finished_at: str) -> int:
         with self._lock:
             reconciled = 0
-            restart_time = datetime.fromisoformat(
-                finished_at.replace("Z", "+00:00")
-            )
+            restart_time = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
             for records, terminal in (
                 (self._curve_lab_build_runs, {"QUEUED", "RESOLVING_DEPENDENCIES", "SOLVING"}),
                 (self._curve_lab_import_jobs, {"QUEUED", "RUNNING"}),

--- a/dal-web/backend/tests/playwright_backend.py
+++ b/dal-web/backend/tests/playwright_backend.py
@@ -68,19 +68,13 @@ def _build_app() -> FastAPI:
                 Decimal(0),
             )
             parameter_shift = sum(
-                (
-                    Decimal(str(bump))
-                    for _, bump in (kwargs.get("parameter_bumps") or ())
-                ),
+                (Decimal(str(bump)) for _, bump in (kwargs.get("parameter_bumps") or ())),
                 Decimal(0),
             )
             parameter_axis = kwargs.get("parameter_axis") or ()
-            include_node_sensitivities = bool(
-                kwargs.get("include_node_sensitivities")
-            )
+            include_node_sensitivities = bool(kwargs.get("include_node_sensitivities"))
             component_keys = [
-                str(declaration["component_key"])
-                for declaration in document["declarations"]
+                str(declaration["component_key"]) for declaration in document["declarations"]
             ]
             return [
                 {
@@ -97,9 +91,7 @@ def _build_app() -> FastAPI:
                     "dependency_component_keys": component_keys,
                     "error": "",
                     "aad_node_gradient": (
-                        ["1" for _ in parameter_axis]
-                        if include_node_sensitivities
-                        else None
+                        ["1" for _ in parameter_axis] if include_node_sensitivities else None
                     ),
                     "aad_ineligibility_reason": None,
                 }

--- a/dal-web/backend/tests/test_curve_lab_api.py
+++ b/dal-web/backend/tests/test_curve_lab_api.py
@@ -17,13 +17,11 @@ def test_curve_lab_endpoints_are_async() -> None:
 
 
 def test_curve_lab_styles_follow_the_industrial_terminal_contract() -> None:
-    stylesheet = (
-        Path(__file__).parents[2] / "frontend" / "src" / "styles.css"
-    ).read_text(encoding="utf-8")
+    stylesheet = (Path(__file__).parents[2] / "frontend" / "src" / "styles.css").read_text(
+        encoding="utf-8"
+    )
     shell_rule = stylesheet.split(".curve-lab-v2 {", 1)[1].split("}", 1)[0]
-    active_tab_rule = stylesheet.split(
-        "button.curve-lab-flow-tab.active {", 1
-    )[1].split("}", 1)[0]
+    active_tab_rule = stylesheet.split("button.curve-lab-flow-tab.active {", 1)[1].split("}", 1)[0]
 
     assert "gradient" not in shell_rule
     assert "shadow" not in active_tab_rule
@@ -329,9 +327,7 @@ def test_openapi_quote_contract_is_closed_and_string_valued(client) -> None:
     assert response["properties"]["normalized_quote"]["type"] == "string"
     assert rendering_request["properties"]["canonical_raw_quote"]["type"] == "string"
     assert rendering_response["properties"]["rendered_quote"]["type"] == "string"
-    assert (
-        "/api/curve-lab/quote-renderings" in document["paths"]
-    )
+    assert "/api/curve-lab/quote-renderings" in document["paths"]
     family_schema = request["properties"]["instrument_type"]
     if "$ref" in family_schema:
         family_schema = schemas[family_schema["$ref"].rsplit("/", 1)[-1]]
@@ -347,3 +343,89 @@ def test_openapi_quote_contract_is_closed_and_string_valued(client) -> None:
 
     encoded = json.dumps(document, sort_keys=True)
     assert '"raw_quote": {"type": "number"}' not in encoded
+
+
+def test_capability_defaults_are_the_single_risk_admission_source(client) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.schemas.curve_lab import (
+        CURVE_LAB_RISK_COST_COEFFICIENTS,
+        CURVE_LAB_RISK_LIMITS,
+    )
+
+    capabilities = client.get("/api/curve-lab/capabilities")
+
+    assert capabilities.status_code == 200
+    assert capabilities.json()["risk_limits"] == dict(CURVE_LAB_RISK_LIMITS)
+    assert capabilities.json()["risk_cost_coefficients"] == dict(CURVE_LAB_RISK_COST_COEFFICIENTS)
+    assert not hasattr(curve_risk, "_LIMITS")
+    assert not hasattr(curve_risk, "_COSTS")
+
+
+@pytest.mark.parametrize(
+    ("value", "bump", "expected"),
+    [
+        ("0.04", "0.0001", "0.0401"),
+        ("95.82", "-0.01", "95.81"),
+        ("0", "-0.01", "-0.01"),
+        ("-0.0001", "0.0001", "0"),
+        ("0.0000000000000001", "0.0000000000000001", "0.0000000000000002"),
+    ],
+)
+def test_exact_decimal_bump_preserves_canonical_financial_bytes(
+    value: str,
+    bump: str,
+    expected: str,
+) -> None:
+    from app.services.quote_canonicalization import apply_exact_decimal_bump
+
+    assert apply_exact_decimal_bump(value, bump) == expected
+
+
+@pytest.mark.parametrize("value", ["01", "NaN", "1e-4", "+0.04"])
+def test_exact_decimal_bump_rejects_noncanonical_or_malformed_values(value: str) -> None:
+    from app.services.quote_canonicalization import (
+        QuoteCanonicalizationError,
+        apply_exact_decimal_bump,
+    )
+
+    with pytest.raises(QuoteCanonicalizationError):
+        apply_exact_decimal_bump(value, "0.0001")
+
+
+def test_exact_decimal_bump_rejects_a_move_erased_by_binary64() -> None:
+    from app.services.quote_canonicalization import (
+        QuoteCanonicalizationError,
+        apply_exact_decimal_bump,
+    )
+
+    with pytest.raises(QuoteCanonicalizationError) as raised:
+        apply_exact_decimal_bump(
+            "12345678901234567890.00000000000000000001",
+            "0.00000000000000000009",
+        )
+
+    assert raised.value.code == "RISK_BUMP_NOT_REPRESENTABLE"
+    assert raised.value.field == "raw_quote"
+    assert raised.value.value == "12345678901234567890.00000000000000000001"
+
+
+def test_curve_lab_canonical_json_preserves_exact_ascii_bytes_and_hash() -> None:
+    import hashlib
+
+    from app.services.canonical_json import canonical_json_bytes, canonical_json_hash
+
+    value = {"z": "é", "a": [1, True, None]}
+    expected = b'{"a":[1,true,null],"z":"\\u00e9"}'
+
+    assert canonical_json_bytes(value) == expected
+    assert canonical_json_hash(value) == hashlib.sha256(expected).hexdigest()
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_curve_lab_canonical_json_rejects_non_finite_numbers(value: float) -> None:
+    from app.services.canonical_json import canonical_json_bytes, canonical_json_hash
+
+    with pytest.raises(ValueError):
+        canonical_json_bytes({"value": value})
+    with pytest.raises(ValueError):
+        canonical_json_hash({"value": value})

--- a/dal-web/backend/tests/test_curve_lab_lifecycle_api.py
+++ b/dal-web/backend/tests/test_curve_lab_lifecycle_api.py
@@ -234,10 +234,7 @@ def test_draft_rejects_non_finite_wire_numbers_without_persistence(
     assert response.json()["detail"]["code"] == "REQUEST_VALIDATION_FAILED"
     with get_store()._engine.connect() as connection:
         assert connection.execute(text("SELECT COUNT(*) FROM curve_drafts")).scalar_one() == 0
-        assert (
-            connection.execute(text("SELECT COUNT(*) FROM curve_audit_events")).scalar_one()
-            == 0
-        )
+        assert connection.execute(text("SELECT COUNT(*) FROM curve_audit_events")).scalar_one() == 0
 
 
 def test_draft_compare_and_swap_is_atomic_and_marks_old_run_stale(client) -> None:
@@ -631,6 +628,34 @@ def test_import_create_acknowledges_queued_before_native_reconstruction(
         pytest.fail("import job did not reach SUCCEEDED")
 
 
+def test_import_worker_reuses_the_single_admitted_preflight(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_lab_lifecycle as lifecycle
+
+    payload = b'{"~type":"Bag","name":"curves","keys":[]}'
+    original = lifecycle.preflight_archive
+    calls = 0
+
+    def counted_preflight(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(lifecycle, "preflight_archive", counted_preflight)
+
+    response = client.post(
+        "/api/curve-lab/import-jobs",
+        content=payload,
+        headers={"Content-Type": "application/json"},
+    )
+
+    completed = _completed_import(client, response)
+    assert completed["state"] == "SUCCEEDED"
+    assert calls == 1
+
+
 def test_import_allowlist_failure_never_calls_native_reader(client, monkeypatch) -> None:
     import app.services.dal_gateway as gateway_module
 
@@ -744,6 +769,7 @@ def test_gzip_preflight_failure_persists_exact_wire_and_expanded_lengths(
     persisted = client.get(f"/api/curve-lab/import-jobs/{detail['resource_id']}").json()
     assert persisted["compressed_payload_length"] == len(payload)
     assert persisted["expanded_payload_length"] == len(expanded)
+    assert persisted["error"] == detail
 
 
 def test_import_publication_rolls_back_version_when_job_write_fails(
@@ -916,20 +942,59 @@ def test_database_restart_terminalizes_all_inflight_curve_lab_work(tmp_path) -> 
         },
         [],
     )
+    for run_id, state, deadline_at in (
+        ("risk-running-restart", "RUNNING", "2026-01-15T00:15:00+00:00"),
+        ("risk-expired-restart", "RUNNING", "2026-01-15T00:00:30+00:00"),
+    ):
+        first.publish_curve_lab_risk_run(
+            {
+                "id": run_id,
+                "curve_version_id": version["id"],
+                "calibration_run_id": None,
+                "import_job_id": None,
+                "source_kind": "VERSION",
+                "request": {},
+                "fixing_snapshot_hash": "b" * 64,
+                "target_fingerprint": "c" * 64,
+                "quote_axis": None,
+                "parameter_axis": [],
+                "estimated_work": {},
+                "state": state,
+                "result": None,
+                "error": None,
+                "created_at": "2026-01-15T00:00:00+00:00",
+                "deadline_at": deadline_at,
+                "finished_at": None,
+            },
+            [],
+        )
     first.close()
 
     restarted = DbStore(database_url)
     try:
         finished_at = "2026-01-15T00:01:00+00:00"
-        assert restarted.reconcile_curve_lab_inflight(finished_at) == 3
+        assert restarted.reconcile_curve_lab_inflight(finished_at) == 5
         records = (
             restarted.get_curve_lab_build_run(run["id"]),
             restarted.get_curve_lab_import_job("import-restart"),
             restarted.get_curve_lab_risk_run("risk-restart"),
+            restarted.get_curve_lab_risk_run("risk-running-restart"),
+            restarted.get_curve_lab_risk_run("risk-expired-restart"),
         )
-        for record in (records[0], records[2]):
+        for record, previous_state in (
+            (records[0], "SOLVING"),
+            (records[2], "QUEUED"),
+            (records[3], "RUNNING"),
+        ):
             assert record["state"] == "FAILED"
-            assert record["error"]["code"] == "SERVER_RESTARTED"
+            assert record["error"] == {
+                "code": "SERVER_RESTARTED",
+                "message": "Server restarted while Curve Lab work was running.",
+                "field": "state",
+                "value": previous_state,
+                "resource_id": record["id"],
+                "details": {},
+            }
             assert record["finished_at"] == finished_at
         assert records[1]["state"] == "TIMED_OUT"
         assert records[1]["error"] == {
@@ -941,8 +1006,97 @@ def test_database_restart_terminalizes_all_inflight_curve_lab_work(tmp_path) -> 
             "details": {},
         }
         assert records[1]["finished_at"] == finished_at
+        assert records[4]["state"] == "TIMED_OUT"
+        assert records[4]["error"] == {
+            "code": "SOFT_DEADLINE_EXCEEDED",
+            "message": "Curve Lab work exceeded its persisted soft deadline.",
+            "field": "deadline_at",
+            "value": "2026-01-15T00:00:30+00:00",
+            "resource_id": "risk-expired-restart",
+            "details": {},
+        }
+        assert records[4]["finished_at"] == finished_at
+        assert restarted.reconcile_curve_lab_inflight(finished_at) == 0
     finally:
         restarted.close()
+
+
+def test_memory_restart_terminalizes_risk_without_replay_or_partial_artifacts(
+    monkeypatch,
+) -> None:
+    import app.services.curve_lab_lifecycle as lifecycle
+    import app.services.curve_risk as curve_risk
+    from app.services.store import Store
+
+    store = Store()
+    for run_id, state, deadline_at in (
+        ("queued-risk", "QUEUED", "2026-01-15T00:15:00+00:00"),
+        ("running-risk", "RUNNING", "2026-01-15T00:15:00+00:00"),
+        ("expired-risk", "RUNNING", "2026-01-15T00:00:30+00:00"),
+    ):
+        store.publish_curve_lab_risk_run(
+            {
+                "id": run_id,
+                "curve_version_id": "version",
+                "calibration_run_id": None,
+                "import_job_id": None,
+                "source_kind": "VERSION",
+                "request": {},
+                "fixing_snapshot_hash": "a" * 64,
+                "target_fingerprint": "b" * 64,
+                "quote_axis": None,
+                "parameter_axis": [],
+                "estimated_work": {},
+                "state": state,
+                "result": None,
+                "error": None,
+                "created_at": "2026-01-15T00:00:00+00:00",
+                "deadline_at": deadline_at,
+                "finished_at": None,
+            },
+            [],
+        )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("restart reconciliation dispatched risk work")
+
+    monkeypatch.setattr(curve_risk, "estimate_work", forbidden)
+    monkeypatch.setattr(curve_risk, "_execute_risk_run_guarded", forbidden)
+    monkeypatch.setattr(lifecycle, "preflight_archive", forbidden)
+    monkeypatch.setattr(lifecycle, "_reserve_job", forbidden)
+    finished_at = "2026-01-15T00:01:00+00:00"
+
+    assert store.reconcile_curve_lab_inflight(finished_at) == 3
+
+    for run_id, previous_state in (
+        ("queued-risk", "QUEUED"),
+        ("running-risk", "RUNNING"),
+    ):
+        record = store.get_curve_lab_risk_run(run_id)
+        assert record["state"] == "FAILED"
+        assert record["error"] == {
+            "code": "SERVER_RESTARTED",
+            "message": "Server restarted while Curve Lab work was running.",
+            "field": "state",
+            "value": previous_state,
+            "resource_id": run_id,
+            "details": {},
+        }
+        assert record["finished_at"] == finished_at
+    expired = store.get_curve_lab_risk_run("expired-risk")
+    assert expired["state"] == "TIMED_OUT"
+    assert expired["error"] == {
+        "code": "SOFT_DEADLINE_EXCEEDED",
+        "message": "Curve Lab work exceeded its persisted soft deadline.",
+        "field": "deadline_at",
+        "value": "2026-01-15T00:00:30+00:00",
+        "resource_id": "expired-risk",
+        "details": {},
+    }
+    assert expired["finished_at"] == finished_at
+    assert store._curve_lab_matrices == {}
+    assert store._curve_lab_audit_events == []
+    assert store.reconcile_curve_lab_inflight(finished_at) == 0
 
 
 def test_curve_lab_migration_upgrade_downgrade_upgrade(tmp_path, monkeypatch) -> None:
@@ -1070,9 +1224,7 @@ def test_queued_build_cannot_assume_a_later_draft_identity_or_publish(
         block_after_queued_snapshot_read,
     )
     try:
-        admitted_response = client.post(
-            f"/api/curve-lab/drafts/{draft['id']}/build-runs"
-        )
+        admitted_response = client.post(f"/api/curve-lab/drafts/{draft['id']}/build-runs")
         assert admitted_response.status_code == 202, admitted_response.text
         admitted = admitted_response.json()
         assert admitted["state"] == "QUEUED"
@@ -1080,9 +1232,9 @@ def test_queued_build_cannot_assume_a_later_draft_identity_or_publish(
 
         changed_document = _document("0.041")
         changed_document["market_snapshot_id"] = "market-2026-01-16"
-        changed_document["instruments"][0]["instrument_id"] = draft["document"][
-            "instruments"
-        ][0]["instrument_id"]
+        changed_document["instruments"][0]["instrument_id"] = draft["document"]["instruments"][0][
+            "instrument_id"
+        ]
         updated_response = client.put(
             f"/api/curve-lab/drafts/{draft['id']}",
             headers={"If-Match": '"1"'},

--- a/dal-web/backend/tests/test_curve_lab_risk_api.py
+++ b/dal-web/backend/tests/test_curve_lab_risk_api.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 import time
+from dataclasses import FrozenInstanceError, fields, is_dataclass
 from decimal import Decimal
 
 import pytest
@@ -349,9 +351,7 @@ def test_risk_admission_preserves_missing_fixing_error_after_utc_normalization(
         },
         "resource_id": "wrong-time-fixings",
         "details": {
-            "constraint": (
-                "fixing_time before evaluation_time requires an exact snapshot value"
-            )
+            "constraint": ("fixing_time before evaluation_time requires an exact snapshot value")
         },
     }
 
@@ -601,6 +601,239 @@ def test_risk_create_acknowledges_queued_before_native_pricing(
     assert completed["state"] == "SUCCEEDED"
 
 
+@pytest.mark.parametrize("expire_after_running", [False, True])
+def test_risk_deadline_terminalizes_without_partial_matrices(
+    client,
+    monkeypatch,
+    expire_after_running: bool,
+) -> None:
+    import app.services.curve_risk as curve_risk
+
+    _, version = _publish_version(client)
+
+    class CapturingReservation:
+        submitted: tuple[object, ...] | None = None
+
+        def submit(self, function, /, *args):
+            self.submitted = (function, *args)
+
+        def cancel(self) -> None:
+            pass
+
+    reservation = CapturingReservation()
+    monkeypatch.setattr(curve_risk, "_reserve_job", lambda: reservation)
+    request = _request(version["id"])
+    request["measures"] = ["PV"]
+    request["sensitivity_layers"] = []
+    response = client.post("/api/curve-lab/risk-runs", json=request)
+    assert response.status_code == 202, response.text
+    assert reservation.submitted is not None
+    function, worker_store, gateway, snapshot = reservation.submitted
+
+    deadline_checks = 0
+
+    def expired(_deadline):
+        nonlocal deadline_checks
+        deadline_checks += 1
+        return deadline_checks > int(expire_after_running)
+
+    monkeypatch.setattr(curve_risk, "deadline_expired", expired)
+    native_calls = 0
+
+    def price(_document, trades, _evaluation_time, base_currency, **_kwargs):
+        nonlocal native_calls
+        native_calls += 1
+        return [
+            {
+                "trade_id": trades[0]["trade_id"],
+                "instrument_type": "DEPOSIT",
+                "succeeded": True,
+                "pv": "100",
+                "currency": base_currency,
+                "required_historical_fixings": [],
+                "missing_historical_fixings": [],
+                "dependency_component_keys": [],
+                "error": "",
+            }
+        ]
+
+    monkeypatch.setattr(gateway, "price_curve_lab_trades", price)
+    states: list[tuple[str, list[dict]]] = []
+    original_publish = worker_store.publish_curve_lab_risk_run
+
+    def publish(record, matrices):
+        states.append((record["state"], matrices))
+        return original_publish(record, matrices)
+
+    monkeypatch.setattr(worker_store, "publish_curve_lab_risk_run", publish)
+
+    function(worker_store, gateway, snapshot)
+
+    completed = client.get(f"/api/curve-lab/risk-runs/{response.json()['id']}").json()
+    assert completed["state"] == "TIMED_OUT"
+    assert completed["error"] == {
+        "code": "SOFT_DEADLINE_EXCEEDED",
+        "message": "Curve Lab work exceeded its persisted soft deadline.",
+        "field": "deadline_at",
+        "value": completed["deadline_at"],
+        "resource_id": completed["id"],
+        "details": {},
+    }
+    assert completed["created_at"] <= completed["finished_at"]
+    assert states == (
+        [("RUNNING", []), ("TIMED_OUT", [])] if expire_after_running else [("TIMED_OUT", [])]
+    )
+    assert native_calls == int(expire_after_running)
+    matrix = client.get(f"/api/curve-lab/risk-runs/{completed['id']}/matrices/key-rate-dv01")
+    assert matrix.status_code == 404
+
+
+def test_risk_worker_receives_one_deeply_immutable_admission_snapshot(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+
+    _, version = _publish_version(client)
+
+    class CapturingReservation:
+        submitted: tuple[object, ...] | None = None
+
+        def submit(self, function, /, *args):
+            self.submitted = (function, *args)
+
+        def cancel(self) -> None:
+            pass
+
+    reservation = CapturingReservation()
+    monkeypatch.setattr(curve_risk, "_reserve_job", lambda: reservation)
+    original_snapshot = curve_risk._AdmittedRiskSnapshot
+    snapshot_constructions = 0
+
+    def construct_snapshot(*args, **kwargs):
+        nonlocal snapshot_constructions
+        snapshot_constructions += 1
+        return original_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "_AdmittedRiskSnapshot", construct_snapshot)
+    original_estimate = curve_risk.estimate_work
+    estimate_calls = 0
+
+    def counted_estimate(*args, **kwargs):
+        nonlocal estimate_calls
+        estimate_calls += 1
+        return original_estimate(*args, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "estimate_work", counted_estimate)
+    original_admit = curve_risk._admit_risk_run
+    admitted_models: list[object] = []
+
+    def admit(store, gateway, request, **kwargs):
+        admitted_models.append(request)
+        return original_admit(store, gateway, request, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "_admit_risk_run", admit)
+    request = _request(version["id"])
+    request["measures"] = ["PV"]
+    response = client.post("/api/curve-lab/risk-runs", json=request)
+
+    assert response.status_code == 202, response.text
+    assert reservation.submitted is not None
+    function, store, gateway, snapshot = reservation.submitted
+    assert function is curve_risk._execute_risk_run_guarded
+    assert snapshot.run_id == response.json()["id"]
+    assert snapshot_constructions == 1
+    assert estimate_calls == 1
+
+    def assert_deeply_immutable(value: object) -> None:
+        if is_dataclass(value):
+            for field in fields(value):
+                assert_deeply_immutable(getattr(value, field.name))
+            return
+        if isinstance(value, tuple):
+            for item in value:
+                assert_deeply_immutable(item)
+            return
+        assert value is None or isinstance(value, (bool, int, float, str, bytes))
+
+    assert_deeply_immutable(snapshot)
+    with pytest.raises(FrozenInstanceError):
+        snapshot.run_id = "mutated"
+
+    admitted_request = json.loads(snapshot.request_bytes)
+    admitted_document = curve_risk._thaw_json_object(snapshot.document)
+    request["target"]["trades"][0]["terms"]["notional"] = "999"
+    object.__setattr__(
+        admitted_models[0].target.trades[0].terms,
+        "notional",
+        Decimal("999"),
+    )
+    reconstructed = curve_risk.RiskRunRequestV2.model_validate_json(snapshot.request_bytes)
+    object.__setattr__(
+        reconstructed.target.trades[0].terms,
+        "notional",
+        Decimal("999"),
+    )
+    visible_version = store.get_curve_lab_version(version["id"])
+    visible_version["verification"]["document"]["declarations"].clear()
+    visible_build = store.get_curve_lab_build_run(visible_version["build_run_id"])
+    visible_build["request"]["instruments"].clear()
+    visible_fixing = store.get_curve_lab_fixing_snapshot("fixings-2026-01-15")
+    visible_fixing["observations"].append({"mutated": True})
+
+    assert json.loads(snapshot.request_bytes) == admitted_request
+    assert curve_risk._thaw_json_object(snapshot.request_projection) == admitted_request
+    assert curve_risk._thaw_json_object(snapshot.document) == admitted_document
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("worker reread mutable admitted source state")
+
+    for method in (
+        "get_curve_lab_version",
+        "get_curve_lab_build_run",
+        "get_curve_lab_draft",
+        "get_curve_lab_import_job",
+        "get_curve_lab_fixing_snapshot",
+        "resolve_curve_lab_versions",
+    ):
+        monkeypatch.setattr(store, method, forbidden)
+
+    def price(_document, trades, _evaluation_time, base_currency, **_kwargs):
+        return [
+            {
+                "trade_id": trade["trade_id"],
+                "instrument_type": trade["instrument_type"],
+                "succeeded": True,
+                "pv": "100",
+                "currency": base_currency,
+                "required_historical_fixings": [],
+                "missing_historical_fixings": [],
+                "dependency_component_keys": [],
+                "error": "",
+            }
+            for trade in trades
+        ]
+
+    monkeypatch.setattr(gateway, "price_curve_lab_trades", price)
+    original_execute = curve_risk._execute_risk_run
+    received_identical_snapshot: list[bool] = []
+
+    def execute(worker_store, current_gateway, received_snapshot):
+        received_identical_snapshot.append(received_snapshot is snapshot)
+        return original_execute(worker_store, current_gateway, received_snapshot)
+
+    monkeypatch.setattr(curve_risk, "_execute_risk_run", execute)
+
+    function(store, gateway, snapshot)
+
+    completed = client.get(f"/api/curve-lab/risk-runs/{snapshot.run_id}").json()
+    assert completed["state"] == "SUCCEEDED", completed
+    assert completed["result"]["pricing"][0]["pv"] == "100"
+    assert received_identical_snapshot == [True]
+    assert snapshot_constructions == 1
+    assert estimate_calls == 1
+
+
 def test_risk_queue_rejects_after_two_running_and_one_hundred_queued(
     client,
     monkeypatch,
@@ -754,6 +987,805 @@ def test_risk_reuses_every_pinned_dependency_archive_after_publication_and_archi
     assert all(payload for _, payload in observed)
 
 
+def test_admitted_risk_snapshot_survives_source_and_dependency_archive_without_rereads(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+
+    _, source = _publish_version(client)
+    dependent_document = _document()
+    dependent_document["dependency_version_ids"] = [source["id"]]
+    dependent_draft_response = client.post(
+        "/api/curve-lab/drafts",
+        json=dependent_document,
+    )
+    assert dependent_draft_response.status_code == 201, dependent_draft_response.text
+    dependent_draft = dependent_draft_response.json()
+    dependent_run_response = client.post(
+        f"/api/curve-lab/drafts/{dependent_draft['id']}/build-runs"
+    )
+    assert dependent_run_response.status_code == 202, dependent_run_response.text
+    dependent_run = _wait_for_job(
+        client,
+        "build-runs",
+        dependent_run_response.json()["id"],
+        {"SUCCEEDED", "FAILED", "TIMED_OUT"},
+    )
+    assert dependent_run["state"] == "SUCCEEDED", dependent_run
+    dependent_response = client.post(
+        "/api/curve-lab/versions",
+        json={
+            "draft_id": dependent_draft["id"],
+            "draft_revision": dependent_draft["revision"],
+            "draft_fingerprint": dependent_draft["fingerprint"],
+            "build_run_id": dependent_run["id"],
+            "name": "dependent snapshot source",
+            "idempotency_key": "dependent-snapshot-source",
+        },
+    )
+    assert dependent_response.status_code == 201, dependent_response.text
+    dependent = dependent_response.json()
+
+    class CapturingReservation:
+        submitted: tuple[object, ...] | None = None
+
+        def submit(self, function, /, *args):
+            self.submitted = (function, *args)
+
+        def cancel(self) -> None:
+            pass
+
+    reservation = CapturingReservation()
+    monkeypatch.setattr(curve_risk, "_reserve_job", lambda: reservation)
+    original_snapshot = curve_risk._AdmittedRiskSnapshot
+    snapshot_constructions = 0
+
+    def construct_snapshot(*args, **kwargs):
+        nonlocal snapshot_constructions
+        snapshot_constructions += 1
+        return original_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "_AdmittedRiskSnapshot", construct_snapshot)
+    original_estimate = curve_risk.estimate_work
+    estimate_calls = 0
+
+    def counted_estimate(*args, **kwargs):
+        nonlocal estimate_calls
+        estimate_calls += 1
+        return original_estimate(*args, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "estimate_work", counted_estimate)
+    request = _request(dependent["id"])
+    request["measures"] = ["PV"]
+    request["sensitivity_layers"] = []
+
+    admitted_response = client.post("/api/curve-lab/risk-runs", json=request)
+
+    assert admitted_response.status_code == 202, admitted_response.text
+    assert reservation.submitted is not None
+    function, worker_store, gateway, snapshot = reservation.submitted
+    assert snapshot_constructions == 1
+    assert estimate_calls == 1
+    assert client.post(f"/api/curve-lab/versions/{source['id']}/archive").status_code == 200
+    assert client.post(f"/api/curve-lab/versions/{dependent['id']}/archive").status_code == 200
+    archived = client.get(
+        "/api/curve-lab/versions",
+        params={"include_archived": True},
+    ).json()
+    archived_by_id = {version["id"]: version for version in archived}
+    assert archived_by_id[source["id"]]["visibility_state"] == "ARCHIVED"
+    assert archived_by_id[dependent["id"]]["visibility_state"] == "ARCHIVED"
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("worker reread mutable admitted source state")
+
+    for method in (
+        "get_curve_lab_version",
+        "get_curve_lab_build_run",
+        "get_curve_lab_draft",
+        "get_curve_lab_import_job",
+        "get_curve_lab_fixing_snapshot",
+        "resolve_curve_lab_versions",
+    ):
+        monkeypatch.setattr(worker_store, method, forbidden)
+
+    observed_dependencies: list[str] = []
+
+    def price(
+        _document,
+        trades,
+        _evaluation_time,
+        base_currency,
+        *,
+        curve_version,
+        dependencies,
+        **_kwargs,
+    ):
+        assert curve_version["id"] == dependent["id"]
+        assert isinstance(curve_version["native_payload"], bytes)
+        observed_dependencies.extend(item["id"] for item in dependencies)
+        assert all(isinstance(item["native_payload"], bytes) for item in dependencies)
+        return [
+            {
+                "trade_id": trades[0]["trade_id"],
+                "instrument_type": "DEPOSIT",
+                "succeeded": True,
+                "pv": "100",
+                "currency": base_currency,
+                "required_historical_fixings": [],
+                "missing_historical_fixings": [],
+                "dependency_component_keys": ["clab/v1/local/discount/USD/OIS"],
+                "error": "",
+            }
+        ]
+
+    monkeypatch.setattr(gateway, "price_curve_lab_trades", price)
+    original_execute = curve_risk._execute_risk_run
+    received_identical_snapshot: list[bool] = []
+
+    def execute(store, current_gateway, received_snapshot):
+        received_identical_snapshot.append(received_snapshot is snapshot)
+        return original_execute(store, current_gateway, received_snapshot)
+
+    monkeypatch.setattr(curve_risk, "_execute_risk_run", execute)
+
+    function(worker_store, gateway, snapshot)
+
+    completed = client.get(f"/api/curve-lab/risk-runs/{admitted_response.json()['id']}").json()
+    assert completed["state"] == "SUCCEEDED", completed
+    assert completed["result"]["pricing"][0]["pv"] == "100"
+    assert observed_dependencies == [source["id"]]
+    assert received_identical_snapshot == [True]
+    assert snapshot_constructions == 1
+    assert estimate_calls == 1
+
+
+def test_staged_xccy_snapshot_preserves_dependency_axis_and_aad_order_after_archive(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.services.canonical_json import canonical_json_bytes
+    from app.services.curve_lab_plan import resolved_declaration_order
+    from app.services.store import get_store
+
+    store = get_store()
+    fixing_response = client.post(
+        "/api/curve-lab/fixing-snapshots",
+        json={"id": "staged-xccy-fixings", "observations": []},
+    )
+    assert fixing_response.status_code == 201, fixing_response.text
+
+    domestic_key = "clab/v1/local/discount/USD/OIS"
+    foreign_key = "clab/v1/local/discount/EUR/OIS"
+    basis_key = "clab/v1/xccy/basis/USD-EUR/3M"
+    domestic_id = "d" * 32
+    foreign_id = "e" * 32
+    staged_id = "f" * 32
+    build_id = "b" * 32
+    draft_id = "a" * 32
+    created_at = "2026-01-15T10:00:00Z"
+
+    def add_dependency(
+        version_id: str,
+        component_key: str,
+        currency: str,
+        payload: bytes,
+    ) -> dict:
+        content_hash = hashlib.sha256(payload).hexdigest()
+        document = {
+            "mode": "SINGLE",
+            "declarations": [
+                {
+                    "component_key": component_key,
+                    "role": "DISCOUNT",
+                    "currency": currency,
+                    "parameterization": "PIECEWISE_CONSTANT_FWD",
+                }
+            ],
+            "dependency_version_ids": [],
+        }
+        record = {
+            "id": version_id,
+            "idempotency_key": f"staged-{currency.lower()}-dependency",
+            "source_kind": "IMPORT",
+            "build_run_id": None,
+            "import_job_id": None,
+            "native_payload": payload,
+            "native_payload_length": len(payload),
+            "native_payload_hash": content_hash,
+            "archive_numeric_format": "JSON_MAX_DIGITS10_V1",
+            "root_kind": "DISCOUNT_CURVE",
+            "build_validation_state": "VERIFIED",
+            "visibility_state": "VISIBLE",
+            "name": f"{currency} dependency",
+            "version_note": None,
+            "tags": [],
+            "verification": {
+                "document": document,
+                "dependency_manifest": [],
+                "resolved_plan": {},
+                "quote_axis": [],
+                "parameter_axis": [],
+            },
+            "created_at": created_at,
+        }
+        stored, was_created = store.add_curve_lab_version(record)
+        assert was_created is True
+        return stored
+
+    domestic = add_dependency(domestic_id, domestic_key, "USD", b"domestic-archive")
+    foreign = add_dependency(foreign_id, foreign_key, "EUR", b"foreign-archive")
+    dependency_manifest = [
+        {
+            "version_id": domestic_id,
+            "content_hash": domestic["native_payload_hash"],
+            "root_kind": domestic["root_kind"],
+        },
+        {
+            "version_id": foreign_id,
+            "content_hash": foreign["native_payload_hash"],
+            "root_kind": foreign["root_kind"],
+        },
+    ]
+    staged_document = {
+        "schema_version": 2,
+        "mode": "STAGED_XCCY",
+        "as_of_date": "2026-01-15",
+        "market_snapshot_id": "staged-xccy-market",
+        "declarations": [
+            {
+                "component_key": basis_key,
+                "role": "BASIS",
+                "currency": "USD",
+                "parameterization": "PIECEWISE_CONSTANT_FWD",
+            },
+            {
+                "component_key": foreign_key,
+                "role": "DISCOUNT",
+                "currency": "EUR",
+                "parameterization": "PIECEWISE_CONSTANT_FWD",
+            },
+            {
+                "component_key": domestic_key,
+                "role": "DISCOUNT",
+                "currency": "USD",
+                "parameterization": "PIECEWISE_CONSTANT_FWD",
+            },
+        ],
+        "instruments": [
+            {
+                "instrument_id": "9" * 32,
+                "instrument_type": "XCCY",
+                "trade_date": "2026-01-15",
+                "start_date": "2026-01-16",
+                "maturity_date": "2028-01-15",
+                "currency_or_pair": "USD-EUR",
+                "raw_quote": "0.001",
+                "normalized_quote": "0.001",
+                "included": True,
+                "terms": {
+                    "component_key": basis_key,
+                    "fx_spot": 1.1,
+                },
+            }
+        ],
+        "dependency_version_ids": [domestic_id, foreign_id],
+        "solver": {
+            "solve_mode": "EXACT",
+            "parameterization": "PIECEWISE_CONSTANT_FWD",
+        },
+    }
+    parameter_axis = [
+        {
+            "global_parameter_index": 0,
+            "parameter_id": f"{domestic_key}:PIECEWISE_CONSTANT_FWD:2028-01-15:RIGHT",
+            "component_key": domestic_key,
+            "stage_id": "stage-0",
+            "stage_local_parameter_index": 0,
+            "component_local_parameter_index": 0,
+            "coordinate_kind": "PIECEWISE_CONSTANT_FWD",
+            "node_date": "2028-01-15",
+            "side": "RIGHT",
+            "native_parameter_unit": "DECIMAL_RATE",
+            "display_label": "USD late",
+        },
+        {
+            "global_parameter_index": 1,
+            "parameter_id": f"{domestic_key}:PIECEWISE_CONSTANT_FWD:2027-01-15:RIGHT",
+            "component_key": domestic_key,
+            "stage_id": "stage-0",
+            "stage_local_parameter_index": 1,
+            "component_local_parameter_index": 1,
+            "coordinate_kind": "PIECEWISE_CONSTANT_FWD",
+            "node_date": "2027-01-15",
+            "side": "RIGHT",
+            "native_parameter_unit": "DECIMAL_RATE",
+            "display_label": "USD early",
+        },
+        {
+            "global_parameter_index": 2,
+            "parameter_id": f"{foreign_key}:PIECEWISE_CONSTANT_FWD:2028-01-15:RIGHT",
+            "component_key": foreign_key,
+            "stage_id": "stage-1",
+            "stage_local_parameter_index": 0,
+            "component_local_parameter_index": 0,
+            "coordinate_kind": "PIECEWISE_CONSTANT_FWD",
+            "node_date": "2028-01-15",
+            "side": "RIGHT",
+            "native_parameter_unit": "DECIMAL_RATE",
+            "display_label": "EUR duplicate date",
+        },
+        {
+            "global_parameter_index": 3,
+            "parameter_id": f"{basis_key}:PIECEWISE_CONSTANT_FWD:2028-01-15:RIGHT",
+            "component_key": basis_key,
+            "stage_id": "stage-2",
+            "stage_local_parameter_index": 0,
+            "component_local_parameter_index": 0,
+            "coordinate_kind": "PIECEWISE_CONSTANT_FWD",
+            "node_date": "2028-01-15",
+            "side": "RIGHT",
+            "native_parameter_unit": "DECIMAL_RATE",
+            "display_label": "basis duplicate date",
+        },
+        {
+            "global_parameter_index": 4,
+            "parameter_id": f"{basis_key}:PIECEWISE_CONSTANT_FWD:2029-01-15:RIGHT",
+            "component_key": basis_key,
+            "stage_id": "stage-2",
+            "stage_local_parameter_index": 1,
+            "component_local_parameter_index": 1,
+            "coordinate_kind": "PIECEWISE_CONSTANT_FWD",
+            "node_date": "2029-01-15",
+            "side": "RIGHT",
+            "native_parameter_unit": "DECIMAL_RATE",
+            "display_label": "basis later knot",
+        },
+    ]
+    quote_axis = [
+        {
+            "global_quote_index": 0,
+            "quote_id": "9" * 32,
+            "instrument_id": "9" * 32,
+            "component_key": basis_key,
+            "stage_id": "stage-2",
+            "group_id": basis_key,
+            "stage_local_quote_index": 0,
+            "quote_coordinate_kind": "SPREAD",
+            "canonical_raw_unit": "DECIMAL",
+            "raw_quote": "0.001",
+            "normalized_quote": "0.001",
+            "normalized_unit": "DECIMAL_RATE",
+            "exact_risk_raw_bump": "0.0001",
+            "normalized_risk_bump": "0.0001",
+            "display_label": "XCCY 2028-01-15",
+        }
+    ]
+    store.add_curve_lab_draft(
+        {
+            "id": draft_id,
+            "schema_version": 2,
+            "revision": 1,
+            "fingerprint": "1" * 64,
+            "document": staged_document,
+            "state": "ACTIVE",
+            "created_at": created_at,
+            "updated_at": created_at,
+        }
+    )
+    staged_payload = b"staged-xccy-archive"
+    staged_hash = hashlib.sha256(staged_payload).hexdigest()
+    resolved_plan = {
+        "mode": "STAGED_XCCY",
+        "runtime_manifest": {
+            "components": [
+                {"component_key": domestic_key},
+                {"component_key": foreign_key},
+                {"component_key": basis_key},
+            ]
+        },
+    }
+    store.add_curve_lab_build_run(
+        {
+            "id": build_id,
+            "draft_id": draft_id,
+            "draft_revision": 1,
+            "draft_fingerprint": "1" * 64,
+            "state": "SUCCEEDED",
+            "request": staged_document,
+            "resolved_plan": resolved_plan,
+            "quote_axis": quote_axis,
+            "parameter_axis": parameter_axis,
+            "dependency_manifest": dependency_manifest,
+            "native_payload": staged_payload,
+            "native_payload_hash": staged_hash,
+            "diagnostics": {},
+            "error": None,
+            "created_at": created_at,
+            "deadline_at": "2099-01-01T00:00:00Z",
+            "finished_at": created_at,
+        }
+    )
+    staged_version = {
+        "id": staged_id,
+        "idempotency_key": "staged-xccy-source",
+        "source_kind": "BUILD",
+        "build_run_id": build_id,
+        "import_job_id": None,
+        "native_payload": staged_payload,
+        "native_payload_length": len(staged_payload),
+        "native_payload_hash": staged_hash,
+        "archive_numeric_format": "JSON_MAX_DIGITS10_V1",
+        "root_kind": "CURVE_SET",
+        "build_validation_state": "VERIFIED",
+        "visibility_state": "VISIBLE",
+        "name": "staged XCCY",
+        "version_note": None,
+        "tags": [],
+        "verification": {
+            "draft_id": draft_id,
+            "draft_revision": 1,
+            "draft_fingerprint": "1" * 64,
+            "document": staged_document,
+            "dependency_manifest": dependency_manifest,
+            "resolved_plan": resolved_plan,
+            "quote_axis": quote_axis,
+            "parameter_axis": parameter_axis,
+        },
+        "created_at": created_at,
+    }
+    _, was_created = store.add_curve_lab_version(staged_version)
+    assert was_created is True
+
+    assert [
+        declaration["component_key"] for declaration in resolved_declaration_order(staged_document)
+    ] == [domestic_key, foreign_key, basis_key]
+    assert [entry["version_id"] for entry in dependency_manifest] == [
+        domestic_id,
+        foreign_id,
+    ]
+    assert [axis["parameter_id"] for axis in parameter_axis] == [
+        f"{domestic_key}:PIECEWISE_CONSTANT_FWD:2028-01-15:RIGHT",
+        f"{domestic_key}:PIECEWISE_CONSTANT_FWD:2027-01-15:RIGHT",
+        f"{foreign_key}:PIECEWISE_CONSTANT_FWD:2028-01-15:RIGHT",
+        f"{basis_key}:PIECEWISE_CONSTANT_FWD:2028-01-15:RIGHT",
+        f"{basis_key}:PIECEWISE_CONSTANT_FWD:2029-01-15:RIGHT",
+    ]
+    assert [axis["node_date"] for axis in parameter_axis if axis["component_key"] == basis_key] == [
+        "2028-01-15",
+        "2029-01-15",
+    ]
+
+    class CapturingReservation:
+        submitted: tuple[object, ...] | None = None
+
+        def submit(self, function, /, *args):
+            self.submitted = (function, *args)
+
+        def cancel(self) -> None:
+            pass
+
+    reservations: list[CapturingReservation] = []
+
+    def reserve():
+        reservation = CapturingReservation()
+        reservations.append(reservation)
+        return reservation
+
+    monkeypatch.setattr(curve_risk, "_reserve_job", reserve)
+    original_snapshot = curve_risk._AdmittedRiskSnapshot
+    snapshot_constructions = 0
+
+    def construct_snapshot(*args, **kwargs):
+        nonlocal snapshot_constructions
+        snapshot_constructions += 1
+        return original_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "_AdmittedRiskSnapshot", construct_snapshot)
+    original_estimate = curve_risk.estimate_work
+    estimate_calls = 0
+
+    def estimate(*args, **kwargs):
+        nonlocal estimate_calls
+        estimate_calls += 1
+        return original_estimate(*args, **kwargs)
+
+    monkeypatch.setattr(curve_risk, "estimate_work", estimate)
+    from app.services.dal_gateway import get_gateway
+
+    risk_gateway = get_gateway()
+    monkeypatch.setattr(
+        risk_gateway,
+        "curve_lab_required_historical_fixings",
+        lambda *_args, **_kwargs: [],
+    )
+    dependency_orders: list[list[str]] = []
+    native_gradient = ["1.25", "2.5", "3.75", "5", "6.25"]
+    central_gradient = {
+        _trade(0)["trade_id"]: [Decimal(value) for value in native_gradient],
+        "2" * 32: [
+            Decimal("10"),
+            Decimal("20"),
+            Decimal("30"),
+            Decimal("40"),
+            Decimal("50"),
+        ],
+    }
+
+    def price(
+        _document,
+        trades,
+        _evaluation_time,
+        base_currency,
+        *,
+        dependencies,
+        **_kwargs,
+    ):
+        dependency_orders.append([dependency["id"] for dependency in dependencies])
+        return [
+            {
+                "trade_id": trade["trade_id"],
+                "instrument_type": trade["instrument_type"],
+                "succeeded": True,
+                "pv": "100" if trade["instrument_type"] == "DEPOSIT" else "200",
+                "currency": base_currency,
+                "required_historical_fixings": [],
+                "missing_historical_fixings": [],
+                "dependency_component_keys": [
+                    domestic_key,
+                    foreign_key,
+                    basis_key,
+                ],
+                "error": "",
+                "aad_node_gradient": (
+                    native_gradient if trade["instrument_type"] == "DEPOSIT" else None
+                ),
+            }
+            for trade in trades
+        ]
+
+    def parameter_bump(
+        _document,
+        trades,
+        _evaluation_time,
+        base_currency,
+        axis,
+        bump,
+        *,
+        dependencies,
+        **_kwargs,
+    ):
+        dependency_orders.append([dependency["id"] for dependency in dependencies])
+        parameter_index = next(
+            index
+            for index, item in enumerate(parameter_axis)
+            if item["parameter_id"] == axis["parameter_id"]
+        )
+        return [
+            {
+                "trade_id": trade["trade_id"],
+                "instrument_type": trade["instrument_type"],
+                "succeeded": True,
+                "pv": str(
+                    (Decimal("100") if trade["instrument_type"] == "DEPOSIT" else Decimal("200"))
+                    + Decimal(str(bump)) * central_gradient[trade["trade_id"]][parameter_index]
+                ),
+                "currency": base_currency,
+                "required_historical_fixings": [],
+                "missing_historical_fixings": [],
+                "dependency_component_keys": [],
+                "error": "",
+            }
+            for trade in trades
+        ]
+
+    monkeypatch.setattr(risk_gateway, "price_curve_lab_trades", price)
+    monkeypatch.setattr(
+        risk_gateway,
+        "price_curve_lab_parameter_bump",
+        parameter_bump,
+    )
+    audit_actions: list[tuple[str, str]] = []
+    original_audit = store.add_curve_lab_audit_event
+
+    def add_audit(record):
+        audit_actions.append((record["action"], record["target_id"]))
+        original_audit(record)
+
+    monkeypatch.setattr(store, "add_curve_lab_audit_event", add_audit)
+    publications: list[tuple[str, str, list[str]]] = []
+    original_publish = store.publish_curve_lab_risk_run
+
+    def publish(record, matrices):
+        publications.append(
+            (
+                record["id"],
+                record["state"],
+                [matrix["matrix_id"] for matrix in matrices],
+            )
+        )
+        return original_publish(record, matrices)
+
+    monkeypatch.setattr(store, "publish_curve_lab_risk_run", publish)
+
+    deposit = _trade(0)
+    deposit["terms"]["discount_component_key"] = domestic_key
+    xccy = {
+        "trade_id": "2" * 32,
+        "instrument_type": "XCCY",
+        "trade_date": "2026-01-15",
+        "start_date": "2026-01-16",
+        "maturity_date": "2028-01-15",
+        "currency_or_pair": "USD-EUR",
+        "terms": {
+            "position_count": "1",
+            "contract_spread": "0.001",
+            "side": "RECEIVE_NON_SPREAD_PAY_SPREAD",
+            "domestic_notional": "100",
+            "foreign_notional": "90",
+            "fx_spot": "1.1",
+        },
+    }
+
+    def request(trades: list[dict], fallback: str) -> dict:
+        return {
+            "curve_version_id": staged_id,
+            "target": {"trades": trades},
+            "measures": ["PV"],
+            "sensitivity_layers": ["TRADE_TO_NODE"],
+            "fixing_snapshot_id": "staged-xccy-fixings",
+            "evaluation_time": "2026-01-15T10:30:00Z",
+            "base_currency": "USD",
+            "options": {"aad_fallback": fallback},
+        }
+
+    full_response = client.post(
+        "/api/curve-lab/risk-runs",
+        json=request([deposit], "FORBID"),
+    )
+    assert full_response.status_code == 202, full_response.text
+    assert reservations[0].submitted is not None
+    full_function, full_store, full_gateway, full_snapshot = reservations[0].submitted
+    assert full_function is curve_risk._execute_risk_run_guarded
+    curve_risk._execute_risk_run(full_store, full_gateway, full_snapshot)
+    full_run = client.get(f"/api/curve-lab/risk-runs/{full_response.json()['id']}").json()
+    assert full_run["state"] == "SUCCEEDED", full_run
+    full_matrix = client.get(
+        f"/api/curve-lab/risk-runs/{full_run['id']}/matrices/trade-to-node"
+    ).json()
+    assert full_matrix["values"] == [native_gradient]
+    assert full_matrix["trade_methods"] == ["NATIVE_AAD"]
+
+    rejected = client.post(
+        "/api/curve-lab/risk-runs",
+        json=request([deposit, xccy], "FORBID"),
+    )
+    assert rejected.status_code == 422, rejected.text
+    assert rejected.json()["detail"] == {
+        "code": "AAD_METHOD_UNAVAILABLE",
+        "message": "At least one admitted trade has no complete native AAD pricing plan.",
+        "field": "options.aad_fallback",
+        "value": "FORBID",
+        "resource_id": None,
+        "details": {"constraint": "statically ineligible trades require aad_fallback=ALLOW"},
+    }
+    assert len(reservations) == 1
+
+    partial_request = request([deposit, xccy], "ALLOW")
+    control_response = client.post("/api/curve-lab/risk-runs", json=partial_request)
+    assert control_response.status_code == 202, control_response.text
+    assert reservations[1].submitted is not None
+    control_function, control_store, control_gateway, control_snapshot = reservations[1].submitted
+    assert control_function is curve_risk._execute_risk_run_guarded
+    curve_risk._execute_risk_run(control_store, control_gateway, control_snapshot)
+    control_run = client.get(f"/api/curve-lab/risk-runs/{control_response.json()['id']}").json()
+    control_matrix = client.get(
+        f"/api/curve-lab/risk-runs/{control_run['id']}/matrices/trade-to-node"
+    ).json()
+    assert control_run["state"] == "SUCCEEDED", control_run
+    assert control_matrix["values"] == [
+        native_gradient,
+        ["10", "20", "30", "40", "50"],
+    ]
+    assert control_matrix["trade_methods"] == [
+        "NATIVE_AAD",
+        "CENTRAL_NATIVE_PARAMETER_BUMP",
+    ]
+    assert set(control_run["result"]) == {"pricing", "sensitivity_matrices"}
+
+    archived_response = client.post("/api/curve-lab/risk-runs", json=partial_request)
+    assert archived_response.status_code == 202, archived_response.text
+    assert reservations[2].submitted is not None
+    archived_function, archived_store, archived_gateway, archived_snapshot = reservations[
+        2
+    ].submitted
+    assert [
+        curve_risk._thaw_json_object(item)["id"] for item in archived_snapshot.dependencies
+    ] == [domestic_id, foreign_id]
+    assert [
+        curve_risk._thaw_json_object(item)["parameter_id"]
+        for item in archived_snapshot.parameter_axis
+    ] == [axis["parameter_id"] for axis in parameter_axis]
+
+    for version_id in (domestic_id, foreign_id, staged_id):
+        archived = client.post(f"/api/curve-lab/versions/{version_id}/archive")
+        assert archived.status_code == 200, archived.text
+        assert archived.json()["visibility_state"] == "ARCHIVED"
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("staged worker reread archived mutable state")
+
+    for method in (
+        "get_curve_lab_version",
+        "get_curve_lab_build_run",
+        "get_curve_lab_draft",
+        "get_curve_lab_import_job",
+        "get_curve_lab_fixing_snapshot",
+        "resolve_curve_lab_versions",
+    ):
+        monkeypatch.setattr(archived_store, method, forbidden)
+    original_execute = curve_risk._execute_risk_run
+    worker_identity: list[bool] = []
+
+    def execute(worker_store, gateway_instance, received_snapshot):
+        worker_identity.append(received_snapshot is archived_snapshot)
+        return original_execute(worker_store, gateway_instance, received_snapshot)
+
+    monkeypatch.setattr(curve_risk, "_execute_risk_run", execute)
+    archived_function(archived_store, archived_gateway, archived_snapshot)
+
+    archived_run = client.get(f"/api/curve-lab/risk-runs/{archived_response.json()['id']}").json()
+    archived_matrix = client.get(
+        f"/api/curve-lab/risk-runs/{archived_run['id']}/matrices/trade-to-node"
+    ).json()
+
+    stable_run_fields = (
+        "curve_version_id",
+        "calibration_run_id",
+        "import_job_id",
+        "source_kind",
+        "request",
+        "fixing_snapshot_hash",
+        "target_fingerprint",
+        "quote_axis",
+        "parameter_axis",
+        "estimated_work",
+        "state",
+        "result",
+        "error",
+    )
+    assert canonical_json_bytes(
+        {field: control_run[field] for field in stable_run_fields}
+    ) == canonical_json_bytes({field: archived_run[field] for field in stable_run_fields})
+    stable_matrix_fields = tuple(field for field in control_matrix if field not in {"risk_run_id"})
+    assert canonical_json_bytes(
+        {field: control_matrix[field] for field in stable_matrix_fields}
+    ) == canonical_json_bytes({field: archived_matrix[field] for field in stable_matrix_fields})
+    assert archived_run["created_at"] <= archived_run["finished_at"]
+    assert worker_identity == [True]
+    assert snapshot_constructions == 3
+    assert estimate_calls == 3
+    assert all(order == [domestic_id, foreign_id] for order in dependency_orders)
+    assert audit_actions[-4:] == [
+        ("VERSION_ARCHIVED", domestic_id),
+        ("VERSION_ARCHIVED", foreign_id),
+        ("VERSION_ARCHIVED", staged_id),
+        ("RISK_RUN_SUCCEEDED", archived_run["id"]),
+    ]
+    for run_id in (full_run["id"], control_run["id"], archived_run["id"]):
+        assert [
+            (state, matrix_ids)
+            for published_id, state, matrix_ids in publications
+            if published_id == run_id
+        ] == [
+            ("QUEUED", []),
+            ("RUNNING", []),
+            ("SUCCEEDED", ["trade-to-node"]),
+        ]
+
+
 def test_risk_run_recalibrates_parallel_and_each_key_rate_and_persists_matrix(
     client, monkeypatch
 ) -> None:
@@ -829,6 +1861,33 @@ def test_risk_run_recalibrates_parallel_and_each_key_rate_and_persists_matrix(
     assert matrix.json()["orientation"] == "TRADE_X_QUOTE"
     assert matrix.json()["availability"] == "AVAILABLE"
     assert matrix.json()["values"] == [["0.0001"]]
+
+
+def test_risk_quote_replay_delegates_to_the_exact_decimal_bump(monkeypatch) -> None:
+    import app.services.curve_risk as curve_risk
+
+    calls: list[tuple[str, str]] = []
+
+    def apply(value: str, bump: str) -> str:
+        calls.append((value, bump))
+        return "0.0401"
+
+    monkeypatch.setattr(curve_risk, "apply_exact_decimal_bump", apply)
+    document = _document()
+    document["instruments"][0]["instrument_id"] = "a" * 32
+    axis = [
+        {
+            "instrument_id": "a" * 32,
+            "raw_quote": "0.04",
+            "exact_risk_raw_bump": "0.0001",
+            "canonical_raw_unit": "DECIMAL",
+        }
+    ]
+
+    bumped = curve_risk._bumped_document(document, axis, None)
+
+    assert calls == [("0.04", "0.0001")]
+    assert bumped["instruments"][0]["raw_quote"] == "0.0401"
 
 
 def test_import_job_is_readable_and_import_quote_risk_requires_lineage(client) -> None:
@@ -957,8 +2016,11 @@ def test_base_pricing_partial_failure_uses_exact_discriminated_key_sets(
 
 
 def test_work_estimator_charges_full_two_parameter_bumps_per_trade() -> None:
+    from inspect import signature
+
     from app.services.curve_risk import estimate_work
 
+    assert "allow_aad_fallback" not in signature(estimate_work).parameters
     estimate = estimate_work(
         trades=1_000,
         aad_eligible_trades=1_000,
@@ -966,7 +2028,6 @@ def test_work_estimator_charges_full_two_parameter_bumps_per_trade() -> None:
         quotes=0,
         measures=("PV",),
         sensitivity_layers=("TRADE_TO_NODE",),
-        allow_aad_fallback=False,
     )
 
     assert estimate["parameter_bump_price_evaluations"] == 1_000_000
@@ -1205,13 +2266,9 @@ def test_aad_parity_failure_reuses_central_row_when_fallback_is_allowed(
 
     run = _completed_risk(client, client.post("/api/curve-lab/risk-runs", json=request))
 
-    matrix = client.get(
-        f"/api/curve-lab/risk-runs/{run['id']}/matrices/trade-to-node"
-    ).json()
+    matrix = client.get(f"/api/curve-lab/risk-runs/{run['id']}/matrices/trade-to-node").json()
     assert matrix["method"] == "CENTRAL_PARAMETER_BUMP_AFTER_AAD_PARITY_FAILURE"
-    assert matrix["trade_methods"] == [
-        "CENTRAL_PARAMETER_BUMP_AFTER_AAD_PARITY_FAILURE"
-    ]
+    assert matrix["trade_methods"] == ["CENTRAL_PARAMETER_BUMP_AFTER_AAD_PARITY_FAILURE"]
     assert matrix["values"] == [["2"]]
     assert matrix["aad_parity"][0]["status"] == "FAILED"
     assert bumps == [1e-06, -1e-06]

--- a/dal-web/backend/tests/test_curve_lab_risk_api.py
+++ b/dal-web/backend/tests/test_curve_lab_risk_api.py
@@ -601,6 +601,57 @@ def test_risk_create_acknowledges_queued_before_native_pricing(
     assert completed["state"] == "SUCCEEDED"
 
 
+def test_risk_deadline_starts_after_admission_preflight(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.services.dal_gateway import get_gateway
+
+    _, version = _publish_version(client)
+
+    class CapturingReservation:
+        submitted: tuple[object, ...] | None = None
+
+        def submit(self, function, /, *args):
+            self.submitted = (function, *args)
+
+        def cancel(self) -> None:
+            pass
+
+    reservation = CapturingReservation()
+    monkeypatch.setattr(curve_risk, "_reserve_job", lambda: reservation)
+    clock = {"now": "2026-01-15T10:00:00Z"}
+    monkeypatch.setattr(curve_risk, "_now", lambda: clock["now"])
+    gateway = get_gateway()
+    original_preflight = gateway.curve_lab_required_historical_fixings
+
+    def advancing_preflight(*args, **kwargs):
+        required = original_preflight(*args, **kwargs)
+        clock["now"] = "2026-01-15T10:05:00Z"
+        return required
+
+    monkeypatch.setattr(
+        gateway,
+        "curve_lab_required_historical_fixings",
+        advancing_preflight,
+    )
+    request = _request(version["id"])
+    request["measures"] = ["PV"]
+    request["sensitivity_layers"] = []
+
+    response = client.post("/api/curve-lab/risk-runs", json=request)
+
+    assert response.status_code == 202, response.text
+    queued = response.json()
+    assert reservation.submitted is not None
+    _, _, _, snapshot = reservation.submitted
+    assert queued["created_at"] == "2026-01-15T10:05:00Z"
+    assert queued["deadline_at"] == "2026-01-15T10:20:00Z"
+    assert snapshot.created_at == queued["created_at"]
+    assert snapshot.deadline_at == queued["deadline_at"]
+
+
 @pytest.mark.parametrize("expire_after_running", [False, True])
 def test_risk_deadline_terminalizes_without_partial_matrices(
     client,

--- a/dal-web/backend/tests/test_dal_gateway.py
+++ b/dal-web/backend/tests/test_dal_gateway.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import inspect
+import json
+from types import SimpleNamespace
+from typing import Any
+
 import dal  # the fake installed by conftest
 import pytest
 
@@ -112,7 +118,9 @@ def test_value_restores_date_even_on_pricing_failure(monkeypatch):
     dal.EvaluationDate_Set(dal.Date_(2020, 1, 1))
     gw = make_gateway()
 
-    monkeypatch.setattr(dal, "MonteCarlo_Value", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        dal, "MonteCarlo_Value", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
 
     with pytest.raises(RuntimeError):
         gw.value(_european_request(evaluation_date=(2022, 9, 15)))
@@ -137,3 +145,388 @@ def test_gateway_builds_non_flat_dupire_surface():
     )
 
     assert model["vols"] == surface  # nosec B101 - pytest assertions are intentional
+
+
+def test_curve_lab_pricing_uses_the_shared_native_trade_builder() -> None:
+    source = inspect.getsource(DalGateway.price_curve_lab_trades)
+
+    assert "self._curve_lab_native_trade_definitions(" in source
+    assert "DepositTradeTerms_" not in source
+    assert "FraTradeTerms_" not in source
+    assert "FutureTradeTerms_" not in source
+    assert "FixedFloatTradeTerms_" not in source
+    assert "BasisTradeTerms_" not in source
+    assert "XccyTradeTerms_" not in source
+
+
+def test_curve_lab_native_trade_builder_preserves_all_families_and_fixings(
+    monkeypatch,
+) -> None:
+    families = (
+        "DEPOSIT",
+        "FRA",
+        "FUTURE",
+        "OIS",
+        "IRS",
+        "BASIS_SWAP",
+        "XCCY",
+    )
+
+    def record(kind: str):
+        def construct(*args, **kwargs):
+            return {"kind": kind, "args": args, **kwargs}
+
+        return construct
+
+    class FixingIdentity:
+        index_name = ""
+        fixing_hour = 0
+        fixing_minute = 0
+
+    class XccyConvention:
+        pass
+
+    class HashableRecord:
+        def __init__(self, kind: str, *args: object) -> None:
+            self.kind = kind
+            self.args = args
+
+        def __hash__(self) -> int:
+            return hash((self.kind, self.args))
+
+    class XccyBuilder:
+        def Build(self):  # noqa: N802 - mirror native builder API
+            return {
+                "pair": self.pair,
+                "domestic_notional": self.domestic_notional,
+                "foreign_notional": self.foreign_notional,
+                "convention": vars(self.convention),
+                "notional_mode": self.notional_mode,
+                "domestic_rate_fixing": vars(self.domestic_rate_fixing),
+                "foreign_rate_fixing": vars(self.foreign_rate_fixing),
+            }
+
+    native = SimpleNamespace(
+        Date_=lambda year, month, day: f"{year:04d}-{month:02d}-{day:02d}",
+        DateTime_=record("DATETIME"),
+        PeriodLength_New=record("PERIOD"),
+        DayBasis_New=record("DAY_BASIS"),
+        CollateralType_=lambda value: HashableRecord("COLLATERAL", value),
+        RateIndexConvention_New=record("INDEX"),
+        RateLegConvention_New=record("LEG"),
+        FixingIdentity_=FixingIdentity,
+        CrossCurrencyConvention_=XccyConvention,
+        CrossCurrencySwapConfigBuilder_=XccyBuilder,
+        CurrencyPair_New=record("PAIR"),
+        XccyNotionalMode=SimpleNamespace(FIXED="FIXED"),
+        RateInstrumentType=SimpleNamespace(**dict.fromkeys(families, None)),
+        DepositTradeTerms_=record("DEPOSIT_TERMS"),
+        FraTradeTerms_=record("FRA_TERMS"),
+        FutureTradeTerms_=record("FUTURE_TERMS"),
+        FixedFloatTradeTerms_=record("FIXED_FLOAT_TERMS"),
+        OisTradeTerms_=record("OIS_TERMS"),
+        IrsTradeTerms_=record("IRS_TERMS"),
+        BasisTradeTerms_=record("BASIS_TERMS"),
+        XccyTradeTerms_=record("XCCY_TERMS"),
+        RateTradeDefinition_=record("TRADE"),
+    )
+    for family in families:
+        setattr(native.RateInstrumentType, family, family)
+
+    common = {
+        "trade_date": "2026-01-15",
+        "start_date": "2026-01-16",
+        "maturity_date": "2027-01-15",
+        "currency_or_pair": "USD",
+    }
+    index = {
+        "forecast_tenor": "3M",
+        "day_basis": "ACT_365F",
+        "collateral": "OIS",
+        "index_name": "USD-SOFR",
+        "fixing_hour": 10,
+        "fixing_minute": 15,
+    }
+    trades = [
+        {
+            **common,
+            "trade_id": f"{position + 1:032x}",
+            "instrument_type": family,
+            "terms": terms,
+        }
+        for position, (family, terms) in enumerate(
+            (
+                (
+                    "DEPOSIT",
+                    {
+                        **index,
+                        "notional": "100",
+                        "contract_rate": "0.04",
+                        "side": "LEND",
+                    },
+                ),
+                (
+                    "FRA",
+                    {
+                        **index,
+                        "notional": "100",
+                        "contract_rate": "0.04",
+                        "side": "RECEIVE_FLOATING",
+                    },
+                ),
+                (
+                    "FUTURE",
+                    {
+                        **index,
+                        "contract_count": "2",
+                        "reference_price": "95",
+                        "contract_value_per_price_point": "1000",
+                        "side": "LONG",
+                    },
+                ),
+                (
+                    "OIS",
+                    {
+                        **index,
+                        "notional": "100",
+                        "contract_rate": "0.04",
+                        "side": "PAY_FIXED",
+                        "float_index_name": "USD-OIS",
+                    },
+                ),
+                (
+                    "IRS",
+                    {
+                        **index,
+                        "notional": "100",
+                        "contract_rate": "0.04",
+                        "side": "RECEIVE_FIXED",
+                        "float_index_name": "USD-IBOR-3M",
+                    },
+                ),
+                (
+                    "BASIS_SWAP",
+                    {
+                        **index,
+                        "notional": "100",
+                        "contract_spread": "0.001",
+                        "side": "RECEIVE_REFERENCE_PAY_SPREAD",
+                        "spread_index_name": "USD-IBOR-3M",
+                        "reference_index_name": "USD-IBOR-6M",
+                    },
+                ),
+                (
+                    "XCCY",
+                    {
+                        **index,
+                        "position_count": "2",
+                        "contract_spread": "0.001",
+                        "side": "RECEIVE_NON_SPREAD_PAY_SPREAD",
+                        "domestic_notional": "100",
+                        "foreign_notional": "90",
+                        "fx_spot": "1.1",
+                        "domestic_index_name": "USD-SOFR",
+                        "foreign_index_name": "EUR-ESTR",
+                    },
+                ),
+            )
+        )
+    ]
+    trades[-1]["currency_or_pair"] = "USD-EUR"
+    gateway = make_gateway()
+    gateway._dal = native
+
+    definitions = gateway._curve_lab_native_trade_definitions(
+        trades,
+        "discount-default",
+    )
+
+    assert [row["instrument_id"] for row in definitions] == [trade["trade_id"] for trade in trades]
+    assert [row["instrument_type"] for row in definitions] == list(families)
+    assert [row["terms"]["kind"] for row in definitions] == [
+        "DEPOSIT_TERMS",
+        "FRA_TERMS",
+        "FUTURE_TERMS",
+        "OIS_TERMS",
+        "IRS_TERMS",
+        "BASIS_TERMS",
+        "XCCY_TERMS",
+    ]
+    assert definitions[1]["terms"]["fixing_identity"].index_name == "USD-SOFR"
+    assert definitions[3]["terms"]["value"]["fixing_identity"].index_name == "USD-OIS"
+    assert definitions[5]["terms"]["spread_fixing_identity"].index_name == "USD-IBOR-3M"
+    assert definitions[5]["terms"]["reference_fixing_identity"].index_name == "USD-IBOR-6M"
+    config = definitions[6]["terms"]["config"]
+    assert config["pair"]["args"] == ("USD", "EUR")
+    assert config["domestic_rate_fixing"]["index_name"] == "USD-SOFR"
+    assert config["foreign_rate_fixing"]["index_name"] == "EUR-ESTR"
+
+    captured: list[list[dict[str, Any]]] = []
+
+    def required_fixings(native_trades, _evaluation_time):
+        captured.append(native_trades)
+        return []
+
+    native._dal = SimpleNamespace(
+        _RequiredHistoricalRateTradeFixings=required_fixings,
+    )
+    assert (
+        gateway.curve_lab_required_historical_fixings(
+            trades,
+            "2026-01-15T10:30:00Z",
+            "discount-default",
+        )
+        == []
+    )
+
+    def plain(value):
+        if isinstance(value, dict):
+            return {key: plain(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [plain(item) for item in value]
+        if hasattr(value, "__dict__"):
+            return plain(vars(value))
+        return value
+
+    def definition_hash(value: object) -> str:
+        return hashlib.sha256(
+            json.dumps(
+                plain(value),
+                ensure_ascii=True,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("ascii")
+        ).hexdigest()
+
+    # Canonical fake-native definitions captured from baseline b089b8c9.
+    baseline_hash = "4fdaf76f74e59273ab85c83ec9c97d4e05e0b1fdffdb89f576831ea1fdcd3cb6"
+    assert definition_hash(definitions) == baseline_hash
+    assert len(captured) == 1
+    assert definition_hash(captured[0]) == baseline_hash
+
+    priced_definitions: list[list[dict[str, Any]]] = []
+
+    def price_rate_trades(*, trades, market):
+        assert market["kind"] == "MARKET"
+        priced_definitions.append(trades)
+        return [
+            SimpleNamespace(
+                succeeded=True,
+                pv=str(position),
+                currency="USD",
+                required_historical_fixings=[],
+                missing_historical_fixings=[],
+                dependency_component_keys=[],
+                error="",
+            )
+            for position in range(len(trades))
+        ]
+
+    native.MarketFixingSnapshot_New = record("FIXINGS")
+    native.CurveBlock_New = record("CURVE_BLOCK")
+    native.CrossCurrencyMarket_New = record("XCCY_MARKET")
+    native.RatePricingMarket_ = record("MARKET")
+    native.PriceRateTrades = price_rate_trades
+    gradients = {
+        "discount-default": ["1.25", "2.5"],
+        "discount-eur": ["3.75"],
+        "basis-usd-eur": ["5"],
+    }
+
+    def rate_trade_node_sensitivities(*, trade, market, component_key):
+        assert trade["kind"] == "TRADE"
+        assert market["kind"] == "MARKET"
+        return SimpleNamespace(
+            eligible=True,
+            gradient=gradients[component_key],
+            reason="",
+        )
+
+    native.RateTradeNodeSensitivities = rate_trade_node_sensitivities
+    parameter_axis = [
+        {
+            "parameter_id": "usd-late",
+            "component_key": "discount-default",
+            "node_date": "2028-01-15",
+        },
+        {
+            "parameter_id": "usd-early",
+            "component_key": "discount-default",
+            "node_date": "2027-01-15",
+        },
+        {
+            "parameter_id": "eur-duplicate-date",
+            "component_key": "discount-eur",
+            "node_date": "2028-01-15",
+        },
+        {
+            "parameter_id": "basis-duplicate-date",
+            "component_key": "basis-usd-eur",
+            "node_date": "2028-01-15",
+        },
+    ]
+    document = {
+        "mode": "STAGED_XCCY",
+        "declarations": [
+            {
+                "component_key": "discount-default",
+                "role": "DISCOUNT",
+                "currency": "USD",
+            },
+            {
+                "component_key": "discount-eur",
+                "role": "DISCOUNT",
+                "currency": "EUR",
+            },
+            {
+                "component_key": "basis-usd-eur",
+                "role": "BASIS",
+                "currency": "USD",
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        gateway,
+        "_curve_lab_passive_curves",
+        lambda *_args, **_kwargs: {
+            "discount-default": "USD curve",
+            "discount-eur": "EUR curve",
+            "basis-usd-eur": "basis curve",
+        },
+    )
+
+    priced = gateway.price_curve_lab_trades(
+        document,
+        trades,
+        "2026-01-15T10:30:00Z",
+        "USD",
+        parameter_axis=parameter_axis,
+        include_node_sensitivities=True,
+    )
+
+    assert [row["trade_id"] for row in priced] == [trade["trade_id"] for trade in trades]
+    assert [row["aad_node_gradient"] for row in priced] == [
+        ["1.25", "2.5", "3.75", "5"] for _ in trades
+    ]
+    assert len(priced_definitions) == 1
+    assert definition_hash(priced_definitions[0]) == baseline_hash
+
+    document["mode"] = "JOINT_XCCY"
+    joint_trades = [trades[6], trades[2], trades[0]]
+    priced_definitions.clear()
+
+    joint_priced = gateway.price_curve_lab_trades(
+        document,
+        joint_trades,
+        "2026-01-15T10:30:00Z",
+        "USD",
+    )
+
+    assert [row["trade_id"] for row in joint_priced] == [
+        trade["trade_id"] for trade in joint_trades
+    ]
+    assert len(priced_definitions) == 1
+    # Separate JOINT_XCCY order golden captured from baseline b089b8c9.
+    joint_baseline_hash = "a75c68779c083b610fb5aefc5581fe3acddf2336729a6c4cd47c9f4da42a1b88"
+    assert definition_hash(priced_definitions[0]) == joint_baseline_hash

--- a/dal-web/frontend/src/api/client.ts
+++ b/dal-web/frontend/src/api/client.ts
@@ -120,8 +120,9 @@ export type CurveLabSuccessFamily =
   | "BASIS_SWAP"
   | "XCCY";
 export type QuoteCoordinateKind = "RATE" | "PRICE" | "SPREAD";
-export type QuoteInputConvention = "DECIMAL" | "PERCENT" | "PRICE_POINTS";
-export type QuoteDisplayConvention = "DECIMAL" | "PERCENT" | "PRICE_POINTS";
+type QuoteConventionValue = "DECIMAL" | "PERCENT" | "PRICE_POINTS";
+export type QuoteInputConvention = QuoteConventionValue;
+export type QuoteDisplayConvention = QuoteConventionValue;
 
 export interface CurveLabQuoteAuthoringRequest {
   instrument_type: CurveLabSuccessFamily;
@@ -498,8 +499,6 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
-  getCurveLabDraft: (id: string) =>
-    request<CurveLabDraft>(`/curve-lab/drafts/${id}`),
   updateCurveLabDraft: (id: string, revision: number, body: unknown) =>
     request<CurveLabDraft>(`/curve-lab/drafts/${id}`, {
       method: "PUT",

--- a/dal-web/frontend/src/components/CurveLabQuoteAuthoring.tsx
+++ b/dal-web/frontend/src/components/CurveLabQuoteAuthoring.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import {
   api,
-  ApiClientError,
   type CurveLabCanonicalQuote,
   type CurveLabQuoteAuthoringRequest,
   type CurveLabQuoteRenderingRequest,
@@ -14,6 +13,7 @@ import {
   CURVE_LAB_FAMILY_REGISTRY,
   curveLabFamily,
 } from "../curves/curveLabRegistry";
+import { curveLabErrorMessage } from "../curves/curveLabUtils";
 import { css } from "../format";
 
 type CanonicalizeQuote = (
@@ -36,16 +36,6 @@ interface CurveLabQuoteAuthoringProps {
 
 function signedBump(value: string): string {
   return value.startsWith("-") ? value : `+${value}`;
-}
-
-function errorMessage(reason: unknown): string {
-  if (reason instanceof ApiClientError && typeof reason.detail === "object" && reason.detail) {
-    const detail = reason.detail as { message?: string; field?: string };
-    return detail.field && detail.message
-      ? `${detail.field}: ${detail.message}`
-      : detail.message ?? reason.message;
-  }
-  return reason instanceof Error ? reason.message : String(reason);
 }
 
 export default function CurveLabQuoteAuthoring({
@@ -88,13 +78,16 @@ export default function CurveLabQuoteAuthoring({
     family: activeFamily,
     targetToken,
   };
-
-  useEffect(() => {
-    if (targetInstrumentFamily === undefined) return;
+  const invalidateCanonicalRequest = () => {
     canonicalRequestGenerationRef.current += 1;
     setSubmitting(false);
     setCanonical(null);
     setError(null);
+  };
+
+  useEffect(() => {
+    if (targetInstrumentFamily === undefined) return;
+    invalidateCanonicalRequest();
     if (targetInstrumentFamily === null || targetInstrumentFamily === family) return;
     const targetProjection = curveLabFamily(targetInstrumentFamily);
     setFamily(targetInstrumentFamily);
@@ -119,7 +112,7 @@ export default function CurveLabQuoteAuthoring({
       }
     }).catch((reason: unknown) => {
       if (generation === renderRequestGenerationRef.current) {
-        setRenderingError(errorMessage(reason));
+        setRenderingError(curveLabErrorMessage(reason));
       }
     });
     return () => {
@@ -161,7 +154,7 @@ export default function CurveLabQuoteAuthoring({
     } catch (reason) {
       if (!requestIsCurrent()) return;
       setCanonical(null);
-      setError(errorMessage(reason));
+      setError(curveLabErrorMessage(reason));
     } finally {
       if (requestIsCurrent()) setSubmitting(false);
     }
@@ -184,15 +177,12 @@ export default function CurveLabQuoteAuthoring({
             value={activeFamily}
             disabled={targetInstrumentFamily !== undefined}
             onChange={(event) => {
-              canonicalRequestGenerationRef.current += 1;
-              setSubmitting(false);
+              invalidateCanonicalRequest();
               const next = event.target.value as CurveLabSuccessFamily;
               const nextProjection = curveLabFamily(next);
               setFamily(next);
               setConvention(nextProjection.inputConventions[0]);
               setDisplayConvention(nextProjection.inputConventions[0]);
-              setCanonical(null);
-              setError(null);
             }}
           >
             {CURVE_LAB_FAMILY_REGISTRY.map((row) => (
@@ -208,11 +198,8 @@ export default function CurveLabQuoteAuthoring({
           <select
             value={activeInputConvention}
             onChange={(event) => {
-              canonicalRequestGenerationRef.current += 1;
-              setSubmitting(false);
+              invalidateCanonicalRequest();
               setConvention(event.target.value as QuoteInputConvention);
-              setCanonical(null);
-              setError(null);
             }}
           >
             {projection.inputConventions.map((item) => (
@@ -228,11 +215,8 @@ export default function CurveLabQuoteAuthoring({
             inputMode="decimal"
             spellCheck={false}
             onChange={(event) => {
-              canonicalRequestGenerationRef.current += 1;
-              setSubmitting(false);
+              invalidateCanonicalRequest();
               setLexeme(event.target.value);
-              setCanonical(null);
-              setError(null);
             }}
             onKeyDown={(event) => {
               if (event.key === "Enter") {

--- a/dal-web/frontend/src/components/CurveLabWorkspace.tsx
+++ b/dal-web/frontend/src/components/CurveLabWorkspace.tsx
@@ -19,6 +19,12 @@ import {
   type CurveLabSuccessFamily,
   type CurveLabVersion,
 } from "../api/client";
+import { CURVE_LAB_SUCCESS_FAMILIES } from "../curves/curveLabRegistry";
+import {
+  curveLabErrorMessage,
+  downloadCurveLabArtifacts,
+  omitCurveLabInstrumentId,
+} from "../curves/curveLabUtils";
 import { css } from "../format";
 
 type WorkspaceTab = "build" | "runs" | "risk" | "versions";
@@ -47,15 +53,6 @@ const TABS: { id: WorkspaceTab; label: string; note: string }[] = [
 ];
 
 const COMPONENT_KEY = "clab/v1/local/discount/USD/OIS";
-const CURVE_LAB_FAMILIES: readonly CurveLabSuccessFamily[] = [
-  "DEPOSIT",
-  "FRA",
-  "FUTURE",
-  "OIS",
-  "IRS",
-  "BASIS_SWAP",
-  "XCCY",
-];
 
 const DEFAULT_DRAFT = {
   schema_version: 2,
@@ -291,10 +288,6 @@ function topologyForMode(mode: CurveLabBuildMode) {
   };
 }
 
-function message(reason: unknown): string {
-  return reason instanceof Error ? reason.message : String(reason);
-}
-
 function itemAt<T>(values: T[] | undefined, index: number): T | undefined {
   return values?.find((_, position) => position === index);
 }
@@ -361,12 +354,12 @@ function AxisTable({
         <div {...css("table-container")}>
           <table>
             <thead>
-              <tr><th>#</th><th>Label</th><th>Component</th><th>Coordinate</th></tr>
+              <tr><th {...css("num")}>#</th><th>Label</th><th>Component</th><th>Coordinate</th></tr>
             </thead>
             <tbody>
               {rows.map((row, index) => (
                 <tr key={row.quote_id ?? row.parameter_id ?? index}>
-                  <td {...css("mono")}>{row.global_quote_index ?? row.global_parameter_index}</td>
+                  <td {...css("mono", "num")}>{row.global_quote_index ?? row.global_parameter_index}</td>
                   <td>{row.display_label}</td>
                   <td {...css("mono")}>{row.component_key}</td>
                   <td {...css("mono")}>
@@ -496,6 +489,10 @@ const CurveLabWorkspace = forwardRef<
     canonicalTargetTokenRef.current += 1;
     setCanonicalTargetToken(canonicalTargetTokenRef.current);
   };
+  const selectCanonicalTarget = (index: number | null) => {
+    invalidateCanonicalTarget();
+    setSelectedInstrumentIndex(index);
+  };
   const replaceDraftSource = (next: string) => {
     invalidateCanonicalTarget();
     setDraftSource(next);
@@ -604,11 +601,9 @@ const CurveLabWorkspace = forwardRef<
     const template = visualInstruments.slice(-1).pop()
       ?? DEFAULT_DRAFT.instruments[0];
     const next = {
-      ...template,
-      instrument_id: undefined,
+      ...omitCurveLabInstrumentId(template),
       raw_quote: "0.04",
     };
-    delete next.instrument_id;
     updateVisualDraft((current) => ({
       ...current,
       instruments: [...visualInstruments, next],
@@ -628,7 +623,7 @@ const CurveLabWorkspace = forwardRef<
   const selectedInstrumentFamily = useMemo(() => {
     if (selectedInstrumentIndex === null) return null;
     const value = itemAt(visualInstruments, selectedInstrumentIndex)?.instrument_type;
-    return CURVE_LAB_FAMILIES.includes(value as CurveLabSuccessFamily)
+    return CURVE_LAB_SUCCESS_FAMILIES.includes(value as CurveLabSuccessFamily)
       ? value as CurveLabSuccessFamily
       : null;
   }, [selectedInstrumentIndex, visualInstruments]);
@@ -720,7 +715,7 @@ const CurveLabWorkspace = forwardRef<
 
   useEffect(() => {
     void refreshVersions().catch((reason: unknown) => {
-      setError(message(reason));
+      setError(curveLabErrorMessage(reason));
     });
   }, [refreshVersions]);
 
@@ -730,7 +725,7 @@ const CurveLabWorkspace = forwardRef<
     try {
       await action();
     } catch (reason) {
-      setError(message(reason));
+      setError(curveLabErrorMessage(reason));
     } finally {
       setBusy(false);
     }
@@ -879,21 +874,12 @@ const CurveLabWorkspace = forwardRef<
       api.downloadCurveLabVersion(version.id),
       api.getCurveLabRuntimeManifest(version.id),
     ]);
-    const manifestUrl = URL.createObjectURL(new Blob(
-      [JSON.stringify(manifest, null, 2)],
-      { type: "application/json" },
-    ));
-    const manifestAnchor = document.createElement("a");
-    manifestAnchor.href = manifestUrl;
-    manifestAnchor.download = `${version.name.replace(/ /g, "-")}-${version.id.slice(0, 8)}.manifest.json`;
-    manifestAnchor.click();
-    URL.revokeObjectURL(manifestUrl);
-    const url = URL.createObjectURL(payload);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `${version.name.replace(/ /g, "-")}-${version.id.slice(0, 8)}.json`;
-    anchor.click();
-    URL.revokeObjectURL(url);
+    downloadCurveLabArtifacts({
+      payload,
+      manifest,
+      versionName: version.name,
+      versionId: version.id,
+    });
     setStatus(`Exported native JSON for ${version.name}.`);
   });
 
@@ -1157,8 +1143,7 @@ const CurveLabWorkspace = forwardRef<
                     {...css("ghost")}
                     disabled={selectedInstrumentIndex === null}
                     onClick={() => {
-                      invalidateCanonicalTarget();
-                      setSelectedInstrumentIndex(null);
+                      selectCanonicalTarget(null);
                     }}
                   >
                     Clear quote target
@@ -1179,8 +1164,7 @@ const CurveLabWorkspace = forwardRef<
                             aria-label={`Canonical quote target ${index + 1}`}
                             checked={selectedInstrumentIndex === index}
                             onChange={() => {
-                              invalidateCanonicalTarget();
-                              setSelectedInstrumentIndex(index);
+                              selectCanonicalTarget(index);
                             }}
                           />
                         </td>
@@ -1195,7 +1179,7 @@ const CurveLabWorkspace = forwardRef<
                               );
                             }}
                           >
-                            {CURVE_LAB_FAMILIES.map(
+                            {CURVE_LAB_SUCCESS_FAMILIES.map(
                               (family) => <option key={family} value={family}>{family}</option>,
                             )}
                           </select>
@@ -1432,7 +1416,7 @@ const CurveLabWorkspace = forwardRef<
                               setTradeField(index, "instrument_type", event.target.value);
                             }}
                           >
-                            {CURVE_LAB_FAMILIES.map(
+                            {CURVE_LAB_SUCCESS_FAMILIES.map(
                               (family) => <option key={family}>{family}</option>,
                             )}
                           </select>
@@ -1592,7 +1576,7 @@ const CurveLabWorkspace = forwardRef<
                     void file.text().then((source) => {
                       setImportManifest(JSON.parse(source) as Record<string, unknown>);
                     }).catch((reason: unknown) => {
-                      setError(message(reason));
+                      setError(curveLabErrorMessage(reason));
                     });
                   }
                 }}

--- a/dal-web/frontend/src/curves/curveLabUtils.ts
+++ b/dal-web/frontend/src/curves/curveLabUtils.ts
@@ -1,6 +1,10 @@
 import { ApiClientError } from "../api/client";
 
-type CurveLabErrorDetail = { code?: string; message?: string; field?: string };
+interface CurveLabErrorDetail {
+  code?: string;
+  message?: string;
+  field?: string;
+}
 
 function curveLabErrorDetailMessage(detail: unknown): string | undefined {
   if (typeof detail !== "object" || !detail) return undefined;

--- a/dal-web/frontend/src/curves/curveLabUtils.ts
+++ b/dal-web/frontend/src/curves/curveLabUtils.ts
@@ -1,22 +1,29 @@
 import { ApiClientError } from "../api/client";
 
+type CurveLabErrorDetail = { code?: string; message?: string; field?: string };
+
+function curveLabErrorDetailMessage(detail: unknown): string | undefined {
+  if (typeof detail !== "object" || !detail) return undefined;
+  const { code, message, field } = detail as CurveLabErrorDetail;
+  if (!message) return undefined;
+  const prefix = code ? `${code} · ` : "";
+  return field ? `${prefix}${field}: ${message}` : `${prefix}${message}`;
+}
+
 export function curveLabErrorMessage(reason: unknown): string {
-  if (reason instanceof ApiClientError && typeof reason.detail === "object" && reason.detail) {
-    const detail = reason.detail as { code?: string; message?: string; field?: string };
-    const prefix = detail.code ? `${detail.code} · ` : "";
-    if (detail.field && detail.message) {
-      return `${prefix}${detail.field}: ${detail.message}`;
-    }
-    if (detail.message) return `${prefix}${detail.message}`;
-  }
+  const detailMessage = reason instanceof ApiClientError
+    ? curveLabErrorDetailMessage(reason.detail)
+    : undefined;
+  if (detailMessage) return detailMessage;
   return reason instanceof Error ? reason.message : String(reason);
 }
 
 export function omitCurveLabInstrumentId(
   instrument: Record<string, unknown>,
 ): Record<string, unknown> {
-  const { instrument_id: _instrumentId, ...withoutInstrumentId } = instrument;
-  return withoutInstrumentId;
+  return Object.fromEntries(
+    Object.entries(instrument).filter(([key]) => key !== "instrument_id"),
+  );
 }
 
 function downloadBlob(payload: Blob, fileName: string): void {

--- a/dal-web/frontend/src/curves/curveLabUtils.ts
+++ b/dal-web/frontend/src/curves/curveLabUtils.ts
@@ -1,0 +1,54 @@
+import { ApiClientError } from "../api/client";
+
+export function curveLabErrorMessage(reason: unknown): string {
+  if (reason instanceof ApiClientError && typeof reason.detail === "object" && reason.detail) {
+    const detail = reason.detail as { code?: string; message?: string; field?: string };
+    const prefix = detail.code ? `${detail.code} · ` : "";
+    if (detail.field && detail.message) {
+      return `${prefix}${detail.field}: ${detail.message}`;
+    }
+    if (detail.message) return `${prefix}${detail.message}`;
+  }
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+export function omitCurveLabInstrumentId(
+  instrument: Record<string, unknown>,
+): Record<string, unknown> {
+  const { instrument_id: _instrumentId, ...withoutInstrumentId } = instrument;
+  return withoutInstrumentId;
+}
+
+function downloadBlob(payload: Blob, fileName: string): void {
+  const url = URL.createObjectURL(payload);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = fileName;
+    anchor.click();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export function downloadCurveLabArtifacts({
+  payload,
+  manifest,
+  versionName,
+  versionId,
+}: {
+  payload: Blob;
+  manifest: Record<string, unknown>;
+  versionName: string;
+  versionId: string;
+}): void {
+  const prefix = `${versionName.replace(/ /g, "-")}-${versionId.slice(0, 8)}`;
+  downloadBlob(
+    new Blob(
+      [JSON.stringify(manifest, null, 2)],
+      { type: "application/json" },
+    ),
+    `${prefix}.manifest.json`,
+  );
+  downloadBlob(payload, `${prefix}.json`);
+}

--- a/dal-web/frontend/tests/unit/api_client.test.ts
+++ b/dal-web/frontend/tests/unit/api_client.test.ts
@@ -22,6 +22,10 @@ describe("api client", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not expose the zero-caller Curve Lab draft getter", () => {
+    expect("getCurveLabDraft" in api).toBe(false);
+  });
+
   it("issues GET requests without a JSON content-type", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ status: "ok", backend: "b", is_native: true, evaluation_date: "d" }));
 

--- a/dal-web/frontend/tests/unit/curve_lab_utils.test.ts
+++ b/dal-web/frontend/tests/unit/curve_lab_utils.test.ts
@@ -22,9 +22,23 @@ describe("Curve Lab UI utilities", () => {
         field: "raw_quote",
       },
     ))).toBe("QUOTE_DECIMAL_INVALID · raw_quote: Use a plain decimal.");
+    expect(curveLabErrorMessage(new ApiClientError(
+      "422: invalid quote",
+      422,
+      {
+        code: "QUOTE_DECIMAL_INVALID",
+        message: "Use a plain decimal.",
+      },
+    ))).toBe("QUOTE_DECIMAL_INVALID · Use a plain decimal.");
+    expect(curveLabErrorMessage(new ApiClientError(
+      "422: invalid quote",
+      422,
+      { field: "raw_quote" },
+    ))).toBe("422: invalid quote");
     expect(curveLabErrorMessage(new Error("network unavailable"))).toBe(
       "network unavailable",
     );
+    expect(curveLabErrorMessage("unknown failure")).toBe("unknown failure");
   });
 
   it("omits server-owned instrument ids during construction", () => {

--- a/dal-web/frontend/tests/unit/curve_lab_utils.test.ts
+++ b/dal-web/frontend/tests/unit/curve_lab_utils.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "../../src/api/client";
+import {
+  curveLabErrorMessage,
+  downloadCurveLabArtifacts,
+  omitCurveLabInstrumentId,
+} from "../../src/curves/curveLabUtils";
+
+describe("Curve Lab UI utilities", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("projects structured API errors consistently", () => {
+    expect(curveLabErrorMessage(new ApiClientError(
+      "422: invalid quote",
+      422,
+      {
+        code: "QUOTE_DECIMAL_INVALID",
+        message: "Use a plain decimal.",
+        field: "raw_quote",
+      },
+    ))).toBe("QUOTE_DECIMAL_INVALID · raw_quote: Use a plain decimal.");
+    expect(curveLabErrorMessage(new Error("network unavailable"))).toBe(
+      "network unavailable",
+    );
+  });
+
+  it("omits server-owned instrument ids during construction", () => {
+    const source = {
+      instrument_id: "server-owned",
+      instrument_type: "DEPOSIT",
+      raw_quote: "0.04",
+    };
+
+    const result = omitCurveLabInstrumentId(source);
+
+    expect(result).toEqual({
+      instrument_type: "DEPOSIT",
+      raw_quote: "0.04",
+    });
+    expect(source.instrument_id).toBe("server-owned");
+  });
+
+  it("downloads manifest and native payload with one shared browser helper", () => {
+    const createObjectURL = vi.fn()
+      .mockReturnValueOnce("blob:manifest")
+      .mockReturnValueOnce("blob:payload");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    downloadCurveLabArtifacts({
+      payload: new Blob(["payload"], { type: "application/json" }),
+      manifest: { schema_version: 1 },
+      versionName: "USD OIS",
+      versionId: "1234567890abcdef",
+    });
+
+    expect(createObjectURL).toHaveBeenCalledTimes(2);
+    expect(click).toHaveBeenCalledTimes(2);
+    expect(revokeObjectURL.mock.calls).toEqual([
+      ["blob:manifest"],
+      ["blob:payload"],
+    ]);
+  });
+});

--- a/dal-web/frontend/tests/unit/curve_lab_workspace.test.tsx
+++ b/dal-web/frontend/tests/unit/curve_lab_workspace.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../src/api/client";
 import CurveLabWorkspace from "../../src/components/CurveLabWorkspace";
+import { CURVE_LAB_SUCCESS_FAMILIES } from "../../src/curves/curveLabRegistry";
 
 describe("Curve Lab V2 workspace", () => {
   afterEach(() => {
@@ -24,6 +25,10 @@ describe("Curve Lab V2 workspace", () => {
     expect(screen.getByRole("button", { name: "Add instrument" })).not.toBeNull();
     const advanced = screen.getByText("Advanced JSON").closest("details");
     expect(advanced?.open).toBe(false);
+    expect(
+      Array.from((screen.getByLabelText("Family 1") as HTMLSelectElement).options)
+        .map((option) => option.value),
+    ).toEqual(CURVE_LAB_SUCCESS_FAMILIES);
   });
 
   it("materializes a legal visual topology when the build mode changes", () => {
@@ -202,8 +207,21 @@ describe("Curve Lab V2 workspace", () => {
       stale: false,
       request: {},
       resolved_plan: { mode: "SINGLE" },
-      quote_axis: [],
-      parameter_axis: [],
+      quote_axis: [{
+        global_quote_index: 0,
+        quote_id: "quote-0",
+        component_key: "curve",
+        display_label: "Deposit 2027",
+        normalized_quote: "0.04",
+      }],
+      parameter_axis: [{
+        global_parameter_index: 0,
+        parameter_id: "parameter-0",
+        component_key: "curve",
+        display_label: "USD 2027",
+        coordinate_kind: "PIECEWISE_CONSTANT_FWD",
+        node_date: "2027-01-15",
+      }],
       dependency_manifest: [],
       diagnostics: { fit_state: "NATIVE_ARCHIVE_VALIDATED" },
       native_payload_hash: "d".repeat(64),
@@ -240,6 +258,10 @@ describe("Curve Lab V2 workspace", () => {
     await waitFor(() => expect(api.createCurveLabDraft).toHaveBeenCalledOnce());
     fireEvent.click(screen.getByRole("button", { name: "Build curve" }));
     await waitFor(() => expect(api.createCurveLabBuildRun).toHaveBeenCalledWith(draft.id));
+    fireEvent.click(screen.getByRole("tab", { name: "Runs" }));
+    const quoteAxis = screen.getByRole("heading", { name: "Quote axis" }).closest("section");
+    expect(quoteAxis?.querySelector("th")?.className).toContain("num");
+    expect(quoteAxis?.querySelector("tbody td")?.className).toContain("num");
     fireEvent.click(screen.getByRole("tab", { name: "Build" }));
     fireEvent.change(screen.getByLabelText("Version name"), {
       target: { value: "USD OIS" },


### PR DESCRIPTION
Related to DAL-58. This package has no close intent.

## Summary

- freeze one deeply immutable admitted risk snapshot so uninterrupted workers use admitted request, version, dependency, fixing, axis, AAD, and estimate evidence without mutable rereads
- single-source exact canonical JSON, capability limits and costs, decimal quote bumping, import preflight projection, and seven-family native trade construction
- consolidate Curve Lab frontend family, invalidation, error, artifact-download, target-copy, and convention helpers without changing public/OpenAPI contracts
- preserve restart reconciliation, deadlines, STAGED_XCCY/JOINT_XCCY ordering, persisted AAD axis mapping, and archive-after-admission behavior with focused regression coverage
- preserve the baseline deadline origin by stamping the immutable risk snapshot only after successful admission/preflight; clear the actionable Curve Lab utility Codacy annotations, including the private object-shape declaration style

## Test plan

- [x] `uv run --no-sync pytest -q` — 441 passed, 2 deselected at repair head `68ff47890a5103cadd3b252c1855a0c78153240e`
- [x] named Curve Lab/API/OpenAPI suites — 154 passed at repair head `68ff47890a5103cadd3b252c1855a0c78153240e`
- [x] focused deadline/admission/snapshot tests — 5 passed
- [x] `uv run --no-sync ruff check .`
- [x] Ruff format check for the exact 11 P3-owned files; global format debt remains only the 11 named P1-owned files
- [x] frontend Vitest — 77 passed; TypeScript project build and Vite production build passed at repair head `68ff47890a5103cadd3b252c1855a0c78153240e`
- [x] Curve Lab utility Vitest — 3 passed; TypeScript project build passed at final Codacy follow-up head `c4d19bde564490468275a390fc4ab10db785812e`
- [x] Lizard complexity gate — `curveLabErrorMessage` CCN 4 with threshold 8
- [x] Curve Lab Playwright test-backend flow — 4 passed at repair head `68ff47890a5103cadd3b252c1855a0c78153240e`
- [ ] focused independent tester verification and reviewer re-review for head `c4d19bde564490468275a390fc4ab10db785812e`
