### PR TITLE
feat: align Curve Lab UI to Curve Builder and unify page style

### DIFF
--- a/dal-web/frontend/src/components/CurveLabWorkspace.tsx
+++ b/dal-web/frontend/src/components/CurveLabWorkspace.tsx
@@ -1398,7 +1398,7 @@ const CurveLabWorkspace = forwardRef<
                               <input
                                 aria-label={`Included ${index + 1}`}
                                 type="checkbox"
-                                checked={Boolean(instrument.included)}
+                                checked={instrument.included !== false}
                                 onChange={(event) => {
                                   setInstrumentField(index, "included", event.target.checked);
                                 }}

--- a/dal-web/frontend/src/components/CurveLabWorkspace.tsx
+++ b/dal-web/frontend/src/components/CurveLabWorkspace.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   forwardRef,
   useCallback,
   useEffect,
@@ -19,7 +20,18 @@ import {
   type CurveLabSuccessFamily,
   type CurveLabVersion,
 } from "../api/client";
+import CurvePreview from "./CurvePreview";
 import { CURVE_LAB_SUCCESS_FAMILIES } from "../curves/curveLabRegistry";
+import {
+  declarationLabel,
+  formatTenor,
+  instrumentDayCount,
+  quoteSeries,
+  quotesAsOf,
+  stepperStates,
+  type CurveBuilderStepId,
+  type CurveBuilderStepState,
+} from "../curves/curveBuilderUtils";
 import {
   curveLabErrorMessage,
   downloadCurveLabArtifacts,
@@ -50,6 +62,21 @@ const TABS: { id: WorkspaceTab; label: string; note: string }[] = [
   { id: "runs", label: "Runs", note: "Axes and lifecycle evidence" },
   { id: "risk", label: "Pricing & Risk", note: "PV, DV01, KRD and matrices" },
   { id: "versions", label: "Versions", note: "Clone, archive, import and export" },
+];
+
+const BUILD_MODES: { value: CurveLabBuildMode; label: string }[] = [
+  { value: "SINGLE", label: "Single" },
+  { value: "MULTI_CURVE", label: "Multi-Curve" },
+  { value: "STAGED_XCCY", label: "Staged XCCY" },
+  { value: "JOINT_XCCY", label: "Joint XCCY" },
+];
+
+const BUILDER_STEPS: { id: CurveBuilderStepId; label: string }[] = [
+  { id: "declaration", label: "Declaration" },
+  { id: "dependencies", label: "Dependencies" },
+  { id: "instruments", label: "Instruments" },
+  { id: "solve", label: "Solve" },
+  { id: "validate", label: "Validate" },
 ];
 
 const COMPONENT_KEY = "clab/v1/local/discount/USD/OIS";
@@ -446,6 +473,11 @@ const CurveLabWorkspace = forwardRef<
   const [baseCurrency, setBaseCurrency] = useState("USD");
   const [compareVersionId, setCompareVersionId] = useState("");
   const [busy, setBusy] = useState(false);
+  const [selectedDeclarationIndex, setSelectedDeclarationIndex] = useState(0);
+  const [depListOpen, setDepListOpen] = useState(false);
+  const [editedAfterBuild, setEditedAfterBuild] = useState(false);
+  const [bannerDismissedKey, setBannerDismissedKey] = useState<string | null>(null);
+  const [lastSuccess, setLastSuccess] = useState<string | null>(null);
   const selectedVersion = useMemo(
     () => versions.find((item) => item.id === selectedVersionId) ?? null,
     [selectedVersionId, versions],
@@ -501,6 +533,7 @@ const CurveLabWorkspace = forwardRef<
     // eslint-disable-next-line no-unused-vars -- core ESLint sees type-only parameter names.
     transform: (...args: [Record<string, unknown>]) => Record<string, unknown>,
   ) => {
+    setEditedAfterBuild(true);
     replaceDraftSource(JSON.stringify(transform(visualDraft), null, 2));
   };
   const setDraftField = (field: string, value: unknown) => {
@@ -509,6 +542,7 @@ const CurveLabWorkspace = forwardRef<
   const setBuildMode = (mode: CurveLabBuildMode) => {
     const topology = topologyForMode(mode);
     setSelectedInstrumentIndex(null);
+    setSelectedDeclarationIndex(0);
     updateVisualDraft((current) => ({
       ...current,
       mode,
@@ -736,25 +770,50 @@ const CurveLabWorkspace = forwardRef<
     setDraft(created);
     replaceDraftSource(JSON.stringify(editableDocument(created.document), null, 2));
     setBuild(null);
+    setEditedAfterBuild(false);
     setStatus(`Draft ${created.id.slice(0, 8)} revision ${created.revision} is ready.`);
   });
 
-  const pollBuild = async (initial: CurveLabBuildRun) => {
+  const pollBuild = async (
+    initial: CurveLabBuildRun,
+    options?: { switchToRuns?: boolean },
+  ) => {
     const terminal = await waitForTerminal(
       initial,
       api.getCurveLabBuildRun,
       setBuild,
     );
     setStatus(`Build ${terminal.id.slice(0, 8)} finished ${terminal.state}.`);
-    setTab("runs");
+    if (terminal.state === "SUCCEEDED") {
+      setLastSuccess(terminal.finished_at ?? new Date().toISOString());
+    }
+    if (options?.switchToRuns !== false) {
+      setTab("runs");
+    }
   };
 
   const buildCurve = () => execute(async () => {
     if (!draft) throw new Error("Create a draft before building.");
+    setEditedAfterBuild(false);
     const created = await api.createCurveLabBuildRun(draft.id);
     setBuild(created);
     setStatus(`Build ${created.id.slice(0, 8)} admitted ${created.state}.`);
     await pollBuild(created);
+  });
+
+  // Header orchestration: persist the current document, then build, without
+  // leaving the builder screen (preview and status strip update in place).
+  const buildAndValidate = () => execute(async () => {
+    const persisted = draft === null
+      ? await api.createCurveLabDraft(parseJson(draftSource))
+      : await api.updateCurveLabDraft(draft.id, draft.revision, parseJson(draftSource));
+    setDraft(persisted);
+    replaceDraftSource(JSON.stringify(editableDocument(persisted.document), null, 2));
+    setEditedAfterBuild(false);
+    const created = await api.createCurveLabBuildRun(persisted.id);
+    setBuild(created);
+    setStatus(`Build ${created.id.slice(0, 8)} admitted ${created.state}.`);
+    await pollBuild(created, { switchToRuns: false });
   });
 
   const resumeBuild = () => execute(async () => {
@@ -772,6 +831,7 @@ const CurveLabWorkspace = forwardRef<
     setDraft(updated);
     replaceDraftSource(JSON.stringify(editableDocument(updated.document), null, 2));
     setBuild(null);
+    setEditedAfterBuild(false);
     setStatus(`Saved draft ${updated.id.slice(0, 8)} revision ${updated.revision}; rebuild required.`);
   });
 
@@ -864,6 +924,8 @@ const CurveLabWorkspace = forwardRef<
     setDraft(cloned);
     replaceDraftSource(JSON.stringify(editableDocument(cloned.document), null, 2));
     setSelectedInstrumentIndex(null);
+    setSelectedDeclarationIndex(0);
+    setEditedAfterBuild(false);
     setBuild(null);
     setTab("build");
     setStatus(`Cloned ${version.name} into draft ${cloned.id.slice(0, 8)}.`);
@@ -907,16 +969,41 @@ const CurveLabWorkspace = forwardRef<
     await pollImport(importJob);
   });
 
-  return (
-    <section {...css("curve-lab-v2")} aria-labelledby="curve-lab-v2-title">
-      <div {...css("curve-lab-v2-heading")}>
-        <div>
-          <span {...css("eyebrow")}>CURVE LAB / REVISION 8</span>
-          <h2 id="curve-lab-v2-title">Durable curve workflow</h2>
-        </div>
-        <span {...css("tag")}>native JSON · exact axes · replayable risk</span>
-      </div>
+  const asOfDate = String(visualDraft.as_of_date ?? "");
+  const includedInstruments = visualInstruments.filter(
+    (instrument) => instrument.included !== false,
+  );
+  const activeDeclarationIndex = visualDeclarations.length === 0
+    ? 0
+    : Math.min(selectedDeclarationIndex, visualDeclarations.length - 1);
+  const activeDeclaration = itemAt(visualDeclarations, activeDeclarationIndex);
+  const fitState = build?.diagnostics && typeof build.diagnostics.fit_state === "string"
+    ? build.diagnostics.fit_state
+    : null;
+  const steps = stepperStates({
+    declarationCount: visualDeclarations.length,
+    dependencyCount: dependencyVersionIds.length,
+    dependencyAvailable: versions.length,
+    includedInstrumentCount: includedInstruments.length,
+    buildState: build?.state ?? null,
+    fitState,
+    mode: String(visualDraft.mode ?? "SINGLE"),
+  });
+  const rebuildRequired = build !== null && (
+    editedAfterBuild
+    || build.stale
+    || (draft !== null && build.draft_revision !== draft.revision)
+  );
+  const bannerKey = `${build?.id ?? "none"}:${draft?.revision ?? 0}:${editedAfterBuild ? "edited" : "clean"}`;
+  const showRebuildBanner = rebuildRequired && bannerDismissedKey !== bannerKey;
+  const previewPoints = quoteSeries(
+    visualInstruments,
+    asOfDate,
+    build?.state === "SUCCEEDED" ? build.quote_axis : null,
+  );
 
+  return (
+    <section {...css("curve-lab-v2")} aria-label="Curve Lab workflow">
       <div {...css("curve-lab-flow-tabs")} role="tablist" aria-label="Curve Lab workflow">
         {TABS.map((item, index) => (
           <button
@@ -941,183 +1028,172 @@ const CurveLabWorkspace = forwardRef<
       {status && <div {...css("curve-lab-success", "curve-lab-workspace-message")}>{status}</div>}
 
       {tab === "build" && (
-        <div {...css("curve-lab-flow-layout")}>
-          <section {...css("request-editor", "curve-lab-flow-editor")}>
-            <div {...css("editor-heading")}>
-              <strong>Visual curve builder</strong>
-              <span {...css("tag")}>closed V2 controls</span>
+        <div {...css("curve-builder")}>
+          <div {...css("curve-builder-header")}>
+            <div {...css("curve-builder-header-fields")}>
+              <label>
+                <span>As of</span>
+                <input
+                  type="date"
+                  aria-label="As-of date"
+                  value={asOfDate}
+                  onChange={(event) => {
+                    setDraftField("as_of_date", event.target.value);
+                  }}
+                />
+              </label>
+              <label>
+                <span>Market</span>
+                <input
+                  aria-label="Market snapshot"
+                  value={String(visualDraft.market_snapshot_id ?? "")}
+                  onChange={(event) => {
+                    setDraftField("market_snapshot_id", event.target.value);
+                  }}
+                />
+              </label>
             </div>
-            <section {...css("panel")}>
-              <h3>Curve topology</h3>
-              <div {...css("form-grid")}>
-                <label>
-                  <span>Build mode</span>
-                  <select
-                    value={String(visualDraft.mode ?? "SINGLE")}
-                    onChange={(event) => {
-                      setBuildMode(event.target.value as CurveLabBuildMode);
-                    }}
-                  >
-                    <option value="SINGLE">Single curve</option>
-                    <option value="MULTI_CURVE">Joint multi-curve</option>
-                    <option value="STAGED_XCCY">XCCY staged</option>
-                    <option value="JOINT_XCCY">XCCY joint</option>
-                  </select>
-                </label>
-                <label>
-                  <span>As-of date</span>
-                  <input
-                    type="date"
-                    value={String(visualDraft.as_of_date ?? "")}
-                    onChange={(event) => {
-                      setDraftField("as_of_date", event.target.value);
-                    }}
-                  />
-                </label>
-                <label>
-                  <span>Market snapshot</span>
-                  <input
-                    value={String(visualDraft.market_snapshot_id ?? "")}
-                    onChange={(event) => {
-                      setDraftField("market_snapshot_id", event.target.value);
-                    }}
-                  />
-                </label>
+            <button
+              type="button"
+              {...css("curve-builder-primary")}
+              disabled={busy}
+              onClick={() => void buildAndValidate()}
+            >
+              Build &amp; Validate
+            </button>
+          </div>
+
+          <div {...css("curve-builder-mode-tabs")} role="tablist" aria-label="Build mode">
+            {BUILD_MODES.map((item, index) => (
+              <button
+                key={item.value}
+                type="button"
+                role="tab"
+                aria-selected={String(visualDraft.mode ?? "SINGLE") === item.value}
+                {...css(
+                  "curve-builder-mode-tab",
+                  String(visualDraft.mode ?? "SINGLE") === item.value && "active",
+                )}
+                onClick={() => {
+                  setBuildMode(item.value);
+                }}
+              >
+                <span aria-hidden="true">0{index + 1}</span>
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          <div {...css("curve-builder-stepper")} aria-label="Build progress">
+            {BUILDER_STEPS.map((step, index) => {
+              const state: CurveBuilderStepState = steps[step.id];
+              const previousDone = index > 0
+                && steps[BUILDER_STEPS[index - 1].id] === "done";
+              return (
+                <Fragment key={step.id}>
+                  {index > 0 && (
+                    <span {...css("curve-builder-step-link", previousDone && "done")} />
+                  )}
+                  <div {...css("curve-builder-step", state)}>
+                    <span {...css("curve-builder-step-bubble")} aria-hidden="true">
+                      {state === "done" ? "✓" : state === "failed" ? "!" : index + 1}
+                    </span>
+                    {step.label}
+                  </div>
+                </Fragment>
+              );
+            })}
+          </div>
+
+          {showRebuildBanner && (
+            <div {...css("curve-builder-banner")} role="status">
+              <span aria-hidden="true">⚠</span>
+              <span>Draft changed · rebuild required</span>
+              <button
+                type="button"
+                aria-label="Dismiss rebuild notice"
+                onClick={() => {
+                  setBannerDismissedKey(bannerKey);
+                }}
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          <div {...css("curve-builder-grid")}>
+            <aside {...css("panel", "curve-builder-set")}>
+              <h3 {...css("panel-title")}>Curve set</h3>
+              <div {...css("curve-builder-nodes")}>
+                {visualDeclarations.map((declaration, index) => {
+                  const key = String(declaration.component_key ?? index);
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      aria-pressed={activeDeclarationIndex === index}
+                      {...css(
+                        "curve-builder-node",
+                        activeDeclarationIndex === index && "selected",
+                      )}
+                      onClick={() => {
+                        setSelectedDeclarationIndex(index);
+                      }}
+                    >
+                      <span {...css("curve-builder-node-text")}>
+                        <strong>{declarationLabel(key)}</strong>
+                        <small {...css("mono")}>{key}</small>
+                      </span>
+                      <span {...css("curve-builder-chip", "draft")}>
+                        {draft ? draft.state.replace(/_/g, " ") : "local"}
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
-              <div {...css("curve-lab-section-heading")}>
-                <div>
-                  <h3>Curve declarations</h3>
-                  <p {...css("muted")}>
-                    Each component owns an included calibration instrument.
-                  </p>
-                </div>
+              <div {...css("curve-builder-set-row")}>
                 <button
                   type="button"
+                  {...css("ghost")}
                   disabled={visualDraft.mode === "SINGLE"}
                   onClick={addDeclaration}
                 >
                   Add declaration
                 </button>
+                <button
+                  type="button"
+                  {...css("danger")}
+                  aria-label={`Remove declaration ${activeDeclarationIndex + 1}`}
+                  disabled={visualDeclarations.length === 1}
+                  onClick={() => {
+                    removeDeclaration(activeDeclarationIndex);
+                  }}
+                >
+                  Remove
+                </button>
               </div>
-              <div {...css("table-container")}>
-                <table aria-label="Curve declarations">
-                  <thead>
-                    <tr>
-                      <th>Role</th>
-                      <th>Currency</th>
-                      <th>Component key</th>
-                      <th>Parameterization</th>
-                      <th>Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {visualDeclarations.map((declaration, index) => (
-                      <tr key={String(declaration.component_key ?? index)}>
-                        <td>
-                          <select
-                            aria-label={`Declaration role ${index + 1}`}
-                            value={String(declaration.role ?? "DISCOUNT")}
-                            onChange={(event) => {
-                              setDeclarationField(index, "role", event.target.value);
-                            }}
-                          >
-                            <option value="DISCOUNT">Discount</option>
-                            <option value="PROJECTION">Projection</option>
-                            <option value="BASIS">Basis</option>
-                          </select>
-                        </td>
-                        <td>
-                          <input
-                            aria-label={`Declaration currency ${index + 1}`}
-                            value={String(declaration.currency ?? "")}
-                            maxLength={3}
-                            onChange={(event) => {
-                              setDeclarationField(
-                                index,
-                                "currency",
-                                event.target.value.toUpperCase(),
-                              );
-                            }}
-                          />
-                        </td>
-                        <td>
-                          <input
-                            aria-label={`Declaration component key ${index + 1}`}
-                            {...css("mono")}
-                            value={String(declaration.component_key ?? "")}
-                            onChange={(event) => {
-                              setDeclarationField(
-                                index,
-                                "component_key",
-                                event.target.value,
-                              );
-                            }}
-                          />
-                        </td>
-                        <td>
-                          <select
-                            aria-label={`Declaration parameterization ${index + 1}`}
-                            value={String(
-                              declaration.parameterization ?? "PIECEWISE_CONSTANT_FWD"
-                            )}
-                            onChange={(event) => {
-                              setDeclarationField(
-                                index,
-                                "parameterization",
-                                event.target.value,
-                              );
-                            }}
-                          >
-                            <option value="PIECEWISE_CONSTANT_FWD">PWC forward</option>
-                            <option value="PIECEWISE_LINEAR_FWD">Linear forward</option>
-                            <option value="ZERO_RATE">Zero rate</option>
-                            <option value="LOG_DISCOUNT">Log discount</option>
-                          </select>
-                        </td>
-                        <td>
-                          <button
-                            type="button"
-                            {...css("danger")}
-                            aria-label={`Remove declaration ${index + 1}`}
-                            disabled={visualDeclarations.length === 1}
-                            onClick={() => {
-                              removeDeclaration(index);
-                            }}
-                          >
-                            Remove
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-            <section {...css("panel")}>
-              <div {...css("curve-lab-section-heading")}>
-                <div>
-                  <h3>Curve dependencies</h3>
-                  <p {...css("muted")}>
-                    Bind visible immutable versions needed by this build.
-                  </p>
-                </div>
-                <span {...css("tag")}>{dependencyVersionIds.length} selected</span>
-              </div>
-              {versions.length === 0 ? (
-                <p {...css("muted")}>No visible curve versions are available.</p>
-              ) : (
-                <div {...css("curve-lab-dependency-list")}>
-                  {versions.map((version) => (
+              <button
+                type="button"
+                {...css("curve-builder-add-dep")}
+                aria-expanded={depListOpen}
+                onClick={() => {
+                  setDepListOpen(!depListOpen);
+                }}
+              >
+                + Add dependency
+              </button>
+              <div {...css("curve-builder-dep-list", depListOpen && "open")}>
+                {versions.length === 0 ? (
+                  <p {...css("muted")}>No visible curve versions are available.</p>
+                ) : (
+                  versions.map((version) => (
                     <label key={version.id}>
                       <input
                         type="checkbox"
                         aria-label={`Use ${version.name} as dependency`}
                         checked={dependencyVersionIds.includes(version.id)}
                         onChange={(event) => {
-                          toggleDependency(
-                            version.id,
-                            event.target.checked,
-                          );
+                          toggleDependency(version.id, event.target.checked);
                         }}
                       />
                       <span>
@@ -1127,172 +1203,353 @@ const CurveLabWorkspace = forwardRef<
                         </small>
                       </span>
                     </label>
-                  ))}
+                  ))
+                )}
+              </div>
+              {activeDeclaration && (
+                <div {...css("curve-builder-fields")}>
+                  <label>
+                    <span>Currency</span>
+                    <input
+                      aria-label={`Declaration currency ${activeDeclarationIndex + 1}`}
+                      value={String(activeDeclaration.currency ?? "")}
+                      maxLength={3}
+                      onChange={(event) => {
+                        setDeclarationField(
+                          activeDeclarationIndex,
+                          "currency",
+                          event.target.value.toUpperCase(),
+                        );
+                      }}
+                    />
+                  </label>
+                  <label>
+                    <span>Role</span>
+                    <select
+                      aria-label={`Declaration role ${activeDeclarationIndex + 1}`}
+                      value={String(activeDeclaration.role ?? "DISCOUNT")}
+                      onChange={(event) => {
+                        setDeclarationField(activeDeclarationIndex, "role", event.target.value);
+                      }}
+                    >
+                      <option value="DISCOUNT">Discount</option>
+                      <option value="PROJECTION">Projection</option>
+                      <option value="BASIS">Basis</option>
+                    </select>
+                  </label>
+                  <label>
+                    <span>Component key</span>
+                    <input
+                      aria-label={`Declaration component key ${activeDeclarationIndex + 1}`}
+                      {...css("mono")}
+                      value={String(activeDeclaration.component_key ?? "")}
+                      onChange={(event) => {
+                        setDeclarationField(
+                          activeDeclarationIndex,
+                          "component_key",
+                          event.target.value,
+                        );
+                      }}
+                    />
+                  </label>
+                  <label>
+                    <span>Parameterization</span>
+                    <select
+                      aria-label={`Declaration parameterization ${activeDeclarationIndex + 1}`}
+                      value={String(
+                        activeDeclaration.parameterization ?? "PIECEWISE_CONSTANT_FWD",
+                      )}
+                      onChange={(event) => {
+                        setDeclarationField(
+                          activeDeclarationIndex,
+                          "parameterization",
+                          event.target.value,
+                        );
+                      }}
+                    >
+                      <option value="PIECEWISE_CONSTANT_FWD">PWC forward</option>
+                      <option value="PIECEWISE_LINEAR_FWD">Linear forward</option>
+                      <option value="ZERO_RATE">Zero rate</option>
+                      <option value="LOG_DISCOUNT">Log discount</option>
+                    </select>
+                  </label>
                 </div>
               )}
-            </section>
-            <section {...css("panel")}>
-              <div {...css("curve-lab-section-heading")}>
-                <div>
-                  <h3>Calibration instruments</h3>
-                  <p {...css("muted")}>Edit registry family, dates, inclusion and canonical quote.</p>
-                </div>
-                <div {...css("curve-lab-row-actions")}>
+              <div {...css("curve-builder-set-actions")}>
+                <dl {...css("curve-builder-ids")}>
+                  <dt>Draft</dt>
+                  <dd>{draft ? `${draft.id.slice(0, 8)} · r${draft.revision}` : "not created"}</dd>
+                  <dt>Build</dt>
+                  <dd>{build ? `${build.id.slice(0, 8)} · ${build.state}` : "not run"}</dd>
+                </dl>
+                <div {...css("curve-builder-set-row")}>
                   <button
                     type="button"
                     {...css("ghost")}
-                    disabled={selectedInstrumentIndex === null}
-                    onClick={() => {
-                      selectCanonicalTarget(null);
-                    }}
+                    disabled={busy}
+                    onClick={() => void createDraft()}
                   >
-                    Clear quote target
+                    Create draft
                   </button>
-                  <button type="button" onClick={addInstrument}>Add instrument</button>
+                  <button
+                    type="button"
+                    {...css("ghost")}
+                    disabled={busy || !draft}
+                    onClick={() => void saveDraft()}
+                  >
+                    Save draft changes
+                  </button>
+                </div>
+                <div {...css("curve-builder-set-row")}>
+                  <button
+                    type="button"
+                    {...css("ghost")}
+                    disabled={busy || !draft}
+                    onClick={() => void buildCurve()}
+                  >
+                    Build curve
+                  </button>
+                  {build && !isTerminal(build) && (
+                    <button
+                      type="button"
+                      {...css("ghost")}
+                      disabled={busy}
+                      aria-label={`Resume build polling ${build.id.slice(0, 8)}`}
+                      onClick={() => void resumeBuild()}
+                    >
+                      Resume build polling
+                    </button>
+                  )}
+                </div>
+                <label>
+                  <span>Version name</span>
+                  <input
+                    value={versionName}
+                    onChange={(event) => {
+                      setVersionName(event.target.value);
+                    }}
+                  />
+                </label>
+                <button
+                  type="button"
+                  disabled={busy || build?.state !== "SUCCEEDED"}
+                  onClick={() => void publishVersion()}
+                >
+                  Publish version
+                </button>
+              </div>
+            </aside>
+
+            <section {...css("curve-builder-instruments")}>
+              <div {...css("panel")}>
+                <div {...css("curve-lab-section-heading")}>
+                  <h3>Calibration instruments</h3>
+                  <div {...css("curve-lab-row-actions")}>
+                    <button
+                      type="button"
+                      {...css("ghost")}
+                      disabled={selectedInstrumentIndex === null}
+                      onClick={() => {
+                        selectCanonicalTarget(null);
+                      }}
+                    >
+                      Clear quote target
+                    </button>
+                    <button type="button" onClick={addInstrument}>Add instrument</button>
+                  </div>
+                </div>
+                <div {...css("table-container")}>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th><span {...css("sr-only")}>Canonical target</span></th>
+                        <th>Include</th>
+                        <th>Type</th>
+                        <th>Tenor</th>
+                        <th>Maturity</th>
+                        <th {...css("num")}>Quote</th>
+                        <th>Day count</th>
+                        <th>Source</th>
+                        <th>Status</th>
+                        <th><span {...css("sr-only")}>Row actions</span></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {visualInstruments.map((instrument, index) => {
+                        const terms = instrument.terms as Record<string, unknown> | undefined;
+                        const included = instrument.included !== false;
+                        return (
+                          <tr
+                            key={String(instrument.instrument_id ?? index)}
+                            {...css(selectedInstrumentIndex === index && "target")}
+                          >
+                            <td>
+                              <input
+                                type="radio"
+                                name="curve-lab-canonical-target"
+                                aria-label={`Canonical quote target ${index + 1}`}
+                                checked={selectedInstrumentIndex === index}
+                                onChange={() => {
+                                  selectCanonicalTarget(index);
+                                }}
+                              />
+                            </td>
+                            <td>
+                              <input
+                                aria-label={`Included ${index + 1}`}
+                                type="checkbox"
+                                checked={Boolean(instrument.included)}
+                                onChange={(event) => {
+                                  setInstrumentField(index, "included", event.target.checked);
+                                }}
+                              />
+                            </td>
+                            <td>
+                              <select
+                                aria-label={`Family ${index + 1}`}
+                                value={String(instrument.instrument_type ?? "DEPOSIT")}
+                                onChange={(event) => {
+                                  setInstrumentFamily(
+                                    index,
+                                    event.target.value as CurveLabSuccessFamily,
+                                  );
+                                }}
+                              >
+                                {CURVE_LAB_SUCCESS_FAMILIES.map(
+                                  (family) => (
+                                    <option key={family} value={family}>{family}</option>
+                                  ),
+                                )}
+                              </select>
+                            </td>
+                            <td {...css("mono", "muted")}>
+                              {formatTenor(asOfDate, String(instrument.maturity_date ?? ""))}
+                            </td>
+                            <td>
+                              <input
+                                aria-label={`Maturity ${index + 1}`}
+                                type="date"
+                                value={String(instrument.maturity_date ?? "")}
+                                onChange={(event) => {
+                                  setInstrumentField(index, "maturity_date", event.target.value);
+                                }}
+                              />
+                            </td>
+                            <td {...css("num")}>
+                              <input
+                                aria-label={`Quote ${index + 1}`}
+                                {...css("curve-builder-quote")}
+                                inputMode="decimal"
+                                value={String(instrument.raw_quote ?? "")}
+                                onChange={(event) => {
+                                  setInstrumentField(index, "raw_quote", event.target.value);
+                                }}
+                              />
+                            </td>
+                            <td>{instrumentDayCount(terms)}</td>
+                            <td {...css("muted")}>{String(instrument.source ?? "—")}</td>
+                            <td>
+                              <span
+                                {...css(included
+                                  ? "curve-builder-tag-ready"
+                                  : "curve-builder-tag-excluded")}
+                              >
+                                {included ? "Ready" : "Excluded"}
+                              </span>
+                            </td>
+                            <td>
+                              <button
+                                type="button"
+                                {...css("danger")}
+                                disabled={visualInstruments.length === 1}
+                                onClick={() => {
+                                  removeInstrument(index);
+                                }}
+                              >
+                                Remove
+                              </button>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                  <div {...css("curve-builder-table-footer")}>
+                    <span>{visualInstruments.length} instruments</span>
+                    <span>Quotes as of {quotesAsOf(visualInstruments, asOfDate)}</span>
+                  </div>
                 </div>
               </div>
-              <div {...css("table-container")}>
-                <table>
-                  <thead><tr><th>Canonical target</th><th>Family</th><th>Maturity</th><th>Quote</th><th>Included</th><th>Actions</th></tr></thead>
-                  <tbody>
-                    {visualInstruments.map((instrument, index) => (
-                      <tr key={String(instrument.instrument_id ?? index)}>
-                        <td>
-                          <input
-                            type="radio"
-                            name="curve-lab-canonical-target"
-                            aria-label={`Canonical quote target ${index + 1}`}
-                            checked={selectedInstrumentIndex === index}
-                            onChange={() => {
-                              selectCanonicalTarget(index);
-                            }}
-                          />
-                        </td>
-                        <td>
-                          <select
-                            aria-label={`Family ${index + 1}`}
-                            value={String(instrument.instrument_type ?? "DEPOSIT")}
-                            onChange={(event) => {
-                              setInstrumentFamily(
-                                index,
-                                event.target.value as CurveLabSuccessFamily,
-                              );
-                            }}
-                          >
-                            {CURVE_LAB_SUCCESS_FAMILIES.map(
-                              (family) => <option key={family} value={family}>{family}</option>,
-                            )}
-                          </select>
-                        </td>
-                        <td>
-                          <input
-                            aria-label={`Maturity ${index + 1}`}
-                            type="date"
-                            value={String(instrument.maturity_date ?? "")}
-                            onChange={(event) => {
-                              setInstrumentField(index, "maturity_date", event.target.value);
-                            }}
-                          />
-                        </td>
-                        <td>
-                          <input
-                            aria-label={`Quote ${index + 1}`}
-                            inputMode="decimal"
-                            value={String(instrument.raw_quote ?? "")}
-                            onChange={(event) => {
-                              setInstrumentField(index, "raw_quote", event.target.value);
-                            }}
-                          />
-                        </td>
-                        <td>
-                          <input
-                            aria-label={`Included ${index + 1}`}
-                            type="checkbox"
-                            checked={Boolean(instrument.included)}
-                            onChange={(event) => {
-                              setInstrumentField(index, "included", event.target.checked);
-                            }}
-                          />
-                        </td>
-                        <td>
-                          <button
-                            type="button"
-                            {...css("danger")}
-                            disabled={visualInstruments.length === 1}
-                            onClick={() => {
-                              removeInstrument(index);
-                            }}
-                          >
-                            Remove
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <details {...css("curve-builder-advanced")}>
+                <summary>Solver &amp; advanced JSON</summary>
+                <p {...css("muted", "mono")}>
+                  {String(
+                    (visualDraft.solver as Record<string, unknown> | undefined)?.solve_mode
+                      ?? "EXACT",
+                  )}
+                  {" · "}
+                  {String(
+                    (visualDraft.solver as Record<string, unknown> | undefined)?.parameterization
+                      ?? "PIECEWISE_CONSTANT_FWD",
+                  )}
+                </p>
+                <label>
+                  <span>Build document JSON</span>
+                  <textarea
+                    value={draftSource}
+                    rows={20}
+                    spellCheck={false}
+                    onChange={(event) => {
+                      setEditedAfterBuild(true);
+                      replaceDraftSource(event.target.value);
+                    }}
+                  />
+                </label>
+              </details>
             </section>
-            <section {...css("panel")}>
-              <h3>Solver controls</h3>
-              <p {...css("muted")}>
-                {String((visualDraft.solver as Record<string, unknown> | undefined)?.solve_mode ?? "EXACT")}
+
+            <CurvePreview
+              points={previewPoints}
+              buildState={build?.state ?? null}
+              fitState={fitState}
+              includedCount={includedInstruments.length}
+              totalCount={visualInstruments.length}
+            />
+          </div>
+
+          <footer {...css("curve-builder-statusbar")}>
+            <span>
+              Curve Set:{" "}
+              <strong>
+                {declarationLabel(String(visualDeclarations[0]?.component_key ?? "—"))}
                 {" · "}
-                {String((visualDraft.solver as Record<string, unknown> | undefined)?.parameterization ?? "PIECEWISE_CONSTANT_FWD")}
-              </p>
-            </section>
-            <details>
-              <summary>Advanced JSON</summary>
-              <label>
-                <span>Build document JSON</span>
-                <textarea
-                  value={draftSource}
-                  rows={24}
-                  spellCheck={false}
-                  onChange={(event) => {
-                    replaceDraftSource(event.target.value);
-                  }}
-                />
-              </label>
-            </details>
-            <div {...css("submit-row")}>
-              <p>Server-derived quote and parameter axes are frozen at build time.</p>
-              <button type="button" disabled={busy} onClick={() => void createDraft()}>
-                Create draft
-              </button>
-            </div>
-          </section>
-          <aside {...css("panel", "curve-lab-actions")}>
-            <h3>Build controls</h3>
-            <dl>
-              <dt>Draft</dt><dd>{draft ? `${draft.id.slice(0, 8)} · r${draft.revision}` : "not created"}</dd>
-              <dt>Build</dt><dd>{build ? `${build.id.slice(0, 8)} · ${build.state}` : "not run"}</dd>
-            </dl>
-            <button type="button" disabled={busy || !draft} onClick={() => void buildCurve()}>
-              Build curve
-            </button>
-            {build && !isTerminal(build) && (
-              <button
-                type="button"
-                disabled={busy}
-                aria-label={`Resume build polling ${build.id.slice(0, 8)}`}
-                onClick={() => void resumeBuild()}
+                {draft ? draft.state.replace(/_/g, " ") : "LOCAL"}
+              </strong>
+            </span>
+            <span>Dependencies: <strong>{dependencyVersionIds.length}</strong></span>
+            <span>Instruments: <strong>{visualInstruments.length}</strong></span>
+            <span>
+              Status:{" "}
+              <strong
+                {...css(rebuildRequired
+                  ? "warn"
+                  : build?.state === "SUCCEEDED" ? "ok" : undefined)}
               >
-                Resume build polling
-              </button>
-            )}
-            <button type="button" disabled={busy || !draft} onClick={() => void saveDraft()}>
-              Save draft changes
-            </button>
-            <label>
-              <span>Version name</span>
-              <input value={versionName} onChange={(event) => {
-                setVersionName(event.target.value);
-              }} />
-            </label>
-            <button type="button" disabled={busy || build?.state !== "SUCCEEDED"} onClick={() => void publishVersion()}>
-              Publish version
-            </button>
-          </aside>
+                {rebuildRequired ? "Rebuild required" : build?.state ?? "Draft"}
+              </strong>
+            </span>
+            <span {...css("curve-builder-statusbar-spacer")} />
+            <span>
+              Last build:{" "}
+              <strong {...css("mono")}>
+                {build ? `${build.id.slice(0, 8)} · ${build.state}` : "—"}
+              </strong>
+            </span>
+            <span>
+              Last success:{" "}
+              <strong {...css("mono")}>{lastSuccess ?? "—"}</strong>
+            </span>
+          </footer>
         </div>
       )}
 

--- a/dal-web/frontend/src/components/CurvePreview.tsx
+++ b/dal-web/frontend/src/components/CurvePreview.tsx
@@ -53,7 +53,9 @@ export default function CurvePreview({
           role="tab"
           aria-selected={view === "raw"}
           {...css(view === "raw" && "active")}
-          onClick={() => setView("raw")}
+          onClick={() => {
+            setView("raw");
+          }}
         >
           Raw quotes
         </button>
@@ -64,7 +66,9 @@ export default function CurvePreview({
           disabled={!hasNormalized}
           title={hasNormalized ? "Normalized quotes from the succeeded build" : "Available after a succeeded build"}
           {...css(view === "normalized" && "active")}
-          onClick={() => setView("normalized")}
+          onClick={() => {
+            setView("normalized");
+          }}
         >
           Normalized
         </button>

--- a/dal-web/frontend/src/components/CurvePreview.tsx
+++ b/dal-web/frontend/src/components/CurvePreview.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import type { QuoteSeriesPoint } from "../curves/curveBuilderUtils";
+import { css } from "../format";
+
+const CHART = { width: 460, height: 210, padLeft: 40, padRight: 10, padTop: 16, padBottom: 26 };
+
+interface CurvePreviewProps {
+  points: QuoteSeriesPoint[];
+  buildState: string | null;
+  fitState: string | null;
+  includedCount: number;
+  totalCount: number;
+}
+
+function yScale(value: number, low: number, high: number): number {
+  const span = high - low || 1;
+  const inner = CHART.height - CHART.padTop - CHART.padBottom;
+  return CHART.padTop + (1 - (value - low) / span) * inner;
+}
+
+function xScale(index: number, count: number): number {
+  const inner = CHART.width - CHART.padLeft - CHART.padRight;
+  return count <= 1
+    ? CHART.padLeft + inner / 2
+    : CHART.padLeft + (index / (count - 1)) * inner;
+}
+
+export default function CurvePreview({
+  points,
+  buildState,
+  fitState,
+  includedCount,
+  totalCount,
+}: CurvePreviewProps) {
+  const [view, setView] = useState<"raw" | "normalized">("raw");
+  const hasNormalized = points.some((point) => point.normalizedPercent !== null);
+  const values = points.flatMap((point) => [
+    point.percent,
+    ...(view === "normalized" && point.normalizedPercent !== null
+      ? [point.normalizedPercent]
+      : []),
+  ]);
+  const low = values.length > 0 ? Math.min(...values) - 0.25 : 0;
+  const high = values.length > 0 ? Math.max(...values) + 0.25 : 1;
+  const stateLabel = buildState ?? "DRAFT";
+  const stateClass = buildState === "SUCCEEDED" ? "pos" : "warn";
+  return (
+    <section {...css("panel", "curve-builder-preview")} aria-label="Curve preview">
+      <h3 {...css("panel-title")}>Curve preview</h3>
+      <div {...css("curve-builder-preview-tabs")} role="tablist" aria-label="Preview view">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "raw"}
+          {...css(view === "raw" && "active")}
+          onClick={() => setView("raw")}
+        >
+          Raw quotes
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "normalized"}
+          disabled={!hasNormalized}
+          title={hasNormalized ? "Normalized quotes from the succeeded build" : "Available after a succeeded build"}
+          {...css(view === "normalized" && "active")}
+          onClick={() => setView("normalized")}
+        >
+          Normalized
+        </button>
+      </div>
+      {points.length === 0 ? (
+        <p {...css("muted")}>No plottable rate quotes yet — add included deposit, futures or swap instruments.</p>
+      ) : (
+        <svg
+          viewBox={`0 0 ${CHART.width} ${CHART.height}`}
+          role="img"
+          aria-label="Quotes by tenor"
+          {...css("curve-builder-chart")}
+        >
+          {[0, 0.5, 1].map((fraction) => {
+            const value = low + fraction * (high - low);
+            const y = yScale(value, low, high);
+            return (
+              <g key={fraction}>
+                <line
+                  x1={CHART.padLeft}
+                  x2={CHART.width - CHART.padRight}
+                  y1={y}
+                  y2={y}
+                  {...css("curve-builder-chart-grid")}
+                />
+                <text x={CHART.padLeft - 6} y={y + 3} textAnchor="end" {...css("curve-builder-chart-tick")}>
+                  {value.toFixed(2)}
+                </text>
+              </g>
+            );
+          })}
+          {points.map((point, index) => (
+            <text
+              key={`label-${point.key}`}
+              x={xScale(index, points.length)}
+              y={CHART.height - 8}
+              textAnchor="middle"
+              {...css("curve-builder-chart-tick")}
+            >
+              {point.tenor}
+            </text>
+          ))}
+          <polyline
+            points={points.map((point, index) => (
+              `${xScale(index, points.length)},${yScale(point.percent, low, high)}`
+            )).join(" ")}
+            {...css("curve-builder-chart-line")}
+          />
+          {points.map((point, index) => (
+            <circle
+              key={`raw-${point.key}`}
+              cx={xScale(index, points.length)}
+              cy={yScale(point.percent, low, high)}
+              r={3.5}
+              {...css("curve-builder-chart-dot")}
+            >
+              <title>{`${point.tenor} · ${point.percent.toFixed(4)}%`}</title>
+            </circle>
+          ))}
+          {view === "normalized" && points.map((point, index) => (
+            point.normalizedPercent === null ? null : (
+              <circle
+                key={`normalized-${point.key}`}
+                cx={xScale(index, points.length)}
+                cy={yScale(point.normalizedPercent, low, high)}
+                r={2.5}
+                {...css("curve-builder-chart-dot-normalized")}
+              >
+                <title>{`${point.tenor} · normalized ${point.normalizedPercent.toFixed(4)}%`}</title>
+              </circle>
+            )
+          ))}
+        </svg>
+      )}
+      <div {...css("curve-builder-legend")}>
+        <span {...css("curve-builder-legend-raw")}>Quotes (raw)</span>
+        {view === "normalized" && hasNormalized && (
+          <span {...css("curve-builder-legend-normalized")}>Normalized (post-build)</span>
+        )}
+      </div>
+      <div {...css("curve-builder-stats")}>
+        <div {...css("curve-builder-stat")}>
+          <h4>State</h4>
+          <div {...css("metric", stateClass)}>{stateLabel}</div>
+        </div>
+        <div {...css("curve-builder-stat")}>
+          <h4>Fit</h4>
+          <div {...css("metric", fitState === "NATIVE_ARCHIVE_VALIDATED" && "pos")}>{fitState ?? "—"}</div>
+        </div>
+        <div {...css("curve-builder-stat")}>
+          <h4>Quotes</h4>
+          <div {...css("metric")}>{includedCount} / {totalCount}</div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/dal-web/frontend/src/components/FitPlot.tsx
+++ b/dal-web/frontend/src/components/FitPlot.tsx
@@ -15,7 +15,7 @@ export default function FitPlot({ rows }: { rows: FitSeriesRow[] }) {
   const high = Math.max(...rates);
   return (
     <section {...css("panel")}>
-      <h2>Market fit & residuals</h2>
+      <h3 {...css("panel-title")}>Market fit & residuals</h3>
       <div {...css("plot-grid")}>
         <svg viewBox="0 0 100 100" role="img" aria-labelledby="fit-title fit-desc">
           <title id="fit-title">Market and model calibration rates</title>

--- a/dal-web/frontend/src/components/MatrixHeatmap.tsx
+++ b/dal-web/frontend/src/components/MatrixHeatmap.tsx
@@ -21,7 +21,7 @@ export default function MatrixHeatmap({
   return (
     <section {...css("panel", "matrix-panel")}>
       <div {...css("matrix-heading")}>
-        <h2>{title}</h2>
+        <h3 {...css("panel-title")}>{title}</h3>
         <span {...css("tag")}>{model.shapeLabel} · {matrix.scaling}</span>
       </div>
       {!model.available ? (

--- a/dal-web/frontend/src/components/PageHeader.tsx
+++ b/dal-web/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { css } from "../format";
+
+interface PageHeaderProps {
+  eyebrow: string;
+  title: string;
+  subtitle?: string;
+  children?: ReactNode;
+}
+
+// Shared page header: section eyebrow, title, optional subtitle and optional
+// right-aligned controls — the same structure every page leads with.
+export default function PageHeader({ eyebrow, title, subtitle, children }: PageHeaderProps) {
+  return (
+    <div {...css("page-header")}>
+      <div>
+        <span {...css("eyebrow")}>{eyebrow}</span>
+        <h1>{title}</h1>
+        {subtitle && <p>{subtitle}</p>}
+      </div>
+      {children && <div {...css("page-header-controls")}>{children}</div>}
+    </div>
+  );
+}

--- a/dal-web/frontend/src/components/ValuationPanel.tsx
+++ b/dal-web/frontend/src/components/ValuationPanel.tsx
@@ -100,7 +100,7 @@ export default function ValuationPanel({ onRun, title = "Run valuation" }: Props
 
   return (
     <div {...css("panel")}>
-      <h2>{title}</h2>
+      <h3 {...css("panel-title")}>{title}</h3>
       {error && <div {...css("error")}>{error}</div>}
       <div {...css("row")} {...inlineStyle({ marginBottom: 12 })}>
         <label>

--- a/dal-web/frontend/src/curves/curveBuilderUtils.ts
+++ b/dal-web/frontend/src/curves/curveBuilderUtils.ts
@@ -36,9 +36,12 @@ export function formatTenor(asOf: string, maturity: string): string {
 
 // First available day-basis term, display-formatted: "ACT_365F" → "ACT/365F".
 export function instrumentDayCount(terms: Record<string, unknown> | undefined): string {
-  const basis = ["day_basis", "fixed_day_basis", "spread_day_basis", "domestic_day_basis"]
-    .map((field) => terms?.[field])
-    .find((value) => typeof value === "string" && value.length > 0);
+  const basis = [
+    terms?.day_basis,
+    terms?.fixed_day_basis,
+    terms?.spread_day_basis,
+    terms?.domestic_day_basis,
+  ].find((value) => typeof value === "string" && value.length > 0);
   return typeof basis === "string" ? basis.replace(/_/g, "/") : "—";
 }
 

--- a/dal-web/frontend/src/curves/curveBuilderUtils.ts
+++ b/dal-web/frontend/src/curves/curveBuilderUtils.ts
@@ -36,11 +36,10 @@ export function formatTenor(asOf: string, maturity: string): string {
 
 // First available day-basis term, display-formatted: "ACT_365F" → "ACT/365F".
 export function instrumentDayCount(terms: Record<string, unknown> | undefined): string {
-  const basis = terms?.day_basis
-    ?? terms?.fixed_day_basis
-    ?? terms?.spread_day_basis
-    ?? terms?.domestic_day_basis;
-  return typeof basis === "string" && basis.length > 0 ? basis.replace(/_/g, "/") : "—";
+  const basis = ["day_basis", "fixed_day_basis", "spread_day_basis", "domestic_day_basis"]
+    .map((field) => terms?.[field])
+    .find((value) => typeof value === "string" && value.length > 0);
+  return typeof basis === "string" ? basis.replace(/_/g, "/") : "—";
 }
 
 // Families whose raw quote is (or converts to) a percentage rate.

--- a/dal-web/frontend/src/curves/curveBuilderUtils.ts
+++ b/dal-web/frontend/src/curves/curveBuilderUtils.ts
@@ -1,0 +1,159 @@
+// Pure helpers backing the Curve Builder screen. No React, no API access:
+// every function maps existing draft/build-run data into display form.
+
+export type CurveBuilderStepId =
+  | "declaration"
+  | "dependencies"
+  | "instruments"
+  | "solve"
+  | "validate";
+
+export type CurveBuilderStepState = "done" | "active" | "todo" | "running" | "failed";
+
+const DAY_MS = 86_400_000;
+
+// "clab/v1/local/discount/USD/OIS" → "USD OIS · Discount".
+export function declarationLabel(componentKey: string): string {
+  const parts = componentKey.split("/").filter(Boolean);
+  const tail = parts.slice(3);
+  if (tail.length < 2) return componentKey;
+  const [role, ...rest] = tail;
+  const roleLabel = role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
+  return `${rest.join(" ")} · ${roleLabel}`;
+}
+
+// Tenor label from the as-of date to maturity: 1D / 3M / 2Y / 5.5Y.
+export function formatTenor(asOf: string, maturity: string): string {
+  const start = Date.parse(asOf);
+  const end = Date.parse(maturity);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return "—";
+  const days = Math.round((end - start) / DAY_MS);
+  if (days < 31) return `${days}D`;
+  if (days < 365) return `${Math.round(days / 30.4375)}M`;
+  const years = Math.round((days / 365.25) * 2) / 2;
+  return `${years}Y`;
+}
+
+// First available day-basis term, display-formatted: "ACT_365F" → "ACT/365F".
+export function instrumentDayCount(terms: Record<string, unknown> | undefined): string {
+  const basis = terms?.day_basis
+    ?? terms?.fixed_day_basis
+    ?? terms?.spread_day_basis
+    ?? terms?.domestic_day_basis;
+  return typeof basis === "string" && basis.length > 0 ? basis.replace(/_/g, "/") : "—";
+}
+
+// Families whose raw quote is (or converts to) a percentage rate.
+const RATE_FAMILIES = new Set(["DEPOSIT", "FRA", "OIS", "IRS", "FUTURE"]);
+
+// Raw quote → percent. Futures prices convert to the implied rate (100 - price);
+// decimal quotes scale to percent; percent lexemes pass through.
+export function quoteToPercent(family: string, rawQuote: unknown): number | null {
+  const value = Number(rawQuote);
+  if (!Number.isFinite(value)) return null;
+  if (family === "FUTURE") return 100 - value;
+  return Math.abs(value) < 1 ? value * 100 : value;
+}
+
+export interface QuoteSeriesPoint {
+  key: string;
+  instrumentIndex: number;
+  tenor: string;
+  days: number;
+  percent: number;
+  normalizedPercent: number | null;
+}
+
+export interface QuoteAxisLike {
+  instrument_id?: string;
+  normalized_quote?: string;
+}
+
+// Plottable points for the curve preview: included, rate-family instruments with a
+// parseable quote and a maturity after the as-of date, sorted by tenor. When a
+// succeeded build supplies its quote axis, normalized quotes join by instrument_id.
+export function quoteSeries(
+  instruments: Record<string, unknown>[],
+  asOf: string,
+  quoteAxis?: QuoteAxisLike[] | null,
+): QuoteSeriesPoint[] {
+  const normalizedByInstrumentId = new Map<string, string>();
+  (quoteAxis ?? []).forEach((entry) => {
+    if (entry.instrument_id && typeof entry.normalized_quote === "string") {
+      normalizedByInstrumentId.set(entry.instrument_id, entry.normalized_quote);
+    }
+  });
+  const start = Date.parse(asOf);
+  if (!Number.isFinite(start)) return [];
+  return instruments.flatMap((instrument, instrumentIndex) => {
+    if (instrument.included === false) return [];
+    const family = String(instrument.instrument_type ?? "");
+    if (!RATE_FAMILIES.has(family)) return [];
+    const percent = quoteToPercent(family, instrument.raw_quote);
+    if (percent === null) return [];
+    const maturity = Date.parse(String(instrument.maturity_date ?? ""));
+    if (!Number.isFinite(maturity) || maturity <= start) return [];
+    const normalizedRaw = typeof instrument.instrument_id === "string"
+      ? normalizedByInstrumentId.get(instrument.instrument_id)
+      : undefined;
+    const normalizedValue = Number(normalizedRaw);
+    const days = Math.round((maturity - start) / DAY_MS);
+    return [{
+      key: String(instrument.instrument_id ?? instrumentIndex),
+      instrumentIndex,
+      tenor: formatTenor(asOf, String(instrument.maturity_date)),
+      days,
+      percent,
+      normalizedPercent: Number.isFinite(normalizedValue)
+        ? Math.abs(normalizedValue) < 1 ? normalizedValue * 100 : normalizedValue
+        : null,
+    }];
+  }).sort((left, right) => left.days - right.days);
+}
+
+export interface CurveBuilderStepperInput {
+  declarationCount: number;
+  dependencyCount: number;
+  dependencyAvailable: number;
+  includedInstrumentCount: number;
+  buildState: string | null;
+  fitState: string | null;
+  mode: string;
+}
+
+const NON_TERMINAL_BUILD_STATES = new Set(["ADMITTED", "QUEUED", "RUNNING"]);
+
+export function stepperStates(
+  input: CurveBuilderStepperInput,
+): Record<CurveBuilderStepId, CurveBuilderStepState> {
+  const declaration: CurveBuilderStepState = input.declarationCount > 0 ? "done" : "active";
+  const dependenciesDone = input.dependencyCount > 0
+    || input.dependencyAvailable === 0
+    || input.mode === "SINGLE";
+  const dependencies: CurveBuilderStepState = dependenciesDone
+    ? "done"
+    : declaration === "done" ? "active" : "todo";
+  const instrumentsDone = input.includedInstrumentCount > 0;
+  const instruments: CurveBuilderStepState = instrumentsDone
+    ? "done"
+    : dependencies === "done" ? "active" : "todo";
+  let solve: CurveBuilderStepState = "todo";
+  if (input.buildState !== null) {
+    if (NON_TERMINAL_BUILD_STATES.has(input.buildState)) solve = "running";
+    else if (input.buildState === "SUCCEEDED") solve = "done";
+    else solve = "failed";
+  }
+  const validate: CurveBuilderStepState = input.fitState === "NATIVE_ARCHIVE_VALIDATED"
+    ? "done"
+    : "todo";
+  return { declaration, dependencies, instruments, solve, validate };
+}
+
+// Latest observed_at across instruments, falling back to the as-of date.
+export function quotesAsOf(instruments: Record<string, unknown>[], asOf: string): string {
+  const observed = instruments
+    .map((instrument) => String(instrument.observed_at ?? ""))
+    .filter((value) => value.length > 0)
+    .sort();
+  return observed.length > 0 ? observed[observed.length - 1] : asOf;
+}

--- a/dal-web/frontend/src/pages/CurveRun.tsx
+++ b/dal-web/frontend/src/pages/CurveRun.tsx
@@ -10,6 +10,7 @@ import { api, type CalibrationRun } from "../api/client";
 import CalibrationLifecycle from "../components/CalibrationLifecycle";
 import FitPlot from "../components/FitPlot";
 import MatrixHeatmap from "../components/MatrixHeatmap";
+import PageHeader from "../components/PageHeader";
 import QuoteBumpPanel from "../components/QuoteBumpPanel";
 import { alignFitSeries } from "../curves/visualization";
 import { css } from "../format";
@@ -63,13 +64,14 @@ function useCalibrationRun(runId: string) {
 
 function CurveRunHeader({ run }: { run: CalibrationRun }) {
   return (
-    <div {...css("run-header")}>
-      <div>
-        <Link to="/curves" {...css("back-link")}>← Curve workbench</Link>
-        <span {...css("eyebrow")}>{run.kind.split("_").join(" ")} / {run.id.slice(0, 8)}</span>
-        <h1>{run.name}</h1>
-      </div>
-      <span {...css("run-status", run.status)}>{run.status}</span>
+    <div>
+      <Link to="/curves" {...css("back-link")}>← Curve Builder</Link>
+      <PageHeader
+        eyebrow={`${run.kind.split("_").join(" ")} / ${run.id.slice(0, 8)}`}
+        title={run.name}
+      >
+        <span {...css("run-status", run.status)}>{run.status}</span>
+      </PageHeader>
     </div>
   );
 }
@@ -130,7 +132,7 @@ function RunMetrics({ run }: { run: CalibrationRun }) {
 function PersistedCurves({ run }: { run: CalibrationRun }) {
   return (
     <section {...css("panel")}>
-      <h2>Persisted curves</h2>
+      <h3 {...css("panel-title")}>Persisted curves</h3>
       <div {...css("table-container")}>
         <table>
           <thead><tr><th>Curve</th><th>Role</th><th>Representation</th><th>Nodes</th><th>State</th></tr></thead>
@@ -159,7 +161,7 @@ function FxForwardCurve({ run }: { run: CalibrationRun }) {
   const forwardValues = forwards.forwards[Symbol.iterator]();
   return (
     <section {...css("panel")}>
-      <h2>FX forward curve</h2>
+      <h3 {...css("panel-title")}>FX forward curve</h3>
       <div {...css("fx-strip")}>
         {forwards.dates.map((item) => (
           <div key={item}><span>{item}</span><strong>{forwardValues.next().value?.toFixed(8)}</strong></div>

--- a/dal-web/frontend/src/pages/Curves.tsx
+++ b/dal-web/frontend/src/pages/Curves.tsx
@@ -11,6 +11,7 @@ import CurveLabWorkspace, {
   type CurveLabCanonicalTarget,
   type CurveLabWorkspaceHandle,
 } from "../components/CurveLabWorkspace";
+import PageHeader from "../components/PageHeader";
 import { calibrationExamples } from "../curves/examples";
 import { locateCalibrationField, type LocatedField } from "../curves/visualization";
 import { css } from "../format";
@@ -95,133 +96,134 @@ export default function Curves() {
 
   return (
     <div {...css("curve-workbench")}>
-      <div {...css("page-header")}>
-        <div>
-          <span {...css("eyebrow")}>CALIBRATION / RISK</span>
-          <h1>Curve Workbench</h1>
-          <p>Author a deterministic solve, then inspect fit, matrices and persisted reconstruction state.</p>
-        </div>
-        <div {...css("workbench-stat")}>
-          <strong>{lines}</strong>
-          <span>request lines</span>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="CURVE LAB / CONSTRUCTION"
+        title="Curve Builder"
+        subtitle="Construct deterministic curve sets from instruments, dependencies and conventions."
+      />
 
       <CurveLabWorkspace
         ref={workspaceRef}
         onCanonicalTargetChange={setCanonicalTarget}
       />
 
-      <CurveLabQuoteAuthoring
-        targetInstrumentFamily={canonicalTarget?.family ?? null}
-        targetToken={canonicalTarget?.token}
-        onCanonicalQuote={applyCanonicalQuote}
-      />
+      <details {...css("curve-builder-legacy")}>
+        <summary>Quote authoring tools</summary>
+        <CurveLabQuoteAuthoring
+          targetInstrumentFamily={canonicalTarget?.family ?? null}
+          targetToken={canonicalTarget?.token}
+          onCanonicalQuote={applyCanonicalQuote}
+        />
+      </details>
 
-      <div {...css("mode-tabs")} role="tablist" aria-label="Calibration mode">
-        {MODES.map((item, index) => (
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mode === item.value}
-            {...css("mode-tab", mode === item.value && "active")}
-            key={item.value}
-            onClick={() => {
-              setMode(item.value);
-              setSource(formattedExample(item.value));
-              setError(null);
-              setLocated(null);
-            }}
-          >
-            <span>0{index + 1}</span>
-            <strong>{item.label}</strong>
-            <small>{item.note}</small>
-          </button>
-        ))}
-      </div>
+      <details {...css("curve-builder-legacy")}>
+        <summary>Legacy JSON calibration</summary>
 
-      <div {...css("workbench-layout")}>
-        <aside {...css("workbench-outline")}>
-          <h2>Request anatomy</h2>
-          {["Declaration & representation", "Knots & initial seeds", "Instruments & conventions", "Solver & matrix settings"].map((item, index) => (
-            <div key={item} {...css("outline-row", located?.row === index && "has-error")}>
-              <span>{index + 1}</span>
-              <p>{item}</p>
-            </div>
-          ))}
-          <div {...css("contract-note")}>
-            <strong>Native boundary</strong>
-            <p>Validation, planning and calibration are executed by the compiled DAL gateway.</p>
-          </div>
-        </aside>
-
-        <section {...css("request-editor")}>
-          <div {...css("editor-heading")}>
-            <div>
-              <span {...css("tag")}>{mode.replace("_", " ")}</span>
-              <strong>JSON contract editor</strong>
-            </div>
+        <div {...css("mode-tabs")} role="tablist" aria-label="Calibration mode">
+          {MODES.map((item, index) => (
             <button
               type="button"
-              {...css("ghost")}
+              role="tab"
+              aria-selected={mode === item.value}
+              {...css("mode-tab", mode === item.value && "active")}
+              key={item.value}
               onClick={() => {
-                setSource(formattedExample(mode));
-              }}
-            >
-              Reset example
-            </button>
-          </div>
-          <label>
-            <span>Calibration request JSON</span>
-            <textarea
-              value={source}
-              spellCheck={false}
-              rows={Math.max(24, Math.min(44, lines))}
-              onChange={(event) => {
-                setSource(event.target.value);
+                setMode(item.value);
+                setSource(formattedExample(item.value));
                 setError(null);
                 setLocated(null);
               }}
-            />
-          </label>
-          {error && (
-            <div {...css("error", "editor-error")}>
-              <strong>{located ? `${located.section} · ${located.field}` : "Request error"}</strong>
-              <span>{error}</span>
-            </div>
-          )}
-          <div {...css("submit-row")}>
-            <p>202 creates an immutable run; this page never performs calibration math.</p>
-            <button
-              type="button"
-              disabled={submitting}
-              onClick={() => {
-                const request = parseCalibrationRequest(source);
-                if (request.error) {
-                  setError(request.error);
-                  return;
-                }
-                setSubmitting(true);
-                setError(null);
-                void api.submitCalibration(mode, request.body)
-                  .then((run) => {
-                    navigate(`/curves/runs/${run.id}`);
-                  })
-                  .catch((reason: unknown) => {
-                    const presented = presentCalibrationError(reason);
-                    setLocated(presented.located);
-                    setError(presented.message);
-                  })
-                  .finally(() => {
-                    setSubmitting(false);
-                  });
-              }}
             >
-              {submitting ? "Submitting…" : "Run calibration"}
+              <span>0{index + 1}</span>
+              <strong>{item.label}</strong>
+              <small>{item.note}</small>
             </button>
-          </div>
-        </section>
-      </div>
+          ))}
+        </div>
+
+        <div {...css("workbench-layout")}>
+          <aside {...css("workbench-outline")}>
+            <h2>Request anatomy</h2>
+            {["Declaration & representation", "Knots & initial seeds", "Instruments & conventions", "Solver & matrix settings"].map((item, index) => (
+              <div key={item} {...css("outline-row", located?.row === index && "has-error")}>
+                <span>{index + 1}</span>
+                <p>{item}</p>
+              </div>
+            ))}
+            <div {...css("contract-note")}>
+              <strong>Native boundary</strong>
+              <p>Validation, planning and calibration are executed by the compiled DAL gateway.</p>
+            </div>
+          </aside>
+
+          <section {...css("request-editor")}>
+            <div {...css("editor-heading")}>
+              <div>
+                <span {...css("tag")}>{mode.replace("_", " ")}</span>
+                <strong>JSON contract editor</strong>
+              </div>
+              <button
+                type="button"
+                {...css("ghost")}
+                onClick={() => {
+                  setSource(formattedExample(mode));
+                }}
+              >
+                Reset example
+              </button>
+            </div>
+            <label>
+              <span>Calibration request JSON</span>
+              <textarea
+                value={source}
+                spellCheck={false}
+                rows={Math.max(24, Math.min(44, lines))}
+                onChange={(event) => {
+                  setSource(event.target.value);
+                  setError(null);
+                  setLocated(null);
+                }}
+              />
+            </label>
+            {error && (
+              <div {...css("error", "editor-error")}>
+                <strong>{located ? `${located.section} · ${located.field}` : "Request error"}</strong>
+                <span>{error}</span>
+              </div>
+            )}
+            <div {...css("submit-row")}>
+              <p>202 creates an immutable run; this page never performs calibration math.</p>
+              <button
+                type="button"
+                disabled={submitting}
+                onClick={() => {
+                  const request = parseCalibrationRequest(source);
+                  if (request.error) {
+                    setError(request.error);
+                    return;
+                  }
+                  setSubmitting(true);
+                  setError(null);
+                  void api.submitCalibration(mode, request.body)
+                    .then((run) => {
+                      navigate(`/curves/runs/${run.id}`);
+                    })
+                    .catch((reason: unknown) => {
+                      const presented = presentCalibrationError(reason);
+                      setLocated(presented.located);
+                      setError(presented.message);
+                    })
+                    .finally(() => {
+                      setSubmitting(false);
+                    });
+                }}
+              >
+                {submitting ? "Submitting…" : "Run calibration"}
+              </button>
+            </div>
+          </section>
+        </div>
+      </details>
     </div>
   );
 }

--- a/dal-web/frontend/src/pages/Dashboard.tsx
+++ b/dal-web/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api, type Portfolio, type Trade, type ValuationResult } from "../api/client";
+import PageHeader from "../components/PageHeader";
 import { css, fmtMoney, inlineStyle } from "../format";
 
 export default function Dashboard() {
@@ -36,12 +37,11 @@ export default function Dashboard() {
 
   return (
     <div>
-      <div {...css("page-header")}>
-        <div>
-          <h1>Dashboard</h1>
-          <p>Portfolio overview and recent valuation activity.</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="DAL WORKBENCH / OVERVIEW"
+        title="Dashboard"
+        subtitle="Portfolio overview and recent valuation activity."
+      />
 
       {error && <div {...css("error")}>{error}</div>}
 
@@ -67,7 +67,7 @@ export default function Dashboard() {
       </div>
 
       <div {...css("panel")}>
-        <h2>Recent valuation runs</h2>
+        <h3 {...css("panel-title")}>Recent valuation runs</h3>
         {loading ? (
           <p {...css("muted")}>Loading…</p>
         ) : valuations.length === 0 ? (

--- a/dal-web/frontend/src/pages/Models.tsx
+++ b/dal-web/frontend/src/pages/Models.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, type ModelDefinition, type ModelKind } from "../api/client";
+import PageHeader from "../components/PageHeader";
 import { css, fmtNum, inlineStyle } from "../format";
 
 export default function Models() {
@@ -90,12 +91,11 @@ export default function Models() {
 
   return (
     <div>
-      <div {...css("page-header")}>
-        <div>
-          <h1>Models</h1>
-          <p>Black-Scholes model data passed to DAL via BSModelData_New.</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="RISK / VOLATILITY MODELS"
+        title="Models"
+        subtitle="Black-Scholes model data passed to DAL via BSModelData_New."
+      />
 
       {error && <div {...css("error")}>{error}</div>}
 
@@ -106,7 +106,7 @@ export default function Models() {
       ) : (
       <>
       <div {...css("panel")}>
-        <h2>New model</h2>
+        <h3 {...css("panel-title")}>New model</h3>
         <div {...css("field")}>
           <label htmlFor="model-name">Name</label>
           <input
@@ -274,7 +274,9 @@ export default function Models() {
         </div>
       </div>
 
-      <div {...css("table-container")}>
+      <div {...css("panel")}>
+        <h3 {...css("panel-title")}>Registered models</h3>
+        <div {...css("table-container")}>
         <table>
           <thead>
             <tr>
@@ -323,6 +325,7 @@ export default function Models() {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
       </>
       )}

--- a/dal-web/frontend/src/pages/Portfolios.tsx
+++ b/dal-web/frontend/src/pages/Portfolios.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, type Portfolio, type Trade } from "../api/client";
+import PageHeader from "../components/PageHeader";
 import { css, fmtMoney, inlineStyle } from "../format";
 import ValuationPanel from "../components/ValuationPanel";
 
@@ -81,12 +82,11 @@ export default function Portfolios() {
 
   return (
     <div>
-      <div {...css("page-header")}>
-        <div>
-          <h1>Portfolios</h1>
-          <p>Group trades into books and price the whole book at once.</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="BOOKS / COMPOSITION"
+        title="Portfolios"
+        subtitle="Group trades into books and price the whole book at once."
+      />
 
       {error && <div {...css("error")}>{error}</div>}
 
@@ -97,7 +97,7 @@ export default function Portfolios() {
       ) : (
       <div {...css("grid-2")}>
         <div {...css("panel")}>
-          <h2>Books</h2>
+          <h3 {...css("panel-title")}>Books</h3>
           <div {...css("row")} {...inlineStyle({ marginBottom: 12 })}>
             <input
               value={name}

--- a/dal-web/frontend/src/pages/ProductBuilder.tsx
+++ b/dal-web/frontend/src/pages/ProductBuilder.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type EventRow, type ProductDefinition, type ProductTemplate } from "../api/client";
+import PageHeader from "../components/PageHeader";
 import { css, inlineStyle } from "../format";
 
 const EMPTY_ROW: EventRow = { date_kind: "label", label: "", event: "" };
@@ -114,12 +115,11 @@ export default function ProductBuilder() {
 
   return (
     <div>
-      <div {...css("page-header")}>
-        <div>
-          <h1>Product Builder</h1>
-          <p>Compose DAL scripted products as a schedule of (date, event) rows.</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="BOOKS / SCRIPTED PRODUCTS"
+        title="Product Builder"
+        subtitle="Compose DAL scripted products as a schedule of (date, event) rows."
+      />
 
       {error && <div {...css("error")}>{error}</div>}
 
@@ -147,7 +147,7 @@ export default function ProductBuilder() {
 
       <div {...css("grid-2")}>
         <div {...css("panel")}>
-          <h2>Definition</h2>
+          <h3 {...css("panel-title")}>Definition</h3>
           <div {...css("field")}>
             <label htmlFor="product-name">Name</label>
             <input
@@ -169,7 +169,7 @@ export default function ProductBuilder() {
             />
           </div>
 
-          <h3>Event schedule</h3>
+          <h3 {...css("panel-title")}>Event schedule</h3>
           {rows.map((r) => (
             <div {...css("event-builder-row")} key={r.row_id}>
               <select
@@ -241,7 +241,7 @@ export default function ProductBuilder() {
         </div>
 
         <div {...css("panel")}>
-          <h2>DAL product debug</h2>
+          <h3 {...css("panel-title")}>DAL product debug</h3>
           {debug ? (
             <pre {...css("debug")}>{debug}</pre>
           ) : (
@@ -254,7 +254,7 @@ export default function ProductBuilder() {
       </div>
 
       <div {...css("panel")}>
-        <h2>Saved products</h2>
+        <h3 {...css("panel-title")}>Saved products</h3>
         {products.length === 0 ? (
           <p {...css("muted")}>No saved products yet. Build one above and click Save.</p>
         ) : (

--- a/dal-web/frontend/src/pages/Trades.tsx
+++ b/dal-web/frontend/src/pages/Trades.tsx
@@ -5,6 +5,7 @@ import {
   type ProductDefinition,
   type Trade,
 } from "../api/client";
+import PageHeader from "../components/PageHeader";
 import { css, fmtMoney, inlineStyle } from "../format";
 import ValuationPanel from "../components/ValuationPanel";
 
@@ -98,12 +99,11 @@ export default function Trades() {
 
   return (
     <div>
-      <div {...css("page-header")}>
-        <div>
-          <h1>Trades</h1>
-          <p>Each trade links a scripted product to a model and a notional.</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="BOOKS / TICKETS"
+        title="Trades"
+        subtitle="Each trade links a scripted product to a model and a notional."
+      />
 
       {error && <div {...css("error")}>{error}</div>}
 
@@ -114,7 +114,7 @@ export default function Trades() {
       ) : (
       <>
       <div {...css("panel")}>
-        <h2>New trade</h2>
+        <h3 {...css("panel-title")}>New trade</h3>
         <div {...css("row")} {...inlineStyle({ marginBottom: 12 })}>
           <div>
             <label htmlFor="trade-name">Name</label>
@@ -214,7 +214,9 @@ export default function Trades() {
         </div>
       </div>
 
-      <div {...css("table-container")}>
+      <div {...css("panel")}>
+        <h3 {...css("panel-title")}>All trades</h3>
+        <div {...css("table-container")}>
         <table>
           <thead>
             <tr>
@@ -258,6 +260,7 @@ export default function Trades() {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
 
       {selected && (

--- a/dal-web/frontend/src/pages/Valuations.tsx
+++ b/dal-web/frontend/src/pages/Valuations.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useState } from "react";
 import { api, type ValuationResult } from "../api/client";
+import PageHeader from "../components/PageHeader";
 import { css, fmtMoney, fmtNum, inlineStyle } from "../format";
 
 export default function Valuations() {
@@ -14,12 +15,11 @@ export default function Valuations() {
 
   return (
     <div>
-      <div {...css("page-header")}>
-        <div>
-          <h1>Valuation Runs</h1>
-          <p>Reproducible history of every Monte Carlo valuation.</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="RISK / VALUATION RUNS"
+        title="Valuation Runs"
+        subtitle="Reproducible history of every Monte Carlo valuation."
+      />
 
       {error && <div {...css("error")}>{error}</div>}
 
@@ -28,7 +28,9 @@ export default function Valuations() {
       ) : runs.length === 0 ? (
         <p {...css("muted")}>No valuation runs recorded yet.</p>
       ) : (
-        <div {...css("table-container")}>
+        <div {...css("panel")}>
+          <h3 {...css("panel-title")}>Run history</h3>
+          <div {...css("table-container")}>
           <table>
             <thead>
               <tr>
@@ -87,7 +89,7 @@ export default function Valuations() {
                   <tr key={`${r.id}-detail`}>
                     <td colSpan={8}>
                       <div {...css("panel")} {...inlineStyle({ margin: 0 })}>
-                        <h2>Greeks</h2>
+                        <h3 {...css("panel-title")}>Greeks</h3>
                         {Object.keys(r.total_greeks).length === 0 ? (
                           <p {...css("muted")}>No Greeks (AAD disabled).</p>
                         ) : (
@@ -99,7 +101,7 @@ export default function Valuations() {
                             ))}
                           </div>
                         )}
-                        <h2 {...inlineStyle({ marginTop: 16 })}>Trades</h2>
+                        <h3 {...css("panel-title")} {...inlineStyle({ marginTop: 16 })}>Trades</h3>
                         <div {...css("table-container")}>
                           <table>
                             <thead>
@@ -128,7 +130,7 @@ export default function Valuations() {
                   <tr key={`${r.id}-detail`}>
                     <td colSpan={8}>
                       <div {...css("panel")} {...inlineStyle({ margin: 0 })}>
-                        <h2>Error</h2>
+                        <h3 {...css("panel-title")}>Error</h3>
                         <p {...css("error")}>{r.error_message || "Unknown error"}</p>
                       </div>
                     </td>
@@ -138,6 +140,7 @@ export default function Valuations() {
             ))}
           </tbody>
         </table>
+        </div>
         </div>
       )}
     </div>

--- a/dal-web/frontend/src/styles.css
+++ b/dal-web/frontend/src/styles.css
@@ -1548,7 +1548,651 @@ pre.debug {
   .brand::before,
   .status-dot,
   .spinner,
-  .status-running::before {
+  .status-running::before,
+  .curve-builder-step.running .curve-builder-step-bubble {
     animation: none;
   }
+}
+
+/* ── Curve Builder (Curve Lab build tab) ─────────────────────────────────── */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.curve-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.curve-builder-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.curve-builder-header-fields {
+  display: flex;
+  gap: 12px;
+}
+
+.curve-builder-header-fields label {
+  display: block;
+  margin-bottom: 0;
+}
+
+.curve-builder-header-fields label > span {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.curve-builder-primary {
+  padding: 10px 20px;
+}
+
+/* Mode tabs */
+.curve-builder-mode-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+}
+
+.curve-builder-mode-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--text-dim);
+  padding: 10px 20px;
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.curve-builder-mode-tab span {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.curve-builder-mode-tab:hover {
+  background: none;
+  color: var(--text);
+}
+
+.curve-builder-mode-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.curve-builder-mode-tab.active span {
+  color: var(--accent);
+}
+
+/* Stepper */
+.curve-builder-stepper {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+.curve-builder-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.curve-builder-step-bubble {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  background: var(--bg-2);
+}
+
+.curve-builder-step.done {
+  color: var(--text-dim);
+}
+
+.curve-builder-step.done .curve-builder-step-bubble {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.curve-builder-step.active {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.curve-builder-step.active .curve-builder-step-bubble {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.curve-builder-step.running .curve-builder-step-bubble {
+  border-color: var(--amber);
+  color: var(--amber);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.curve-builder-step.failed .curve-builder-step-bubble {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.curve-builder-step-link {
+  width: 72px;
+  height: 1px;
+  background: var(--border);
+  margin: 0 14px;
+}
+
+.curve-builder-step-link.done {
+  background: var(--green);
+}
+
+/* Rebuild banner */
+.curve-builder-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--amber-dim);
+  border: 1px solid rgba(210, 153, 34, 0.4);
+  border-radius: var(--radius-lg);
+  color: var(--amber);
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.curve-builder-banner button {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--amber);
+  font-size: 16px;
+  padding: 0 4px;
+}
+
+.curve-builder-banner button:hover {
+  background: none;
+  color: var(--text);
+}
+
+/* Three-column grid */
+.curve-builder-grid {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr) 400px;
+  gap: 16px;
+  align-items: start;
+}
+
+/* Curve set panel */
+.curve-builder-nodes {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.curve-builder-node {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--text);
+  padding: 10px 12px;
+  text-align: left;
+  font-weight: 400;
+}
+
+.curve-builder-node:hover {
+  background: var(--bg);
+  border-color: var(--accent-2);
+}
+
+.curve-builder-node.selected {
+  border-color: var(--accent);
+}
+
+.curve-builder-node-text {
+  min-width: 0;
+}
+
+.curve-builder-node-text strong {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.curve-builder-node-text small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.curve-builder-chip {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+
+.curve-builder-chip.draft {
+  color: var(--amber);
+  border-color: rgba(210, 153, 34, 0.5);
+  background: var(--amber-dim);
+}
+
+.curve-builder-chip.validated {
+  color: var(--green);
+  border-color: rgba(46, 160, 67, 0.5);
+  background: var(--green-dim);
+}
+
+.curve-builder-set-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.curve-builder-set-row button {
+  flex: 1;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.curve-builder-add-dep {
+  width: 100%;
+  background: none;
+  border: 1px dashed var(--border);
+  color: var(--text-dim);
+  padding: 8px;
+}
+
+.curve-builder-add-dep:hover {
+  background: var(--bg-3);
+  color: var(--text);
+}
+
+.curve-builder-dep-list {
+  display: none;
+  margin-top: 8px;
+}
+
+.curve-builder-dep-list.open {
+  display: grid;
+  gap: 4px;
+}
+
+.curve-builder-dep-list label {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 4px;
+  margin-bottom: 0;
+  font-size: 13px;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.curve-builder-dep-list small {
+  display: block;
+  color: var(--text-muted);
+}
+
+.curve-builder-fields {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.curve-builder-fields input,
+.curve-builder-fields select {
+  width: 100%;
+}
+
+.curve-builder-set-actions {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
+  display: grid;
+  gap: 8px;
+}
+
+.curve-builder-set-actions label {
+  margin-bottom: 0;
+}
+
+.curve-builder-set-actions label input {
+  width: 100%;
+  margin-top: 4px;
+}
+
+.curve-builder-ids {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 12px;
+  margin: 0 0 4px;
+  font-size: 12px;
+}
+
+.curve-builder-ids dt {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+
+.curve-builder-ids dd {
+  margin: 0;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--text-dim);
+}
+
+/* Instruments column */
+.curve-builder-instruments tbody tr.target {
+  background: rgba(212, 160, 23, 0.07);
+}
+
+.curve-builder-instruments td input.curve-builder-quote {
+  width: 96px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  text-align: right;
+  padding: 4px 8px;
+}
+
+.curve-builder-tag-ready {
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.curve-builder-tag-excluded {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.curve-builder-table-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.curve-builder-advanced summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+}
+
+.curve-builder-advanced[open] summary {
+  margin-bottom: 12px;
+}
+
+.curve-builder-advanced textarea {
+  width: 100%;
+}
+
+/* Preview panel */
+.curve-builder-preview {
+  margin-bottom: 0;
+}
+
+.curve-builder-preview-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+
+.curve-builder-preview-tabs button {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--text-dim);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 8px 12px;
+}
+
+.curve-builder-preview-tabs button:hover {
+  background: none;
+  color: var(--text);
+}
+
+.curve-builder-preview-tabs button.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.curve-builder-preview-tabs button:disabled {
+  color: var(--border);
+}
+
+.curve-builder-chart {
+  width: 100%;
+  display: block;
+}
+
+.curve-builder-chart-grid {
+  stroke: var(--border-subtle);
+  stroke-width: 1;
+}
+
+.curve-builder-chart-tick {
+  fill: var(--text-muted);
+  font-size: 9px;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.curve-builder-chart-line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.5;
+}
+
+.curve-builder-chart-dot {
+  fill: var(--green);
+  stroke: var(--bg);
+  stroke-width: 1;
+}
+
+.curve-builder-chart-dot-normalized {
+  fill: var(--text-dim);
+}
+
+.curve-builder-legend {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+
+.curve-builder-legend-raw::before,
+.curve-builder-legend-normalized::before {
+  content: "";
+  width: 14px;
+  height: 2px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
+.curve-builder-legend-raw::before {
+  background: var(--accent);
+}
+
+.curve-builder-legend-normalized::before {
+  background: var(--text-dim);
+}
+
+.curve-builder-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.curve-builder-stat {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 10px 12px;
+}
+
+.curve-builder-stat h4 {
+  margin: 0 0 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+}
+
+.curve-builder-stat .metric {
+  font-size: 13px;
+}
+
+.curve-builder-stat .metric.warn {
+  color: var(--amber);
+}
+
+/* Status strip */
+.curve-builder-statusbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 20px;
+  padding: 10px 16px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.curve-builder-statusbar strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.curve-builder-statusbar strong.warn {
+  color: var(--amber);
+}
+
+.curve-builder-statusbar strong.ok {
+  color: var(--green);
+}
+
+.curve-builder-statusbar-spacer {
+  flex: 1;
+}
+
+/* Collapsed legacy sections on the Curves page */
+.curve-builder-legacy {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px 16px;
+  margin-top: 16px;
+}
+
+.curve-builder-legacy summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+}
+
+.curve-builder-legacy[open] summary {
+  margin-bottom: 16px;
+}
+
+@media (max-width: 1280px) {
+  .curve-builder-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.curve-builder-instruments .table-container {
+  overflow-x: auto;
+}
+
+.curve-builder-instruments table td {
+  padding: 8px 8px;
+  white-space: nowrap;
+}
+
+.curve-builder-instruments table input,
+.curve-builder-instruments table select {
+  max-width: 100%;
+}
+
+.curve-builder-instruments table select {
+  min-width: 112px;
+}
+
+.curve-builder-instruments table input[type="date"] {
+  width: 140px;
+}
+
+/* Shared page-header controls slot + unified panel section titles */
+.page-header-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.panel-title {
+  margin: 0 0 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
 }

--- a/dal-web/frontend/tests/e2e/app.spec.ts
+++ b/dal-web/frontend/tests/e2e/app.spec.ts
@@ -28,7 +28,7 @@ test("navigates between primary pages", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Product Builder" })).toBeVisible();
 
   await page.goto("/models");
-  await expect(page.getByRole("heading", { name: "Models" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Models", exact: true })).toBeVisible();
 
   await page.goto("/valuations");
   await expect(page.getByRole("heading", { name: "Valuation Runs" })).toBeVisible();

--- a/dal-web/frontend/tests/e2e/curve_lab_workspace.spec.ts
+++ b/dal-web/frontend/tests/e2e/curve_lab_workspace.spec.ts
@@ -10,6 +10,7 @@ test("canonical authoring drives identical persisted and replayed financial iden
   );
 
   await page.goto("/curves");
+  await page.getByText("Quote authoring tools").click();
   await page.getByLabel("Version name").fill("Canonical equivalence");
   await page.getByLabel("Canonical quote target 1").check();
 
@@ -191,6 +192,7 @@ test("latest same-target canonicalization wins when browser responses finish out
     pending.push(route);
   });
   await page.goto("/curves");
+  await page.getByText("Quote authoring tools").click();
   await page.getByLabel("Canonical quote target 1").check();
   await page.getByLabel("Input convention").selectOption("PERCENT");
   await page.getByLabel("Quote lexeme").fill("4");

--- a/dal-web/frontend/tests/e2e/curves.spec.ts
+++ b/dal-web/frontend/tests/e2e/curves.spec.ts
@@ -7,7 +7,8 @@ test("creates, polls, visualizes and reloads a persisted calibration", async ({ 
   );
 
   await page.goto("/curves");
-  await expect(page.getByRole("heading", { name: "Curve Workbench" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Curve Builder" })).toBeVisible();
+  await page.getByText("Legacy JSON calibration").click();
   await page.getByRole("button", { name: "Run calibration" }).click();
 
   await expect(page).toHaveURL(/\/curves\/runs\/[0-9a-f]{32}$/);

--- a/dal-web/frontend/tests/unit/curve_builder_utils.test.ts
+++ b/dal-web/frontend/tests/unit/curve_builder_utils.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  declarationLabel,
+  formatTenor,
+  instrumentDayCount,
+  quoteSeries,
+  quoteToPercent,
+  quotesAsOf,
+  stepperStates,
+} from "../../src/curves/curveBuilderUtils";
+
+describe("declarationLabel", () => {
+  it("renders the component tail with a readable role", () => {
+    expect(declarationLabel("clab/v1/local/discount/USD/OIS")).toBe("USD OIS · Discount");
+    expect(declarationLabel("clab/v1/local/projection/USD/3M")).toBe("USD 3M · Projection");
+    expect(declarationLabel("clab/v1/local/basis/USD-EUR")).toBe("USD-EUR · Basis");
+  });
+
+  it("falls back to the raw key when the shape is unexpected", () => {
+    expect(declarationLabel("odd")).toBe("odd");
+  });
+});
+
+describe("formatTenor", () => {
+  it("labels days, months and years", () => {
+    expect(formatTenor("2026-01-15", "2026-01-16")).toBe("1D");
+    expect(formatTenor("2026-01-15", "2026-04-15")).toBe("3M");
+    expect(formatTenor("2026-01-15", "2028-01-15")).toBe("2Y");
+    expect(formatTenor("2026-01-15", "2031-01-15")).toBe("5Y");
+  });
+
+  it("returns a placeholder for unparseable or inverted ranges", () => {
+    expect(formatTenor("2026-01-15", "2026-01-15")).toBe("—");
+    expect(formatTenor("2026-01-15", "not-a-date")).toBe("—");
+  });
+});
+
+describe("instrumentDayCount", () => {
+  it("prefers the single-basis term and formats separators", () => {
+    expect(instrumentDayCount({ day_basis: "ACT_365F" })).toBe("ACT/365F");
+    expect(instrumentDayCount({ fixed_day_basis: "ACT_360" })).toBe("ACT/360");
+  });
+
+  it("returns a placeholder without a basis", () => {
+    expect(instrumentDayCount({})).toBe("—");
+    expect(instrumentDayCount(undefined)).toBe("—");
+  });
+});
+
+describe("quoteToPercent", () => {
+  it("converts decimals to percent and passes percent lexemes through", () => {
+    expect(quoteToPercent("DEPOSIT", "0.0433")).toBeCloseTo(4.33);
+    expect(quoteToPercent("IRS", "3.765")).toBeCloseTo(3.765);
+  });
+
+  it("converts futures prices to the implied rate", () => {
+    expect(quoteToPercent("FUTURE", "95.8225")).toBeCloseTo(4.1775);
+  });
+
+  it("rejects unparseable quotes", () => {
+    expect(quoteToPercent("OIS", "abc")).toBeNull();
+  });
+});
+
+describe("quoteSeries", () => {
+  const instruments = [
+    {
+      instrument_id: "a",
+      instrument_type: "DEPOSIT",
+      raw_quote: "0.0433",
+      maturity_date: "2026-01-16",
+      included: true,
+    },
+    {
+      instrument_id: "b",
+      instrument_type: "BASIS_SWAP",
+      raw_quote: "0.001",
+      maturity_date: "2028-01-15",
+      included: true,
+    },
+    {
+      instrument_id: "c",
+      instrument_type: "IRS",
+      raw_quote: "3.765",
+      maturity_date: "2028-01-15",
+      included: false,
+    },
+    {
+      instrument_id: "d",
+      instrument_type: "OIS",
+      raw_quote: "4.228",
+      maturity_date: "2026-04-15",
+      included: true,
+    },
+  ];
+
+  it("keeps included rate families sorted by tenor and skips spreads/excluded rows", () => {
+    const points = quoteSeries(instruments, "2026-01-15");
+    expect(points.map((point) => point.key)).toEqual(["a", "d"]);
+    expect(points[0].tenor).toBe("1D");
+    expect(points[1].tenor).toBe("3M");
+    expect(points[1].percent).toBeCloseTo(4.228);
+    expect(points.every((point) => point.normalizedPercent === null)).toBe(true);
+  });
+
+  it("joins normalized quotes from a succeeded build by instrument id", () => {
+    const points = quoteSeries(instruments, "2026-01-15", [
+      { instrument_id: "d", normalized_quote: "0.0423" },
+    ]);
+    expect(points.find((point) => point.key === "d")?.normalizedPercent).toBeCloseTo(4.23);
+    expect(points.find((point) => point.key === "a")?.normalizedPercent).toBeNull();
+  });
+
+  it("returns nothing without a valid as-of date", () => {
+    expect(quoteSeries(instruments, "not-a-date")).toEqual([]);
+  });
+});
+
+describe("stepperStates", () => {
+  const base = {
+    declarationCount: 1,
+    dependencyCount: 0,
+    dependencyAvailable: 0,
+    includedInstrumentCount: 2,
+    buildState: null,
+    fitState: null,
+    mode: "MULTI_CURVE",
+  };
+
+  it("marks content steps done and leaves solve/validate open before any build", () => {
+    expect(stepperStates(base)).toEqual({
+      declaration: "done",
+      dependencies: "done",
+      instruments: "done",
+      solve: "todo",
+      validate: "todo",
+    });
+  });
+
+  it("activates dependencies when versions exist but none are selected", () => {
+    const states = stepperStates({ ...base, dependencyAvailable: 3 });
+    expect(states.dependencies).toBe("active");
+  });
+
+  it("treats dependencies as done for single-curve builds", () => {
+    const states = stepperStates({ ...base, dependencyAvailable: 3, mode: "SINGLE" });
+    expect(states.dependencies).toBe("done");
+  });
+
+  it("reflects a running, succeeded and failed build", () => {
+    expect(stepperStates({ ...base, buildState: "QUEUED" }).solve).toBe("running");
+    expect(stepperStates({ ...base, buildState: "SUCCEEDED" }).solve).toBe("done");
+    expect(stepperStates({ ...base, buildState: "FAILED" }).solve).toBe("failed");
+  });
+
+  it("completes validate only on the validated fit state", () => {
+    expect(
+      stepperStates({ ...base, buildState: "SUCCEEDED", fitState: "NATIVE_ARCHIVE_VALIDATED" })
+        .validate,
+    ).toBe("done");
+    expect(stepperStates({ ...base, buildState: "SUCCEEDED", fitState: "SOLVING" }).validate)
+      .toBe("todo");
+  });
+});
+
+describe("quotesAsOf", () => {
+  it("takes the latest observation and falls back to the as-of date", () => {
+    expect(quotesAsOf([
+      { observed_at: "2026-01-14T00:00:00Z" },
+      { observed_at: "2026-01-15T16:00:00Z" },
+    ], "2026-01-15")).toBe("2026-01-15T16:00:00Z");
+    expect(quotesAsOf([{}], "2026-01-15")).toBe("2026-01-15");
+  });
+});

--- a/dal-web/frontend/tests/unit/curve_lab_workspace.test.tsx
+++ b/dal-web/frontend/tests/unit/curve_lab_workspace.test.tsx
@@ -15,7 +15,7 @@ describe("Curve Lab V2 workspace", () => {
 
     render(<CurveLabWorkspace />);
 
-    expect(screen.getByRole("heading", { name: "Curve topology" })).not.toBeNull();
+    expect(screen.getByRole("heading", { name: "Curve set" })).not.toBeNull();
     expect(screen.getByRole("heading", { name: "Calibration instruments" })).not.toBeNull();
     expect(screen.getByLabelText("As-of date")).not.toBeNull();
     expect(screen.getByLabelText("Declaration role 1")).not.toBeNull();
@@ -23,7 +23,8 @@ describe("Curve Lab V2 workspace", () => {
     expect(screen.getByLabelText("Quote 1")).not.toBeNull();
     expect(screen.getByRole("button", { name: "Add declaration" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Add instrument" })).not.toBeNull();
-    const advanced = screen.getByText("Advanced JSON").closest("details");
+    expect(screen.getByRole("button", { name: "Build & Validate" })).not.toBeNull();
+    const advanced = screen.getByText("Solver & advanced JSON").closest("details");
     expect(advanced?.open).toBe(false);
     expect(
       Array.from((screen.getByLabelText("Family 1") as HTMLSelectElement).options)
@@ -35,16 +36,20 @@ describe("Curve Lab V2 workspace", () => {
     vi.spyOn(api, "listCurveLabVersions").mockResolvedValue([]);
 
     render(<CurveLabWorkspace />);
-    fireEvent.change(screen.getByLabelText("Build mode"), {
-      target: { value: "STAGED_XCCY" },
-    });
+    fireEvent.click(screen.getByRole("tab", { name: "Staged XCCY" }));
 
-    expect(screen.getAllByLabelText(/Declaration role/)).toHaveLength(3);
+    expect(screen.getByRole("button", { name: /USD OIS · Discount/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /EUR OIS · Discount/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /USD-EUR · Basis/ })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /USD-EUR · Basis/ }));
     expect((screen.getByLabelText("Declaration role 3") as HTMLSelectElement).value).toBe("BASIS");
-    expect((screen.getByLabelText("Declaration currency 1") as HTMLInputElement).value).toBe("USD");
-    expect((screen.getByLabelText("Declaration currency 2") as HTMLInputElement).value).toBe("EUR");
     expect((screen.getByLabelText("Declaration currency 3") as HTMLInputElement).value).toBe("USD");
-    expect(screen.getAllByLabelText(/Family/)).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: /EUR OIS · Discount/ }));
+    expect((screen.getByLabelText("Declaration currency 2") as HTMLInputElement).value).toBe("EUR");
+    expect((screen.getByLabelText("Declaration role 2") as HTMLSelectElement).value).toBe("DISCOUNT");
+    expect(screen.getAllByLabelText(/Family \d/)).toHaveLength(3);
   });
 
   it.each([
@@ -245,7 +250,9 @@ describe("Curve Lab V2 workspace", () => {
       created_at: "2026-01-15T00:00:02Z",
     };
     vi.spyOn(api, "listCurveLabVersions").mockResolvedValue([]);
-    vi.spyOn(api, "createCurveLabDraft").mockResolvedValue(draft);
+    vi.spyOn(api, "createCurveLabDraft").mockImplementation(
+      async (body) => ({ ...draft, document: body as Record<string, unknown> }),
+    );
     vi.spyOn(api, "createCurveLabBuildRun").mockResolvedValue(build);
     vi.spyOn(api, "createCurveLabVersion").mockResolvedValue(version);
 
@@ -399,5 +406,97 @@ describe("Curve Lab V2 workspace", () => {
 
     expect(load).toHaveBeenCalledTimes(2);
     expect(screen.getByText("Build cccccccc finished SUCCEEDED.")).not.toBeNull();
+  });
+
+  it("builds and validates from the header without leaving the builder", async () => {
+    const draft = {
+      id: "a".repeat(32),
+      schema_version: 2 as const,
+      revision: 1,
+      fingerprint: "b".repeat(64),
+      state: "READY_TO_BUILD" as const,
+      document: {},
+      created_at: "2026-01-15T00:00:00Z",
+      updated_at: "2026-01-15T00:00:00Z",
+    };
+    const build = {
+      id: "c".repeat(32),
+      draft_id: draft.id,
+      draft_revision: 1,
+      draft_fingerprint: draft.fingerprint,
+      state: "SUCCEEDED",
+      stale: false,
+      request: {},
+      resolved_plan: { mode: "SINGLE" },
+      quote_axis: [],
+      parameter_axis: [],
+      dependency_manifest: [],
+      diagnostics: { fit_state: "NATIVE_ARCHIVE_VALIDATED" },
+      native_payload_hash: "d".repeat(64),
+      error: null,
+      created_at: "2026-01-15T00:00:00Z",
+      finished_at: "2026-01-15T00:00:01Z",
+    };
+    vi.spyOn(api, "listCurveLabVersions").mockResolvedValue([]);
+    vi.spyOn(api, "createCurveLabDraft").mockImplementation(
+      async (body) => ({ ...draft, document: body as Record<string, unknown> }),
+    );
+    vi.spyOn(api, "createCurveLabBuildRun").mockResolvedValue(build);
+
+    render(<CurveLabWorkspace />);
+    fireEvent.click(screen.getByRole("button", { name: "Build & Validate" }));
+
+    await waitFor(() => expect(api.createCurveLabBuildRun).toHaveBeenCalledWith(draft.id));
+    expect(api.createCurveLabDraft).toHaveBeenCalledOnce();
+    await waitFor(() => expect(screen.getByText("NATIVE_ARCHIVE_VALIDATED")).not.toBeNull());
+    expect(screen.getByRole("heading", { name: "Curve set" })).not.toBeNull();
+    expect(screen.getByText("Last success:")).not.toBeNull();
+  });
+
+  it("raises a dismissible rebuild banner when quotes change after a build", async () => {
+    const draft = {
+      id: "a".repeat(32),
+      schema_version: 2 as const,
+      revision: 1,
+      fingerprint: "b".repeat(64),
+      state: "READY_TO_BUILD" as const,
+      document: {},
+      created_at: "2026-01-15T00:00:00Z",
+      updated_at: "2026-01-15T00:00:00Z",
+    };
+    const build = {
+      id: "c".repeat(32),
+      draft_id: draft.id,
+      draft_revision: 1,
+      draft_fingerprint: draft.fingerprint,
+      state: "SUCCEEDED",
+      stale: false,
+      request: {},
+      resolved_plan: { mode: "SINGLE" },
+      quote_axis: [],
+      parameter_axis: [],
+      dependency_manifest: [],
+      diagnostics: { fit_state: "NATIVE_ARCHIVE_VALIDATED" },
+      native_payload_hash: "d".repeat(64),
+      error: null,
+      created_at: "2026-01-15T00:00:00Z",
+      finished_at: "2026-01-15T00:00:01Z",
+    };
+    vi.spyOn(api, "listCurveLabVersions").mockResolvedValue([]);
+    vi.spyOn(api, "createCurveLabDraft").mockImplementation(
+      async (body) => ({ ...draft, document: body as Record<string, unknown> }),
+    );
+    vi.spyOn(api, "createCurveLabBuildRun").mockResolvedValue(build);
+
+    render(<CurveLabWorkspace />);
+    fireEvent.click(screen.getByRole("button", { name: "Build & Validate" }));
+    await waitFor(() => expect(api.createCurveLabBuildRun).toHaveBeenCalledOnce());
+    expect(screen.queryByText("Draft changed · rebuild required")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Quote 1"), { target: { value: "0.05" } });
+    expect(screen.getByText("Draft changed · rebuild required")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss rebuild notice" }));
+    expect(screen.queryByText("Draft changed · rebuild required")).toBeNull();
   });
 });

--- a/dal-web/frontend/tests/unit/curve_run.test.tsx
+++ b/dal-web/frontend/tests/unit/curve_run.test.tsx
@@ -66,6 +66,7 @@ describe("CurveRun running state", () => {
       ".status-dot",
       ".spinner",
       ".status-running::before",
+      ".curve-builder-step.running .curve-builder-step-bubble",
     ]);
     const reducedMotionStart = styles.indexOf("@media (prefers-reduced-motion: reduce)");
     expect(reducedMotionStart).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## Summary
- Rebuild the Curve Lab **Build** tab as the Curve Builder screen: `AS OF`/`MARKET` header controls with a gold **Build & Validate** orchestration button (create/save draft → build → poll, staying on the builder), four build-mode tabs (Single / Multi-Curve / Staged XCCY / Joint XCCY), and a five-step stepper (Declaration → Dependencies → Instruments → Solve → Validate) driven by draft content and build state.
- Three-column layout: **Curve set** (selectable declaration nodes, dependency picker, per-declaration fields, draft/build/publish actions), **Calibration instruments** (include/type/tenor/maturity/quote/day-count/source/status columns with derived tenor and day-count labels), and **Curve preview** (SVG quotes-by-tenor chart with a raw/normalized toggle plus STATE/FIT/QUOTES stat tiles). No synthetic curve values, iteration counts, or residuals are invented — the build-run API only exposes `fit_state`.
- Dismissible "Draft changed · rebuild required" banner driven by `build.stale`, draft-revision mismatch, or post-build edits, and a bottom status strip (curve set, dependencies, instruments, status, last build/success).
- Shared `PageHeader` (eyebrow/title/subtitle/right controls) and `panel-title` style unify Dashboard, Portfolios, Trades, Product Builder, Models, Valuation Runs, CurveRun, ValuationPanel, FitPlot and MatrixHeatmap to the same Industrial Terminal look; legacy quote-authoring and JSON-calibration sections stay available in collapsed `<details>` blocks.

## Test plan
- [x] `cd dal-web/frontend && npx vitest run` — 12 files, 101 tests pass (new `curve_builder_utils.test.ts`, new Build & Validate / banner workspace tests)
- [x] `cd dal-web/frontend && npm run build` — `tsc -b && vite build` clean
- [x] Visual walkthrough of all pages via headless Chrome screenshots against the dev server