### PR TITLE
DAL-64: harden Krylov numerics and validation

### DIFF
--- a/dal-cpp/CMakeLists.txt
+++ b/dal-cpp/CMakeLists.txt
@@ -277,6 +277,7 @@ if(DAL_CPP_BUILD_TESTS)
     set(DAL_CPP_BCG_WORKSPACE_BOUNDARY_TEST_SOURCES
         "${PROJECT_SOURCE_DIR}/dal/math/matrix/bcg.cpp"
         "${PROJECT_SOURCE_DIR}/tests/math/matrix/test_bcg.cpp"
+        "${PROJECT_SOURCE_DIR}/test-support/bcg_allocation_probe.cpp"
         "${PROJECT_SOURCE_DIR}/tests/test_main.cpp")
 
     add_executable(dal_cpp_tests ${TEST_FILES})
@@ -298,6 +299,12 @@ if(DAL_CPP_BUILD_TESTS)
         NAME "bcg_workspace_boundary::${DAL_CPP_BCG_WORKSPACE_BOUNDARY_TEST_FILTER}"
         COMMAND dal_cpp_bcg_workspace_boundary_tests
                 "--gtest_filter=${DAL_CPP_BCG_WORKSPACE_BOUNDARY_TEST_FILTER}"
+                "--gtest_fail_if_no_test_selected")
+
+    add_test(
+        NAME "bcg_allocation_boundary::MatrixTest.TestCGSolveAndBCGSolveScaledAlphaAddsNoHeapAllocations"
+        COMMAND dal_cpp_bcg_workspace_boundary_tests
+                "--gtest_filter=MatrixTest.TestCGSolveAndBCGSolveScaledAlphaAddsNoHeapAllocations"
                 "--gtest_fail_if_no_test_selected")
 
     install(TARGETS dal_cpp_tests

--- a/dal-cpp/cmake/normalize-calibration-generated-enums.cmake
+++ b/dal-cpp/cmake/normalize-calibration-generated-enums.cmake
@@ -3,27 +3,25 @@ if(NOT DEFINED DAL_REPOSITORY_ROOT)
 endif()
 
 # Machinist's legacy Enumeration template emits trailing whitespace on an
-# otherwise-empty branch and more than one final newline. Keep the generated
-# calibration enums reproducible without rewriting unrelated legacy output.
-set(DAL_CALIBRATION_GENERATED_ENUMS
-    MG_AnalyticIneligibilityReason_enum
-    MG_CurveFreeParameterComponent_enum
-    MG_CurveKnotCandidateDisposition_enum
-    MG_CurveKnotOriginKind_enum
-    MG_RateInstrumentType_enum)
+# otherwise-empty branch and more than one final newline. Keep this manifest
+# explicit so unrelated legacy generated output is never discovered broadly.
+set(DAL_CALIBRATION_GENERATED_PATHS
+    "dal-cpp/dal/auto/MG_AnalyticIneligibilityReason_enum.hpp"
+    "dal-cpp/dal/auto/MG_AnalyticIneligibilityReason_enum.inc"
+    "dal-cpp/dal/auto/MG_CurveFreeParameterComponent_enum.hpp"
+    "dal-cpp/dal/auto/MG_CurveFreeParameterComponent_enum.inc"
+    "dal-cpp/dal/auto/MG_CurveKnotCandidateDisposition_enum.hpp"
+    "dal-cpp/dal/auto/MG_CurveKnotCandidateDisposition_enum.inc"
+    "dal-cpp/dal/auto/MG_CurveKnotOriginKind_enum.hpp"
+    "dal-cpp/dal/auto/MG_CurveKnotOriginKind_enum.inc"
+    "dal-cpp/dal/auto/MG_RateInstrumentType_enum.hpp"
+    "dal-cpp/dal/auto/MG_RateInstrumentType_enum.inc"
+    "dal-cpp/dal/auto/MG_DiscountPWC_object.hpp"
+    "dal-cpp/dal/auto/MG_DiscountPWC_v1_Read.inc"
+    "dal-cpp/dal/auto/MG_DiscountPWC_v1_Write.inc")
 
-set(DAL_CALIBRATION_GENERATED_PATHS)
-foreach(DAL_ENUM_NAME IN LISTS DAL_CALIBRATION_GENERATED_ENUMS)
-    list(APPEND DAL_CALIBRATION_GENERATED_PATHS
-        "${DAL_REPOSITORY_ROOT}/dal-cpp/dal/auto/${DAL_ENUM_NAME}.hpp"
-        "${DAL_REPOSITORY_ROOT}/dal-cpp/dal/auto/${DAL_ENUM_NAME}.inc")
-endforeach()
-list(APPEND DAL_CALIBRATION_GENERATED_PATHS
-    "${DAL_REPOSITORY_ROOT}/dal-cpp/dal/auto/MG_DiscountPWC_object.hpp"
-    "${DAL_REPOSITORY_ROOT}/dal-cpp/dal/auto/MG_DiscountPWC_v1_Read.inc"
-    "${DAL_REPOSITORY_ROOT}/dal-cpp/dal/auto/MG_DiscountPWC_v1_Write.inc")
-
-foreach(DAL_GENERATED_PATH IN LISTS DAL_CALIBRATION_GENERATED_PATHS)
+foreach(DAL_GENERATED_RELATIVE_PATH IN LISTS DAL_CALIBRATION_GENERATED_PATHS)
+    set(DAL_GENERATED_PATH "${DAL_REPOSITORY_ROOT}/${DAL_GENERATED_RELATIVE_PATH}")
     if(NOT EXISTS "${DAL_GENERATED_PATH}")
         message(FATAL_ERROR "Expected generated source is missing: ${DAL_GENERATED_PATH}")
     endif()

--- a/dal-cpp/cmake/tests/test-normalize-calibration-generated-enums.cmake
+++ b/dal-cpp/cmake/tests/test-normalize-calibration-generated-enums.cmake
@@ -1,0 +1,123 @@
+cmake_minimum_required(VERSION 3.21)
+
+get_filename_component(DAL_NORMALIZER_REPOSITORY_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+set(DAL_NORMALIZER_SCRIPT
+    "${DAL_NORMALIZER_REPOSITORY_ROOT}/dal-cpp/cmake/normalize-calibration-generated-enums.cmake")
+if(DEFINED DAL_NORMALIZER_UNDER_TEST)
+    set(DAL_NORMALIZER_SCRIPT "${DAL_NORMALIZER_UNDER_TEST}")
+endif()
+
+set(DAL_NORMALIZER_EXPECTED_PATHS
+    dal-cpp/dal/auto/MG_AnalyticIneligibilityReason_enum.hpp
+    dal-cpp/dal/auto/MG_AnalyticIneligibilityReason_enum.inc
+    dal-cpp/dal/auto/MG_CurveFreeParameterComponent_enum.hpp
+    dal-cpp/dal/auto/MG_CurveFreeParameterComponent_enum.inc
+    dal-cpp/dal/auto/MG_CurveKnotCandidateDisposition_enum.hpp
+    dal-cpp/dal/auto/MG_CurveKnotCandidateDisposition_enum.inc
+    dal-cpp/dal/auto/MG_CurveKnotOriginKind_enum.hpp
+    dal-cpp/dal/auto/MG_CurveKnotOriginKind_enum.inc
+    dal-cpp/dal/auto/MG_RateInstrumentType_enum.hpp
+    dal-cpp/dal/auto/MG_RateInstrumentType_enum.inc
+    dal-cpp/dal/auto/MG_DiscountPWC_object.hpp
+    dal-cpp/dal/auto/MG_DiscountPWC_v1_Read.inc
+    dal-cpp/dal/auto/MG_DiscountPWC_v1_Write.inc)
+
+file(READ "${DAL_NORMALIZER_SCRIPT}" DAL_NORMALIZER_SOURCE)
+foreach(DAL_EXPECTED_PATH IN LISTS DAL_NORMALIZER_EXPECTED_PATHS)
+    string(FIND "${DAL_NORMALIZER_SOURCE}" "\"${DAL_EXPECTED_PATH}\"" DAL_MANIFEST_MEMBER_POSITION)
+    if(DAL_MANIFEST_MEMBER_POSITION EQUAL -1)
+        message(FATAL_ERROR "Normalizer fixed manifest is missing: ${DAL_EXPECTED_PATH}")
+    endif()
+endforeach()
+if(DAL_NORMALIZER_SOURCE MATCHES "file\\([ \t\r\n]*GLOB")
+    message(FATAL_ERROR "Normalizer fixed manifest must not use broad discovery")
+endif()
+if(DAL_NORMALIZER_CONTRACT_ONLY)
+    return()
+endif()
+
+if(DEFINED ENV{TMPDIR} AND NOT "$ENV{TMPDIR}" STREQUAL "")
+    set(DAL_NORMALIZER_TEMP_PARENT "$ENV{TMPDIR}")
+elseif(DEFINED ENV{TEMP} AND NOT "$ENV{TEMP}" STREQUAL "")
+    set(DAL_NORMALIZER_TEMP_PARENT "$ENV{TEMP}")
+else()
+    set(DAL_NORMALIZER_TEMP_PARENT "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+set(DAL_NORMALIZER_TEMP_ROOT "${DAL_NORMALIZER_TEMP_PARENT}/dal-normalizer-selftest")
+file(REMOVE_RECURSE "${DAL_NORMALIZER_TEMP_ROOT}")
+file(MAKE_DIRECTORY "${DAL_NORMALIZER_TEMP_ROOT}")
+
+function(DAL_WRITE_NORMALIZER_FIXTURE DAL_FIXTURE_ROOT)
+    foreach(DAL_EXPECTED_PATH IN LISTS DAL_NORMALIZER_EXPECTED_PATHS)
+        get_filename_component(DAL_EXPECTED_DIRECTORY "${DAL_FIXTURE_ROOT}/${DAL_EXPECTED_PATH}" DIRECTORY)
+        file(MAKE_DIRECTORY "${DAL_EXPECTED_DIRECTORY}")
+        file(WRITE "${DAL_FIXTURE_ROOT}/${DAL_EXPECTED_PATH}" "alpha   \nblank\t \n\n\n")
+    endforeach()
+    set(DAL_LEGACY_PATH "${DAL_FIXTURE_ROOT}/dal-cpp/dal/auto/MG_Legacy_enum.hpp")
+    file(WRITE "${DAL_LEGACY_PATH}" "legacy \t\n\n")
+endfunction()
+
+set(DAL_POSITIVE_ROOT "${DAL_NORMALIZER_TEMP_ROOT}/positive")
+DAL_WRITE_NORMALIZER_FIXTURE("${DAL_POSITIVE_ROOT}")
+file(SHA256 "${DAL_POSITIVE_ROOT}/dal-cpp/dal/auto/MG_Legacy_enum.hpp" DAL_LEGACY_BEFORE)
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" "-DDAL_REPOSITORY_ROOT=${DAL_POSITIVE_ROOT}" -P "${DAL_NORMALIZER_SCRIPT}"
+    RESULT_VARIABLE DAL_POSITIVE_RESULT
+    OUTPUT_VARIABLE DAL_POSITIVE_STDOUT
+    ERROR_VARIABLE DAL_POSITIVE_STDERR)
+if(NOT DAL_POSITIVE_RESULT EQUAL 0)
+    message(FATAL_ERROR "Production normalizer failed the complete fixed manifest: ${DAL_POSITIVE_STDOUT}${DAL_POSITIVE_STDERR}")
+endif()
+foreach(DAL_EXPECTED_PATH IN LISTS DAL_NORMALIZER_EXPECTED_PATHS)
+    file(READ "${DAL_POSITIVE_ROOT}/${DAL_EXPECTED_PATH}" DAL_NORMALIZED_CONTENT)
+    if(NOT DAL_NORMALIZED_CONTENT STREQUAL "alpha\nblank\n")
+        message(FATAL_ERROR "Fixed manifest member was not normalized: ${DAL_EXPECTED_PATH}")
+    endif()
+endforeach()
+file(SHA256 "${DAL_POSITIVE_ROOT}/dal-cpp/dal/auto/MG_Legacy_enum.hpp" DAL_LEGACY_AFTER)
+if(NOT DAL_LEGACY_BEFORE STREQUAL DAL_LEGACY_AFTER)
+    message(FATAL_ERROR "Unlisted legacy enum was modified")
+endif()
+
+set(DAL_MISSING_MEMBER "dal-cpp/dal/auto/MG_CurveKnotOriginKind_enum.inc")
+set(DAL_MISSING_ROOT "${DAL_NORMALIZER_TEMP_ROOT}/missing")
+DAL_WRITE_NORMALIZER_FIXTURE("${DAL_MISSING_ROOT}")
+file(REMOVE "${DAL_MISSING_ROOT}/${DAL_MISSING_MEMBER}")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" "-DDAL_REPOSITORY_ROOT=${DAL_MISSING_ROOT}" -P "${DAL_NORMALIZER_SCRIPT}"
+    RESULT_VARIABLE DAL_MISSING_RESULT
+    OUTPUT_VARIABLE DAL_MISSING_STDOUT
+    ERROR_VARIABLE DAL_MISSING_STDERR)
+if(DAL_MISSING_RESULT EQUAL 0)
+    message(FATAL_ERROR "Missing fixed manifest member was accepted: ${DAL_MISSING_MEMBER}")
+endif()
+string(FIND "${DAL_MISSING_STDOUT}${DAL_MISSING_STDERR}" "MG_CurveKnotOriginKind_enum.inc" DAL_MISSING_NAME_POSITION)
+if(DAL_MISSING_NAME_POSITION EQUAL -1)
+    message(FATAL_ERROR "Missing-member failure did not name: ${DAL_MISSING_MEMBER}")
+endif()
+
+set(DAL_MANIFEST_LOSS_MEMBER "dal-cpp/dal/auto/MG_RateInstrumentType_enum.inc")
+set(DAL_MUTATED_SCRIPT "${DAL_NORMALIZER_TEMP_ROOT}/normalizer-with-manifest-loss.cmake")
+string(REPLACE "    \"${DAL_MANIFEST_LOSS_MEMBER}\"\n" "" DAL_MUTATED_SOURCE "${DAL_NORMALIZER_SOURCE}")
+if(DAL_MUTATED_SOURCE STREQUAL DAL_NORMALIZER_SOURCE)
+    message(FATAL_ERROR "Manifest-loss mutation anchor was not unique")
+endif()
+file(WRITE "${DAL_MUTATED_SCRIPT}" "${DAL_MUTATED_SOURCE}")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+            "-DDAL_NORMALIZER_UNDER_TEST=${DAL_MUTATED_SCRIPT}"
+            -DDAL_NORMALIZER_CONTRACT_ONLY=ON
+            -P "${CMAKE_CURRENT_LIST_FILE}"
+    RESULT_VARIABLE DAL_MANIFEST_LOSS_RESULT
+    OUTPUT_VARIABLE DAL_MANIFEST_LOSS_STDOUT
+    ERROR_VARIABLE DAL_MANIFEST_LOSS_STDERR)
+if(DAL_MANIFEST_LOSS_RESULT EQUAL 0)
+    message(FATAL_ERROR "Fixed manifest loss was accepted: ${DAL_MANIFEST_LOSS_MEMBER}")
+endif()
+string(FIND "${DAL_MANIFEST_LOSS_STDOUT}${DAL_MANIFEST_LOSS_STDERR}" "MG_RateInstrumentType_enum.inc" DAL_MANIFEST_LOSS_NAME_POSITION)
+if(DAL_MANIFEST_LOSS_NAME_POSITION EQUAL -1)
+    message(FATAL_ERROR "Manifest-loss failure did not name: ${DAL_MANIFEST_LOSS_MEMBER}")
+endif()
+
+file(REMOVE_RECURSE "${DAL_NORMALIZER_TEMP_ROOT}")
+message(STATUS "Calibration generated normalizer fixed-manifest self-test passed")

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -2,7 +2,6 @@
 // Created by wegamekinglc on 22-12-17.
 //
 
