### PR TITLE
fix: reject invalid deposit node sensitivities (DAL-61)

### DIFF
--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -12,7 +12,7 @@
 #include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveparameterization.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
-#include <dal/curve/tapeguard.hpp>
+#include <dal/curve/ratecashflowpricing_internal.hpp>
 #include <dal/curve/xccypricing.hpp>
 #include <dal/curve/ycconst.hpp>
 #include <dal/curve/yclogdf.hpp>
@@ -334,6 +334,59 @@ namespace Dal {
                 return PriceXccy(trade, *terms, market);
             THROW("Rate trade terms alternative is unsupported");
         }
+
+        struct NodeSensitivityPreparation_ {
+            CurveDefinition_ definition_;
+            Vector_<> passiveParameters_;
+            Handle_<DiscountCurve_> passiveBase_;
+            int expectedParameterCount_ = 0;
+        };
+
+        NodeSensitivityPreparation_ PrepareNodeSensitivityCurve(const RateCashflowPricingInternal::NodeSensitivityCurve_& classifiedCurve,
+                                                                const Date_& valuationDate) {
+            NodeSensitivityPreparation_ result;
+            std::visit(
+                [&](const auto& taggedCurve) {
+                    using curve_t = std::decay_t<decltype(taggedCurve)>;
+                    if constexpr (std::is_same_v<curve_t, std::monostate>) {
+                        REQUIRE(false, "Node sensitivity curve representation is unsupported");
+                    } else {
+                        REQUIRE(taggedCurve, "Node sensitivity curve classification is empty");
+                        if constexpr (std::is_same_v<curve_t, const Tape::DiscountPWC_<double>*>) {
+                            result.definition_ = MakeCurveDefinition(
+                                taggedCurve->Name(), taggedCurve->ccy_.String(), CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD,
+                                LogDfScheme_::Value_::LOG_LINEAR, taggedCurve->KnotDates(), valuationDate, DayBasis_("ACT_365F"));
+                            result.passiveParameters_ = taggedCurve->FRight();
+                        } else if constexpr (std::is_same_v<curve_t, const Tape::DiscountPWLF_<double>*>) {
+                            result.definition_ = MakeCurveDefinition(
+                                taggedCurve->Name(), taggedCurve->ccy_.String(), CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD,
+                                LogDfScheme_::Value_::LOG_LINEAR, taggedCurve->KnotDates(), valuationDate, DayBasis_("ACT_365F"));
+                            const Vector_<> left = taggedCurve->FLeft();
+                            const Vector_<> right = taggedCurve->FRight();
+                            result.passiveParameters_ = Vector_<>(2 * left.size());
+                            for (int i = 0; i < static_cast<int>(left.size()); ++i) {
+                                result.passiveParameters_[2 * i] = left[i];
+                                result.passiveParameters_[2 * i + 1] = right[i];
+                            }
+                        } else if constexpr (std::is_same_v<curve_t, const Tape::DiscountLogDF_<double>*>) {
+                            result.definition_ = MakeCurveDefinition(
+                                taggedCurve->Name(), taggedCurve->ccy_.String(), CurveParameterization_::Value_::LOG_DISCOUNT, taggedCurve->Scheme(),
+                                taggedCurve->NodeDates(), taggedCurve->NodeDates().front(), taggedCurve->DayCount());
+                            const Vector_<> stored = taggedCurve->NodeLogDF();
+                            result.passiveParameters_ = Vector_<>(stored.begin() + 1, stored.end());
+                        } else if constexpr (std::is_same_v<curve_t, const Tape::DiscountZeroRate_<double>*>) {
+                            result.definition_ = MakeCurveDefinition(taggedCurve->Name(), taggedCurve->ccy_.String(),
+                                                                     CurveParameterization_::Value_::ZERO_RATE, taggedCurve->Scheme(),
+                                                                     taggedCurve->NodeDates(), taggedCurve->AnchorDate(), taggedCurve->DayCount());
+                            result.passiveParameters_ = taggedCurve->NodeZeroRates();
+                        }
+                        result.passiveBase_ = taggedCurve->Base();
+                    }
+                },
+                classifiedCurve);
+            result.expectedParameterCount_ = BuildCurveParameterLayout(result.definition_).parameterCount_;
+            return result;
+        }
     } // namespace
 
     // #lizard forgives -- one plan builder keeps family-specific cashflow admission atomic.
