### PR TITLE
fix: reject extra DCF arguments (DAL-75)

### DIFF
--- a/dal-cpp/dal/script/parser.cpp
+++ b/dal-cpp/dal/script/parser.cpp
@@ -287,6 +287,7 @@ namespace Dal::Script {
             end_date += *cur;
             ++cur;
         }
+        REQUIRE2(cur == closeIt, "too many arguments for `DCF`", ScriptError_);
 
         cur = ++closeIt;
         // TODO: we only implement normal day count fraction convention and leave `context` as empty

--- a/dal-cpp/tests/script/test_parser.cpp
+++ b/dal-cpp/tests/script/test_parser.cpp
@@ -87,6 +87,11 @@ TEST(ScriptTest, TestParserDCF) {
     ASSERT_NEAR(val, 1.00274, 1e-5);
 }
 
+TEST(ScriptTest, TestParserDCFRejectsExtraArguments) {
+    Parser_ parser;
+    ASSERT_THROW(parser.Parse("x = DCF(ACT365F, 2023-04-23, 2024-04-23, 2025-04-23)"), ScriptError_);
+}
+
 TEST(ScriptTest, TestParseIf) {
     Parser_ parser;
     String_ event = R"(


### PR DESCRIPTION
## Summary
- reject `DCF` calls that contain tokens after the required basis, start date, and end date
- add a deterministic parser regression test for the malformed four-argument call

## Reproduction
`Parser_::Parse` accepted `x = DCF(ACT365F, 2023-04-23, 2024-04-23, 2025-04-23)` without throwing.

## Root cause
`ParseDCF` stopped reading the end date at the next comma, then advanced directly past the matched closing parenthesis without validating the remaining tokens.

## Test plan
- [x] `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptTest.TestParserDCF:ScriptTest.TestParserDCFRejectsExtraArguments'`
- [x] `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptTest.*'` (169 passed)
- [x] `bash ./build_linux.sh` (1,224 passed; 0 failed)

## Risks
Valid three-argument `DCF` calls are unchanged. Malformed calls with trailing arguments now fail with `ScriptError_` instead of being silently accepted.

Closes DAL-75