-#include <array>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -18,6 +17,9 @@
 #include <dal/utilities/algorithms.hpp>
 #include <dal/utilities/numerics.hpp>
 #include <dal/math/matrix/bcg_scaled_alpha.inc>
+#if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
+#include <test-support/bcg_allocation_probe.hpp>
+#endif
 
 #if defined(DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION) && !defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
 #error "DAL35_PROBE_ORDINARY_WORKSPACE_CONSTRUCTION requires DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM"
@@ -135,29 +137,47 @@ namespace Dal {
             return NormalizeScaled(lhs.mantissa_ + std::ldexp(rhs.mantissa_, rhs.exponent_ - lhs.exponent_), lhs.exponent_);
         }
 
-        Scaled_ SlowScaledNorm(const Vector_<>& values) {
-            double scale = 0.0;
-            double sumSquares = 1.0;
-            for (const double value : values) {
+        struct ScaledSumSquares_ {
+            double scale_ = 0.0;
+            double sumSquares_ = 1.0;
+
+            void Add(double value) {
                 const double magnitude = std::fabs(value);
                 if (magnitude == 0.0)
-                    continue;
-                if (scale < magnitude) {
-                    const double ratio = scale / magnitude;
-                    sumSquares = 1.0 + sumSquares * ratio * ratio;
-                    scale = magnitude;
+                    return;
+                if (scale_ < magnitude) {
+                    const double ratio = scale_ / magnitude;
+                    sumSquares_ = 1.0 + sumSquares_ * ratio * ratio;
+                    scale_ = magnitude;
                 } else {
-                    const double ratio = magnitude / scale;
-                    sumSquares += ratio * ratio;
+                    const double ratio = magnitude / scale_;
+                    sumSquares_ += ratio * ratio;
                 }
             }
-            return scale == 0.0 ? Scaled_{0.0, 0, false} : MultiplyScaled(ScaledFromDouble(scale), std::sqrt(sumSquares));
+
+            Scaled_ Norm() const {
+                return scale_ == 0.0 ? Scaled_{0.0, 0, false} : MultiplyScaled(ScaledFromDouble(scale_), std::sqrt(sumSquares_));
+            }
+        };
+
+        Scaled_ SlowScaledNorm(const Vector_<>& values) {
+            ScaledSumSquares_ statistics;
+            for (const double value : values)
+                statistics.Add(value);
+            return statistics.Norm();
+        }
+
+        bool IsReliableSquareSum(double sumSquares) {
+            return std::isfinite(sumSquares) && sumSquares >= std::numeric_limits<double>::min();
+        }
+
+        Scaled_ NormFromSquareSum(const Vector_<>& values, double sumSquares) {
+            return IsReliableSquareSum(sumSquares) ? ScaledFromDouble(std::sqrt(sumSquares)) : SlowScaledNorm(values);
         }
 
         Scaled_ ScaledNorm(const Vector_<>& values) {
             const double sumSquares = InnerProduct(values, values);
-            return std::isfinite(sumSquares) && sumSquares >= std::numeric_limits<double>::min() ? ScaledFromDouble(std::sqrt(sumSquares))
-                                                                                                 : SlowScaledNorm(values);
+            return NormFromSquareSum(values, sumSquares);
         }
 
         bool ScaledLessOrEqual(Scaled_ lhs, Scaled_ rhs) {
@@ -202,38 +222,18 @@ namespace Dal {
                           BcgScaledAlphaPrivate_::REVIEWED_BOUNDS_FINGERPRINT_),
                       "DAL35_PRODUCTION_DERIVED_BOUNDS_FINGERPRINT_MISMATCH");
 
-        struct ExactPositive_ {
-            std::array<std::uint32_t, EXACT_LIMB_COUNT> limbs_{};
-            int first_ = EXACT_LIMB_COUNT;
-            int last_ = -1;
-        };
-
-        void ExactAddAt(int index, std::uint32_t value, ExactPositive_* result) {
-            std::uint64_t carry = value;
-            while (carry != 0) {
-                const std::uint64_t sum = static_cast<std::uint64_t>(result->limbs_[index]) + carry;
-                result->limbs_[index] = static_cast<std::uint32_t>(sum);
-                result->first_ = std::min(result->first_, index);
-                result->last_ = std::max(result->last_, index);
-                carry = sum >> EXACT_LIMB_BITS;
-                ++index;
-            }
-        }
+        using ExactPositive_ =
+            BcgExactMagnitudePrivate_::Magnitude_<EXACT_LIMB_COUNT, EXACT_LIMB_COUNT * EXACT_LIMB_BITS - 1>;
 
         void ExactAddShiftedLimb(std::uint32_t value, int exponent, ExactPositive_* result) {
             if (value == 0)
                 return;
             const int offset = exponent - EXACT_MIN_EXPONENT;
-            const int index = offset / EXACT_LIMB_BITS;
-            const int shift = offset % EXACT_LIMB_BITS;
-            const std::uint64_t shifted = static_cast<std::uint64_t>(value) << shift;
-            ExactAddAt(index, static_cast<std::uint32_t>(shifted), result);
-            ExactAddAt(index + 1, static_cast<std::uint32_t>(shifted >> EXACT_LIMB_BITS), result);
+            (void)BcgExactMagnitudePrivate_::AddShiftedLimb_(value, offset, result);
         }
 
         void ExactAddShiftedWord(std::uint64_t value, int exponent, ExactPositive_* result) {
-            ExactAddShiftedLimb(static_cast<std::uint32_t>(value), exponent, result);
-            ExactAddShiftedLimb(static_cast<std::uint32_t>(value >> EXACT_LIMB_BITS), exponent + EXACT_LIMB_BITS, result);
+            (void)BcgExactMagnitudePrivate_::AddShiftedWord_(value, exponent - EXACT_MIN_EXPONENT, result);
         }
 
         void ExactAddDoubleProduct(double lhs, double rhs, ExactPositive_* result) {
@@ -243,14 +243,8 @@ namespace Dal {
             int rhsExponent = 0;
             const std::uint64_t lhsSignificand = static_cast<std::uint64_t>(std::ldexp(std::frexp(std::fabs(lhs), &lhsExponent), 53));
             const std::uint64_t rhsSignificand = static_cast<std::uint64_t>(std::ldexp(std::frexp(std::fabs(rhs), &rhsExponent), 53));
-            const std::uint64_t lhsLow = static_cast<std::uint32_t>(lhsSignificand);
-            const std::uint64_t lhsHigh = lhsSignificand >> EXACT_LIMB_BITS;
-            const std::uint64_t rhsLow = static_cast<std::uint32_t>(rhsSignificand);
-            const std::uint64_t rhsHigh = rhsSignificand >> EXACT_LIMB_BITS;
             const int exponent = lhsExponent + rhsExponent - 106;
-            ExactAddShiftedWord(lhsLow * rhsLow, exponent, result);
-            ExactAddShiftedWord(lhsLow * rhsHigh + lhsHigh * rhsLow, exponent + EXACT_LIMB_BITS, result);
-            ExactAddShiftedWord(lhsHigh * rhsHigh, exponent + 2 * EXACT_LIMB_BITS, result);
+            (void)BcgExactMagnitudePrivate_::AddProduct_(lhsSignificand, rhsSignificand, exponent - EXACT_MIN_EXPONENT, result);
         }
 
         ExactPositive_ ExactNormSquare(const Vector_<>& values) {
@@ -260,73 +254,26 @@ namespace Dal {
             return result;
         }
 
-        void ExactTrim(ExactPositive_* value) {
-            while (value->first_ <= value->last_ && value->limbs_[value->first_] == 0)
-                ++value->first_;
-            while (value->last_ >= value->first_ && value->limbs_[value->last_] == 0)
-                --value->last_;
-            if (value->last_ < value->first_) {
-                value->first_ = EXACT_LIMB_COUNT;
-                value->last_ = -1;
-            }
-        }
-
         int ExactCompare(const ExactPositive_& lhs, const ExactPositive_& rhs) {
-            if (lhs.last_ != rhs.last_)
-                return lhs.last_ < rhs.last_ ? -1 : 1;
-            for (int index = lhs.last_; index >= std::min(lhs.first_, rhs.first_); --index) {
-                if (lhs.limbs_[index] != rhs.limbs_[index])
-                    return lhs.limbs_[index] < rhs.limbs_[index] ? -1 : 1;
-            }
-            return 0;
+            return BcgExactMagnitudePrivate_::Compare_(lhs, rhs);
         }
 
         ExactPositive_ ExactAdd(ExactPositive_ lhs, const ExactPositive_& rhs) {
-            for (int index = rhs.first_; index <= rhs.last_; ++index)
-                ExactAddAt(index, rhs.limbs_[index], &lhs);
+            (void)BcgExactMagnitudePrivate_::Add_(rhs, &lhs);
             return lhs;
         }
 
         ExactPositive_ ExactSubtract(const ExactPositive_& lhs, const ExactPositive_& rhs) {
-            ExactPositive_ result;
-            std::uint64_t borrow = 0;
-            for (int index = 0; index < EXACT_LIMB_COUNT; ++index) {
-                const std::uint64_t subtrahend = static_cast<std::uint64_t>(rhs.limbs_[index]) + borrow;
-                const std::uint64_t minuend = lhs.limbs_[index];
-                if (minuend < subtrahend) {
-                    result.limbs_[index] = static_cast<std::uint32_t>((1ULL << EXACT_LIMB_BITS) + minuend - subtrahend);
-                    borrow = 1;
-                } else {
-                    result.limbs_[index] = static_cast<std::uint32_t>(minuend - subtrahend);
-                    borrow = 0;
-                }
-            }
-            result.first_ = 0;
-            result.last_ = EXACT_LIMB_COUNT - 1;
-            ExactTrim(&result);
+            ExactPositive_ result = lhs;
+            (void)BcgExactMagnitudePrivate_::Subtract_(rhs, &result);
             return result;
         }
 
-        bool ExactBit(const ExactPositive_& value, int bit) { return (value.limbs_[bit / EXACT_LIMB_BITS] & (1U << (bit % EXACT_LIMB_BITS))) != 0; }
+        bool ExactBit(const ExactPositive_& value, int bit) { return BcgExactMagnitudePrivate_::Bit_(value, bit); }
 
-        bool ExactHasBitBelow(const ExactPositive_& value, int bit) {
-            const int lastFullLimb = bit / EXACT_LIMB_BITS;
-            for (int index = value.first_; index < lastFullLimb; ++index)
-                if (value.limbs_[index] != 0)
-                    return true;
-            const int partialBits = bit % EXACT_LIMB_BITS;
-            if (lastFullLimb < value.first_ || partialBits == 0)
-                return false;
-            const std::uint32_t mask = (1U << partialBits) - 1U;
-            return (value.limbs_[lastFullLimb] & mask) != 0;
-        }
+        bool ExactHasBitBelow(const ExactPositive_& value, int bit) { return BcgExactMagnitudePrivate_::HasBitBelow_(value, bit); }
 
-        int ExactHighestBit(const ExactPositive_& value) {
-            int highestLimbBit = 0;
-            for (std::uint32_t top = value.limbs_[value.last_]; top > 1; top >>= 1)
-                ++highestLimbBit;
-            return EXACT_LIMB_BITS * value.last_ + highestLimbBit;
-        }
+        int ExactHighestBit(const ExactPositive_& value) { return BcgExactMagnitudePrivate_::HighestBit_(value); }
 
         std::uint64_t ExactLeadingSignificand(const ExactPositive_& value, int highestBit) {
             std::uint64_t significand = 0;
@@ -641,10 +588,7 @@ namespace Dal {
             return ratio;
         }
 
-        void StableCombination(
-            double multiplier, const Vector_<>& values, const Vector_<>& base, const char* solver, const char* subject, Vector_<>* result) {
-            (void)solver;
-            (void)subject;
+        void StableCombination(double multiplier, const Vector_<>& values, const Vector_<>& base, Vector_<>* result) {
             for (int i = 0; i < static_cast<int>(values.size()); ++i)
                 (*result)[i] = std::fma(multiplier, values[i], base[i]);
         }
@@ -755,11 +699,6 @@ namespace Dal {
                 ThrowFailure(solver, "numerical breakdown", "direct residual");
         }
 
-        Scaled_ DirectResidualNorm(const Vector_<>& residual, double squareSum) {
-            if (std::isfinite(squareSum) && squareSum >= std::numeric_limits<double>::min())
-                return ScaledFromDouble(std::sqrt(squareSum));
-            return SlowScaledNorm(residual);
-        }
 #endif
 
         Scaled_ ValidatedDirectResidual(Vector_<>* callbackValues, const Vector_<>& b, int expectedSize, const char* solver, const char* callback) {
@@ -768,11 +707,11 @@ namespace Dal {
             DirectResidualEvidence_ evidence = AccumulateDirectResidualPrefix(callbackValues, b, expectedSize);
             AccumulateDirectResidualTail(callbackValues, b, expectedSize, &evidence);
             ValidateDirectResidualEvidence(*callbackValues, expectedSize, evidence, solver, callback);
-            return DirectResidualNorm(*callbackValues, evidence.squareSum_);
+            return NormFromSquareSum(*callbackValues, evidence.squareSum_);
 #else
             ValidateCallbackResult(*callbackValues, expectedSize, solver, callback, false);
             StableBatch_ stableBatch;
-            StableCombination(-1.0, *callbackValues, b, solver, "direct residual", callbackValues);
+            StableCombination(-1.0, *callbackValues, b, callbackValues);
             stableBatch.Finish(solver, *callbackValues, "direct residual");
             return ScaledNorm(*callbackValues);
 #endif
@@ -840,10 +779,10 @@ namespace Dal {
         void PrepareDirectionCandidates(
             KrylovState_* state, double betaRatio, const Vector_<>& leftPreconditioned, const Vector_<>& rightPreconditioned, const char* solver) {
             StableBatch_ stableBatch;
-            StableCombination(betaRatio, state->p_, leftPreconditioned, solver, "candidate direction", &state->pCandidate_);
+            StableCombination(betaRatio, state->p_, leftPreconditioned, &state->pCandidate_);
             const Vector_<>* shadowCandidate = nullptr;
             if (NeedsShadowDirection(*state)) {
-                StableCombination(betaRatio, state->pp_, rightPreconditioned, solver, "candidate shadow direction", &state->ppCandidate_);
+                StableCombination(betaRatio, state->pp_, rightPreconditioned, &state->ppCandidate_);
                 shadowCandidate = &state->ppCandidate_;
             }
             stableBatch.Finish(solver, state->pCandidate_, "candidate direction", shadowCandidate, "candidate shadow direction");
@@ -868,6 +807,10 @@ namespace Dal {
         }
 
         void PrepareScaledCandidates(KrylovState_& s, const BcgScaledAlphaPrivate_::ExactAlpha_& alpha, const Vector_<>& x, const char* solver) {
+#if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
+            BcgAllocationProbePrivate_::Reset_();
+            BcgAllocationProbePrivate_::Measurement_ allocationMeasurement;
+#endif
             BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
 #if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
             Dal35ObserveExactWorkspaceConstructionForTest_();
@@ -880,6 +823,9 @@ namespace Dal {
                                                                 &s.rCandidate_,
                                                                 s.biConjugate_ ? &s.rrCandidate_ : nullptr};
             const BcgScaledAlphaPrivate_::CandidateEvidence_ evidence = BcgScaledAlphaPrivate_::EvaluateCandidateGroup_(alpha, group, &workspace);
+#if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
+            allocationMeasurement.Finish_();
+#endif
             if (evidence.subject_ == BcgScaledAlphaPrivate_::CandidateSubject_::X)
                 ThrowFailure(solver, "numerical breakdown", "candidate x");
             if (evidence.subject_ == BcgScaledAlphaPrivate_::CandidateSubject_::RESIDUAL)
@@ -922,10 +868,10 @@ namespace Dal {
             s.A_.MultiplyLeft(s.pCandidate_, &s.rCandidate_);
             ValidateCallbackResult(s.rCandidate_, s.A_.Size(), solver, "MultiplyLeft", false);
             const Vector_<>& rightDirection = s.symmetricBiConjugate_ ? s.pCandidate_ : s.ppCandidate_;
-            if (s.biConjugate_)
+            if (s.biConjugate_) {
                 s.A_.MultiplyRight(rightDirection, &s.rrCandidate_);
-            if (s.biConjugate_)
                 ValidateCallbackResult(s.rrCandidate_, s.A_.Size(), solver, "MultiplyRight", false);
+            }
 
             const Vector_<>& shadowDirection = s.biConjugate_ ? rightDirection : s.pCandidate_;
             const Scaled_ alphaDenominator = ScaledDot(s.rCandidate_, shadowDirection);
@@ -942,10 +888,10 @@ namespace Dal {
                 return;
 #endif
             StableBatch_ stableBatch;
-            StableCombination(alpha, s.pCandidate_, x, solver, "candidate x", &s.xCandidate_);
-            StableCombination(-alpha, s.rCandidate_, s.r_, solver, "candidate residual", &s.rCandidate_);
+            StableCombination(alpha, s.pCandidate_, x, &s.xCandidate_);
+            StableCombination(-alpha, s.rCandidate_, s.r_, &s.rCandidate_);
             if (s.biConjugate_)
-                StableCombination(-alpha, s.rrCandidate_, s.rr_, solver, "candidate shadow residual", &s.rrCandidate_);
+                StableCombination(-alpha, s.rrCandidate_, s.rr_, &s.rrCandidate_);
             stableBatch.Finish(solver, s.xCandidate_, "candidate x", &s.rCandidate_, "candidate residual", s.biConjugate_ ? &s.rrCandidate_ : nullptr,
                                "candidate shadow residual");
         }
@@ -994,8 +940,7 @@ namespace Dal {
                 ValidateFiniteInput(b, solver, "b");
                 ValidateFiniteInput(x, solver, "x");
             }
-            return std::isfinite(sumSquares) && sumSquares >= std::numeric_limits<double>::min() ? ScaledFromDouble(std::sqrt(sumSquares))
-                                                                                                 : SlowScaledNorm(b);
+            return NormFromSquareSum(b, sumSquares);
         }
 
         void

--- a/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
+++ b/dal-cpp/dal/math/matrix/bcg_scaled_alpha.inc
@@ -1,3 +1,7 @@
+//
+// Created by dal-implementer on 2026/8/1.
+//
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -10,6 +14,193 @@
 
 namespace Dal {
     namespace {
+        namespace BcgExactMagnitudePrivate_ {
+            constexpr int LIMB_BITS_ = 32;
+
+            template <int LimbCount_, int MaxBitIndex_> struct Magnitude_ {
+                static constexpr int LIMB_COUNT_ = LimbCount_;
+                static constexpr int MAX_BIT_INDEX_ = MaxBitIndex_;
+
+                std::array<std::uint32_t, LimbCount_> limbs_{};
+                int first_ = LimbCount_;
+                int last_ = -1;
+            };
+
+            template <class Magnitude_> inline void Reset_(Magnitude_* magnitude) noexcept {
+                if (magnitude->first_ == Magnitude_::LIMB_COUNT_ && magnitude->last_ == -1)
+                    return;
+                if (magnitude->first_ >= 0 && magnitude->first_ <= magnitude->last_ && magnitude->last_ < Magnitude_::LIMB_COUNT_) {
+                    for (int i = magnitude->first_; i <= magnitude->last_; ++i)
+                        magnitude->limbs_[i] = 0;
+                } else {
+                    for (std::uint32_t& limb : magnitude->limbs_)
+                        limb = 0;
+                }
+                magnitude->first_ = Magnitude_::LIMB_COUNT_;
+                magnitude->last_ = -1;
+            }
+
+            template <class Magnitude_> inline void Touch_(int limb, Magnitude_* magnitude) noexcept {
+                magnitude->first_ = std::min(magnitude->first_, limb);
+                magnitude->last_ = std::max(magnitude->last_, limb);
+            }
+
+            template <class Magnitude_> inline bool WordFits_(int limb, std::uint32_t value) noexcept {
+                if (value == 0)
+                    return true;
+                if (limb < 0 || limb >= Magnitude_::LIMB_COUNT_)
+                    return false;
+                const int availableBits = Magnitude_::MAX_BIT_INDEX_ - LIMB_BITS_ * limb + 1;
+                return availableBits >= LIMB_BITS_ || (availableBits > 0 && (value >> availableBits) == 0);
+            }
+
+            template <class Magnitude_> inline bool AddAt_(int limb, std::uint32_t value, Magnitude_* magnitude) noexcept {
+                std::uint64_t carry = value;
+                while (carry != 0) {
+                    if (limb < 0 || limb >= Magnitude_::LIMB_COUNT_)
+                        return false;
+                    const std::uint64_t sum = static_cast<std::uint64_t>(magnitude->limbs_[limb]) + carry;
+                    const std::uint32_t word = static_cast<std::uint32_t>(sum);
+                    if (!WordFits_<Magnitude_>(limb, word))
+                        return false;
+                    magnitude->limbs_[limb] = word;
+                    Touch_(limb, magnitude);
+                    carry = sum >> LIMB_BITS_;
+                    ++limb;
+                }
+                return true;
+            }
+
+            template <class Magnitude_>
+            inline bool AddShiftedLimb_(std::uint32_t value, int firstBit, Magnitude_* magnitude) noexcept {
+                if (value == 0)
+                    return true;
+                if (firstBit < 0)
+                    return false;
+                const int limb = firstBit / LIMB_BITS_;
+                const int shift = firstBit % LIMB_BITS_;
+                const std::uint64_t shifted = static_cast<std::uint64_t>(value) << shift;
+                return AddAt_(limb, static_cast<std::uint32_t>(shifted), magnitude) &&
+                       AddAt_(limb + 1, static_cast<std::uint32_t>(shifted >> LIMB_BITS_), magnitude);
+            }
+
+            template <class Magnitude_>
+            inline bool AddShiftedWord_(std::uint64_t value, int firstBit, Magnitude_* magnitude) noexcept {
+                return AddShiftedLimb_(static_cast<std::uint32_t>(value), firstBit, magnitude) &&
+                       AddShiftedLimb_(static_cast<std::uint32_t>(value >> LIMB_BITS_), firstBit + LIMB_BITS_, magnitude);
+            }
+
+            inline std::array<std::uint32_t, 4> Multiply53_(std::uint64_t lhs, std::uint64_t rhs) noexcept {
+                const std::array<std::uint32_t, 2> left = {static_cast<std::uint32_t>(lhs), static_cast<std::uint32_t>(lhs >> LIMB_BITS_)};
+                const std::array<std::uint32_t, 2> right = {static_cast<std::uint32_t>(rhs), static_cast<std::uint32_t>(rhs >> LIMB_BITS_)};
+                std::array<std::uint32_t, 4> result{};
+                for (int i = 0; i < 2; ++i) {
+                    std::uint64_t carry = 0;
+                    for (int j = 0; j < 2; ++j) {
+                        const std::uint64_t sum = static_cast<std::uint64_t>(result[i + j]) + static_cast<std::uint64_t>(left[i]) * right[j] + carry;
+                        result[i + j] = static_cast<std::uint32_t>(sum);
+                        carry = sum >> LIMB_BITS_;
+                    }
+                    int output = i + 2;
+                    while (carry != 0 && output < static_cast<int>(result.size())) {
+                        const std::uint64_t sum = static_cast<std::uint64_t>(result[output]) + carry;
+                        result[output] = static_cast<std::uint32_t>(sum);
+                        carry = sum >> LIMB_BITS_;
+                        ++output;
+                    }
+                }
+                return result;
+            }
+
+            template <class Magnitude_>
+            inline bool AddProduct_(std::uint64_t lhs, std::uint64_t rhs, int firstBit, Magnitude_* magnitude) noexcept {
+                if (lhs == 0 || rhs == 0)
+                    return true;
+                const std::array<std::uint32_t, 4> product = Multiply53_(lhs, rhs);
+                for (int word = 0; word < static_cast<int>(product.size()); ++word)
+                    if (!AddShiftedLimb_(product[word], firstBit + LIMB_BITS_ * word, magnitude))
+                        return false;
+                return true;
+            }
+
+            template <class Magnitude_> inline void Trim_(Magnitude_* magnitude) noexcept {
+                while (magnitude->first_ <= magnitude->last_ && magnitude->limbs_[magnitude->first_] == 0)
+                    ++magnitude->first_;
+                while (magnitude->last_ >= magnitude->first_ && magnitude->limbs_[magnitude->last_] == 0)
+                    --magnitude->last_;
+                if (magnitude->last_ < magnitude->first_) {
+                    magnitude->first_ = Magnitude_::LIMB_COUNT_;
+                    magnitude->last_ = -1;
+                }
+            }
+
+            template <class Magnitude_> inline int Compare_(const Magnitude_& lhs, const Magnitude_& rhs) noexcept {
+                if (lhs.last_ != rhs.last_)
+                    return lhs.last_ < rhs.last_ ? -1 : 1;
+                for (int i = lhs.last_; i >= std::min(lhs.first_, rhs.first_); --i)
+                    if (lhs.limbs_[i] != rhs.limbs_[i])
+                        return lhs.limbs_[i] < rhs.limbs_[i] ? -1 : 1;
+                return 0;
+            }
+
+            template <class Magnitude_> inline bool Add_(const Magnitude_& rhs, Magnitude_* lhs) noexcept {
+                for (int i = rhs.first_; i <= rhs.last_; ++i)
+                    if (!AddAt_(i, rhs.limbs_[i], lhs))
+                        return false;
+                return true;
+            }
+
+            template <class Magnitude_> inline bool Subtract_(const Magnitude_& rhs, Magnitude_* lhs) noexcept {
+                const int first = std::min(lhs->first_, rhs.first_);
+                const int last = lhs->last_;
+                lhs->first_ = first;
+                std::uint64_t borrow = 0;
+                for (int i = first; i <= last; ++i) {
+                    Touch_(i, lhs);
+                    const std::uint64_t subtrahend = static_cast<std::uint64_t>(rhs.limbs_[i]) + borrow;
+                    const std::uint64_t minuend = lhs->limbs_[i];
+                    if (minuend < subtrahend) {
+                        lhs->limbs_[i] = static_cast<std::uint32_t>((1ULL << LIMB_BITS_) + minuend - subtrahend);
+                        borrow = 1;
+                    } else {
+                        lhs->limbs_[i] = static_cast<std::uint32_t>(minuend - subtrahend);
+                        borrow = 0;
+                    }
+                }
+                Trim_(lhs);
+                return borrow == 0;
+            }
+
+            template <class Magnitude_> inline bool Bit_(const Magnitude_& value, int bit) noexcept {
+                if (bit < 0 || bit > Magnitude_::MAX_BIT_INDEX_)
+                    return false;
+                return (value.limbs_[bit / LIMB_BITS_] & (1U << (bit % LIMB_BITS_))) != 0;
+            }
+
+            template <class Magnitude_> inline bool HasBitBelow_(const Magnitude_& value, int exclusiveBit) noexcept {
+                if (exclusiveBit <= 0 || value.last_ < value.first_)
+                    return false;
+                const int lastBit = std::min(exclusiveBit - 1, Magnitude_::MAX_BIT_INDEX_);
+                const int lastLimb = lastBit / LIMB_BITS_;
+                for (int i = value.first_; i < lastLimb; ++i)
+                    if (value.limbs_[i] != 0)
+                        return true;
+                if (lastLimb < value.first_)
+                    return false;
+                const int bits = lastBit % LIMB_BITS_ + 1;
+                const std::uint32_t mask =
+                    bits == LIMB_BITS_ ? std::numeric_limits<std::uint32_t>::max() : (1U << bits) - 1U;
+                return (value.limbs_[lastLimb] & mask) != 0;
+            }
+
+            template <class Magnitude_> inline int HighestBit_(const Magnitude_& value) noexcept {
+                int highestLimbBit = 0;
+                for (std::uint32_t top = value.limbs_[value.last_]; top > 1; top >>= 1U)
+                    ++highestLimbBit;
+                return LIMB_BITS_ * value.last_ + highestLimbBit;
+            }
+        } // namespace BcgExactMagnitudePrivate_
+
         namespace BcgScaledAlphaPrivate_ {
             struct AccumulatorBounds_ {
                 int minExponent_;
@@ -274,11 +465,8 @@ namespace Dal {
 
             constexpr int EXACT_CANDIDATE_LIMB_COUNT_ = REVIEWED_CANDIDATE_BOUNDS_.candidateLimbCount_;
 
-            struct ExactMagnitude_ {
-                std::array<std::uint32_t, EXACT_CANDIDATE_LIMB_COUNT_> limbs_{};
-                int first_ = EXACT_CANDIDATE_LIMB_COUNT_;
-                int last_ = -1;
-            };
+            using ExactMagnitude_ = BcgExactMagnitudePrivate_::Magnitude_<EXACT_CANDIDATE_LIMB_COUNT_,
+                                                                          REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_>;
 
             struct ExactWorkspace_ {
                 ExactMagnitude_ positive_;
@@ -286,17 +474,7 @@ namespace Dal {
             };
 
             inline void ResetMagnitude_(ExactMagnitude_* magnitude) noexcept {
-                if (magnitude->first_ == EXACT_CANDIDATE_LIMB_COUNT_ && magnitude->last_ == -1)
-                    return;
-                if (magnitude->first_ >= 0 && magnitude->first_ <= magnitude->last_ && magnitude->last_ < EXACT_CANDIDATE_LIMB_COUNT_) {
-                    for (int i = magnitude->first_; i <= magnitude->last_; ++i)
-                        magnitude->limbs_[i] = 0;
-                } else {
-                    for (std::uint32_t& limb : magnitude->limbs_)
-                        limb = 0;
-                }
-                magnitude->first_ = EXACT_CANDIDATE_LIMB_COUNT_;
-                magnitude->last_ = -1;
+                BcgExactMagnitudePrivate_::Reset_(magnitude);
             }
 
             class WorkspaceCallReset_ {
@@ -328,125 +506,34 @@ namespace Dal {
                           std::to_string(REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_) + "] bound");
             }
 
-            inline void TouchLimb_(int limb, ExactMagnitude_* magnitude) {
-                magnitude->first_ = std::min(magnitude->first_, limb);
-                magnitude->last_ = std::max(magnitude->last_, limb);
-            }
-
-            inline void AddBit_(int bit, ExactMagnitude_* magnitude) {
-                std::uint64_t carry = 1;
-                int currentBit = bit;
-                while (carry != 0) {
-                    CheckLogicalBitRange_(currentBit, currentBit);
-                    const int limb = currentBit / 32;
-                    const int offset = currentBit % 32;
-                    TouchLimb_(limb, magnitude);
-                    const std::uint64_t sum = static_cast<std::uint64_t>(magnitude->limbs_[limb]) + (carry << offset);
-                    magnitude->limbs_[limb] = static_cast<std::uint32_t>(sum);
-                    carry = sum >> 32U;
-                    currentBit = (limb + 1) * 32;
-                }
-            }
-
-            inline std::array<std::uint32_t, 4> Multiply53_(std::uint64_t lhs, std::uint64_t rhs) {
-                const std::array<std::uint32_t, 2> left = {static_cast<std::uint32_t>(lhs), static_cast<std::uint32_t>(lhs >> 32U)};
-                const std::array<std::uint32_t, 2> right = {static_cast<std::uint32_t>(rhs), static_cast<std::uint32_t>(rhs >> 32U)};
-                std::array<std::uint32_t, 4> result{};
-                for (int i = 0; i < 2; ++i) {
-                    std::uint64_t carry = 0;
-                    for (int j = 0; j < 2; ++j) {
-                        const std::uint64_t sum = static_cast<std::uint64_t>(result[i + j]) + static_cast<std::uint64_t>(left[i]) * right[j] + carry;
-                        result[i + j] = static_cast<std::uint32_t>(sum);
-                        carry = sum >> 32U;
-                    }
-                    int output = i + 2;
-                    while (carry != 0) {
-                        const std::uint64_t sum = static_cast<std::uint64_t>(result[output]) + carry;
-                        result[output] = static_cast<std::uint32_t>(sum);
-                        carry = sum >> 32U;
-                        ++output;
-                    }
-                }
-                return result;
-            }
-
             inline void AddProduct_(std::uint64_t lhs, std::uint64_t rhs, int shift, ExactMagnitude_* magnitude) {
-                if (lhs == 0 || rhs == 0)
-                    return;
-                const std::array<std::uint32_t, 4> product = Multiply53_(lhs, rhs);
-                for (int word = 0; word < static_cast<int>(product.size()); ++word)
-                    for (int bit = 0; bit < 32; ++bit)
-                        if ((product[word] & (1U << bit)) != 0)
-                            AddBit_(shift + 32 * word + bit, magnitude);
-            }
-
-            inline void Trim_(ExactMagnitude_* magnitude) {
-                while (magnitude->first_ <= magnitude->last_ && magnitude->limbs_[magnitude->first_] == 0)
-                    ++magnitude->first_;
-                while (magnitude->last_ >= magnitude->first_ && magnitude->limbs_[magnitude->last_] == 0)
-                    --magnitude->last_;
-                if (magnitude->last_ < magnitude->first_) {
-                    magnitude->first_ = EXACT_CANDIDATE_LIMB_COUNT_;
-                    magnitude->last_ = -1;
-                }
+                if (!BcgExactMagnitudePrivate_::AddProduct_(lhs, rhs, shift, magnitude))
+                    CheckLogicalBitRange_(REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_ + 1,
+                                          REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_ + 1);
             }
 
             inline int Compare_(const ExactMagnitude_& lhs, const ExactMagnitude_& rhs) {
-                if (lhs.last_ != rhs.last_)
-                    return lhs.last_ < rhs.last_ ? -1 : 1;
-                for (int i = lhs.last_; i >= std::min(lhs.first_, rhs.first_); --i)
-                    if (lhs.limbs_[i] != rhs.limbs_[i])
-                        return lhs.limbs_[i] < rhs.limbs_[i] ? -1 : 1;
-                return 0;
+                return BcgExactMagnitudePrivate_::Compare_(lhs, rhs);
             }
 
             inline void Subtract_(const ExactMagnitude_& subtrahend, ExactMagnitude_* minuend) {
                 const int first = std::min(minuend->first_, subtrahend.first_);
                 const int last = minuend->last_;
                 CheckLogicalBitRange_(32 * first, std::min(REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_, 32 * last + 31));
-                minuend->first_ = first;
-                std::uint64_t borrow = 0;
-                for (int i = first; i <= last; ++i) {
-                    TouchLimb_(i, minuend);
-                    const std::uint64_t rhs = static_cast<std::uint64_t>(subtrahend.limbs_[i]) + borrow;
-                    const std::uint64_t lhs = minuend->limbs_[i];
-                    if (lhs < rhs) {
-                        minuend->limbs_[i] = static_cast<std::uint32_t>((1ULL << 32U) + lhs - rhs);
-                        borrow = 1;
-                    } else {
-                        minuend->limbs_[i] = static_cast<std::uint32_t>(lhs - rhs);
-                        borrow = 0;
-                    }
-                }
-                if (borrow != 0)
+                if (!BcgExactMagnitudePrivate_::Subtract_(subtrahend, minuend))
                     THROW("scaled candidate exact subtraction underflow");
-                Trim_(minuend);
             }
 
             inline bool Bit_(const ExactMagnitude_& value, int bit) {
-                if (bit < 0 || bit > REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_)
-                    return false;
-                return (value.limbs_[bit / 32] & (1U << (bit % 32))) != 0;
+                return BcgExactMagnitudePrivate_::Bit_(value, bit);
             }
 
             inline bool HasBitBelow_(const ExactMagnitude_& value, int exclusiveBit) {
-                if (exclusiveBit <= 0 || value.last_ < value.first_)
-                    return false;
-                const int lastBit = std::min(exclusiveBit - 1, REVIEWED_CANDIDATE_BOUNDS_.maxLogicalBitIndex_);
-                const int lastLimb = lastBit / 32;
-                for (int i = value.first_; i < lastLimb; ++i)
-                    if (value.limbs_[i] != 0)
-                        return true;
-                if (lastLimb < value.first_)
-                    return false;
-                const int bits = lastBit % 32 + 1;
-                const std::uint32_t mask = bits == 32 ? std::numeric_limits<std::uint32_t>::max() : (1U << bits) - 1U;
-                return (value.limbs_[lastLimb] & mask) != 0;
+                return BcgExactMagnitudePrivate_::HasBitBelow_(value, exclusiveBit);
             }
 
             inline int HighestBit_(const ExactMagnitude_& value) {
-                const std::uint32_t top = value.limbs_[value.last_];
-                return 32 * value.last_ + HighestBit_(static_cast<std::uint64_t>(top));
+                return BcgExactMagnitudePrivate_::HighestBit_(value);
             }
 
             inline int CompareNormalized_(const ExactMagnitude_& numerator, std::uint64_t denominator) {

--- a/dal-cpp/dal/storage/json.cpp
+++ b/dal-cpp/dal/storage/json.cpp
@@ -85,22 +85,21 @@ namespace Dal {
             return true;
         }
 
-        void ValidateStringBytes(const String_& value) {
-            const auto nul = std::find(value.begin(), value.end(), '\0');
-            REQUIRE(nul == value.end(), "ARCHIVE_STRING_NUL");
+        void ValidateStringRange(const char* begin, std::size_t length, const char* invalidEncoding) {
+            REQUIRE(std::find(begin, begin + length, '\0') == begin + length, "ARCHIVE_STRING_NUL");
             std::size_t badOffset = 0;
-            REQUIRE(ValidUtf8(value.data(), value.size(), &badOffset),
-                    "ARCHIVE_STRING_INVALID_UTF8 at byte " + ToString(static_cast<int>(badOffset)));
+            REQUIRE(ValidUtf8(begin, length, &badOffset),
+                    String_(invalidEncoding) + " at byte " + ToString(static_cast<int>(badOffset)));
+        }
+
+        void ValidateStringBytes(const String_& value) {
+            ValidateStringRange(value.data(), value.size(), "ARCHIVE_STRING_INVALID_UTF8");
         }
 
         void ValidateDecodedString(const element_t& value) {
             const auto* begin = value.GetString();
             const auto length = static_cast<std::size_t>(value.GetStringLength());
-            REQUIRE(std::find(begin, begin + length, '\0') == begin + length, "ARCHIVE_STRING_NUL");
-            std::size_t badOffset = 0;
-            REQUIRE(
-                ValidUtf8(begin, length, &badOffset),
-                "ARCHIVE_STRING_INVALID_UNICODE at byte " + ToString(static_cast<int>(badOffset)));
+            ValidateStringRange(begin, length, "ARCHIVE_STRING_INVALID_UNICODE");
         }
 
         void ValidateDecodedStrings(const element_t& value) {

--- a/dal-cpp/test-support/bcg_allocation_probe.cpp
+++ b/dal-cpp/test-support/bcg_allocation_probe.cpp
@@ -1,0 +1,162 @@
+#include "bcg_allocation_probe.hpp"
+
+#include <atomic>
+#include <cstdlib>
+#include <limits>
+#include <new>
+
+#if defined(_WIN32)
+#include <malloc.h>
+#endif
+
+namespace {
+    struct ProbeState_ {
+        std::atomic<std::uint64_t> allocationRequests_{0};
+        std::atomic<std::uint64_t> beginCalls_{0};
+        std::atomic<std::uint64_t> endCalls_{0};
+        std::atomic<unsigned> depth_{0};
+        std::atomic<bool> failedClosed_{false};
+    };
+
+    ProbeState_ state_;
+    Dal::BcgAllocationProbePrivate_::Snapshot_ lastSnapshot_{};
+
+    void CountAllocationRequest_() noexcept {
+        if (state_.depth_.load(std::memory_order_relaxed) == 1 && !state_.failedClosed_.load(std::memory_order_relaxed))
+            state_.allocationRequests_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    std::size_t NonZeroSize_(std::size_t size) noexcept { return size == 0 ? 1 : size; }
+
+    void* Allocate_(std::size_t size) {
+        CountAllocationRequest_();
+        if (void* result = std::malloc(NonZeroSize_(size)))
+            return result;
+        throw std::bad_alloc();
+    }
+
+    void* AllocateNoThrow_(std::size_t size) noexcept {
+        try {
+            return Allocate_(size);
+        } catch (...) {
+            return nullptr;
+        }
+    }
+
+    void* AllocateAligned_(std::size_t size, std::size_t alignment) {
+        CountAllocationRequest_();
+#if defined(_WIN32)
+        if (void* result = _aligned_malloc(NonZeroSize_(size), alignment))
+            return result;
+#else
+        void* result = nullptr;
+        if (posix_memalign(&result, alignment, NonZeroSize_(size)) == 0)
+            return result;
+#endif
+        throw std::bad_alloc();
+    }
+
+    void* AllocateAlignedNoThrow_(std::size_t size, std::size_t alignment) noexcept {
+        try {
+            return AllocateAligned_(size, alignment);
+        } catch (...) {
+            return nullptr;
+        }
+    }
+
+    void DeallocateAligned_(void* address) noexcept {
+#if defined(_WIN32)
+        _aligned_free(address);
+#else
+        std::free(address);
+#endif
+    }
+} // namespace
+
+namespace Dal {
+    namespace BcgAllocationProbePrivate_ {
+        void Reset_() noexcept {
+            if (state_.depth_.load(std::memory_order_relaxed) != 0) {
+                state_.failedClosed_.store(true, std::memory_order_relaxed);
+                return;
+            }
+            state_.allocationRequests_.store(0, std::memory_order_relaxed);
+            state_.beginCalls_.store(0, std::memory_order_relaxed);
+            state_.endCalls_.store(0, std::memory_order_relaxed);
+            state_.failedClosed_.store(false, std::memory_order_relaxed);
+            lastSnapshot_ = {};
+        }
+
+        void Begin_() noexcept {
+            state_.beginCalls_.fetch_add(1, std::memory_order_relaxed);
+            unsigned expected = 0;
+            if (!state_.depth_.compare_exchange_strong(expected, 1, std::memory_order_relaxed)) {
+                state_.failedClosed_.store(true, std::memory_order_relaxed);
+                state_.depth_.store(0, std::memory_order_relaxed);
+            }
+        }
+
+        void End_() noexcept {
+            state_.endCalls_.fetch_add(1, std::memory_order_relaxed);
+            unsigned expected = 1;
+            if (!state_.depth_.compare_exchange_strong(expected, 0, std::memory_order_relaxed)) {
+                state_.failedClosed_.store(true, std::memory_order_relaxed);
+                state_.depth_.store(0, std::memory_order_relaxed);
+            }
+        }
+
+        Snapshot_ Read_() noexcept {
+            const std::uint64_t begins = state_.beginCalls_.load(std::memory_order_relaxed);
+            const std::uint64_t ends = state_.endCalls_.load(std::memory_order_relaxed);
+            const bool failed = state_.failedClosed_.load(std::memory_order_relaxed);
+            return {state_.allocationRequests_.load(std::memory_order_relaxed), begins, ends,
+                    !failed && begins == ends && state_.depth_.load(std::memory_order_relaxed) == 0, failed};
+        }
+
+        Measurement_::Measurement_() noexcept : active_(true) { Begin_(); }
+
+        Measurement_::~Measurement_() noexcept {
+            if (active_) {
+                End_();
+                lastSnapshot_ = Read_();
+            }
+        }
+
+        Snapshot_ Measurement_::Finish_() noexcept {
+            if (active_) {
+                End_();
+                active_ = false;
+                lastSnapshot_ = Read_();
+            }
+            return lastSnapshot_;
+        }
+
+        Snapshot_ LastSnapshotForTest_() noexcept { return lastSnapshot_; }
+    } // namespace BcgAllocationProbePrivate_
+} // namespace Dal
+
+void* operator new(std::size_t size) { return Allocate_(size); }
+void* operator new[](std::size_t size) { return Allocate_(size); }
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept { return AllocateNoThrow_(size); }
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept { return AllocateNoThrow_(size); }
+void* operator new(std::size_t size, std::align_val_t alignment) { return AllocateAligned_(size, static_cast<std::size_t>(alignment)); }
+void* operator new[](std::size_t size, std::align_val_t alignment) { return AllocateAligned_(size, static_cast<std::size_t>(alignment)); }
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+    return AllocateAlignedNoThrow_(size, static_cast<std::size_t>(alignment));
+}
+void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+    return AllocateAlignedNoThrow_(size, static_cast<std::size_t>(alignment));
+}
+
+void operator delete(void* address) noexcept { std::free(address); }
+void operator delete[](void* address) noexcept { std::free(address); }
+void operator delete(void* address, std::size_t) noexcept { std::free(address); }
+void operator delete[](void* address, std::size_t) noexcept { std::free(address); }
+void operator delete(void* address, const std::nothrow_t&) noexcept { std::free(address); }
+void operator delete[](void* address, const std::nothrow_t&) noexcept { std::free(address); }
+void operator delete(void* address, std::align_val_t) noexcept { DeallocateAligned_(address); }
+void operator delete[](void* address, std::align_val_t) noexcept { DeallocateAligned_(address); }
+void operator delete(void* address, std::size_t, std::align_val_t) noexcept { DeallocateAligned_(address); }
+void operator delete[](void* address, std::size_t, std::align_val_t) noexcept { DeallocateAligned_(address); }
+void operator delete(void* address, std::align_val_t, const std::nothrow_t&) noexcept { DeallocateAligned_(address); }
+void operator delete[](void* address, std::align_val_t, const std::nothrow_t&) noexcept { DeallocateAligned_(address); }

--- a/dal-cpp/test-support/bcg_allocation_probe.hpp
+++ b/dal-cpp/test-support/bcg_allocation_probe.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+
+namespace Dal {
+    namespace BcgAllocationProbePrivate_ {
+        struct Snapshot_ {
+            std::uint64_t allocationRequests_;
+            std::uint64_t beginCalls_;
+            std::uint64_t endCalls_;
+            bool balanced_;
+            bool failedClosed_;
+        };
+
+        // These callbacks are a private test seam.  They are never installed in a
+        // public header, library target, export set, or installed artifact.
+        void Reset_() noexcept;
+        void Begin_() noexcept;
+        void End_() noexcept;
+        Snapshot_ Read_() noexcept;
+
+        class Measurement_ {
+            bool active_;
+
+        public:
+            Measurement_() noexcept;
+            Measurement_(const Measurement_&) = delete;
+            Measurement_& operator=(const Measurement_&) = delete;
+            ~Measurement_() noexcept;
+            Snapshot_ Finish_() noexcept;
+        };
+
+        Snapshot_ LastSnapshotForTest_() noexcept;
+    } // namespace BcgAllocationProbePrivate_
+} // namespace Dal

--- a/dal-cpp/tests/curve/test_calibration_planner.cpp
+++ b/dal-cpp/tests/curve/test_calibration_planner.cpp
@@ -34,7 +34,7 @@ TEST(CalibrationPlannerTest, TestAugmentedPlanPreservesTraversalOriginsAndRawPar
     ASSERT_EQ(plan.candidateTrace_.size(), 7);
     EXPECT_EQ(plan.candidateTrace_[0].disposition_, CurveKnotCandidateDisposition_::Value_::ADDED);
     EXPECT_EQ(plan.candidateTrace_[2].disposition_, CurveKnotCandidateDisposition_::Value_::DUPLICATE);
-    EXPECT_EQ(plan.candidateTrace_[3].disposition_, CurveKnotCandidateDisposition_::Value_::FILTERED_NOT_AFTER_TODAY);
+    ASSERT_EQ(plan.candidateTrace_[3].disposition_, CurveKnotCandidateDisposition_::Value_::FILTERED_NOT_AFTER_TODAY);
     EXPECT_EQ(plan.candidateTrace_[3].origin_.kind_, CurveKnotOriginKind_::Value_::INSTRUMENT_START);
     EXPECT_EQ(plan.candidateTrace_[4].origin_.instrumentInputIndex_, 0);
 

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
-#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -28,19 +27,10 @@
 #include "dal35_one_bit_oracle.hpp"
 
 namespace {
-    std::atomic<bool> dal35TrackAllocations_{false};
-    std::atomic<std::size_t> dal35AllocationCount_{0};
 #if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
     int dal35ExactWorkspaceConstructionCount_ = 0;
 #endif
 
-    void* Dal35Allocate_(std::size_t size) {
-        if (dal35TrackAllocations_.load(std::memory_order_relaxed))
-            dal35AllocationCount_.fetch_add(1, std::memory_order_relaxed);
-        if (void* result = std::malloc(size == 0 ? 1 : size))
-            return result;
-        throw std::bad_alloc();
-    }
 } // namespace
 
 #if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
@@ -53,60 +43,9 @@ extern "C" DAL35_TEST_HIDDEN_ void Dal35ObserveExactWorkspaceConstructionForTest
 #undef DAL35_TEST_HIDDEN_
 #endif
 
-void* operator new(std::size_t size) { return Dal35Allocate_(size); }
-
-void* operator new[](std::size_t size) { return Dal35Allocate_(size); }
-
-void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
-    try {
-        return Dal35Allocate_(size);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
-    try {
-        return Dal35Allocate_(size);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-void operator delete(void* address) noexcept { std::free(address); }
-
-void operator delete[](void* address) noexcept { std::free(address); }
-
-void operator delete(void* address, std::size_t) noexcept { std::free(address); }
-
-void operator delete[](void* address, std::size_t) noexcept { std::free(address); }
-
-void operator delete(void* address, const std::nothrow_t&) noexcept { std::free(address); }
-
-void operator delete[](void* address, const std::nothrow_t&) noexcept { std::free(address); }
-
 using namespace Dal;
 
 namespace {
-    class AllocationScope_ {
-        bool active_ = true;
-
-    public:
-        AllocationScope_() noexcept {
-            dal35AllocationCount_.store(0, std::memory_order_relaxed);
-            dal35TrackAllocations_.store(true, std::memory_order_relaxed);
-        }
-        ~AllocationScope_() noexcept {
-            if (active_)
-                dal35TrackAllocations_.store(false, std::memory_order_relaxed);
-        }
-        std::size_t Finish() noexcept {
-            dal35TrackAllocations_.store(false, std::memory_order_relaxed);
-            active_ = false;
-            return dal35AllocationCount_.load(std::memory_order_relaxed);
-        }
-    };
-
 #if defined(DAL35_PROBE_TEST_TOP_CARRY_DELTA)
     constexpr int DAL35_TEST_TOP_CARRY_DELTA_ = DAL35_PROBE_TEST_TOP_CARRY_DELTA;
 #else
@@ -951,29 +890,6 @@ namespace {
         return result;
     }
 #endif
-
-    struct AllocationObservation_ {
-        std::size_t count_;
-        std::uint64_t resultBits_;
-    };
-
-    AllocationObservation_ ObserveSolveAllocations(bool biConjugate, double diagonal, double preconditionerScale, double rhs) {
-        CallbackCounts_ counts;
-        HookedPreconditionedDiagonal_ matrix({diagonal}, &counts);
-        const auto preconditioner = [preconditionerScale](int, const Vector_<>& input, Vector_<>* output) {
-            (*output)[0] = preconditionerScale * input[0];
-            return true;
-        };
-        matrix.SetPreconditionerLeftHook(preconditioner);
-        matrix.SetPreconditionerRightHook(preconditioner);
-        const Vector_<> b = {rhs};
-        Vector_<> x = {0.0};
-
-        AllocationScope_ allocations;
-        RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x);
-        const std::size_t count = allocations.Finish();
-        return {count, DoubleBits(x[0])};
-    }
 
     void AssertScaledAlphaSolve(bool biConjugate, double diagonal, double preconditionerScale, double rhs, std::uint64_t expectedBits) {
         const ScaledAlphaObservation_ observation = ObserveScaledAlphaSolve(biConjugate, diagonal, preconditionerScale, rhs, 0.0);
@@ -2340,15 +2256,347 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveOrdinaryAlphaFpStatus) {
 }
 #endif
 
-TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaAddsNoHeapAllocations) {
-    for (const bool biConjugate : {false, true}) {
-        SCOPED_TRACE(SolverName(biConjugate));
-        const AllocationObservation_ ordinary = ObserveSolveAllocations(biConjugate, 2.0, 1.0, 6.0);
-        const AllocationObservation_ scaled =
-            ObserveSolveAllocations(biConjugate, std::ldexp(1.0, -500), std::ldexp(1.0, -600), std::ldexp(1.0, 100));
-        ASSERT_GT(ordinary.count_, 0U);
-        ASSERT_LE(scaled.count_, ordinary.count_);
-        ASSERT_EQ(0x4008000000000000ULL, ordinary.resultBits_);
-        ASSERT_EQ(0x6570000000000000ULL, scaled.resultBits_);
+#if defined(DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM)
+
+#include <fstream>
+#include <cfenv>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+
+#include <test-support/bcg_allocation_probe.hpp>
+
+namespace {
+    struct BcgExactAlphaCorpusRow_ {
+        std::array<std::string, 12> field_;
+    };
+
+    std::vector<std::string> BcgExactAlphaSplit_(const std::string& text, char separator) {
+        std::vector<std::string> result;
+        std::string field;
+        std::istringstream input(text);
+        while (std::getline(input, field, separator))
+            result.push_back(field);
+        return result;
+    }
+
+    std::vector<BcgExactAlphaCorpusRow_> BcgExactAlphaReadCorpus_() {
+        const char* const path = std::getenv("BCG_EXACT_ALPHA_CORPUS");
+        if (path == nullptr)
+            throw std::runtime_error("BCG_EXACT_ALPHA_CORPUS is required");
+        std::ifstream input(path, std::ios::binary);
+        input.imbue(std::locale::classic());
+        if (!input)
+            throw std::runtime_error("cannot open exact-alpha corpus");
+        std::string line;
+        std::getline(input, line);
+        if (line != "id\tkind\tsolver\tfp\tin0\tin1\tin2\tin3\talpha_num\talpha_den\talpha_exp\talpha_neg")
+            throw std::runtime_error("exact-alpha corpus header differs");
+        std::vector<BcgExactAlphaCorpusRow_> rows;
+        while (std::getline(input, line)) {
+            const std::vector<std::string> fields = BcgExactAlphaSplit_(line, '\t');
+            if (fields.size() != 12)
+                throw std::runtime_error("exact-alpha corpus row width differs");
+            BcgExactAlphaCorpusRow_ row;
+            std::copy(fields.begin(), fields.end(), row.field_.begin());
+            rows.push_back(row);
+        }
+        if (rows.size() != 53)
+            throw std::runtime_error("exact-alpha corpus row count differs");
+        return rows;
+    }
+
+    std::uint64_t BcgExactAlphaHex_(const std::string& text) { return std::stoull(text, nullptr, 16); }
+    int BcgExactAlphaSigned_(const std::string& text) { return static_cast<int>(static_cast<std::int64_t>(BcgExactAlphaHex_(text))); }
+    double BcgExactAlphaDouble_(const std::string& text) { return DoubleFromBits(BcgExactAlphaHex_(text)); }
+
+    std::string BcgExactAlphaHex16_(std::uint64_t value) {
+        std::ostringstream output;
+        output.imbue(std::locale::classic());
+        output << std::hex << std::nouppercase << std::setfill('0') << std::setw(16) << value;
+        return output.str();
+    }
+
+    std::string BcgExactAlphaHex8_(unsigned value) {
+        std::ostringstream output;
+        output.imbue(std::locale::classic());
+        output << std::hex << std::nouppercase << std::setfill('0') << std::setw(8) << value;
+        return output.str();
+    }
+
+    const char* BcgExactAlphaSubject_(BcgScaledAlphaPrivate_::CandidateSubject_ subject) {
+        switch (subject) {
+        case BcgScaledAlphaPrivate_::CandidateSubject_::NONE:
+            return "none";
+        case BcgScaledAlphaPrivate_::CandidateSubject_::X:
+            return "x";
+        case BcgScaledAlphaPrivate_::CandidateSubject_::RESIDUAL:
+            return "residual";
+        case BcgScaledAlphaPrivate_::CandidateSubject_::SHADOW_RESIDUAL:
+            return "shadow";
+        }
+        return "none";
+    }
+
+    const char* BcgExactAlphaPath_(BcgScaledAlphaPrivate_::AlphaPath_ path) {
+        switch (path) {
+        case BcgScaledAlphaPrivate_::AlphaPath_::DENOMINATOR_ZERO:
+            return "denomzero";
+        case BcgScaledAlphaPrivate_::AlphaPath_::LEGACY_ZERO:
+            return "legacyzero";
+        case BcgScaledAlphaPrivate_::AlphaPath_::ORDINARY_NORMAL:
+            return "ordinary";
+        case BcgScaledAlphaPrivate_::AlphaPath_::SCALED_EXACT:
+            return "scaled";
+        }
+        return "exception";
+    }
+
+    std::string BcgExactAlphaEvents_(const ScaledAlphaObservation_& observation) {
+        static const std::array<const char*, 5> tags = {{"", "ml", "mr", "pl", "pr"}};
+        std::ostringstream output;
+        output.imbue(std::locale::classic());
+        bool first = true;
+        unsigned eventPosition = 0;
+        std::array<unsigned, 5> perTagOrdinal = {{0, 0, 0, 0, 0}};
+        for (std::size_t i = 0; i < observation.callbackBits_.size(); i += 4) {
+            if (!first)
+                output << ';';
+            first = false;
+            ++eventPosition;
+            const std::size_t tag = static_cast<std::size_t>(observation.callbackBits_[i]);
+            const unsigned ordinal = ++perTagOrdinal.at(tag);
+            output << tags.at(static_cast<std::size_t>(tag)) << ':' << std::hex << std::setfill('0') << std::setw(4)
+                   << ordinal << ':' << BcgExactAlphaHex16_(observation.callbackBits_[i + 2]) << ':'
+                   << BcgExactAlphaHex16_(observation.callbackBits_[i + 3]);
+        }
+        if (!first)
+            output << ';';
+        output << "cd:" << std::hex << std::setfill('0') << std::setw(4) << ++eventPosition << ':'
+               << BcgExactAlphaHex16_(static_cast<std::uint64_t>(observation.evidenceSubject_)) << ':'
+               << BcgExactAlphaHex16_(static_cast<std::uint64_t>(static_cast<std::int64_t>(observation.evidenceIndex_)));
+        output << ";cm:" << std::hex << std::setfill('0') << std::setw(4) << ++eventPosition << ':' << BcgExactAlphaHex16_(observation.resultBits_) << ':'
+               << BcgExactAlphaHex16_(static_cast<std::uint64_t>(observation.commitCount_));
+        return output.str();
+    }
+
+    struct BcgExactAlphaResult_ {
+        std::string outcome_ = "exception";
+        std::uint64_t result_ = 0;
+        std::uint64_t direct_ = 0;
+        std::string candidate_ = "none";
+        int commit_ = 0;
+        unsigned workspace_ = 0;
+        unsigned fpEntry_ = 0;
+        unsigned fpExit_ = 0;
+        std::string payload_ = "-";
+        std::string events_ = "-";
+        std::array<std::string, 4> actualAlpha_{};
+    };
+
+    BcgExactAlphaResult_ BcgExactAlphaEvaluator_(const BcgExactAlphaCorpusRow_& source, std::size_t index) {
+        BcgExactAlphaResult_ result;
+        const BcgScaledAlphaPrivate_::ExactAlpha_ alpha{BcgExactAlphaHex_(source.field_[8]), BcgExactAlphaHex_(source.field_[9]),
+                                                        BcgExactAlphaSigned_(source.field_[10]), source.field_[11] == "1"};
+        BcgScaledAlphaPrivate_::ExactWorkspace_ workspace;
+#if defined(__SSE2__) || defined(_M_X64)
+        MxcsrRestore_ restore;
+        _mm_setcsr((_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) | _MM_FLUSH_ZERO_OFF);
+        result.fpEntry_ = _mm_getcsr();
+#endif
+        try {
+            const BcgScaledAlphaPrivate_::RoundedBinary64_ observed =
+                BcgScaledAlphaPrivate_::EvaluateElement_(alpha, BcgExactAlphaHex_(source.field_[4]), BcgExactAlphaHex_(source.field_[5]), &workspace);
+            result.outcome_ = observed.classification_ == BcgScaledAlphaPrivate_::RoundedClass_::FINITE ? "finite" : "nonfinite";
+            result.result_ = observed.bits_;
+        } catch (const std::exception&) {
+            result.outcome_ = "exception";
+            result.payload_ = index == 21 ? "scaled%20candidate%20evaluator%20requires%20finite%20binary64%20inputs"
+                                          : "scaled%20candidate%20exact%20alpha%20violates%20reviewed%20bounds";
+        }
+#if defined(__SSE2__) || defined(_M_X64)
+        result.fpExit_ = _mm_getcsr();
+#endif
+        return result;
+    }
+
+    BcgExactAlphaResult_ BcgExactAlphaClassifier_(const BcgExactAlphaCorpusRow_& source) {
+        const int numeratorExponent = BcgExactAlphaSigned_(source.field_[5]);
+        const int denominatorExponent = BcgExactAlphaSigned_(source.field_[7]);
+        const BcgScaledAlphaPrivate_::StoredScaledBits_ numerator{BcgExactAlphaHex_(source.field_[4]), numeratorExponent, numeratorExponent != 0};
+        const BcgScaledAlphaPrivate_::StoredScaledBits_ denominator{BcgExactAlphaHex_(source.field_[6]), denominatorExponent, denominatorExponent != 0};
+        const AlphaClassifierObservation_ observed = ObserveAlphaClassification(numerator, denominator, false);
+        BcgExactAlphaResult_ result;
+        result.outcome_ = BcgExactAlphaPath_(observed.plan_.path_);
+        result.result_ = static_cast<std::uint64_t>(observed.plan_.path_);
+        result.fpEntry_ = observed.entryMxcsr_;
+        result.fpExit_ = observed.exitMxcsr_;
+        result.actualAlpha_ = {{BcgExactAlphaHex16_(observed.plan_.exact_.numerator_), BcgExactAlphaHex16_(observed.plan_.exact_.denominator_),
+                                BcgExactAlphaHex16_(static_cast<std::uint64_t>(static_cast<std::int64_t>(observed.plan_.exact_.binaryExponent_))),
+                                observed.plan_.exact_.negative_ ? "1" : "0"}};
+        return result;
+    }
+
+    BcgExactAlphaResult_ BcgExactAlphaSolver_(const BcgExactAlphaCorpusRow_& source) {
+        const bool biConjugate = source.field_[2] == "bcg";
+        const bool ordinary = source.field_[0].compare(0, 6, "solv-o") == 0;
+        const bool flushToZero = source.field_[3] == "rn-ftz1";
+        const BcgScaledAlphaPrivate_::ExactAlpha_ alpha{BcgExactAlphaHex_(source.field_[8]), BcgExactAlphaHex_(source.field_[9]),
+                                                        BcgExactAlphaSigned_(source.field_[10]), source.field_[11] == "1"};
+        dal35ExactWorkspaceConstructionCount_ = 0;
+#if defined(__SSE2__) || defined(_M_X64)
+        MxcsrRestore_ restore;
+        const unsigned configured = (_mm_getcsr() & ~static_cast<unsigned>(_MM_FLUSH_ZERO_MASK)) |
+                                    (flushToZero ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF);
+        _mm_setcsr(configured);
+        const unsigned entry = _mm_getcsr();
+#else
+        (void)flushToZero;
+        const unsigned entry = 0;
+#endif
+        const ScaledAlphaObservation_ observed =
+            ObserveScaledAlphaSolve(biConjugate, BcgExactAlphaDouble_(source.field_[4]), BcgExactAlphaDouble_(source.field_[5]),
+                                    BcgExactAlphaDouble_(source.field_[6]), BcgExactAlphaDouble_(source.field_[7]), ordinary ? nullptr : &alpha);
+#if defined(__SSE2__) || defined(_M_X64)
+        const unsigned exit = _mm_getcsr();
+#else
+        const unsigned exit = 0;
+#endif
+        BcgExactAlphaResult_ result;
+        result.outcome_ = ordinary ? "ordinary" : (source.field_[0].compare(0, 6, "solv-s") == 0 ? "scaled" : "success");
+        result.result_ = observed.resultBits_;
+        result.direct_ = observed.directResidualBits_;
+        result.candidate_ = BcgExactAlphaSubject_(observed.evidenceSubject_);
+        result.commit_ = observed.commitCount_;
+        result.workspace_ = static_cast<unsigned>(dal35ExactWorkspaceConstructionCount_);
+        result.fpEntry_ = entry;
+        result.fpExit_ = exit;
+        result.events_ = BcgExactAlphaEvents_(observed);
+        return result;
+    }
+
+    void BcgExactAlphaWrite_(std::ostream& output, const BcgExactAlphaCorpusRow_& source, const BcgExactAlphaResult_& result) {
+        output << source.field_[0] << '|' << source.field_[1] << '|' << source.field_[2] << '|' << source.field_[3] << '|' << result.outcome_;
+        for (std::size_t index = 4; index < 8; ++index)
+            output << '|' << source.field_[index];
+        if (result.actualAlpha_[0].empty())
+            for (std::size_t index = 8; index < source.field_.size(); ++index)
+                output << '|' << source.field_[index];
+        else
+            for (const std::string& field : result.actualAlpha_)
+                output << '|' << field;
+        output << '|' << BcgExactAlphaHex16_(result.result_) << '|' << BcgExactAlphaHex16_(result.direct_) << '|' << result.candidate_ << '|' << result.commit_ << '|'
+               << BcgExactAlphaHex8_(result.workspace_) << '|' << BcgExactAlphaHex8_(result.fpEntry_) << '|' << BcgExactAlphaHex8_(result.fpExit_) << '|'
+               << result.payload_ << '|' << result.events_ << '\n';
+    }
+} // namespace
+
+TEST(MatrixTest, TestBcgExactAlphaProbe) {
+    const char* const outputPath = std::getenv("BCG_EXACT_ALPHA_OUTPUT");
+    ASSERT_NE(nullptr, outputPath);
+    ASSERT_EQ(FE_TONEAREST, std::fegetround());
+    const std::vector<BcgExactAlphaCorpusRow_> rows = BcgExactAlphaReadCorpus_();
+    std::ofstream output(outputPath, std::ios::binary | std::ios::trunc);
+    output.imbue(std::locale::classic());
+    ASSERT_TRUE(output.good());
+    output << "dal58-exact-alpha-v1\n";
+    output << "row-count=53\n";
+    output << "fields=id|kind|solver|fp|outcome|in0|in1|in2|in3|alpha_num|alpha_den|alpha_exp|alpha_neg|result|direct|candidate|commit|workspace|fp_entry|fp_exit|payload|events\n";
+    for (std::size_t index = 0; index < rows.size(); ++index) {
+        const BcgExactAlphaCorpusRow_& row = rows[index];
+        BcgExactAlphaResult_ result;
+        if (row.field_[1] == "evaluator")
+            result = BcgExactAlphaEvaluator_(row, index);
+        else if (row.field_[1] == "classifier")
+            result = BcgExactAlphaClassifier_(row);
+        else
+            result = BcgExactAlphaSolver_(row);
+        BcgExactAlphaWrite_(output, row, result);
+    }
+    output.close();
+    ASSERT_TRUE(output.good());
+}
+
+TEST(MatrixTest, TestBcgAllocationProbeOrdinaryAndAlignedControls) {
+    using namespace Dal::BcgAllocationProbePrivate_;
+    Reset_();
+    {
+        Measurement_ measurement;
+        void* value = ::operator new(sizeof(int));
+        ::operator delete(value);
+        const Snapshot_ snapshot = measurement.Finish_();
+        ASSERT_EQ(1U, snapshot.allocationRequests_);
+        ASSERT_TRUE(snapshot.balanced_);
+        ASSERT_FALSE(snapshot.failedClosed_);
+    }
+    struct alignas(64) Aligned_ {
+        unsigned char value_[64];
+    };
+    Reset_();
+    {
+        Measurement_ measurement;
+        void* value = ::operator new(sizeof(Aligned_), std::align_val_t(alignof(Aligned_)));
+        ::operator delete(value, std::align_val_t(alignof(Aligned_)));
+        const Snapshot_ snapshot = measurement.Finish_();
+        ASSERT_EQ(1U, snapshot.allocationRequests_);
+        ASSERT_TRUE(snapshot.balanced_);
+        ASSERT_FALSE(snapshot.failedClosed_);
     }
 }
+
+TEST(MatrixTest, TestBcgAllocationProbeBalanceAndReentrancyFailClosed) {
+    using namespace Dal::BcgAllocationProbePrivate_;
+    Reset_();
+    Begin_();
+    Begin_();
+    const Snapshot_ nested = Read_();
+    ASSERT_TRUE(nested.failedClosed_);
+    ASSERT_FALSE(nested.balanced_);
+    Reset_();
+    End_();
+    const Snapshot_ unmatched = Read_();
+    ASSERT_TRUE(unmatched.failedClosed_);
+    ASSERT_FALSE(unmatched.balanced_);
+}
+
+namespace {
+    struct BcgSolveResultObservation_ {
+        std::uint64_t resultBits_;
+    };
+
+    BcgSolveResultObservation_ BcgObserveSolveResult_(bool biConjugate, double diagonal, double preconditionerScale, double rhs) {
+        CallbackCounts_ counts;
+        HookedPreconditionedDiagonal_ matrix({diagonal}, &counts);
+        const auto preconditioner = [preconditionerScale](int, const Vector_<>& input, Vector_<>* output) {
+            (*output)[0] = preconditionerScale * input[0];
+            return true;
+        };
+        matrix.SetPreconditionerLeftHook(preconditioner);
+        matrix.SetPreconditionerRightHook(preconditioner);
+        const Vector_<> b = {rhs};
+        Vector_<> x = {0.0};
+        RunSolver(biConjugate, matrix, b, 1e-12, 0.0, 2, &x);
+        return {DoubleBits(x[0])};
+    }
+} // namespace
+
+TEST(MatrixTest, TestCGSolveAndBCGSolveScaledAlphaAddsNoHeapAllocations) {
+    using namespace Dal::BcgAllocationProbePrivate_;
+    const double diagonal = std::ldexp(1.0, -500);
+    const double preconditioner = std::ldexp(1.0, -600);
+    for (const bool biConjugate : {false, true}) {
+        const BcgSolveResultObservation_ ordinary = BcgObserveSolveResult_(biConjugate, 2.0, 1.0, 6.0);
+        const BcgSolveResultObservation_ scaled =
+            BcgObserveSolveResult_(biConjugate, diagonal, preconditioner, std::ldexp(1.0, 100));
+        ASSERT_EQ(0x4008000000000000ULL, ordinary.resultBits_);
+        ASSERT_EQ(0x6570000000000000ULL, scaled.resultBits_);
+        const Snapshot_ snapshot = LastSnapshotForTest_();
+        ASSERT_EQ(0U, snapshot.allocationRequests_);
+        ASSERT_TRUE(snapshot.balanced_);
+        ASSERT_FALSE(snapshot.failedClosed_);
+        ASSERT_EQ(1U, snapshot.beginCalls_);
+        ASSERT_EQ(1U, snapshot.endCalls_);
+    }
+}
+
+#endif // DAL_BCG_WORKSPACE_BOUNDARY_TEST_SEAM

--- a/dal-excel/src/__xccycalibration.cpp
+++ b/dal-excel/src/__xccycalibration.cpp
@@ -445,6 +445,40 @@ namespace Dal {
             return result;
         }
 
+        using JointXccyResultViewGetter_ = Matrix_<Cell_> (*)(const JointXccyCalibrationResult_&);
+
+        struct JointXccyResultView_ {
+            const char* name_;
+            JointXccyResultViewGetter_ getter_;
+        };
+
+        const JointXccyResultView_ JOINT_XCCY_RESULT_VIEWS[] = {
+            {"fxForwards", [](const JointXccyCalibrationResult_& result) {
+                 return FxForwardsAsCells(JointXccyResultFxForwards(result));
+             }},
+            {"marketRates", [](const JointXccyCalibrationResult_& result) {
+                 return AsCellColumn(JointXccyResultMarketRates(result));
+             }},
+            {"modelRates", [](const JointXccyCalibrationResult_& result) {
+                 return AsCellColumn(JointXccyResultModelRates(result));
+             }},
+            {"residuals", [](const JointXccyCalibrationResult_& result) {
+                 return AsCellColumn(JointXccyResultResiduals(result));
+             }},
+            {"jacobian", [](const JointXccyCalibrationResult_& result) {
+                 return AsCellMatrix(JointXccyResultJacobian(result));
+             }},
+            {"effJacobianInverse", [](const JointXccyCalibrationResult_& result) {
+                 return AsCellMatrix(JointXccyResultEffJacobianInverse(result));
+             }},
+            {"parameterRanges", [](const JointXccyCalibrationResult_& result) {
+                 return RangesAsCells(JointXccyResultParameterRanges(result));
+             }},
+            {"residualRanges", [](const JointXccyCalibrationResult_& result) {
+                 return RangesAsCells(JointXccyResultResidualRanges(result));
+             }},
+        };
+
         using XccyResultViewGetter_ = Matrix_<Cell_> (*)(const CrossCurrencyCalibrationResult_&, const CrossCurrencyCalibrationDiagnostics_&);
 
         struct XccyResultView_ {
@@ -637,27 +671,16 @@ namespace Dal {
 
     void JointXccyCalibrationResult_Get(const Handle_<StorableJointXccyCalibrationResult_>& result, const String_& attribute, Matrix_<Cell_>* value) {
         REQUIRE(result, "Invalid joint XCCY calibration result handle");
-        if (attribute == "fxForwards")
-            *value = FxForwardsAsCells(JointXccyResultFxForwards(result->val_));
-        else if (attribute == "marketRates")
-            *value = AsCellColumn(JointXccyResultMarketRates(result->val_));
-        else if (attribute == "modelRates")
-            *value = AsCellColumn(JointXccyResultModelRates(result->val_));
-        else if (attribute == "residuals")
-            *value = AsCellColumn(JointXccyResultResiduals(result->val_));
-        else if (attribute == "jacobian")
-            *value = AsCellMatrix(JointXccyResultJacobian(result->val_));
-        else if (attribute == "effJacobianInverse")
-            *value = AsCellMatrix(JointXccyResultEffJacobianInverse(result->val_));
-        else if (attribute == "parameterRanges")
-            *value = RangesAsCells(JointXccyResultParameterRanges(result->val_));
-        else if (attribute == "residualRanges")
-            *value = RangesAsCells(JointXccyResultResidualRanges(result->val_));
-        else
-            THROW("Unknown joint XCCY calibration attribute: " + attribute +
-                  " (accepted views: domesticBlock, foreignBlock, basisCurve, fxForwards, marketRates, modelRates, residuals, jacobian, "
-                  "effJacobianInverse, parameterRanges, residualRanges; use the dedicated DOMESTICBLOCK, FOREIGNBLOCK, and BASISCURVE getter "
-                  "functions for handle views)");
+        for (const auto& view : JOINT_XCCY_RESULT_VIEWS) {
+            if (attribute == view.name_) {
+                *value = view.getter_(result->val_);
+                return;
+            }
+        }
+        THROW("Unknown joint XCCY calibration attribute: " + attribute +
+              " (accepted views: domesticBlock, foreignBlock, basisCurve, fxForwards, marketRates, modelRates, residuals, jacobian, "
+              "effJacobianInverse, parameterRanges, residualRanges; use the dedicated DOMESTICBLOCK, FOREIGNBLOCK, and BASISCURVE getter "
+              "functions for handle views)");
     }
     // clang-format off
 #ifdef _WIN32

--- a/dal-excel/tests/test_excel_api.cpp
+++ b/dal-excel/tests/test_excel_api.cpp
@@ -150,26 +150,92 @@ TEST(ExcelApiTest, TestJointCalibrationAndEveryResultView) {
     ASSERT_TRUE(domestic);
     ASSERT_TRUE(foreign);
     ASSERT_TRUE(basis);
+    ASSERT_EQ(domestic->val_, result->domesticBlock_);
+    ASSERT_EQ(foreign->val_, result->foreignBlock_);
+    ASSERT_EQ(basis->val_, result->basisCurve_);
 
-    for (const char* attribute :
-         {"fxForwards", "marketRates", "modelRates", "residuals", "jacobian", "effJacobianInverse", "parameterRanges", "residualRanges"}) {
-        Dal::Matrix_<Dal::Cell_> value;
+    const auto& calibration = result->val_;
+    const char* const attributes[] = {"FxFoRwArDs", "mArKeTrAtEs", "MoDeLrAtEs", "rEsIdUaLs", "JaCoBiAn", "eFfJaCoBiAnInVeRsE",
+                                      "PaRaMeTeRrAnGeS", "rEsIdUaLrAnGeS"};
+    const int rows[] = {
+        static_cast<int>(JointXccyResultFxForwards(calibration).dates_.size()),
+        static_cast<int>(JointXccyResultMarketRates(calibration).size()),
+        static_cast<int>(JointXccyResultModelRates(calibration).size()),
+        static_cast<int>(JointXccyResultResiduals(calibration).size()),
+        JointXccyResultJacobian(calibration).Rows(),
+        JointXccyResultEffJacobianInverse(calibration).Rows(),
+        static_cast<int>(JointXccyResultParameterRanges(calibration).size()),
+        static_cast<int>(JointXccyResultResidualRanges(calibration).size()),
+    };
+    const int cols[] = {
+        2,
+        1,
+        1,
+        1,
+        JointXccyResultJacobian(calibration).Cols(),
+        JointXccyResultEffJacobianInverse(calibration).Cols(),
+        3,
+        3,
+    };
+    Matrix_<Cell_> values[8];
+    for (int i = 0; i < 8; ++i) {
+        const char* const attribute = attributes[i];
+        auto& value = values[i];
         JointXccyCalibrationResult_Get(result, attribute, &value);
-        ASSERT_FALSE(value.Empty()) << attribute;
+        ASSERT_EQ(value.Rows(), rows[i]) << attribute;
+        ASSERT_EQ(value.Cols(), cols[i]) << attribute;
     }
+
+    const auto& forwards = JointXccyResultFxForwards(calibration);
+    for (int i = 0; i < forwards.dates_.size(); ++i) {
+        ASSERT_EQ(Cell::ToDate(values[0](i, 0)), forwards.dates_[i]);
+        ASSERT_DOUBLE_EQ(Cell::ToDouble(values[0](i, 1)), forwards.forwards_[i]);
+    }
+    const Vector_<>* const vectors[] = {
+        &JointXccyResultMarketRates(calibration),
+        &JointXccyResultModelRates(calibration),
+        &JointXccyResultResiduals(calibration),
+    };
+    for (int view = 0; view < 3; ++view)
+        for (int row = 0; row < vectors[view]->size(); ++row)
+            ASSERT_DOUBLE_EQ(Cell::ToDouble(values[view + 1](row, 0)), (*vectors[view])[row]);
+    const Matrix_<>* const matrices[] = {
+        &JointXccyResultJacobian(calibration),
+        &JointXccyResultEffJacobianInverse(calibration),
+    };
+    for (int view = 0; view < 2; ++view)
+        for (int row = 0; row < matrices[view]->Rows(); ++row)
+            for (int col = 0; col < matrices[view]->Cols(); ++col)
+                ASSERT_DOUBLE_EQ(Cell::ToDouble(values[view + 4](row, col)), (*matrices[view])(row, col));
+    const Vector_<CalibrationBlockRange_>* const ranges[] = {
+        &JointXccyResultParameterRanges(calibration),
+        &JointXccyResultResidualRanges(calibration),
+    };
+    for (int view = 0; view < 2; ++view)
+        for (int row = 0; row < ranges[view]->size(); ++row) {
+            ASSERT_EQ(Cell::ToString(values[view + 6](row, 0)), (*ranges[view])[row].name_);
+            ASSERT_DOUBLE_EQ(Cell::ToDouble(values[view + 6](row, 1)), (*ranges[view])[row].offset_);
+            ASSERT_DOUBLE_EQ(Cell::ToDouble(values[view + 6](row, 2)), (*ranges[view])[row].size_);
+        }
 }
 
 TEST(ExcelApiTest, TestUnknownJointResultViewListsEveryAcceptedAttribute) {
     const auto result = JointResult();
-    try {
-        Dal::Matrix_<Dal::Cell_> value;
-        JointXccyCalibrationResult_Get(result, "unknown", &value);
-        FAIL() << "Expected an unknown joint result attribute to fail";
-    } catch (const Dal::Exception_& exception) {
-        const std::string message(exception.what());
-        for (const char* attribute : {"domesticBlock", "foreignBlock", "basisCurve", "fxForwards", "marketRates", "modelRates", "residuals",
-                                      "jacobian", "effJacobianInverse", "parameterRanges", "residualRanges"})
-            ASSERT_NE(message.find(attribute), std::string::npos) << attribute << ": " << message;
+    for (const char* attribute : {"unknown", "DOMESTICBLOCK", "FOREIGNBLOCK", "BASISCURVE"}) {
+        try {
+            Dal::Matrix_<Dal::Cell_> value;
+            JointXccyCalibrationResult_Get(result, attribute, &value);
+            FAIL() << "Expected an unknown joint result attribute to fail";
+        } catch (const Dal::Exception_& exception) {
+            const std::string message(exception.what());
+            const std::string expected =
+                std::string("Unknown joint XCCY calibration attribute: ") + attribute +
+                " (accepted views: domesticBlock, foreignBlock, basisCurve, fxForwards, marketRates, modelRates, residuals, jacobian, "
+                "effJacobianInverse, parameterRanges, residualRanges; use the dedicated DOMESTICBLOCK, FOREIGNBLOCK, and BASISCURVE getter "
+                "functions for handle views)";
+            ASSERT_GE(message.size(), expected.size());
+            ASSERT_EQ(message.substr(message.size() - expected.size()), expected);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- harden CG/BCG numerics across the finite binary64 range, including exact scaled-alpha candidate evaluation and shared scale-safe reductions
- keep allocation instrumentation and its migrated zero-allocation test isolated in the existing private boundary executable
- tighten JSON, planner, Excel selector, and fixed generated-normalizer validation without changing public signatures or accepted payloads

## Validation

- fresh GCC 15 Release Linux suite: 1210/1210
- fresh GCC 14 Release Linux: native 1210/1210, XAD 1206/1206, CoDiPack 1207/1207, Adept 1207/1207
- exact-only base/head artifacts: 53 records and 17,437 bytes each, byte-identical; grammar, implementation, workspace, allocation, CMake, P2, and observation mutations passed
- private allocation boundary, symbol isolation, JSON/planner, portable Excel, generated normalizer, and generated-output checks passed
- paired two-round performance gate passed; maximum measured regression was BCG +1.6974%, below the 4% threshold
- independent reviewer verdict: Approve; documentation disposition: no-op / non-blocking

## Residual platform coverage

Windows/MSVC/COFF, the supported Windows Excel host, GCC 13, and Clang 18/19 remain required but not run; they are not represented as passed.

Closes DAL-64
