### PR TITLE
fix: DAL-58 offload Curve Lab risk admission

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -262,6 +262,7 @@ jobs:
           uv sync --locked --inexact
           uv run --no-sync pytest
           uv run --no-sync ruff check .
+          uv run --no-sync ruff format --check .
 
       - name: Install and build frontend
         working-directory: dal-web/frontend

--- a/dal-web/backend/app/routers/calibrations.py
+++ b/dal-web/backend/app/routers/calibrations.py
@@ -124,9 +124,7 @@ _FAILED_EXPECTED_IDENTITY_EXAMPLE = {
                 "origins": [{"kind": "INPUT", "input_knot_index": 0}],
             }
         ],
-        "free_parameters": [
-            {"date": "2027-01-02", "component": "right_forward"}
-        ],
+        "free_parameters": [{"date": "2027-01-02", "component": "right_forward"}],
         "anchor_added": False,
         "counts": {
             "submitted_knots": 1,
@@ -136,9 +134,7 @@ _FAILED_EXPECTED_IDENTITY_EXAMPLE = {
             "free_parameters": 1,
         },
     },
-    "resolved_knot_plan_hash": (
-        "e79378f7c5d80b13e2087bb5db77418334b35fe7b8f9de409dab8305d74455a8"
-    ),
+    "resolved_knot_plan_hash": ("e79378f7c5d80b13e2087bb5db77418334b35fe7b8f9de409dab8305d74455a8"),
     "expected_execution_identity": {
         "identity_version": 1,
         "execution_policy": "INPUT",
@@ -147,9 +143,7 @@ _FAILED_EXPECTED_IDENTITY_EXAMPLE = {
         "log_df_scheme": None,
         "resolved_declared_dates": ["2027-01-02"],
         "storage_dates": ["2027-01-02"],
-        "free_parameters": [
-            {"date": "2027-01-02", "component": "right_forward"}
-        ],
+        "free_parameters": [{"date": "2027-01-02", "component": "right_forward"}],
         "counts": {
             "resolved_declared_nodes": 1,
             "storage_nodes": 1,
@@ -165,8 +159,7 @@ _FAILED_EXPECTED_IDENTITY_EXAMPLE = {
     "error": {
         "code": "PERSISTED_EXPECTED_EXECUTION_IDENTITY_HASH_MISMATCH",
         "message": (
-            "persisted expected single-knot execution identity failed canonical "
-            "hash verification"
+            "persisted expected single-knot execution identity failed canonical hash verification"
         ),
         "location": None,
         "context": {
@@ -186,18 +179,16 @@ _FAILED_EXPECTED_IDENTITY_EXAMPLE = {
 def patch_openapi_examples(document: dict[str, object]) -> None:
     """Restore contract-significant nulls stripped by OpenAPI encoding."""
     paths = document["paths"]
-    joint_examples = paths["/api/calibrations/xccy/joint"]["post"]["responses"][
-        "422"
-    ]["content"]["application/json"]["examples"]
-    joint_examples["joint_free_parameter_limit_exceeded"][
-        "value"
-    ] = _JOINT_CAPACITY_EXAMPLE
-    run_examples = paths["/api/calibrations/{calibration_id}"]["get"]["responses"][
-        "200"
-    ]["content"]["application/json"]["examples"]
-    run_examples["persisted_expected_execution_identity_hash_mismatch"][
-        "value"
-    ] = _FAILED_EXPECTED_IDENTITY_EXAMPLE
+    joint_examples = paths["/api/calibrations/xccy/joint"]["post"]["responses"]["422"]["content"][
+        "application/json"
+    ]["examples"]
+    joint_examples["joint_free_parameter_limit_exceeded"]["value"] = _JOINT_CAPACITY_EXAMPLE
+    run_examples = paths["/api/calibrations/{calibration_id}"]["get"]["responses"]["200"][
+        "content"
+    ]["application/json"]["examples"]
+    run_examples["persisted_expected_execution_identity_hash_mismatch"]["value"] = (
+        _FAILED_EXPECTED_IDENTITY_EXAMPLE
+    )
 
 
 def _sanitize(value: object, *, depth: int = 0) -> object:
@@ -250,9 +241,7 @@ class CalibrationAPIRoute(APIRoute):
                 return _error_response(exc.status_code, exc.error)
             except Exception:  # noqa: BLE001 - deliberately sanitized boundary
                 incident_id = uuid4().hex
-                logger.exception(
-                    "Unhandled calibration API error; incident_id=%s", incident_id
-                )
+                logger.exception("Unhandled calibration API error; incident_id=%s", incident_id)
                 return _error_response(
                     500,
                     ApiErrorDTO(

--- a/dal-web/backend/app/routers/curve_lab.py
+++ b/dal-web/backend/app/routers/curve_lab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
@@ -37,6 +38,7 @@ from app.schemas.curve_lab import (
 from app.services.archive_preflight import ArchiveLimits
 from app.services.curve_lab_lifecycle import (
     CurveLabLifecycleError,
+    _version_public,
     archive_version,
     clone_version,
     create_build_run,
@@ -45,6 +47,7 @@ from app.services.curve_lab_lifecycle import (
     get_build_run,
     get_draft,
     get_import_job,
+    get_version,
     import_native_json,
     list_versions,
     native_payload,
@@ -250,15 +253,8 @@ async def list_curve_versions(
 
 @router.get("/versions/{version_id}", response_model=CurveVersionResponse)
 async def get_curve_version(version_id: str, store=Depends(store_dependency)) -> dict:
-    from app.services.curve_lab_lifecycle import get_version
-
     try:
-        record = get_version(store, version_id)
-        return {
-            key: value
-            for key, value in record.items()
-            if key not in {"native_payload", "idempotency_key", "verification"}
-        }
+        return _version_public(get_version(store, version_id))
     except CurveLabLifecycleError as exc:
         _raise_lifecycle(exc)
 
@@ -406,7 +402,7 @@ async def create_curve_risk_run(
     gateway=Depends(gateway_dependency),
 ) -> dict:
     try:
-        return create_risk_run(store, gateway, request)
+        return await asyncio.to_thread(create_risk_run, store, gateway, request)
     except CurveLabLifecycleError as exc:
         _raise_lifecycle(exc)
 

--- a/dal-web/backend/migrations/versions/c2d8f43a9e71_add_curve_calibration.py
+++ b/dal-web/backend/migrations/versions/c2d8f43a9e71_add_curve_calibration.py
@@ -34,14 +34,10 @@ def upgrade() -> None:
         sa.Column("resolved_knot_plan", sa.JSON(), nullable=True),
         sa.Column("resolved_knot_plan_hash", sa.String(length=64), nullable=True),
         sa.Column("expected_execution_identity", sa.JSON(), nullable=True),
-        sa.Column(
-            "expected_execution_identity_hash", sa.String(length=64), nullable=True
-        ),
+        sa.Column("expected_execution_identity_hash", sa.String(length=64), nullable=True),
         sa.Column("actual_jacobian_mode", sa.String(length=16), nullable=True),
         sa.Column("actual_execution_identity", sa.JSON(), nullable=True),
-        sa.Column(
-            "actual_execution_identity_hash", sa.String(length=64), nullable=True
-        ),
+        sa.Column("actual_execution_identity_hash", sa.String(length=64), nullable=True),
         sa.Column("result_payload", sa.JSON(), nullable=True),
         sa.Column("error_payload", sa.JSON(), nullable=True),
         sa.Column("backend", sa.String(length=64), nullable=False),
@@ -66,8 +62,7 @@ def upgrade() -> None:
             name="ck_calibration_run_status_phase",
         ),
         sa.CheckConstraint(
-            "actual_jacobian_mode IS NULL OR "
-            "actual_jacobian_mode IN ('ANALYTIC','BUMPED')",
+            "actual_jacobian_mode IS NULL OR actual_jacobian_mode IN ('ANALYTIC','BUMPED')",
             name="ck_calibration_run_actual_jacobian_mode",
         ),
         sa.PrimaryKeyConstraint("id"),
@@ -94,12 +89,8 @@ def upgrade() -> None:
             "role IN ('discount','forward','basis','base')",
             name="ck_curve_definition_role",
         ),
-        sa.ForeignKeyConstraint(
-            ["base_curve_id"], ["curve_definition.id"], ondelete="RESTRICT"
-        ),
-        sa.ForeignKeyConstraint(
-            ["source_run_id"], ["calibration_run.id"], ondelete="RESTRICT"
-        ),
+        sa.ForeignKeyConstraint(["base_curve_id"], ["curve_definition.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["source_run_id"], ["calibration_run.id"], ondelete="RESTRICT"),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -130,12 +121,8 @@ def upgrade() -> None:
             "calibration_index >= 0",
             name="ck_calibration_instrument_calibration_index",
         ),
-        sa.CheckConstraint(
-            "input_index >= 0", name="ck_calibration_instrument_input_index"
-        ),
-        sa.ForeignKeyConstraint(
-            ["run_id"], ["calibration_run.id"], ondelete="CASCADE"
-        ),
+        sa.CheckConstraint("input_index >= 0", name="ck_calibration_instrument_input_index"),
+        sa.ForeignKeyConstraint(["run_id"], ["calibration_run.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "run_id",
@@ -154,14 +141,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("calibration_instrument_definition")
-    op.drop_index(
-        "ix_curve_definition_base_curve_id", table_name="curve_definition"
-    )
-    op.drop_index(
-        "ix_curve_definition_source_run_id", table_name="curve_definition"
-    )
+    op.drop_index("ix_curve_definition_base_curve_id", table_name="curve_definition")
+    op.drop_index("ix_curve_definition_source_run_id", table_name="curve_definition")
     op.drop_table("curve_definition")
-    op.drop_index(
-        "ix_calibration_run_status_created_at", table_name="calibration_run"
-    )
+    op.drop_index("ix_calibration_run_status_created_at", table_name="calibration_run")
     op.drop_table("calibration_run")

--- a/dal-web/backend/tests/calibration_contract_fixtures.py
+++ b/dal-web/backend/tests/calibration_contract_fixtures.py
@@ -153,9 +153,7 @@ def xccy_swap() -> dict[str, object]:
     }
 
 
-def staged_request(
-    domestic_curve_id: str, foreign_curve_id: str
-) -> dict[str, object]:
+def staged_request(domestic_curve_id: str, foreign_curve_id: str) -> dict[str, object]:
     return {
         "schema_version": 1,
         "name": "usd_eur_basis_2026_01_02",
@@ -342,9 +340,7 @@ def policy_resolution_request(policy: str) -> dict[str, object]:
     request["declaration"].update(
         {
             "knot_policy": policy,
-            "knot_dates": (
-                [] if policy == "INSTRUMENTS" else ["2026-03-02", "2026-05-02"]
-            ),
+            "knot_dates": ([] if policy == "INSTRUMENTS" else ["2026-03-02", "2026-05-02"]),
             "initial_guess_per_node": [],
         }
     )
@@ -413,9 +409,7 @@ def first_offender_request(source: str) -> tuple[dict[str, object], dict[str, ob
                 "knot_policy": "INSTRUMENTS",
                 "knot_dates": [],
                 "parameterization": (
-                    "PIECEWISE_CONSTANT_FWD"
-                    if source == "start"
-                    else "ZERO_RATE"
+                    "PIECEWISE_CONSTANT_FWD" if source == "start" else "ZERO_RATE"
                 ),
                 "log_df_scheme": None if source == "start" else "LOG_LINEAR",
             }
@@ -429,11 +423,7 @@ def first_offender_request(source: str) -> tuple[dict[str, object], dict[str, ob
             "candidate_ordinal": candidate_ordinal,
             "candidate_date": instruments[instrument_index][field],
             "origin": {
-                "kind": (
-                    "INSTRUMENT_START"
-                    if source == "start"
-                    else "INSTRUMENT_END"
-                ),
+                "kind": ("INSTRUMENT_START" if source == "start" else "INSTRUMENT_END"),
                 "instrument_input_index": instrument_index,
             },
         }
@@ -476,9 +466,7 @@ def first_offender_request(source: str) -> tuple[dict[str, object], dict[str, ob
     raise ValueError("unsupported first-offender fixture")
 
 
-def wait_for_terminal(
-    client: TestClient, submitted: Mapping[str, object]
-) -> dict[str, object]:
+def wait_for_terminal(client: TestClient, submitted: Mapping[str, object]) -> dict[str, object]:
     location = str(submitted["location"])
     for _ in range(200):
         response = client.get(location)
@@ -489,9 +477,7 @@ def wait_for_terminal(
     raise AssertionError(f"calibration remained running at {location}")
 
 
-def submit_and_wait(
-    client: TestClient, path: str, payload: dict[str, object]
-) -> dict[str, object]:
+def submit_and_wait(client: TestClient, path: str, payload: dict[str, object]) -> dict[str, object]:
     response = client.post(path, json=payload)
     assert response.status_code == 202, response.text
     return wait_for_terminal(

--- a/dal-web/backend/tests/curve_reconstruction_subprocess.py
+++ b/dal-web/backend/tests/curve_reconstruction_subprocess.py
@@ -43,14 +43,10 @@ def _single_payload(
             "curve_name": name,
             "parameterization": parameterization,
             "log_df_scheme": (
-                "MIXED"
-                if parameterization in {"ZERO_RATE", "LOG_DISCOUNT"}
-                else None
+                "MIXED" if parameterization in {"ZERO_RATE", "LOG_DISCOUNT"} else None
             ),
             "knot_dates": (
-                ["2026-01-02", *future]
-                if parameterization == "LOG_DISCOUNT"
-                else future
+                ["2026-01-02", *future] if parameterization == "LOG_DISCOUNT" else future
             ),
             "base_curve_id": base_curve_id,
             "initial_guess_per_node": [],
@@ -165,11 +161,7 @@ def _create_http_state(client) -> dict[str, dict[str, str]]:
     )
     run_ids["joint"] = str(joint["id"])
     for index, curve in enumerate(joint["curves"]):
-        key = (
-            "joint_basis"
-            if curve["role"] == "basis"
-            else f"joint_{index}_{curve['name']}"
-        )
+        key = "joint_basis" if curve["role"] == "basis" else f"joint_{index}_{curve['name']}"
         curve_ids[key] = str(curve["id"])
     return {"run_ids": run_ids, "curve_ids": curve_ids}
 
@@ -272,12 +264,10 @@ def _collect_http_state(
         "values": values,
         "actual_schemes": actual_schemes,
         "canonical_runs": {
-            name: canonical_json_bytes(payload).decode("utf-8")
-            for name, payload in runs.items()
+            name: canonical_json_bytes(payload).decode("utf-8") for name, payload in runs.items()
         },
         "canonical_plans": {
-            name: canonical_json_bytes(plan).decode("utf-8")
-            for name, plan in plans.items()
+            name: canonical_json_bytes(plan).decode("utf-8") for name, plan in plans.items()
         },
         "canonical_plan_hashes": hashes,
         "http_reads": {
@@ -307,11 +297,7 @@ def main() -> int:
     dal_gateway._gateway_box[0] = None
     store._store_box[0] = None
     with TestClient(create_app()) as client:
-        ids = (
-            _create_http_state(client)
-            if args.mode == "write"
-            else json.loads(str(args.ids_json))
-        )
+        ids = _create_http_state(client) if args.mode == "write" else json.loads(str(args.ids_json))
         result = _collect_http_state(client, ids)
     print(
         json.dumps(

--- a/dal-web/backend/tests/test_calibration_acceptance_api.py
+++ b/dal-web/backend/tests/test_calibration_acceptance_api.py
@@ -72,9 +72,7 @@ def test_fix_cb1_policy_resolution_matches_direct_planner_and_persistence(
     payload = policy_resolution_request(policy)
     request = SingleCalibrationRequest.model_validate(payload)
     gateway = get_gateway()
-    direct = gateway._plan_single(
-        SingleGatewayAdmissionRequest(request, {})
-    ).to_bounded_dto()
+    direct = gateway._plan_single(SingleGatewayAdmissionRequest(request, {})).to_bounded_dto()
     expected = direct.model_dump(mode="json")
 
     with mock.patch.object(
@@ -126,8 +124,7 @@ def test_fix_cb1_policy_resolution_matches_direct_planner_and_persistence(
         ],
     }[policy]
     assert [
-        (item["origin"]["kind"], item["disposition"])
-        for item in expected["candidate_trace"]
+        (item["origin"]["kind"], item["disposition"]) for item in expected["candidate_trace"]
     ] == expected_trace
 
 
@@ -390,13 +387,8 @@ def test_fix_b3_serialization_passes_are_two_for_completion_and_one_for_get(
     assert clock.calls == 2
     assert adapter.calls[0] == response.content
     assert int(response.headers["content-length"]) == len(response.content)
-    assert int(response.headers["x-dal-response-bytes"]) == len(
-        response.content
-    )
-    assert (
-        store.get_calibration_run(run_id).serialization_ms
-        == persisted_timing
-    )
+    assert int(response.headers["x-dal-response-bytes"]) == len(response.content)
+    assert store.get_calibration_run(run_id).serialization_ms == persisted_timing
 
 
 def test_fix_b4_preview_reserve_and_defensive_guard_are_atomic(
@@ -448,8 +440,7 @@ def test_fix_b4_preview_reserve_and_defensive_guard_are_atomic(
         before_curves = tuple(
             tuple(row)
             for row in connection.exec_driver_sql(
-                "SELECT * FROM curve_definition "
-                "WHERE source_run_id = ? ORDER BY id",
+                "SELECT * FROM curve_definition WHERE source_run_id = ? ORDER BY id",
                 (run_id,),
             ).all()
         )
@@ -505,8 +496,7 @@ def test_fix_b4_preview_reserve_and_defensive_guard_are_atomic(
         after_curves = tuple(
             tuple(row)
             for row in connection.exec_driver_sql(
-                "SELECT * FROM curve_definition "
-                "WHERE source_run_id = ? ORDER BY id",
+                "SELECT * FROM curve_definition WHERE source_run_id = ? ORDER BY id",
                 (run_id,),
             ).all()
         )
@@ -602,10 +592,11 @@ def test_fix_b8_submitted_index_beats_canonical_issue_order_and_control(
         "/api/calibrations/single",
         payload,
     )
-    assert [
-        diagnostic["market_rate"]
-        for diagnostic in completed["instrument_diagnostics"]
-    ] == [0.01, 0.02, 0.03]
+    assert [diagnostic["market_rate"] for diagnostic in completed["instrument_diagnostics"]] == [
+        0.01,
+        0.02,
+        0.03,
+    ]
 
 
 def test_fix_b9_router_500_covers_retrieval_adapter_and_legacy_boundary(

--- a/dal-web/backend/tests/test_calibration_acceptance_boundaries.py
+++ b/dal-web/backend/tests/test_calibration_acceptance_boundaries.py
@@ -54,23 +54,15 @@ def _single_representation_request(
 ) -> dict[str, object]:
     request = single_request("USD", 0.02)
     future = ["2027-01-02", "2028-01-02"]
-    knots = (
-        ["2026-01-02", *future]
-        if parameterization == "LOG_DISCOUNT"
-        else future
-    )
+    knots = ["2026-01-02", *future] if parameterization == "LOG_DISCOUNT" else future
     request["declaration"].update(
         {
             "parameterization": parameterization,
             "log_df_scheme": (
-                "LOG_LINEAR"
-                if parameterization in {"ZERO_RATE", "LOG_DISCOUNT"}
-                else None
+                "LOG_LINEAR" if parameterization in {"ZERO_RATE", "LOG_DISCOUNT"} else None
             ),
             "knot_dates": knots,
-            "initial_guess_per_node": (
-                [] if submitted_seed is None else submitted_seed
-            ),
+            "initial_guess_per_node": ([] if submitted_seed is None else submitted_seed),
         }
     )
     request["instruments"] = _dated_deposits("USD", future)
@@ -105,9 +97,7 @@ def test_fix_b6_initial_seeds_reach_single_native_inspection_order(
     original = gateway.calibrate_single
 
     def calibrate(pre_lock_request, *args):
-        observed.append(
-            list(pre_lock_request.request.declaration.initial_guess_per_node)
-        )
+        observed.append(list(pre_lock_request.request.declaration.initial_guess_per_node))
         return original(pre_lock_request, *args)
 
     with mock.patch.object(gateway, "calibrate_single", side_effect=calibrate):
@@ -122,9 +112,9 @@ def test_fix_b6_initial_seeds_reach_single_native_inspection_order(
 
     assert completed["status"] == "completed"
     assert observed == [expected]
-    assert _persisted_request(completed)["declaration"][
-        "resolved_initial_guess_per_node"
-    ] == expected
+    assert (
+        _persisted_request(completed)["declaration"]["resolved_initial_guess_per_node"] == expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -142,9 +132,9 @@ def test_fix_b6_log_negative_zero_and_explicit_override(
         "/api/calibrations/single",
         _single_representation_request("LOG_DISCOUNT", scalar=scalar),
     )
-    assert _persisted_request(completed)["declaration"][
-        "resolved_initial_guess_per_node"
-    ] == expected
+    assert (
+        _persisted_request(completed)["declaration"]["resolved_initial_guess_per_node"] == expected
+    )
 
     overridden = submit_and_wait(
         client,
@@ -155,12 +145,14 @@ def test_fix_b6_log_negative_zero_and_explicit_override(
             submitted_seed=[-0.123, -0.456],
         ),
     )
-    assert _persisted_request(overridden)["declaration"][
-        "submitted_initial_guess_per_node"
-    ] == [-0.123, -0.456]
-    assert _persisted_request(overridden)["declaration"][
-        "resolved_initial_guess_per_node"
-    ] == [-0.123, -0.456]
+    assert _persisted_request(overridden)["declaration"]["submitted_initial_guess_per_node"] == [
+        -0.123,
+        -0.456,
+    ]
+    assert _persisted_request(overridden)["declaration"]["resolved_initial_guess_per_node"] == [
+        -0.123,
+        -0.456,
+    ]
 
 
 def test_fix_b6_seed_shape_and_non_finite_values_fail_at_production_api(
@@ -225,9 +217,7 @@ def test_fix_b6_staged_and_joint_gateway_inspection_see_resolved_vectors(
     original_staged = gateway.calibrate_staged_xccy
 
     def calibrate_staged(request, *args):
-        observed_staged.append(
-            list(request.request.basis.initial_guess_per_node)
-        )
+        observed_staged.append(list(request.request.basis.initial_guess_per_node))
         return original_staged(request, *args)
 
     with mock.patch.object(
@@ -320,12 +310,8 @@ def _staged_dimension_request(
         {
             **xccy_swap(),
             "label": f"basis-{index + 1}",
-            "start": (
-                "2026-01-02" if index < 2 else "2026-02-02"
-            ),
-            "maturity": (
-                "2027-01-02" if index == 0 else "2028-01-02"
-            ),
+            "start": ("2026-01-02" if index < 2 else "2026-02-02"),
+            "maturity": ("2027-01-02" if index == 0 else "2028-01-02"),
         }
         for index in range(residual_count)
     ]
@@ -342,12 +328,8 @@ def _joint_dimension_request(overdetermined: bool) -> dict[str, object]:
         {
             **xccy_swap(),
             "label": f"basis-{index + 1}",
-            "start": (
-                "2026-01-02" if index < 2 else "2026-02-02"
-            ),
-            "maturity": (
-                "2027-01-02" if index == 0 else "2028-01-02"
-            ),
+            "start": ("2026-01-02" if index < 2 else "2026-02-02"),
+            "maturity": ("2027-01-02" if index == 0 else "2028-01-02"),
         }
         for index in range(basis_count)
     ]
@@ -491,9 +473,7 @@ def test_fix_b1_joint_basis_schemes_cross_production_gateway_and_rebuild_dto(
                 _observed=observed,
                 _original=original,
             ):
-                _observed.append(
-                    gateway_request.request.basis.log_df_scheme
-                )
+                _observed.append(gateway_request.request.basis.log_df_scheme)
                 return _original(gateway_request, *args)
 
             with mock.patch.object(
@@ -506,11 +486,7 @@ def test_fix_b1_joint_basis_schemes_cross_production_gateway_and_rebuild_dto(
                     "/api/calibrations/xccy/joint",
                     request,
                 )
-            basis_curve = next(
-                curve
-                for curve in completed["curves"]
-                if curve["role"] == "basis"
-            )
+            basis_curve = next(curve for curve in completed["curves"] if curve["role"] == "basis")
             assert observed == [scheme]
             assert basis_curve["parameterization"] == parameterization
             assert basis_curve["log_df_scheme"] == scheme
@@ -540,11 +516,7 @@ def _single_storage_boundary_request(
 ) -> dict[str, object]:
     request = single_request("USD", 0.02)
     future = future_knots(future_count)
-    knots = (
-        ["2026-01-02", *future]
-        if parameterization == "LOG_DISCOUNT"
-        else future
-    )
+    knots = ["2026-01-02", *future] if parameterization == "LOG_DISCOUNT" else future
     request["declaration"].update(
         {
             "parameterization": parameterization,
@@ -577,9 +549,7 @@ def test_fix_b2_storage_boundaries_cover_single_and_joint_anchor_projection(
         curve = completed["curves"][0]
         assert completed["resolved_knot_plan"]["counts"]["storage_nodes"] == 100
         assert curve["anchor_date"] == "2026-01-02"
-        assert len(curve["node_dates"]) == (
-            99 if parameterization == "ZERO_RATE" else 100
-        )
+        assert len(curve["node_dates"]) == (99 if parameterization == "ZERO_RATE" else 100)
 
     gateway = get_gateway()
     store = get_store()
@@ -608,9 +578,7 @@ def test_fix_b2_storage_boundaries_cover_single_and_joint_anchor_projection(
     ):
         response = client.post("/api/calibrations/single", json=overflow)
     assert response.status_code == 422
-    assert response.json()["error"]["code"] == (
-        "CURVE_STORAGE_NODE_LIMIT_EXCEEDED"
-    )
+    assert response.json()["error"]["code"] == ("CURVE_STORAGE_NODE_LIMIT_EXCEEDED")
     assert response.json()["error"]["location"][-1] == 99
     assert admission.call_count == planner.call_count == 1
     assert insert.call_count == native.call_count == 0
@@ -618,9 +586,7 @@ def test_fix_b2_storage_boundaries_cover_single_and_joint_anchor_projection(
     for target in ("domestic", "basis"):
         request = joint_request()
         declaration = (
-            request["domestic"]["declarations"][0]
-            if target == "domestic"
-            else request["basis"]
+            request["domestic"]["declarations"][0] if target == "domestic" else request["basis"]
         )
         declaration.update(
             {
@@ -642,14 +608,10 @@ def test_fix_b2_storage_boundaries_cover_single_and_joint_anchor_projection(
             request,
         )
         expected_name = (
-            declaration["curve_name"]
-            if target == "domestic"
-            else request["basis"]["curve_name"]
+            declaration["curve_name"] if target == "domestic" else request["basis"]["curve_name"]
         )
         target_curve = next(
-            curve
-            for curve in completed["curves"]
-            if curve["name"] == expected_name
+            curve for curve in completed["curves"] if curve["name"] == expected_name
         )
         assert target_curve["anchor_date"] == "2026-01-02"
         assert len(target_curve["node_dates"]) == 99
@@ -678,9 +640,7 @@ def test_fix_b2_storage_boundaries_cover_single_and_joint_anchor_projection(
                 json=request,
             )
         assert rejected.status_code == 422
-        assert rejected.json()["error"]["code"] == (
-            "CURVE_STORAGE_NODE_LIMIT_EXCEEDED"
-        )
+        assert rejected.json()["error"]["code"] == ("CURVE_STORAGE_NODE_LIMIT_EXCEEDED")
         assert insert.call_count == native.call_count == preflight.call_count == 0
 
 
@@ -703,6 +663,7 @@ def test_fix_scheme_min_nodes_reject_accept_boundaries_at_api(
     accept_future: int,
 ) -> None:
     """FIX-SCHEME-MIN-NODES — each scheme rejects N-1 and accepts N."""
+
     def request(count: int) -> dict[str, object]:
         payload = single_request("USD", 0.02)
         future = future_knots(max(count, 1))
@@ -733,9 +694,7 @@ def test_fix_scheme_min_nodes_reject_accept_boundaries_at_api(
             json=request(reject_future),
         )
         assert rejected.status_code == 422
-        assert rejected.json()["error"]["code"] == (
-            "CURVE_SCHEME_NODE_COUNT_INVALID"
-        )
+        assert rejected.json()["error"]["code"] == ("CURVE_SCHEME_NODE_COUNT_INVALID")
     accepted = submit_and_wait(
         client,
         "/api/calibrations/single",
@@ -813,9 +772,7 @@ def test_fix_joint_free_parameter_limit_exhausts_modes_flags_and_downstream(
                     )
                 assert response.status_code == 422
                 error = response.json()["error"]
-                assert error["code"] == (
-                    "JOINT_FREE_PARAMETER_LIMIT_EXCEEDED"
-                )
+                assert error["code"] == ("JOINT_FREE_PARAMETER_LIMIT_EXCEEDED")
                 assert error["context"]["total_free_parameters"] == total
                 assert planner.call_count == 1
                 assert (
@@ -872,9 +829,12 @@ def test_fix_joint_free_parameter_limit_exhausts_modes_flags_and_downstream(
     assert estimator.call_count == 1
     assert estimator.call_args.args[2] == built[0].total_free_parameters
     document = client.app.openapi()
-    assert document["components"]["schemas"]["JointXccyCalibrationRequest"][
-        "x-dal-max-total-free-parameters"
-    ] == 200
+    assert (
+        document["components"]["schemas"]["JointXccyCalibrationRequest"][
+            "x-dal-max-total-free-parameters"
+        ]
+        == 200
+    )
 
 
 def test_reviewer_joint_capacity_precedes_unsupported_convention(client) -> None:
@@ -1163,9 +1123,9 @@ def test_section_18_missing_xccy_leg_route_maps_native_report_to_api(
 ) -> None:
     """API-04/API-06 — missing XCCY discount route has the submitted location."""
     request = joint_request()
-    request["basis"]["instruments"][0]["config"]["convention"]["domestic_index"][
-        "collateral"
-    ] = "MISSING"
+    request["basis"]["instruments"][0]["config"]["convention"]["domestic_index"]["collateral"] = (
+        "MISSING"
+    )
     issue = SimpleNamespace(
         reason=SimpleNamespace(name="DISCOUNT_ROUTE_MISSING"),
         group="basis",
@@ -1355,21 +1315,20 @@ def test_fix_cb1_downstream_counts_share_one_plan_across_every_consumer(
     future = ["2026-02-02", "2026-03-02", "2026-04-02"]
     request = single_request("USD", 0.02)
     log_discount = parameterization == "LOG_DISCOUNT"
-    submitted_knots = (
-        ["2026-01-02", *future[:2]]
-        if log_discount
-        else future
-    )
+    submitted_knots = ["2026-01-02", *future[:2]] if log_discount else future
     if policy == "INSTRUMENTS":
         submitted_knots = []
     request["declaration"].update(
         {
             "knot_policy": policy,
             "parameterization": parameterization,
-            "log_df_scheme": "LOG_LINEAR" if parameterization in {
+            "log_df_scheme": "LOG_LINEAR"
+            if parameterization
+            in {
                 "ZERO_RATE",
                 "LOG_DISCOUNT",
-            } else None,
+            }
+            else None,
             "knot_dates": submitted_knots,
             "initial_guess_per_node": [],
         }
@@ -1435,13 +1394,9 @@ def test_fix_cb1_downstream_counts_share_one_plan_across_every_consumer(
     assert len(completed["effective_inverse"]["row_axis"]) == free
     assert estimated == [(free, free)]
     persisted = _persisted_request(completed)
-    assert len(
-        persisted["declaration"]["resolved_initial_guess_per_node"]
-    ) == free
+    assert len(persisted["declaration"]["resolved_initial_guess_per_node"]) == free
     curve = completed["curves"][0]
-    reconstructed_storage = len(curve["node_dates"]) + int(
-        parameterization == "ZERO_RATE"
-    )
+    reconstructed_storage = len(curve["node_dates"]) + int(parameterization == "ZERO_RATE")
     assert reconstructed_storage == storage
     preview = client.get(
         f"/api/calibrations/{completed['id']}",
@@ -1495,13 +1450,7 @@ def test_fix_cb1_log_policy_rejects_instruments_before_planner_and_augments(
         )
     assert rejected.status_code == 422
     assert rejected.json()["error"]["code"] == "KNOT_POLICY_INCOMPATIBLE"
-    assert (
-        admission.call_count
-        == planner.call_count
-        == insert.call_count
-        == native.call_count
-        == 0
-    )
+    assert admission.call_count == planner.call_count == insert.call_count == native.call_count == 0
 
     augmented = copy.deepcopy(incompatible)
     augmented["declaration"]["knot_policy"] = "AUGMENTED"
@@ -1527,10 +1476,7 @@ def test_fix_cb1_log_policy_rejects_instruments_before_planner_and_augments(
 
 def _boundary_instruments(resolved_count: int) -> list[dict[str, object]]:
     nodes = future_knots(resolved_count)
-    spans = [
-        (nodes[index], nodes[index + 1])
-        for index in range(0, resolved_count - 1, 2)
-    ]
+    spans = [(nodes[index], nodes[index + 1]) for index in range(0, resolved_count - 1, 2)]
     if resolved_count % 2:
         spans.append((nodes[-2], nodes[-1]))
     return [
@@ -1574,9 +1520,7 @@ def _policy_boundary_request(
             "knot_policy": policy,
             "parameterization": parameterization,
             "log_df_scheme": (
-                "LOG_LINEAR"
-                if parameterization in {"ZERO_RATE", "LOG_DISCOUNT"}
-                else None
+                "LOG_LINEAR" if parameterization in {"ZERO_RATE", "LOG_DISCOUNT"} else None
             ),
             "knot_dates": knots,
             "initial_guess_per_node": [],
@@ -1627,9 +1571,7 @@ def test_fix_cb1_policy_boundaries_cover_every_policy_representation_maximum(
         parameterization in {"ZERO_RATE", "LOG_DISCOUNT"}
     )
     assert counts["free_parameters"] == (
-        2 * accept_count
-        if parameterization == "PIECEWISE_LINEAR_FWD"
-        else accept_count
+        2 * accept_count if parameterization == "PIECEWISE_LINEAR_FWD" else accept_count
     )
 
     gateway = get_gateway()
@@ -1666,9 +1608,7 @@ def test_fix_cb1_policy_boundaries_cover_every_policy_representation_maximum(
         )
     assert rejected.status_code == 422
     assert rejected.json()["error"]["code"] == (
-        "VALIDATION_ERROR"
-        if schema_reject
-        else "CURVE_STORAGE_NODE_LIMIT_EXCEEDED"
+        "VALIDATION_ERROR" if schema_reject else "CURVE_STORAGE_NODE_LIMIT_EXCEEDED"
     )
     assert insert.call_count == native.call_count == 0
     if schema_reject:

--- a/dal-web/backend/tests/test_calibration_acceptance_faults.py
+++ b/dal-web/backend/tests/test_calibration_acceptance_faults.py
@@ -76,10 +76,7 @@ def test_fix_bk07_frozen_integrity_error_evidence_is_deep_and_byte_stable() -> N
     }
     evidence = calibration_service.freeze_integrity_error_evidence(
         "PERSISTED_EXPECTED_EXECUTION_IDENTITY_HASH_MISMATCH",
-        (
-            "persisted expected single-knot execution identity failed "
-            "canonical hash verification"
-        ),
+        ("persisted expected single-knot execution identity failed canonical hash verification"),
         source_location,
         source_context,
     )
@@ -122,12 +119,11 @@ def test_fix_bk07_frozen_integrity_error_evidence_is_deep_and_byte_stable() -> N
     first_wire.context["nested"]["array"][0]["leaf"] = "wire changed"
     second_wire = calibration_service.to_api_error_dto(evidence)
     decoded_wire = json.loads(evidence.canonical_error_utf8)
-    assert calibration_service.canonical_json_bytes(
-        second_wire.model_dump(mode="json")
-    ) == evidence.canonical_error_utf8
-    assert calibration_service.canonical_json_bytes(decoded_wire) == (
-        evidence.canonical_error_utf8
+    assert (
+        calibration_service.canonical_json_bytes(second_wire.model_dump(mode="json"))
+        == evidence.canonical_error_utf8
     )
+    assert calibration_service.canonical_json_bytes(decoded_wire) == (evidence.canonical_error_utf8)
     assert second_wire.context["nested"]["array"][0]["leaf"] == "before"
     assert source_context["nested"] is not second_wire.context["nested"]
 
@@ -171,9 +167,7 @@ def test_fix_bk06_untyped_callback_fault_is_a_lifecycle_failure(
 
     assert terminal["status"] == "failed"
     assert terminal["error"]["code"] == "LIFECYCLE_TRANSITION_FAILED"
-    assert terminal["error"]["context"]["transition"] == (
-        "verify_pre_native_admission_evidence"
-    )
+    assert terminal["error"]["context"]["transition"] == ("verify_pre_native_admission_evidence")
     assert build.call_count == inspect_identity.call_count == native.call_count == 0
     assert terminal["actual_execution_identity"] is None
     assert terminal["timings"] == {
@@ -303,12 +297,8 @@ def test_fix_worker_execution_identity_faults_are_atomic_and_never_repaired(
 
     def terminal_identity(expected, result, elapsed_ms):
         if fault_stage != "post_solve_storage":
-            return gateway_module._require_terminal_single_identity(
-                expected, result, elapsed_ms
-            )
-        actual = expected.model_copy(
-            update={"today": expected.today.replace(day=3)}
-        )
+            return gateway_module._require_terminal_single_identity(expected, result, elapsed_ms)
+        actual = expected.model_copy(update={"today": expected.today.replace(day=3)})
         raise calibration_service.NativeExecutionIdentityMismatchError(
             expected,
             actual,
@@ -441,9 +431,7 @@ def test_fix_b5_bk06_shared_recorder_proves_conc_01_06_production_order(
         canonical_hash,
     )
 
-    original_validate = (
-        calibration_service._validate_single_worker_admission_context
-    )
+    original_validate = calibration_service._validate_single_worker_admission_context
 
     def validate(*args, **kwargs):
         result = original_validate(*args, **kwargs)
@@ -717,11 +705,7 @@ def test_fix_cb1_bk01_bk03_integrity_faults_are_atomic_and_never_repaired(
         run_id = submitted.json()["id"]
         assert load_entered.wait(timeout=5.0)
 
-        field = (
-            "resolved_knot_plan"
-            if domain == "plan"
-            else "expected_execution_identity"
-        )
+        field = "resolved_knot_plan" if domain == "plan" else "expected_execution_identity"
         hash_field = f"{field}_hash"
         with store._session() as session:
             row = session.get(CalibrationRunRow, run_id)
@@ -930,9 +914,7 @@ def test_fix_bk07_integrity_terminal_fault_matrix_uses_atomic_fallback(
     assert build.call_count == inspect_identity.call_count == native.call_count == 0
     assert complete.call_count == 0
     assert projection_calls == int(fault_stage != "factory")
-    assert bytes_guard_calls == int(
-        fault_stage in {"terminal_bytes", "store_commit"}
-    )
+    assert bytes_guard_calls == int(fault_stage in {"terminal_bytes", "store_commit"})
     assert integrity_store_calls == int(fault_stage == "store_commit")
     with store._session() as session:
         curve_count = session.scalar(

--- a/dal-web/backend/tests/test_calibration_api.py
+++ b/dal-web/backend/tests/test_calibration_api.py
@@ -171,8 +171,7 @@ def test_single_admission_maps_unknown_day_basis_to_stable_convention_error(
     assert response.json()["error"] == {
         "code": "UNSUPPORTED_CONVENTION",
         "message": (
-            "instruments[0].index.day_basis value 'NOT_A_DAY_BASIS' "
-            "is not a supported day_basis"
+            "instruments[0].index.day_basis value 'NOT_A_DAY_BASIS' is not a supported day_basis"
         ),
         "location": ["body", "instruments", 0, "index", "day_basis"],
         "context": {
@@ -207,15 +206,10 @@ def test_instrument_knot_policy_rejects_an_all_historical_candidate_set(
 def test_openapi_pins_joint_capacity_and_failed_integrity_examples(client) -> None:
     document = client.app.openapi()
     schemas = document["components"]["schemas"]
-    assert (
-        schemas["JointXccyCalibrationRequest"][
-            "x-dal-max-total-free-parameters"
-        ]
-        == 200
-    )
-    joint_422 = document["paths"]["/api/calibrations/xccy/joint"]["post"][
-        "responses"
-    ]["422"]["content"]["application/json"]["examples"]
+    assert schemas["JointXccyCalibrationRequest"]["x-dal-max-total-free-parameters"] == 200
+    joint_422 = document["paths"]["/api/calibrations/xccy/joint"]["post"]["responses"]["422"][
+        "content"
+    ]["application/json"]["examples"]
     capacity = joint_422["joint_free_parameter_limit_exceeded"]["value"]["error"]
     assert capacity == {
         "code": "JOINT_FREE_PARAMETER_LIMIT_EXCEEDED",
@@ -232,12 +226,10 @@ def test_openapi_pins_joint_capacity_and_failed_integrity_examples(client) -> No
             "offending_storage_nodes": 2,
         },
     }
-    run_examples = document["paths"]["/api/calibrations/{calibration_id}"][
-        "get"
-    ]["responses"]["200"]["content"]["application/json"]["examples"]
-    failed = run_examples[
-        "persisted_expected_execution_identity_hash_mismatch"
-    ]["value"]
+    run_examples = document["paths"]["/api/calibrations/{calibration_id}"]["get"]["responses"][
+        "200"
+    ]["content"]["application/json"]["examples"]
+    failed = run_examples["persisted_expected_execution_identity_hash_mismatch"]["value"]
     assert failed["status"] == "failed"
     assert failed["actual_jacobian_mode"] is None
     assert failed["actual_execution_identity"] is None
@@ -246,10 +238,7 @@ def test_openapi_pins_joint_capacity_and_failed_integrity_examples(client) -> No
         "native_solve_ms": None,
         "serialization_ms": None,
     }
-    assert (
-        failed["error"]["code"]
-        == "PERSISTED_EXPECTED_EXECUTION_IDENTITY_HASH_MISMATCH"
-    )
+    assert failed["error"]["code"] == "PERSISTED_EXPECTED_EXECUTION_IDENTITY_HASH_MISMATCH"
 
 
 def test_new_router_has_stable_validation_and_not_found_envelopes(client) -> None:

--- a/dal-web/backend/tests/test_calibration_contract.py
+++ b/dal-web/backend/tests/test_calibration_contract.py
@@ -263,9 +263,7 @@ def test_single_analytic_issue_is_mapped_back_to_submitted_instrument():
     report = SimpleNamespace(eligible=False, issues=(issue,))
 
     with pytest.raises(CalibrationHttpError) as captured:
-        _check_single_analytic_eligibility(
-            request, report, ("Deposit", "Deposit")
-        )
+        _check_single_analytic_eligibility(request, report, ("Deposit", "Deposit"))
 
     assert captured.value.error.location == ["body", "instruments", 0, "trade_date"]
     assert captured.value.error.context["input_index"] == 0
@@ -530,9 +528,7 @@ def test_unknown_native_failure_exposes_only_a_sanitized_native_message():
 
     payload = store.fail_calibration.call_args.kwargs["error_payload"]
     assert payload["code"] == "NATIVE_CALIBRATION_FAILED"
-    assert payload["context"] == {
-        "native_message": "RuntimeError: native calibration failed"
-    }
+    assert payload["context"] == {"native_message": "RuntimeError: native calibration failed"}
 
 
 def test_gateway_translates_only_the_private_native_convergence_type(
@@ -552,9 +548,7 @@ def test_gateway_translates_only_the_private_native_convergence_type(
     def exhaust() -> None:
         raise NativeConvergenceError("native detail")
 
-    request = SimpleNamespace(
-        solver=SimpleNamespace(max_evaluations=7)
-    )
+    request = SimpleNamespace(solver=SimpleNamespace(max_evaluations=7))
     with pytest.raises(NativeSolverDidNotConvergeError) as captured:
         gateway._call_native_calibration(exhaust, request)
 
@@ -583,9 +577,7 @@ def test_worker_bounded_evidence_is_validated_against_request_context():
         log_df_scheme="LOG_LINEAR",
         resolved_declared_dates=(maturity,),
         storage_dates=(today, maturity),
-        free_parameters=(
-            {"date": maturity, "component": "zero_rate"},
-        ),
+        free_parameters=({"date": maturity, "component": "zero_rate"},),
         counts={
             "resolved_declared_nodes": 1,
             "storage_nodes": 2,
@@ -593,9 +585,7 @@ def test_worker_bounded_evidence_is_validated_against_request_context():
         },
     )
 
-    with pytest.raises(
-        ValueError, match="expected execution identity does not match"
-    ):
+    with pytest.raises(ValueError, match="expected execution identity does not match"):
         _validate_single_worker_admission_context(
             SimpleNamespace(request=request),
             plan,
@@ -627,18 +617,14 @@ def test_gateway_compares_terminal_identity_to_exact_verified_carrier(
         log_df_scheme=None,
         resolved_declared_dates=(maturity,),
         storage_dates=(maturity,),
-        free_parameters=(
-            {"date": maturity, "component": "right_forward"},
-        ),
+        free_parameters=({"date": maturity, "component": "right_forward"},),
         counts={
             "resolved_declared_nodes": 1,
             "storage_nodes": 1,
             "free_parameters": 1,
         },
     )
-    mismatched = expected.model_copy(
-        update={"execution_policy": "INSTRUMENTS"}
-    )
+    mismatched = expected.model_copy(update={"execution_policy": "INSTRUMENTS"})
     evidence = VerifiedSingleWorkerAdmissionEvidence(
         resolved_knot_plan=plan,
         resolved_knot_plan_hash="plan-hash",
@@ -646,9 +632,7 @@ def test_gateway_compares_terminal_identity_to_exact_verified_carrier(
         expected_execution_identity_hash="identity-hash",
     )
     gateway = DalGateway()
-    monkeypatch.setattr(
-        gateway, "_build_single_execution_spec", lambda _verified: None
-    )
+    monkeypatch.setattr(gateway, "_build_single_execution_spec", lambda _verified: None)
     monkeypatch.setattr(
         gateway,
         "_calibrate_single_verified",
@@ -658,9 +642,7 @@ def test_gateway_compares_terminal_identity_to_exact_verified_carrier(
         ),
     )
 
-    with pytest.raises(
-        NativeExecutionIdentityMismatchError
-    ) as captured:
+    with pytest.raises(NativeExecutionIdentityMismatchError) as captured:
         gateway.calibrate_single(
             SingleGatewayPreLockRequest(request, {}),
             lambda _acquired_at: None,
@@ -697,9 +679,7 @@ def test_gateway_holds_continuous_calibration_lock_through_evidence_and_solve(
         log_df_scheme=None,
         resolved_declared_dates=(maturity,),
         storage_dates=(maturity,),
-        free_parameters=(
-            {"date": maturity, "component": "right_forward"},
-        ),
+        free_parameters=({"date": maturity, "component": "right_forward"},),
         counts={
             "resolved_declared_nodes": 1,
             "storage_nodes": 1,
@@ -717,9 +697,7 @@ def test_gateway_holds_continuous_calibration_lock_through_evidence_and_solve(
     release_verify = threading.Event()
     events: list[str] = []
     failures: list[BaseException] = []
-    monkeypatch.setattr(
-        gateway, "_build_single_execution_spec", lambda _verified: None
-    )
+    monkeypatch.setattr(gateway, "_build_single_execution_spec", lambda _verified: None)
 
     def solve(*_args):
         events.append("solve")

--- a/dal-web/backend/tests/test_calibration_migration.py
+++ b/dal-web/backend/tests/test_calibration_migration.py
@@ -31,8 +31,7 @@ def _insert_legacy_entities(engine: Engine) -> None:
     with engine.begin() as connection:
         connection.exec_driver_sql("PRAGMA foreign_keys=ON")
         connection.exec_driver_sql(
-            "INSERT INTO product "
-            "(id, name, description, template, rows) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO product (id, name, description, template, rows) VALUES (?, ?, ?, ?, ?)",
             (
                 "legacy-product",
                 "Legacy product",
@@ -83,8 +82,7 @@ def _insert_legacy_entities(engine: Engine) -> None:
             ("legacy-portfolio", "Legacy portfolio", "must survive"),
         )
         connection.exec_driver_sql(
-            "INSERT INTO portfolio_trade "
-            "(portfolio_id, trade_id, position) VALUES (?, ?, ?)",
+            "INSERT INTO portfolio_trade (portfolio_id, trade_id, position) VALUES (?, ?, ?)",
             ("legacy-portfolio", "legacy-trade", 0),
         )
         connection.exec_driver_sql(
@@ -114,9 +112,7 @@ def _legacy_rows(engine: Engine) -> dict[str, tuple[tuple[object, ...], ...]]:
         return {
             table: tuple(
                 tuple(row)
-                for row in connection.exec_driver_sql(
-                    f"SELECT * FROM {table} ORDER BY 1"
-                ).all()
+                for row in connection.exec_driver_sql(f"SELECT * FROM {table} ORDER BY 1").all()
             )
             for table in _LEGACY_TABLES
         }
@@ -176,9 +172,7 @@ def _assert_legacy_unchanged(
     _assert_legacy_fk_enforcement(engine)
 
 
-def test_calibration_migration_upgrade_downgrade_upgrade(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_calibration_migration_upgrade_downgrade_upgrade(tmp_path: Path, monkeypatch) -> None:
     database_url = f"sqlite:///{tmp_path / 'migration.db'}"
     monkeypatch.setenv("DAL_WEB_DB_URL", database_url)
     config = _config()
@@ -226,9 +220,7 @@ def test_calibration_migration_upgrade_downgrade_upgrade(
     }
     assert {
         constraint["name"]
-        for constraint in inspector.get_unique_constraints(
-            "calibration_instrument_definition"
-        )
+        for constraint in inspector.get_unique_constraints("calibration_instrument_definition")
     } == {
         "uq_calibration_instrument_run_group_calibration",
         "uq_calibration_instrument_run_group_input",

--- a/dal-web/backend/tests/test_curve_lab_risk_admission_offload.py
+++ b/dal-web/backend/tests/test_curve_lab_risk_admission_offload.py
@@ -28,6 +28,67 @@ def _prepared_admission(client, monkeypatch):
     return get_store(), gateway, request
 
 
+def test_risk_admission_native_failure_preserves_http_error_without_side_effects(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.services.curve_lab_lifecycle import CurveLabLifecycleError
+
+    store, gateway, request = _prepared_admission(client, monkeypatch)
+    expected_error = CurveLabLifecycleError(
+        422,
+        "MISSING_HISTORICAL_FIXING",
+        "A required historical fixing is absent from the immutable snapshot.",
+        "target.trades[0]",
+        {
+            "index_name": "USD-SOFR",
+            "fixing_time": "2026-01-14T11:00:00",
+        },
+        resource_id="native-preflight-fixings",
+        constraint="fixing_time before evaluation_time requires an exact snapshot value",
+    )
+    reservations: list[object] = []
+    publications: list[tuple[dict, list[dict]]] = []
+    audits: list[dict] = []
+
+    class UnexpectedReservation:
+        def submit(self, _function, /, *_args) -> None:
+            pytest.fail("native admission failure must not submit a worker")
+
+        def cancel(self) -> None:
+            pytest.fail("native admission failure must not reserve capacity")
+
+    def reserve():
+        reservation = UnexpectedReservation()
+        reservations.append(reservation)
+        return reservation
+
+    def fail_preflight(*_args, **_kwargs):
+        raise expected_error
+
+    monkeypatch.setattr(gateway, "curve_lab_required_historical_fixings", fail_preflight)
+    monkeypatch.setattr(curve_risk, "_reserve_job", reserve)
+    monkeypatch.setattr(
+        store,
+        "publish_curve_lab_risk_run",
+        lambda record, matrices: publications.append((record, matrices)),
+    )
+    monkeypatch.setattr(
+        store,
+        "add_curve_lab_audit_event",
+        lambda record: audits.append(record),
+    )
+
+    response = client.post("/api/curve-lab/risk-runs", json=request)
+
+    assert response.status_code == expected_error.status_code
+    assert response.json() == {"detail": expected_error.detail}
+    assert reservations == []
+    assert publications == []
+    assert audits == []
+
+
 def test_risk_admission_preflight_runs_off_request_loop_while_heartbeat_advances(
     client,
     monkeypatch,

--- a/dal-web/backend/tests/test_curve_lab_risk_admission_offload.py
+++ b/dal-web/backend/tests/test_curve_lab_risk_admission_offload.py
@@ -1,0 +1,287 @@
+"""Risk admission event-loop and reservation compatibility regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tests.test_curve_lab_risk_api import _publish_version, _request
+
+
+def _prepared_admission(client, monkeypatch):
+    from app.services.dal_gateway import get_gateway
+    from app.services.store import get_store
+
+    _, version = _publish_version(client)
+    gateway = get_gateway()
+    monkeypatch.setattr(
+        gateway,
+        "curve_lab_required_historical_fixings",
+        lambda *_args, **_kwargs: [],
+    )
+    request = _request(version["id"])
+    request["measures"] = ["PV"]
+    request["sensitivity_layers"] = []
+    return get_store(), gateway, request
+
+
+def test_risk_admission_preflight_runs_off_request_loop_while_heartbeat_advances(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.services.dal_gateway import get_gateway
+
+    _, version = _publish_version(client)
+    blocked = threading.Event()
+    release = threading.Event()
+    preflight_thread_ids: list[int] = []
+
+    def blocking_preflight(*_args, **_kwargs):
+        preflight_thread_ids.append(threading.get_ident())
+        blocked.set()
+        release.wait(timeout=1)
+        blocked.clear()
+        return []
+
+    monkeypatch.setattr(
+        get_gateway(),
+        "curve_lab_required_historical_fixings",
+        blocking_preflight,
+    )
+
+    class CapturingReservation:
+        submitted: tuple[object, ...] | None = None
+
+        def submit(self, function, /, *args):
+            self.submitted = (function, *args)
+
+        def cancel(self) -> None:
+            pass
+
+    reservation = CapturingReservation()
+    monkeypatch.setattr(curve_risk, "_reserve_job", lambda: reservation)
+    request = _request(version["id"])
+    request["measures"] = ["PV"]
+    request["sensitivity_layers"] = []
+
+    async def exercise_route():
+        heartbeat_count = 0
+        request_loop_thread_id = threading.get_ident()
+        transport = ASGITransport(app=client.app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+            request_task = asyncio.create_task(
+                async_client.post("/api/curve-lab/risk-runs", json=request)
+            )
+            while not blocked.is_set() and not request_task.done():
+                await asyncio.sleep(0)
+            while blocked.is_set():
+                heartbeat_count += 1
+                release.set()
+                await asyncio.sleep(0)
+            response = await request_task
+        return response, heartbeat_count, request_loop_thread_id
+
+    response, heartbeat_count, request_loop_thread_id = asyncio.run(exercise_route())
+
+    assert response.status_code == 202, response.text
+    assert response.json()["state"] == "QUEUED"
+    assert heartbeat_count >= 1
+    assert len(preflight_thread_ids) == 1
+    assert preflight_thread_ids[0] != request_loop_thread_id
+    assert reservation.submitted is not None
+
+
+def test_risk_admission_preserves_reserve_publish_submit_order_and_terminal_audit(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+
+    store, gateway, request = _prepared_admission(client, monkeypatch)
+    events: list[str] = []
+    publications: list[tuple[dict, list[dict]]] = []
+    audits: list[dict] = []
+    original_publish = store.publish_curve_lab_risk_run
+    original_audit = store.add_curve_lab_audit_event
+
+    def publish(record, matrices):
+        events.append(f"publish:{record['state']}")
+        publications.append((dict(record), list(matrices)))
+        return original_publish(record, matrices)
+
+    def add_audit(record):
+        audits.append(dict(record))
+        original_audit(record)
+
+    monkeypatch.setattr(store, "publish_curve_lab_risk_run", publish)
+    monkeypatch.setattr(store, "add_curve_lab_audit_event", add_audit)
+
+    def price(_document, trades, _evaluation_time, base_currency, **_kwargs):
+        return [
+            {
+                "trade_id": trade["trade_id"],
+                "instrument_type": trade["instrument_type"],
+                "succeeded": True,
+                "pv": "100",
+                "currency": base_currency,
+                "required_historical_fixings": [],
+                "missing_historical_fixings": [],
+                "dependency_component_keys": [],
+                "error": "",
+            }
+            for trade in trades
+        ]
+
+    monkeypatch.setattr(gateway, "price_curve_lab_trades", price)
+
+    class InlineReservation:
+        def submit(self, function, /, *args):
+            events.append("submit")
+            function(*args)
+
+        def cancel(self) -> None:
+            pytest.fail("successful admission must not cancel its reservation")
+
+    def reserve():
+        events.append("reserve")
+        return InlineReservation()
+
+    monkeypatch.setattr(curve_risk, "_reserve_job", reserve)
+
+    response = client.post("/api/curve-lab/risk-runs", json=request)
+
+    assert response.status_code == 202, response.text
+    admitted = response.json()
+    assert admitted["state"] == "QUEUED"
+    assert events[:3] == ["reserve", "publish:QUEUED", "submit"]
+    assert [record["state"] for record, _ in publications] == [
+        "QUEUED",
+        "RUNNING",
+        "SUCCEEDED",
+    ]
+    assert publications[0][1] == []
+    completed = store.get_curve_lab_risk_run(admitted["id"])
+    assert completed["state"] == "SUCCEEDED"
+    assert completed["result"] is not None
+    assert completed["error"] is None
+    assert completed["finished_at"] is not None
+    assert len(audits) == 1
+    assert audits[0]["action"] == "RISK_RUN_SUCCEEDED"
+    assert audits[0]["target_type"] == "curve_risk_run"
+    assert audits[0]["target_id"] == admitted["id"]
+    assert audits[0]["outcome"] == "SUCCEEDED"
+    assert audits[0]["details"] == {"estimated_work": completed["estimated_work"]}
+
+
+def test_risk_admission_publication_failure_restores_capacity_without_side_effects(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.services.curve_lab_jobs import BoundedCurveLabExecutor, CurveLabQueueFullError
+    from app.services.store import NotFoundError
+
+    store, _gateway, request = _prepared_admission(client, monkeypatch)
+    jobs = BoundedCurveLabExecutor(max_workers=1, max_queued=0)
+    captured_run_ids: list[str] = []
+    audits: list[dict] = []
+    submit_calls = 0
+
+    class PublicationError(RuntimeError):
+        pass
+
+    expected_error = PublicationError("publish failed")
+
+    def fail_publish(record, _matrices):
+        captured_run_ids.append(record["id"])
+        raise expected_error
+
+    def submit(*_args, **_kwargs):
+        nonlocal submit_calls
+        submit_calls += 1
+
+    monkeypatch.setattr(store, "publish_curve_lab_risk_run", fail_publish)
+    monkeypatch.setattr(store, "add_curve_lab_audit_event", lambda record: audits.append(record))
+    monkeypatch.setattr(jobs, "_submit", submit)
+    monkeypatch.setattr(curve_risk, "_reserve_job", jobs.reserve)
+
+    try:
+        with pytest.raises(PublicationError) as caught:
+            client.post("/api/curve-lab/risk-runs", json=request)
+
+        assert caught.value is expected_error
+        assert len(captured_run_ids) == 1
+        assert submit_calls == 0
+        assert audits == []
+        with pytest.raises(NotFoundError):
+            store.get_curve_lab_risk_run(captured_run_ids[0])
+        replacement = jobs.reserve()
+        with pytest.raises(CurveLabQueueFullError):
+            jobs.reserve()
+        replacement.cancel()
+    finally:
+        jobs.shutdown()
+
+
+def test_risk_admission_submission_failure_keeps_queued_row_and_releases_one_slot(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.curve_risk as curve_risk
+    from app.services.curve_lab_jobs import BoundedCurveLabExecutor, CurveLabQueueFullError
+
+    store, _gateway, request = _prepared_admission(client, monkeypatch)
+    jobs = BoundedCurveLabExecutor(max_workers=1, max_queued=0)
+    publications: list[tuple[dict, list[dict]]] = []
+    audits: list[dict] = []
+    original_publish = store.publish_curve_lab_risk_run
+    submit_calls = 0
+
+    class SubmissionError(RuntimeError):
+        pass
+
+    expected_error = SubmissionError("submit failed")
+
+    def publish(record, matrices):
+        publications.append((dict(record), list(matrices)))
+        return original_publish(record, matrices)
+
+    def fail_submit(*_args, **_kwargs):
+        nonlocal submit_calls
+        submit_calls += 1
+        raise expected_error
+
+    monkeypatch.setattr(store, "publish_curve_lab_risk_run", publish)
+    monkeypatch.setattr(store, "add_curve_lab_audit_event", lambda record: audits.append(record))
+    monkeypatch.setattr(jobs, "_submit", fail_submit)
+    monkeypatch.setattr(curve_risk, "_reserve_job", jobs.reserve)
+
+    try:
+        with pytest.raises(SubmissionError) as caught:
+            client.post("/api/curve-lab/risk-runs", json=request)
+
+        assert caught.value is expected_error
+        assert submit_calls == 1
+        assert len(publications) == 1
+        published, matrices = publications[0]
+        assert matrices == []
+        assert published["state"] == "QUEUED"
+        assert published["result"] is None
+        assert published["error"] is None
+        assert published["finished_at"] is None
+        stored = store.get_curve_lab_risk_run(published["id"])
+        assert stored["state"] == "QUEUED"
+        assert stored["result"] is None
+        assert stored["error"] is None
+        assert stored["finished_at"] is None
+        assert audits == []
+        replacement = jobs.reserve()
+        with pytest.raises(CurveLabQueueFullError):
+            jobs.reserve()
+        replacement.cancel()
+    finally:
+        jobs.shutdown()

--- a/dal-web/backend/tests/test_restart_recovery.py
+++ b/dal-web/backend/tests/test_restart_recovery.py
@@ -239,9 +239,7 @@ def test_running_calibration_phases_reconcile_without_changing_evidence(
     run_ids: list[str] = []
     with _fresh_app(monkeypatch, tmp_path):
         store = get_store()
-        for index, phase in enumerate(
-            ("queued", "solving", "serializing", "persisting"), start=1
-        ):
+        for index, phase in enumerate(("queued", "solving", "serializing", "persisting"), start=1):
             run = _calibration(str(index) * 32, status="running", phase=phase)
             store.add_calibration_admission(run, ())
             run_ids.append(run.id)

--- a/dal-web/frontend/src/pages/CurveRun.tsx
+++ b/dal-web/frontend/src/pages/CurveRun.tsx
@@ -77,7 +77,7 @@ function CurveRunHeader({ run }: { run: CalibrationRun }) {
 function RunningPanel({ run }: { run: CalibrationRun }) {
   return (
     <section {...css("panel", "running-panel")}>
-      <span {...css("spinner")} />
+      <span {...css("spinner")} aria-hidden="true" />
       <div>
         <h2>Native solve in progress</h2>
         <p {...css("muted")}>Polling persisted phase: <code>{run.phase}</code></p>

--- a/dal-web/frontend/src/styles.css
+++ b/dal-web/frontend/src/styles.css
@@ -829,15 +829,13 @@ button.mode-tab.active strong {
 }
 
 .spinner {
-  width: 28px;
-  height: 28px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+  background: var(--amber);
+  animation: pulse 1.5s ease-in-out infinite;
+  flex: 0 0 auto;
 }
-
-@keyframes spin { to { transform: rotate(360deg); } }
 
 .failed-panel {
   border-left: 3px solid var(--red);
@@ -1543,5 +1541,14 @@ pre.debug {
 
   .cards {
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brand::before,
+  .status-dot,
+  .spinner,
+  .status-running::before {
+    animation: none;
   }
 }

--- a/dal-web/frontend/tests/unit/curve_run.test.tsx
+++ b/dal-web/frontend/tests/unit/curve_run.test.tsx
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { api, type CalibrationRun } from "../../src/api/client";
+import CurveRun from "../../src/pages/CurveRun";
+
+const styles = readFileSync("src/styles.css", "utf8");
+
+function runningRun(): CalibrationRun {
+  return {
+    id: "run-1",
+    kind: "single",
+    name: "USD OIS",
+    status: "running",
+    phase: "solving",
+    created_at: "2026-01-15T10:00:00Z",
+    started_at: "2026-01-15T10:00:01Z",
+    finished_at: null,
+    requested_jacobian_mode: "ANALYTIC",
+    actual_jacobian_mode: null,
+    curves: [],
+    instrument_diagnostics: [],
+    solver_diagnostics: null,
+    fx_forwards: null,
+    named_ranges: null,
+    jacobian: null,
+    effective_inverse: null,
+    quote_bump_preview: null,
+    error: null,
+  };
+}
+
+describe("CurveRun running state", () => {
+  it("keeps meaningful running text while hiding the animated glyph", async () => {
+    vi.spyOn(api, "getCalibration").mockResolvedValue(runningRun());
+
+    render(
+      <MemoryRouter initialEntries={["/curves/runs/run-1"]}>
+        <Routes>
+          <Route path="/curves/runs/:runId" element={<CurveRun />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Native solve in progress" }),
+    ).not.toBeNull();
+    expect(screen.getByText(/Polling persisted phase:/)).not.toBeNull();
+    expect(document.querySelector(".spinner")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("uses an opacity pulse and disables every repeating page animation for reduced motion", () => {
+    expect(styles).not.toMatch(/@keyframes\s+spin|rotate\s*\(/);
+    expect(styles).toMatch(
+      /\.spinner\s*\{[^}]*animation:\s*pulse\s+1\.5s\s+ease-in-out\s+infinite;/s,
+    );
+
+    const repeatingSelectors = Array.from(
+      styles.matchAll(/([^{}]+)\{[^{}]*animation:[^;]*infinite;[^{}]*\}/g),
+      (match) => match[1].trim(),
+    );
+    expect(repeatingSelectors).toEqual([
+      ".brand::before",
+      ".status-dot",
+      ".spinner",
+      ".status-running::before",
+    ]);
+    const reducedMotionStart = styles.indexOf("@media (prefers-reduced-motion: reduce)");
+    expect(reducedMotionStart).toBeGreaterThanOrEqual(0);
+    const reducedMotion = styles.slice(reducedMotionStart);
+    for (const selector of repeatingSelectors) {
+      expect(reducedMotion).toContain(selector);
+    }
+    expect(reducedMotion).toMatch(/animation:\s*none;/);
+  });
+});

--- a/dal-web/frontend/tests/unit/curve_run.test.tsx
+++ b/dal-web/frontend/tests/unit/curve_run.test.tsx
@@ -1,3 +1,4 @@
+// @ts-expect-error -- Vitest runs in Node; production typings intentionally exclude Node.
 import { readFileSync } from "node:fs";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -5,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { api, type CalibrationRun } from "../../src/api/client";
 import CurveRun from "../../src/pages/CurveRun";
 
-const styles = readFileSync("src/styles.css", "utf8");
+const styles = readFileSync("src/styles.css", "utf8") as string;
 
 function runningRun(): CalibrationRun {
   return {

--- a/dal-web/frontend/tests/unit/node-fs.d.ts
+++ b/dal-web/frontend/tests/unit/node-fs.d.ts
@@ -1,0 +1,3 @@
+declare module "node:fs" {
+  export function readFileSync(path: string, encoding: "utf8"): string;
+}

--- a/dal-web/frontend/tests/unit/node-fs.d.ts
+++ b/dal-web/frontend/tests/unit/node-fs.d.ts
@@ -1,3 +1,0 @@
-declare module "node:fs" {
-  export function readFileSync(path: string, encoding: "utf8"): string;
-}


### PR DESCRIPTION
## Summary
- offload synchronous Curve Lab risk admission from the FastAPI request loop and reuse the lifecycle version projector
- preserve reservation, QUEUED publication, submission-failure, audit, error, and capacity behavior with focused regression coverage
- prove native admission failures preserve HTTP status/detail and create no reservation, risk row, matrix, or audit
- add the locked Ruff format CI gate and apply exactly the 11 approved Package 1 formatter-only changes
- replace the rotating CurveRun indicator with an accessible opacity pulse that honors reduced motion
- keep Node-only CSS test access local without exposing ambient Node declarations to application TypeScript

Implements Package 1 for DAL-58.

Closes DAL-65

## Public contract
No REST/OpenAPI response, error, schema, service, store, persistence, or AAD contract changes. A submission failure still retains the published QUEUED row and releases exactly one capacity slot.

## Test plan
- [x] `uv run --no-sync pytest tests/test_curve_lab_risk_admission_offload.py -v` — 5 passed
- [x] mutation RED proves the native-failure test catches reserve-before-preflight regressions
- [x] `uv run --no-sync pytest` — 446 passed, 2 deselected
- [x] `uv run --no-sync ruff check .`
- [x] `uv run --no-sync ruff format --check .` — 76 files already formatted
- [x] `npx tsc --noEmit`
- [x] `npm test` — 79 passed
- [x] `npm run build`
- [x] workflow, rotation, reduced-motion, Node typing boundary, formatter AST-identity, diff, and Package 1 scope assertions
- [ ] Playwright e2e — setup completed, but the web server stops at native preflight because compiled `dal-python` is not installed in this checkout
