### PR TITLE
ci: add gcc-15 and clang-20 to the Linux compiler matrix

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang-18, clang-19, gcc-13, gcc-14]
+        compiler: [clang-18, clang-19, clang-20, gcc-13, gcc-14, gcc-15]
         aad-backend: [aadet, xad, codipack, adept]
         include:
           - compiler: clang-18
@@ -25,6 +25,11 @@ jobs:
             cc: clang-19
             cxx: clang++-19
             packages: clang-19 libomp-19-dev libstdc++-14-dev
+            coverage: false
+          - compiler: clang-20
+            cc: clang-20
+            cxx: clang++-20
+            packages: clang-20 libomp-20-dev libstdc++-14-dev
             coverage: false
           - compiler: gcc-13
             cc: gcc-13
@@ -38,6 +43,13 @@ jobs:
             packages: gcc-14 g++-14
             coverage: true
             gcov: gcov-14
+          # gcc-15 comes from ppa:ubuntu-toolchain-r/test (not in the Ubuntu
+          # 24.04 archive); coverage stays on gcc-13/gcc-14 to keep gcov legs lean.
+          - compiler: gcc-15
+            cc: gcc-15
+            cxx: g++-15
+            packages: gcc-15 g++-15
+            coverage: false
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -46,7 +58,7 @@ jobs:
 
       # The action's key gets only a "ccache-" prefix and a trailing
       # timestamp, so the key itself must carry every matrix dimension
-      # (OS, compiler, backend) to keep the 16 jobs from colliding.
+      # (OS, compiler, backend) to keep the 24 jobs from colliding.
       # Coverage legs are excluded: cache hits skip compilation, and the
       # .gcno notes gcov needs are only emitted when the compiler runs.
       - name: Setup ccache
@@ -60,6 +72,13 @@ jobs:
         run: |
           echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+
+      # gcc-15 is not in the Ubuntu 24.04 archive; the toolchain test PPA
+      # publishes it for noble. add-apt-repository refreshes the apt lists.
+      - name: Add gcc-15 toolchain PPA
+        if: matrix.compiler == 'gcc-15'
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
       - name: Setup
         run: |
@@ -85,7 +104,7 @@ jobs:
               FLAGS="-DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off -DDAL_USE_ADEPT_AAD=on" ;;
           esac
           # Python bindings are backend-agnostic — tested separately in
-          # the build-extended job so the 16-job matrix stays lean.
+          # the build-extended job so the 24-job matrix stays lean.
           FLAGS="$FLAGS -DDAL_BUILD_PYTHON=OFF"
           echo "ADDITIONAL_CMAKE_FLAGS=$FLAGS" >> $GITHUB_ENV
 
@@ -174,7 +193,7 @@ jobs:
           ctest --test-dir build/Release-codipack --output-on-failure -LE benchmark
 
   # Extended build: dal-cpp + dal-public + dal-python.
-  # Lives in a separate job so the main 16-job compiler×backend matrix
+  # Lives in a separate job so the main 24-job compiler×backend matrix
   # stays lean — the Python bindings are backend-agnostic, so testing
   # them against one representative configuration is sufficient.
   build-extended:

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Every push and pull request builds and tests this compiler × AAD-backend
 matrix. GitHub publishes one status badge per workflow; open a workflow run
 for per-job results.
 
