### PR TITLE
fix: prevent Report notice lifetime misuse (DAL-57)

### DIFF
--- a/dal-cpp/dal/risk/report.cpp
+++ b/dal-cpp/dal/risk/report.cpp
@@ -134,10 +134,11 @@ namespace Dal {
     void Report_::AddHeaderRow(const String_& axes, int offset, const Vector_<Cell_>& values) {
         auto& [labels_, values_] = headers_[FindAxis(axes_, axes)];
         const int nLabels = static_cast<int>(labels_.size());
+        const int nValues = static_cast<int>(values.size());
         NOTICE(nLabels);
-        REQUIRE(values.size() == labels_.size(), "Wrong number (= " + ToString(static_cast<int>(values.size())) + " of labels");
+        REQUIRE(nValues == nLabels, "Wrong number (= " + ToString(nValues) + ") of labels (= " + ToString(nLabels) + ")");
         if (offset >= values_.Rows())
-            values_.Resize(offset + 1, static_cast<int>(labels_.size()));
+            values_.Resize(offset + 1, nLabels);
         auto row = values_.Row(offset);
         Copy(values, &row);
     }

--- a/dal-cpp/dal/risk/report.cpp
+++ b/dal-cpp/dal/risk/report.cpp
@@ -133,9 +133,9 @@ namespace Dal {
 
     void Report_::AddHeaderRow(const String_& axes, int offset, const Vector_<Cell_>& values) {
         auto& [labels_, values_] = headers_[FindAxis(axes_, axes)];
-        const auto n_labels = labels_.size();
-        NOTICE(static_cast<int>(n_labels));
-        REQUIRE(values.size() == n_labels, "Wrong number (= " + ToString(static_cast<int>(values.size())) + " of labels");
+        const int nLabels = static_cast<int>(labels_.size());
+        NOTICE(nLabels);
+        REQUIRE(values.size() == labels_.size(), "Wrong number (= " + ToString(static_cast<int>(values.size())) + " of labels");
         if (offset >= values_.Rows())
             values_.Resize(offset + 1, static_cast<int>(labels_.size()));
         auto row = values_.Row(offset);

--- a/dal-cpp/tests/risk/test_report.cpp
+++ b/dal-cpp/tests/risk/test_report.cpp
@@ -166,7 +166,9 @@ TEST(RiskTest, TestReportAddHeaderRowRejectsWrongWidth) {
         report.AddHeaderRow("header1", 0, {Cell_(1.0)});
         FAIL() << "Expected AddHeaderRow to reject the wrong width";
     } catch (const Dal::Exception_& e) {
-        ASSERT_NE(std::string(e.what()).find("nLabels = 2"), std::string::npos);
+        const std::string message(e.what());
+        ASSERT_NE(message.find("Wrong number (= 1) of labels (= 2)"), std::string::npos);
+        ASSERT_NE(message.find("nLabels = 2"), std::string::npos);
     }
 }
 

--- a/dal-cpp/tests/risk/test_report.cpp
+++ b/dal-cpp/tests/risk/test_report.cpp
@@ -3,6 +3,9 @@
 //
 
 #include <gtest/gtest.h>
+
+#include <string>
+
 #include <dal/risk/report.hpp>
 #include <dal/storage/json.hpp>
 
@@ -159,7 +162,12 @@ TEST(RiskTest, TestReportSetAll) {
 TEST(RiskTest, TestReportAddHeaderRowRejectsWrongWidth) {
     const Vector_<Report::Axis_> axes = {{"header1", 2, {"a", "b"}}};
     Report_ report("test_report", axes);
-    ASSERT_THROW(report.AddHeaderRow("header1", 0, {Cell_(1.0)}), Dal::Exception_);
+    try {
+        report.AddHeaderRow("header1", 0, {Cell_(1.0)});
+        FAIL() << "Expected AddHeaderRow to reject the wrong width";
+    } catch (const Dal::Exception_& e) {
+        ASSERT_NE(std::string(e.what()).find("nLabels = 2"), std::string::npos);
+    }
 }
 
 TEST(RiskTest, TestReportAddHeaderRowExtendsValues) {


### PR DESCRIPTION
## Summary
- materialize the Report header label count before registering exception stack context, keeping the referenced integer alive for the full function scope
- strengthen the wrong-width regression test to verify the exception still reports the expected label count

## Root cause
`NOTICE(static_cast<int>(n_labels))` registered an address to a temporary integer. Exception construction dereferenced that address after the temporary's lifetime ended, producing a deterministic ASan stack-use-after-scope.

## Test plan
- [x] Configure and build Release with `DAL_ENABLE_SANITIZERS=address;undefined`
- [x] Run `RiskTest.TestReportAddHeaderRowRejectsWrongWidth` under ASan/UBSan
- [x] Run all `RiskTest.*` tests under ASan/UBSan (12 passed)
- [x] Run all `dal_cpp_tests` under ASan/UBSan (1132 passed)
- [x] Run all `dal_public_tests` under ASan/UBSan (61 passed)
- [x] Run `git clang-format --diff HEAD` and `git diff --check`

Closes DAL-57