@@ -410,111 +463,53 @@ namespace Dal {
     // #lizard forgives -- backend eligibility and diagnostics must remain aligned in one boundary.
     RateTradeNodeSensitivityResult_
     RateTradeNodeSensitivities(const RateTradeDefinition_& trade, const RatePricingMarket_& market, const String_& componentKey) {
-        RateTradeNodeSensitivityResult_ result;
-        try {
-            const auto* terms = std::get_if<DepositTradeTerms_>(&trade.terms_);
-            if (!terms || trade.instrumentType_ != RateInstrumentType_::Value_::DEPOSIT) {
-                result.reason_ = "TRADE_FAMILY_NOT_AAD_ENABLED";
-                return result;
-            }
-            if (terms->discountComponentKey_ != componentKey) {
-                result.reason_ = "TRADE_DOES_NOT_DEPEND_ON_COMPONENT";
-                return result;
-            }
-            const auto found = market.curveComponents_.find(componentKey);
-            if (found == market.curveComponents_.end() || !found->second) {
-                result.reason_ = "CURVE_COMPONENT_UNAVAILABLE";
-                return result;
-            }
-            const auto& curve = *found->second;
-            CurveDefinition_ definition;
-            Vector_<> passiveParameters;
-            Handle_<DiscountCurve_> passiveBase;
-            if (const auto* pwc = dynamic_cast<const Tape::DiscountPWC_<double>*>(&curve)) {
-                definition = MakeCurveDefinition(
-                    pwc->Name(),
-                    pwc->ccy_.String(),
-                    CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD,
-                    LogDfScheme_::Value_::LOG_LINEAR,
-                    pwc->KnotDates(),
-                    market.valuationTime_.Date(),
-                    DayBasis_("ACT_365F"));
-                passiveParameters = pwc->FRight();
-                passiveBase = pwc->Base();
-            } else if (const auto* pwlf = dynamic_cast<const Tape::DiscountPWLF_<double>*>(&curve)) {
-                definition = MakeCurveDefinition(
-                    pwlf->Name(),
-                    pwlf->ccy_.String(),
-                    CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD,
-                    LogDfScheme_::Value_::LOG_LINEAR,
-                    pwlf->KnotDates(),
-                    market.valuationTime_.Date(),
-                    DayBasis_("ACT_365F"));
-                const Vector_<> left = pwlf->FLeft();
-                const Vector_<> right = pwlf->FRight();
-                passiveParameters = Vector_<>(2 * left.size());
-                for (int i = 0; i < static_cast<int>(left.size()); ++i) {
-                    passiveParameters[2 * i] = left[i];
-                    passiveParameters[2 * i + 1] = right[i];
-                }
-                passiveBase = pwlf->Base();
-            } else if (const auto* logDf = dynamic_cast<const Tape::DiscountLogDF_<double>*>(&curve)) {
-                definition = MakeCurveDefinition(
-                    logDf->Name(),
-                    logDf->ccy_.String(),
-                    CurveParameterization_::Value_::LOG_DISCOUNT,
-                    logDf->Scheme(),
-                    logDf->NodeDates(),
-                    logDf->NodeDates().front(),
-                    logDf->DayCount());
-                const Vector_<> stored = logDf->NodeLogDF();
-                passiveParameters = Vector_<>(stored.begin() + 1, stored.end());
-                passiveBase = logDf->Base();
-            } else if (const auto* zero = dynamic_cast<const Tape::DiscountZeroRate_<double>*>(&curve)) {
-                definition = MakeCurveDefinition(
-                    zero->Name(),
-                    zero->ccy_.String(),
-                    CurveParameterization_::Value_::ZERO_RATE,
-                    zero->Scheme(),
-                    zero->NodeDates(),
-                    zero->AnchorDate(),
-                    zero->DayCount());
-                passiveParameters = zero->NodeZeroRates();
-                passiveBase = zero->Base();
-            } else {
-                result.reason_ = "CURVE_REPRESENTATION_NOT_AAD_ENABLED";
-                return result;
-            }
+        using namespace RateCashflowPricingInternal;
+        const auto* terms = std::get_if<DepositTradeTerms_>(&trade.terms_);
+        if (!terms || trade.instrumentType_ != RateInstrumentType_::Value_::DEPOSIT)
+            return NodeSensitivityFailure("TRADE_FAMILY_NOT_AAD_ENABLED");
+        if (terms->discountComponentKey_ != componentKey)
+            return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+        const auto found = market.curveComponents_.find(componentKey);
+        if (found == market.curveComponents_.end() || !found->second)
+            return NodeSensitivityFailure("CURVE_COMPONENT_UNAVAILABLE");
+        const auto classifiedCurve = ClassifyNodeSensitivityCurve(*found->second);
+        if (std::holds_alternative<std::monostate>(classifiedCurve))
+            return NodeSensitivityFailure("CURVE_REPRESENTATION_NOT_AAD_ENABLED");
 
-            auto* tape = AAD::Tape();
-            TapeGuard_ guard(tape);
-            Vector_<AAD::Number_> parameters = RegisterCurveParameters(passiveParameters);
-            AAD::NewRecording(*tape);
-            const auto activeCurve =
-                BuildDiscountCurveUniqueT<AAD::Number_>(definition, parameters, passiveBase);
+        const auto passive = PriceRateTrade(trade, market);
+        if (!passive.succeeded_ || !std::isfinite(passive.pv_))
+            return NodeSensitivityFailure("TRADE_VALIDATION_FAILED");
+
+        NodeSensitivityPreparation_ preparation;
+        try {
+            preparation = PrepareNodeSensitivityCurve(classifiedCurve, market.valuationTime_.Date());
+        } catch (const std::exception&) {
+            return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+        }
+
+        return RunNodeSensitivityAADStage(preparation.expectedParameterCount_, [&]() {
+            Vector_<AAD::Number_> parameters = RegisterCurveParameters(preparation.passiveParameters_);
+            AAD::NewRecording(*AAD::Tape());
+            const auto activeCurve = BuildDiscountCurveUniqueT<AAD::Number_>(preparation.definition_, parameters, preparation.passiveBase_);
             const double accrual = terms->index_.dayBasis_(trade.startDate_, trade.maturityDate_, nullptr);
-            const AAD::Number_ start =
-                trade.startDate_ < market.valuationTime_.Date()
-                    ? AAD::Number_(0.0)
-                    : -terms->notional_ * (*activeCurve)(market.valuationTime_.Date(), trade.startDate_);
+            const AAD::Number_ start = trade.startDate_ < market.valuationTime_.Date()
+                                           ? AAD::Number_(0.0)
+                                           : -terms->notional_ * (*activeCurve)(market.valuationTime_.Date(), trade.startDate_);
             const AAD::Number_ maturity =
                 trade.maturityDate_ < market.valuationTime_.Date()
                     ? AAD::Number_(0.0)
-                    : terms->notional_ * (1.0 + terms->contractRate_ * accrual) *
-                          (*activeCurve)(market.valuationTime_.Date(), trade.maturityDate_);
+                    : terms->notional_ * (1.0 + terms->contractRate_ * accrual) * (*activeCurve)(market.valuationTime_.Date(), trade.maturityDate_);
             AAD::Number_ pv = start + maturity;
             if (!terms->lend_)
                 pv = -pv;
-            result.pv_ = AAD::Value(pv);
             AAD::Adjoint(pv) = 1.0;
-            AAD::PropagateToStart(*tape);
-            result.gradient_ = Vector_<>(parameters.size());
+            AAD::PropagateToStart(*AAD::Tape());
+            NodeSensitivityCandidate_ candidate;
+            candidate.pv_ = AAD::Value(pv);
+            candidate.gradient_ = Vector_<>(parameters.size());
             for (int i = 0; i < static_cast<int>(parameters.size()); ++i)
-                result.gradient_[i] = AAD::AdjointValue(parameters[i]);
-            result.eligible_ = true;
-        } catch (const std::exception&) {
-            result.reason_ = "AAD_EVALUATION_FAILED";
-        }
-        return result;
+                candidate.gradient_[i] = AAD::AdjointValue(parameters[i]);
+            return candidate;
+        });
     }
 } // namespace Dal

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -1,0 +1,66 @@
+//
+// Created by dal-implementer on 2026/8/1.
+//
+
+#pragma once
+
+#include <cmath>
+#include <exception>
+#include <utility>
+#include <variant>
+
+#include <dal/curve/ratecashflowpricing.hpp>
+#include <dal/curve/tapeguard.hpp>
+#include <dal/curve/ycconst.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/curve/ycpwlf.hpp>
+#include <dal/curve/yczerorate.hpp>
+
+namespace Dal::RateCashflowPricingInternal {
+    using NodeSensitivityCurve_ = std::variant<std::monostate,
+                                               const Tape::DiscountPWC_<double>*,
+                                               const Tape::DiscountPWLF_<double>*,
+                                               const Tape::DiscountLogDF_<double>*,
+                                               const Tape::DiscountZeroRate_<double>*>;
+
+    inline NodeSensitivityCurve_ ClassifyNodeSensitivityCurve(const DiscountCurve_& curve) {
+        if (const auto* pwc = dynamic_cast<const Tape::DiscountPWC_<double>*>(&curve))
+            return pwc;
+        if (const auto* pwlf = dynamic_cast<const Tape::DiscountPWLF_<double>*>(&curve))
+            return pwlf;
+        if (const auto* logDf = dynamic_cast<const Tape::DiscountLogDF_<double>*>(&curve))
+            return logDf;
+        if (const auto* zero = dynamic_cast<const Tape::DiscountZeroRate_<double>*>(&curve))
+            return zero;
+        return std::monostate{};
+    }
+
+    struct NodeSensitivityCandidate_ {
+        double pv_ = 0.0;
+        Vector_<> gradient_;
+    };
+
+    inline RateTradeNodeSensitivityResult_ NodeSensitivityFailure(const String_& reason) {
+        RateTradeNodeSensitivityResult_ result;
+        result.reason_ = reason;
+        return result;
+    }
+
+    inline RateTradeNodeSensitivityResult_ FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_ candidate, int expectedParameterCount) {
+        if (expectedParameterCount < 0 || static_cast<int>(candidate.gradient_.size()) != expectedParameterCount || !std::isfinite(candidate.pv_))
+            return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+        for (const double value : candidate.gradient_)
+            if (!std::isfinite(value))
+                return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+        return {true, candidate.pv_, std::move(candidate.gradient_), String_()};
+    }
+
+    template <class Runner_> RateTradeNodeSensitivityResult_ RunNodeSensitivityAADStage(int expectedParameterCount, Runner_&& runner) {
+        try {
+            TapeGuard_ guard(AAD::Tape());
+            return FinalizeNodeSensitivityCandidate(std::forward<Runner_>(runner)(), expectedParameterCount);
+        } catch (const std::exception&) {
+            return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+        }
+    }
+} // namespace Dal::RateCashflowPricingInternal

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -4,13 +4,24 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <future>
+#include <limits>
+#include <stdexcept>
+#include <thread>
 
 #include <dal/curve/curveblock.hpp>