-| Platform | Compiler | AADet | XAD | CoDiPack | Adept |
-|----------|----------|-------|-----|----------|-------|
-| Ubuntu (`ubuntu-latest`) | GCC 13 | ✓ | ✓ | ✓ | ✓ |
-| Ubuntu (`ubuntu-latest`) | GCC 14 | ✓ | ✓ | ✓ | ✓ |
-| Ubuntu (`ubuntu-latest`) | GCC 15 | ✓ | ✓ | ✓ | ✓ |
-| Ubuntu (`ubuntu-latest`) | Clang 18 | ✓ | ✓ | ✓ | ✓ |
-| Ubuntu (`ubuntu-latest`) | Clang 19 | ✓ | ✓ | ✓ | ✓ |
-| Ubuntu (`ubuntu-latest`) | Clang 20 | ✓ | ✓ | ✓ | ✓ |
-| Windows (`windows-latest`) | MSVC | ✓ | ✓ | — | ✓ |
+| Platform                   | Compiler | AADet | XAD | CoDiPack | Adept |
+|----------------------------|----------|-------|-----|----------|-------|
+| Ubuntu (`ubuntu-latest`)   | GCC 13   | ✓     | ✓   | ✓        | ✓     |
+| Ubuntu (`ubuntu-latest`)   | GCC 14   | ✓     | ✓   | ✓        | ✓     |
+| Ubuntu (`ubuntu-latest`)   | GCC 15   | ✓     | ✓   | ✓        | ✓     |
+| Ubuntu (`ubuntu-latest`)   | Clang 18 | ✓     | ✓   | ✓        | ✓     |
+| Ubuntu (`ubuntu-latest`)   | Clang 19 | ✓     | ✓   | ✓        | ✓     |
+| Ubuntu (`ubuntu-latest`)   | Clang 20 | ✓     | ✓   | ✓        | ✓     |
+| Windows (`windows-latest`) | MSVC     | ✓     | ✓   | —        | ✓     |
 
 - GCC 13/14 legs additionally run gcov coverage; Coveralls tracks GCC 14 + AADet.
 - Windows legs additionally build the `dal-python` bindings and the `dal-excel` add-in.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@
 
 A C++17 quantitative finance library with built-in Automatic Adjoint Differentiation (AAD). Features include yield curve construction, cross-currency pricing and calibration, Monte Carlo simulation, finite difference PDE solvers, a scripting engine for exotic payoffs with tree-walk and compiled evaluators, and parallel model evaluation.
 
+## CI
+
+[![CMake Linux CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-linux.yml/badge.svg?branch=master)](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-linux.yml)
+[![CMake Windows CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-windows.yml/badge.svg?branch=master)](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/workflows/cmake-windows.yml)
+
+Every push and pull request builds and tests this compiler × AAD-backend
+matrix. GitHub publishes one status badge per workflow; open a workflow run
+for per-job results.
+
+| Platform | Compiler | AADet | XAD | CoDiPack | Adept |
+|----------|----------|-------|-----|----------|-------|
+| Ubuntu (`ubuntu-latest`) | GCC 13 | ✓ | ✓ | ✓ | ✓ |
+| Ubuntu (`ubuntu-latest`) | GCC 14 | ✓ | ✓ | ✓ | ✓ |
+| Ubuntu (`ubuntu-latest`) | GCC 15 | ✓ | ✓ | ✓ | ✓ |
+| Ubuntu (`ubuntu-latest`) | Clang 18 | ✓ | ✓ | ✓ | ✓ |
+| Ubuntu (`ubuntu-latest`) | Clang 19 | ✓ | ✓ | ✓ | ✓ |
+| Ubuntu (`ubuntu-latest`) | Clang 20 | ✓ | ✓ | ✓ | ✓ |
+| Windows (`windows-latest`) | MSVC | ✓ | ✓ | — | ✓ |
+
+- GCC 13/14 legs additionally run gcov coverage; Coveralls tracks GCC 14 + AADet.
+- Windows legs additionally build the `dal-python` bindings and the `dal-excel` add-in.
+- Separate Linux jobs cover CoDiPack thread isolation, a warning-clean build,
+  ASan/UBSan/TSan spot tests, Python bindings plus the web gateway, and
+  benchmark regression gating.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Extend the Linux CI compiler x AAD-backend matrix from 16 to 24 legs with GCC 15 and Clang 20 on every push/PR
- gcc-15 legs install from `ppa:ubuntu-toolchain-r/test` (gcc-15 is not in the Ubuntu 24.04 archive); coverage stays on gcc-13/14, so gcc-15 legs run the installed-consumer test instead
- clang-20 legs install straight from the Ubuntu 24.04 universe repo (ships LLVM 20.1)
- README gains a CI section with the full compiler x AAD-backend matrix, including the Windows MSVC legs

## Test plan
- [x] Local `build_linux.sh` with gcc-15.2 (aadet backend): 1222/1222 tests passed
- [x] `python3 .github/scripts/check_docs.py` passes for the README changes
- [x] Workflow YAML validated
- [x] CI green on all 24 Linux matrix legs plus Windows MSVC legs