+#include <dal/curve/curveparameterization.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
+#include <dal/curve/piecewiselinear.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
+#include <dal/curve/ratecashflowpricing_internal.hpp>
 #include <dal/curve/ycconst.hpp>
+#include <dal/curve/ycimp.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/curve/yczerorate.hpp>
 
 namespace {
     Dal::RateIndexConvention_ QuarterlyIndex() {
@@ -49,6 +60,97 @@ namespace {
                                     const Dal::Date_& maturity,
                                     const Dal::RateTradeTerms_& terms) {
         return {"trade-1", type, today, start, maturity, Dal::Ccy_("USD"), terms};
+    }
+
+    Dal::DepositTradeTerms_ DepositTerms() {
+        Dal::DepositTradeTerms_ result;
+        result.notional_ = 100.0;
+        result.contractRate_ = 0.05;
+        result.lend_ = true;
+        result.index_ = QuarterlyIndex();
+        result.discountComponentKey_ = "discount";
+        return result;
+    }
+
+    class UnsupportedDiscountCurve_ : public Dal::DiscountCurve_ {
+    public:
+        UnsupportedDiscountCurve_() : DiscountCurve_("unsupported", "USD") {}
+
+        double operator()(const Dal::Date_&, const Dal::Date_&) const override { return 1.0; }
+        void Poll(Dal::Vector_<const Dal::YCComponent_*>* all) const override { all->push_back(this); }
+        void Poll(std::map<const Dal::YCComponent_*, Dal::Handle_<Dal::YCComponent_>>*) const override {}
+        [[nodiscard]] std::unique_ptr<Dal::YCComponent_> Clone(const Dal::String_&, const Dal::YCComponent_::substitutions_t&) const override {
+            return std::make_unique<UnsupportedDiscountCurve_>();
+        }
+        void Write(Dal::Archive::Store_&) const override {}
+    };
+
+    void AssertCanonicalFailure(const Dal::RateTradeNodeSensitivityResult_& result, const Dal::String_& reason) {
+        ASSERT_FALSE(result.eligible_);
+        ASSERT_DOUBLE_EQ(result.pv_, 0.0);
+        ASSERT_TRUE(result.gradient_.empty());
+        ASSERT_EQ(result.reason_, reason);
+    }
+
+    void
+    AssertTradeValidationFailure(const Dal::RateTradeDefinition_& trade, const Dal::RatePricingMarket_& market, const std::string& errorFragment) {
+        const auto priced = Dal::PriceRateTrade(trade, market);
+        Dal::RateTradeNodeSensitivityResult_ sensitivity;
+        ASSERT_NO_THROW(sensitivity = Dal::RateTradeNodeSensitivities(trade, market, "discount"));
+        ASSERT_FALSE(priced.succeeded_);
+        ASSERT_NE(std::string(priced.error_.c_str()).find(errorFragment), std::string::npos) << priced.error_;
+        AssertCanonicalFailure(sensitivity, "TRADE_VALIDATION_FAILED");
+    }
+
+    template <class Builder_>
+    void AssertRawNodeGradientMatchesCentralBumps(const Builder_& buildCurve,
+                                                  const Dal::Vector_<>& parameters,
+                                                  int expectedParameterCount,
+                                                  double bump,
+                                                  double absoluteTolerance,
+                                                  double relativeTolerance,
+                                                  const Dal::Vector_<int>& structuralZeroColumns) {
+        const Dal::Date_ today(2026, 1, 15);
+        const Dal::Date_ start(2026, 10, 15);
+        const Dal::Date_ maturity(2029, 1, 15);
+        const auto terms = DepositTerms();
+        const auto trade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, start, maturity, terms);
+        const auto market = Market(today, buildCurve(parameters));
+        const auto aad = Dal::RateTradeNodeSensitivities(trade, market, "discount");
+
+        ASSERT_TRUE(aad.eligible_);
+        ASSERT_EQ(static_cast<int>(aad.gradient_.size()), expectedParameterCount);
+        ASSERT_TRUE(std::isfinite(aad.pv_));
+        for (int column = 0; column < expectedParameterCount; ++column) {
+            auto plusParameters = parameters;
+            auto minusParameters = parameters;
+            plusParameters[column] += bump;
+            minusParameters[column] -= bump;
+            const auto plus = Dal::PriceRateTrade(trade, Market(today, buildCurve(plusParameters)));
+            const auto minus = Dal::PriceRateTrade(trade, Market(today, buildCurve(minusParameters)));
+            ASSERT_TRUE(plus.succeeded_);
+            ASSERT_TRUE(minus.succeeded_);
+            const double finiteDifference = (plus.pv_ - minus.pv_) / (2.0 * bump);
+            const double tolerance = absoluteTolerance + relativeTolerance * std::max(std::abs(aad.gradient_[column]), std::abs(finiteDifference));
+            ASSERT_NEAR(aad.gradient_[column], finiteDifference, tolerance) << "raw native-parameter column " << column;
+        }
+
+        auto borrowTerms = terms;
+        borrowTerms.lend_ = false;
+        const auto borrowTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, start, maturity, borrowTerms);
+        const auto borrow = Dal::RateTradeNodeSensitivities(borrowTrade, market, "discount");
+        ASSERT_TRUE(borrow.eligible_);
+        ASSERT_DOUBLE_EQ(borrow.pv_, -aad.pv_);
+        ASSERT_EQ(borrow.gradient_.size(), aad.gradient_.size());
+        for (int column = 0; column < expectedParameterCount; ++column)
+            ASSERT_DOUBLE_EQ(borrow.gradient_[column], -aad.gradient_[column]);
+
+        const auto shortTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, start, terms);
+        const auto structural = Dal::RateTradeNodeSensitivities(shortTrade, market, "discount");
+        ASSERT_TRUE(structural.eligible_);
+        ASSERT_EQ(static_cast<int>(structural.gradient_.size()), expectedParameterCount);
+        for (const int column : structuralZeroColumns)
+            ASSERT_NEAR(structural.gradient_[column], 0.0, 1.0e-12) << "structural-zero raw column " << column;
     }
 } // namespace
 
@@ -113,6 +215,266 @@ TEST(RateCashflowPricingTest, TestDepositNodeAADMatchesCentralNativeParameterBum
     ASSERT_NEAR(aad.gradient_[0], (plus - minus) / (2.0 * epsilon), 1.0e-6);
 }
 
+TEST(RateCashflowPricingTest, TestDepositNodeAADRejectsInvalidTradeCanonically) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ maturity(2027, 1, 15);
+    const auto market = Market(today, FlatCurve(maturity));
+    Dal::DepositTradeTerms_ terms;
+    terms.notional_ = std::numeric_limits<double>::quiet_NaN();
+    terms.contractRate_ = 0.05;
+    terms.lend_ = true;
+    terms.index_ = QuarterlyIndex();
+    terms.discountComponentKey_ = "discount";
+    const auto trade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, terms);
+
+    const auto priced = Dal::PriceRateTrade(trade, market);
+    Dal::RateTradeNodeSensitivityResult_ sensitivity;
+    ASSERT_NO_THROW(sensitivity = Dal::RateTradeNodeSensitivities(trade, market, "discount"));
+
+    ASSERT_FALSE(priced.succeeded_);
+    ASSERT_NE(priced.error_.find("Deposit notional must be positive and finite"), Dal::String_::npos);
+    AssertCanonicalFailure(sensitivity, "TRADE_VALIDATION_FAILED");
+}
+
+TEST(RateCashflowPricingTest, TestNodeSensitivityFinalizerPublishesOnlyCompleteFiniteCandidates) {
+    using Dal::RateCashflowPricingInternal::FinalizeNodeSensitivityCandidate;
+    using Dal::RateCashflowPricingInternal::NodeSensitivityCandidate_;
+
+    const auto success = FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{1.25, {2.0, -3.0}}, 2);
+    ASSERT_TRUE(success.eligible_);
+    ASSERT_DOUBLE_EQ(success.pv_, 1.25);
+    ASSERT_EQ(success.gradient_, Dal::Vector_<>({2.0, -3.0}));
+    ASSERT_TRUE(success.reason_.empty());
+
+    AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{std::numeric_limits<double>::quiet_NaN(), {2.0, -3.0}}, 2),
+                           "AAD_EVALUATION_FAILED");
+    AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{std::numeric_limits<double>::infinity(), {2.0, -3.0}}, 2),
+                           "AAD_EVALUATION_FAILED");
+    AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{-std::numeric_limits<double>::infinity(), {2.0, -3.0}}, 2),
+                           "AAD_EVALUATION_FAILED");
+    AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{1.25, {2.0}}, 2), "AAD_EVALUATION_FAILED");
+    AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{1.25, {2.0, -3.0, 4.0}}, 2), "AAD_EVALUATION_FAILED");
+
+    for (const double invalid :
+         {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()}) {
+        AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{1.25, {invalid, -3.0}}, 2), "AAD_EVALUATION_FAILED");
+        AssertCanonicalFailure(FinalizeNodeSensitivityCandidate(NodeSensitivityCandidate_{1.25, {2.0, invalid}}, 2), "AAD_EVALUATION_FAILED");
+    }
+}
+
+TEST(RateCashflowPricingTest, TestNodeSensitivityAADStageCanonicalizesExceptionAndRewindsTape) {
+    const auto failed = Dal::RateCashflowPricingInternal::RunNodeSensitivityAADStage(1, []() {
+        auto parameters = Dal::RegisterCurveParameters(Dal::Vector_<>{0.04});
+        Dal::AAD::NewRecording(*Dal::AAD::Tape());
+        Dal::AAD::Number_ node = parameters[0] * parameters[0];
+        Dal::AAD::Adjoint(node) = 1.0;
+        throw std::runtime_error("injected after recording");
+        return Dal::RateCashflowPricingInternal::NodeSensitivityCandidate_{};
+    });
+    AssertCanonicalFailure(failed, "AAD_EVALUATION_FAILED");
+
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ maturity(2027, 1, 15);
+    Dal::DepositTradeTerms_ terms;
+    terms.notional_ = 100.0;
+    terms.contractRate_ = 0.05;
+    terms.lend_ = true;
+    terms.index_ = QuarterlyIndex();
+    terms.discountComponentKey_ = "discount";
+    const auto trade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, terms);
+    const auto valid = Dal::RateTradeNodeSensitivities(trade, Market(today, FlatCurve(maturity)), "discount");
+
+    ASSERT_TRUE(valid.eligible_);
+    ASSERT_EQ(valid.gradient_.size(), 1);
+    ASSERT_TRUE(std::isfinite(valid.pv_));
+    ASSERT_TRUE(std::isfinite(valid.gradient_[0]));
+}
+
+TEST(RateCashflowPricingTest, TestNodeSensitivityCurveClassifierReturnsOnlyRepresentationTagAndBorrowedPointer) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const Dal::Vector_<> rates{0.01, 0.02, 0.03};
+    const Dal::Vector_<> logDf{0.0, -0.005, -0.02, -0.06};
+    const Dal::DayBasis_ dayCount("ACT_365F");
+    const std::unique_ptr<Dal::DiscountCurve_> pwc(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(knots, rates)));
+    const std::unique_ptr<Dal::DiscountCurve_> pwlf(Dal::NewDiscountPWLF("pwlf", "USD", Dal::PiecewiseLinear_(knots, rates, rates)));
+    const std::unique_ptr<Dal::DiscountCurve_> logDiscount(Dal::NewDiscountLogDF(
+        "logdf", "USD", Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]}, logDf, dayCount, Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    const std::unique_ptr<Dal::DiscountCurve_> zeroRate(
+        Dal::NewDiscountZeroRate("zero", "USD", today, knots, rates, dayCount, Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    const UnsupportedDiscountCurve_ unsupported;
+
+    const auto classifiedPwc = Dal::RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*pwc);
+    const auto classifiedPwlf = Dal::RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*pwlf);
+    const auto classifiedLogDiscount = Dal::RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*logDiscount);
+    const auto classifiedZeroRate = Dal::RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*zeroRate);
+    ASSERT_EQ(classifiedPwc.index(), 1);
+    ASSERT_EQ(std::get<1>(classifiedPwc), pwc.get());
+    ASSERT_EQ(classifiedPwlf.index(), 2);
+    ASSERT_EQ(std::get<2>(classifiedPwlf), pwlf.get());
+    ASSERT_EQ(classifiedLogDiscount.index(), 3);
+    ASSERT_EQ(std::get<3>(classifiedLogDiscount), logDiscount.get());
+    ASSERT_EQ(classifiedZeroRate.index(), 4);
+    ASSERT_EQ(std::get<4>(classifiedZeroRate), zeroRate.get());
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(unsupported).index(), 0);
+}
+
+TEST(RateCashflowPricingTest, TestDepositNodeAADPassiveValidationBoundaryMatrix) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ maturity(2027, 1, 15);
+    const auto market = Market(today, FlatCurve(maturity));
+
+    for (const double invalid :
+         {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity(), 0.0, -1.0}) {
+        auto terms = DepositTerms();
+        terms.notional_ = invalid;
+        AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, terms), market,
+                                     "Deposit notional must be positive and finite");
+    }
+    for (const double invalid :
+         {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()}) {
+        auto terms = DepositTerms();
+        terms.contractRate_ = invalid;
+        AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, terms), market,
+                                     "Deposit contract rate must be finite");
+    }
+
+    const auto terms = DepositTerms();
+    AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), Dal::Date_(), today, maturity, terms), market,
+                                 "Rate trade dates must be valid and start before maturity");
+    AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, Dal::Date_(), maturity, terms), market,
+                                 "Rate trade dates must be valid and start before maturity");
+    AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, Dal::Date_(), terms), market,
+                                 "Rate trade dates must be valid and start before maturity");
+    AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, today, terms), market,
+                                 "Rate trade dates must be valid and start before maturity");
+
+    auto invalidMarket = market;
+    invalidMarket.valuationTime_ = Dal::DateTime_();
+    AssertTradeValidationFailure(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, terms), invalidMarket,
+                                 "Rate cashflow plan requires a valid valuation time");
+
+    for (const double contractRate : {0.0, -0.01}) {
+        auto validTerms = terms;
+        validTerms.contractRate_ = contractRate;
+        const auto trade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, validTerms);
+        const auto priced = Dal::PriceRateTrade(trade, market);
+        const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, "discount");
+        ASSERT_TRUE(priced.succeeded_);
+        ASSERT_TRUE(std::isfinite(priced.pv_));
+        ASSERT_TRUE(sensitivity.eligible_);
+        ASSERT_TRUE(std::isfinite(sensitivity.pv_));
+        ASSERT_EQ(sensitivity.gradient_.size(), 1);
+        ASSERT_TRUE(std::isfinite(sensitivity.gradient_[0]));
+        ASSERT_TRUE(sensitivity.reason_.empty());
+    }
+
+    auto zeroPvTerms = terms;
+    zeroPvTerms.contractRate_ = 0.0;
+    const auto zeroPvTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, zeroPvTerms);
+    const auto zeroPvSensitivity = Dal::RateTradeNodeSensitivities(zeroPvTrade, Market(today, FlatCurve(maturity, 0.0)), "discount");
+    ASSERT_TRUE(zeroPvSensitivity.eligible_);
+    ASSERT_DOUBLE_EQ(zeroPvSensitivity.pv_, 0.0);
+    ASSERT_EQ(zeroPvSensitivity.gradient_.size(), 1);
+    ASSERT_TRUE(std::isfinite(zeroPvSensitivity.gradient_[0]));
+    ASSERT_TRUE(zeroPvSensitivity.reason_.empty());
+}
+
+TEST(RateCashflowPricingTest, TestDepositNodeAADReasonPrecedenceForCombinedFailures) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ maturity(2027, 1, 15);
+    const auto supportedMarket = Market(today, FlatCurve(maturity));
+    auto invalidTerms = DepositTerms();
+    invalidTerms.notional_ = std::numeric_limits<double>::quiet_NaN();
+    const auto invalidTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, invalidTerms);
+
+    Dal::FraTradeTerms_ fraTerms;
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, fraTerms), supportedMarket, "discount"),
+        "TRADE_FAMILY_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FRA"), today, today, maturity, DepositTerms()), supportedMarket, "discount"),
+        "TRADE_FAMILY_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, supportedMarket, "wrong"), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+
+    auto missingMarket = supportedMarket;
+    missingMarket.curveComponents_.erase("discount");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, missingMarket, "discount"), "CURVE_COMPONENT_UNAVAILABLE");
+    auto nullMarket = supportedMarket;
+    nullMarket.curveComponents_["discount"] = Dal::Handle_<Dal::DiscountCurve_>();
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, nullMarket, "discount"), "CURVE_COMPONENT_UNAVAILABLE");
+
+    auto unsupportedMarket = supportedMarket;
+    unsupportedMarket.curveComponents_["discount"] = Dal::Handle_<Dal::DiscountCurve_>(std::make_shared<const UnsupportedDiscountCurve_>());
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, unsupportedMarket, "discount"), "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, supportedMarket, "discount"), "TRADE_VALIDATION_FAILED");
+
+    const auto validTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, DepositTerms());
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, supportedMarket, "wrong"), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, missingMarket, "discount"), "CURVE_COMPONENT_UNAVAILABLE");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, unsupportedMarket, "discount"), "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+}
+
+TEST(RateCashflowPricingTest, TestDepositNodeAADPwcRawColumnsMatchCentralBumps) {
+    constexpr double PWC_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(knots, parameters)));
+    };
+    AssertRawNodeGradientMatchesCentralBumps(buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP, PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
+                                             PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
+}
+
+TEST(RateCashflowPricingTest, TestDepositNodeAADPwlfRawColumnsMatchCentralBumps) {
+    constexpr double PWLF_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> left(3);
+        Dal::Vector_<> right(3);
+        for (int node = 0; node < 3; ++node) {
+            left[node] = parameters[2 * node];
+            right[node] = parameters[2 * node + 1];
+        }
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWLF("pwlf", "USD", Dal::PiecewiseLinear_(knots, left, right)));
+    };
+    AssertRawNodeGradientMatchesCentralBumps(buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, PWLF_NATIVE_PARAMETER_BUMP,
+                                             PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {3, 4, 5});
+}
+
+TEST(RateCashflowPricingTest, TestDepositNodeAADLogDiscountRawColumnsMatchCentralBumps) {
+    constexpr double LOG_DISCOUNT_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> stored{0.0};
+        stored.Append(parameters);
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountLogDF("logdf", "USD", Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]},
+                                                                       stored, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    AssertRawNodeGradientMatchesCentralBumps(buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
+                                             LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestDepositNodeAADZeroRateRawColumnsMatchCentralBumps) {
+    constexpr double ZERO_RATE_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(
+            Dal::NewDiscountZeroRate("zero", "USD", today, knots, parameters, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    AssertRawNodeGradientMatchesCentralBumps(buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
+                                             ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
 TEST(RateCashflowPricingTest, TestDepositNodeAADRewindsPerTradeAndIsThreadLocal) {
     const Dal::Date_ today(2026, 1, 15);
     const Dal::Date_ maturity(2027, 1, 15);
@@ -123,26 +485,49 @@ TEST(RateCashflowPricingTest, TestDepositNodeAADRewindsPerTradeAndIsThreadLocal)
     terms.index_ = QuarterlyIndex();
     terms.discountComponentKey_ = "discount";
     const auto trade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, terms);
-    const auto evaluate = [=](double rate) {
-        return Dal::RateTradeNodeSensitivities(
-            trade,
-            Market(today, FlatCurve(maturity, rate)),
-            "discount");
-    };
+    const auto evaluate = [=](double rate) { return Dal::RateTradeNodeSensitivities(trade, Market(today, FlatCurve(maturity, rate)), "discount"); };
 
     const auto first = evaluate(0.04);
+    auto invalidTerms = terms;
+    invalidTerms.notional_ = std::numeric_limits<double>::quiet_NaN();
+    const auto invalidTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, invalidTerms);
+    const auto invalid = Dal::RateTradeNodeSensitivities(invalidTrade, Market(today, FlatCurve(maturity, 0.04)), "discount");
     const auto repeated = evaluate(0.04);
-    auto left = std::async(std::launch::async, evaluate, 0.03);
-    auto right = std::async(std::launch::async, evaluate, 0.06);
+    const auto repeatedAgain = evaluate(0.04);
+    std::atomic<int> waiting{0};
+    std::promise<void> release;
+    const auto startTogether = release.get_future().share();
+    auto left = std::async(std::launch::async, [&]() {
+        ++waiting;
+        startTogether.wait();
+        return Dal::RateTradeNodeSensitivities(invalidTrade, Market(today, FlatCurve(maturity, 0.03)), "discount");
+    });
+    auto right = std::async(std::launch::async, [&]() {
+        ++waiting;
+        startTogether.wait();
+        return evaluate(0.06);
+    });
+    while (waiting.load() != 2)
+        std::this_thread::yield();
+    release.set_value();
     const auto leftResult = left.get();
     const auto rightResult = right.get();
 
     ASSERT_TRUE(first.eligible_);
+    AssertCanonicalFailure(invalid, "TRADE_VALIDATION_FAILED");
     ASSERT_TRUE(repeated.eligible_);
-    ASSERT_TRUE(leftResult.eligible_);
+    ASSERT_TRUE(repeatedAgain.eligible_);
+    AssertCanonicalFailure(leftResult, "TRADE_VALIDATION_FAILED");
     ASSERT_TRUE(rightResult.eligible_);
+    ASSERT_DOUBLE_EQ(first.pv_, repeated.pv_);
+    ASSERT_DOUBLE_EQ(first.pv_, repeatedAgain.pv_);
     ASSERT_EQ(first.gradient_, repeated.gradient_);
-    ASSERT_NE(leftResult.gradient_[0], rightResult.gradient_[0]);
+    ASSERT_EQ(first.gradient_, repeatedAgain.gradient_);
+    ASSERT_EQ(first.reason_, repeated.reason_);
+    ASSERT_EQ(first.reason_, repeatedAgain.reason_);
+    const auto rightControl = evaluate(0.06);
+    ASSERT_EQ(rightResult.pv_, rightControl.pv_);
+    ASSERT_EQ(rightResult.gradient_, rightControl.gradient_);
 }
 
 TEST(RateCashflowPricingTest, TestFraAndFutureFormulas) {

--- a/dal-public/tests/test_curvepricing.cpp
+++ b/dal-public/tests/test_curvepricing.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <type_traits>
+
 #include <dal-public/src/curvepricing.hpp>
 
 TEST(CurvePricingPublicTest, TestClosedRegistryAndStructuredTerms) {
@@ -24,4 +26,44 @@ TEST(CurvePricingPublicTest, TestClosedRegistryAndStructuredTerms) {
 
     ASSERT_TRUE(std::holds_alternative<Dal::DepositTradeTerms_>(trade.terms_));
     ASSERT_DOUBLE_EQ(std::get<Dal::DepositTradeTerms_>(trade.terms_).contractRate_, 0.04);
+}
+
+TEST(CurvePricingPublicTest, TestNodeSensitivityPublicShapeRemainsAggregateAndCallable) {
+    static_assert(std::is_aggregate_v<Dal::RateTradeNodeSensitivityResult_>);
+    static_assert(std::is_same_v<decltype(Dal::RateTradeNodeSensitivityResult_::eligible_), bool>);
+    static_assert(std::is_same_v<decltype(Dal::RateTradeNodeSensitivityResult_::pv_), double>);
+    static_assert(std::is_same_v<decltype(Dal::RateTradeNodeSensitivityResult_::gradient_), Dal::Vector_<>>);
+    static_assert(std::is_same_v<decltype(Dal::RateTradeNodeSensitivityResult_::reason_), Dal::String_>);
+    using entry_t = Dal::RateTradeNodeSensitivityResult_ (*)(const Dal::RateTradeDefinition_&, const Dal::RatePricingMarket_&, const Dal::String_&);
+    const entry_t entry = &Dal::RateTradeNodeSensitivities;
+
+    const Dal::RateTradeNodeSensitivityResult_ defaults;
+    ASSERT_NE(entry, nullptr);
+    ASSERT_FALSE(defaults.eligible_);
+    ASSERT_DOUBLE_EQ(defaults.pv_, 0.0);
+    ASSERT_TRUE(defaults.gradient_.empty());
+    ASSERT_TRUE(defaults.reason_.empty());
+}
+
+TEST(CurvePricingPublicTest, TestNodeSensitivityReasonConsumerAcceptsAdditiveValidationFailure) {
+    const auto consume = [](const Dal::String_& reason) {
+        if (reason.empty())
+            return 0;
+        if (reason == "TRADE_FAMILY_NOT_AAD_ENABLED")
+            return 1;
+        if (reason == "TRADE_DOES_NOT_DEPEND_ON_COMPONENT")
+            return 2;
+        if (reason == "CURVE_COMPONENT_UNAVAILABLE")
+            return 3;
+        if (reason == "CURVE_REPRESENTATION_NOT_AAD_ENABLED")
+            return 4;
+        if (reason == "TRADE_VALIDATION_FAILED")
+            return 5;
+        if (reason == "AAD_EVALUATION_FAILED")
+            return 6;
+        return -1;
+    };
+
+    ASSERT_EQ(consume("TRADE_VALIDATION_FAILED"), 5);
+    ASSERT_EQ(consume("UNKNOWN_REASON"), -1);
 }

--- a/dal-python/tests/test_curve_pricing.py
+++ b/dal-python/tests/test_curve_pricing.py
@@ -1,9 +1,10 @@
 """Typed native Curve Lab pricing surface."""
 
 import dal
+import pytest
 
 
-def test_keyword_only_deposit_pricing_calls_native_cashflow_kernel():
+def _deposit_inputs(*, notional=100.0, contract_rate=0.05):
     today = dal.Date_(2026, 1, 15)
     maturity = dal.Date_(2027, 1, 15)
     curve = dal.DiscountPWC_New("usd", "USD", [maturity], [0.04])
@@ -13,8 +14,8 @@ def test_keyword_only_deposit_pricing_calls_native_cashflow_kernel():
         dal.CollateralType_OIS(),
     )
     terms = dal.DepositTradeTerms_(
-        notional=100.0,
-        contract_rate=0.05,
+        notional=notional,
+        contract_rate=contract_rate,
         lend=True,
         index=index,
         discount_component_key="discount",
@@ -34,6 +35,11 @@ def test_keyword_only_deposit_pricing_calls_native_cashflow_kernel():
         curve_components={"discount": curve},
         fixings=dal.MarketFixingSnapshot_New({}),
     )
+    return trade, market
+
+
+def test_keyword_only_deposit_pricing_calls_native_cashflow_kernel():
+    trade, market = _deposit_inputs()
 
     result = dal.PriceRateTrades(trades=[trade], market=market)
     aad = dal.RateTradeNodeSensitivities(
@@ -51,3 +57,59 @@ def test_keyword_only_deposit_pricing_calls_native_cashflow_kernel():
     assert aad.eligible is True  # nosec B101
     assert len(aad.gradient) == 1  # nosec B101
     assert aad.reason == ""  # nosec B101
+
+
+def test_invalid_deposit_node_sensitivity_is_canonical_and_does_not_raise():
+    trade, market = _deposit_inputs(notional=float("nan"))
+
+    priced = dal.PriceRateTrades(trades=[trade], market=market)[0]
+    sensitivity = dal.RateTradeNodeSensitivities(
+        trade=trade,
+        market=market,
+        component_key="discount",
+    )
+
+    assert priced.succeeded is False  # nosec B101
+    assert "Deposit notional must be positive and finite" in priced.error  # nosec B101
+    assert sensitivity.eligible is False  # nosec B101
+    assert sensitivity.pv == 0.0  # nosec B101
+    assert sensitivity.gradient == []  # nosec B101
+    assert sensitivity.reason == "TRADE_VALIDATION_FAILED"  # nosec B101
+
+
+@pytest.mark.parametrize("contract_rate", [0.0, -0.01])
+def test_zero_and_negative_deposit_rates_keep_complete_raw_native_parameter_rows(contract_rate):
+    trade, market = _deposit_inputs(contract_rate=contract_rate)
+
+    sensitivity = dal.RateTradeNodeSensitivities(
+        trade=trade,
+        market=market,
+        component_key="discount",
+    )
+
+    assert sensitivity.eligible is True  # nosec B101
+    assert isinstance(sensitivity.gradient, list)  # nosec B101
+    assert len(sensitivity.gradient) == 1  # nosec B101
+    assert sensitivity.reason == ""  # nosec B101
+
+
+def test_node_sensitivity_binding_remains_keyword_only_and_read_only():
+    signature = dal.RateTradeNodeSensitivities.__doc__.splitlines()[0]
+    assert signature == (  # nosec B101
+        "RateTradeNodeSensitivities(*, trade: dal._dal.RateTradeDefinition_, "
+        "market: dal._dal.RatePricingMarket_, component_key: str) -> dal._dal.RateTradeNodeSensitivityResult_"
+    )
+    trade, market = _deposit_inputs()
+    with pytest.raises(TypeError):
+        dal.RateTradeNodeSensitivities(trade, market, "discount")
+    with pytest.raises(TypeError):
+        dal.RateTradeNodeSensitivities(trade=trade, market=market, component="discount")
+    sensitivity = dal.RateTradeNodeSensitivities(trade=trade, market=market, component_key="discount")
+    with pytest.raises(AttributeError):
+        sensitivity.eligible = False
+    with pytest.raises(AttributeError):
+        sensitivity.pv = 0.0
+    with pytest.raises(AttributeError):
+        sensitivity.gradient = []
+    with pytest.raises(AttributeError):
+        sensitivity.reason = "changed"

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -218,8 +218,20 @@ The supported family enum is closed to `DEPOSIT`, `FRA`, `FUTURE`, `OIS`,
 required historical rate/FX fixing keys before valuation. Batch pricing retains
 a success/failure result per trade.
 
-Native node AAD currently admits deposit trades only. Other families return
-`TRADE_FAMILY_NOT_AAD_ENABLED`; consumers that apply a central-parameter
+Native node AAD currently admits deposit trades only. The first failing gate
+selects the reason in this order: family (`TRADE_FAMILY_NOT_AAD_ENABLED`),
+requested dependency (`TRADE_DOES_NOT_DEPEND_ON_COMPONENT`), component
+availability (`CURVE_COMPONENT_UNAVAILABLE`), curve representation
+(`CURVE_REPRESENTATION_NOT_AAD_ENABLED`), passive trade validation
+(`TRADE_VALIDATION_FAILED`), then AAD evaluation (`AAD_EVALUATION_FAILED`).
+`TRADE_VALIDATION_FAILED` is the stable token for a supported deposit that
+fails passive pricing validation; field-level detail remains available through
+`PriceRateTrade.error_`.
+
+Every node-sensitivity failure uses the canonical four-field result:
+`eligible_ == false`, `pv_ == 0.0`, an empty `gradient_`, and a non-empty stable
+`reason_`. Python projects the equivalent `eligible == False`, `pv == 0.0`,
+`gradient == []`, and `reason` token. Consumers that apply a central-parameter
 fallback must label it separately. See the [Curve Lab guide](curve-lab.md) for
 the complete pricing, fixing, matrix, and provenance contract.
 


### PR DESCRIPTION
## Summary

- preserve existing family, dependency, availability, and representation gate precedence while passively validating supported Deposits before AAD
- return canonical `TRADE_VALIDATION_FAILED` results for invalid supported trades and publish only complete finite AAD candidates
- add the production-used internal classifier/runner/finalizer seam with `TapeGuard_` exception cleanup
- verify raw native gradients for PWC, PWLF, LOG_DISCOUNT, and ZERO_RATE curves plus C++/Python public compatibility
- document the stable validation reason, canonical failure fields, and complete reason precedence in the public API guide

## Root cause

`RateTradeNodeSensitivities` entered the AAD calculation after capability checks without first exercising the passive trade validation path. Invalid Deposit data such as a NaN notional could therefore be reported as eligible with non-finite output.

## Validation

- `bash ./build_linux.sh` — 1221/1221 tests passed
- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='RateCashflowPricingTest.*'` — 18/18 passed
- Python-enabled full build — C++ and Python CTest suite passed
- `PYTHONPATH=../build/Release-linux/dal-python uv run --no-sync pytest -q tests/test_curve_pricing.py` — 5/5 passed
- `PYTHONPATH=../build/Release-linux/dal-python uv run --no-sync pytest -q` — 266/266 passed
- `uv run --no-sync ruff check tests/test_curve_pricing.py` — passed
- `python3 .github/scripts/check_docs.py` — 40 Markdown files passed
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_check_docs.py'` — 18/18 passed
- `git diff --check` and C++ formatting checks — passed

Repository-wide `uv run --no-sync ruff check .` still reports 107 pre-existing findings outside this change; the modified Python test is clean.

Closes DAL-61
