### PR TITLE
fix: restore Curve Lab builds and numeric curve views

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -523,7 +523,7 @@ namespace Dal {
         } else if (spec.parameterization_ == CurveParameterization_::Value_::ZERO_RATE) {
             REQUIRE(knotDates.front() > spec.today_, "ZERO_RATE calibration requires every knot to be strictly after today");
         } else if (spec.parameterization_ == CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD) {
-            REQUIRE(knotDates.front() >= spec.today_, "Piecewise-constant forward calibration knot dates must not precede today");
+            REQUIRE(knotDates.front() >= spec.today_, "PIECEWISE_CONSTANT_FWD calibration requires knot 0 to be on or after today");
         } else {
             REQUIRE(knotDates.front() > spec.today_, "Curve calibration knot dates must be after today");
         }

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -522,6 +522,8 @@ namespace Dal {
             REQUIRE(knotDates.front() == spec.today_, "LOG_DISCOUNT calibration requires knot 0 to be exactly the anchor (== today)");
         } else if (spec.parameterization_ == CurveParameterization_::Value_::ZERO_RATE) {
             REQUIRE(knotDates.front() > spec.today_, "ZERO_RATE calibration requires every knot to be strictly after today");
+        } else if (spec.parameterization_ == CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD) {
+            REQUIRE(knotDates.front() >= spec.today_, "Piecewise-constant forward calibration knot dates must not precede today");
         } else {
             REQUIRE(knotDates.front() > spec.today_, "Curve calibration knot dates must be after today");
         }
@@ -606,16 +608,11 @@ namespace Dal {
                                                           const Matrix_<>* effJacobianInverse) {
             CurveCalibrationResult_ retval;
             retval.curve_ = BuildDiscountCurveUniqueT<double>(definition, result, spec.baseCurve_);
-            // For LOG_DISCOUNT the anchor knot equals today_ and would fail the strict > today check;
-            // validate the free knots only.
-            if (spec.parameterization_ == CurveParameterization_::Value_::LOG_DISCOUNT) {
-                Vector_<Date_> freeKnots;
-                for (int i = 1; i < static_cast<int>(knotDates.size()); ++i)
-                    freeKnots.push_back(knotDates[i]);
-                ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, freeKnots);
-            } else {
-                ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, knotDates);
-            }
+            Vector_<Date_> futureKnots;
+            for (const auto& knot : knotDates)
+                if (knot > spec.today_)
+                    futureKnots.push_back(knot);
+            ValidatePositiveDiscountFactors(*retval.curve_, spec.today_, futureKnots);
             Handle_<DiscountCurve_> diagnosticsCurve(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), retval.curve_.get()));
             auto discountCurves = spec.discountCurves_;
             auto forwardCurves = spec.forwardCurves_;

--- a/dal-cpp/dal/curve/curveparameterization.cpp
+++ b/dal-cpp/dal/curve/curveparameterization.cpp
@@ -111,6 +111,9 @@ namespace Dal {
             nodeDates.Append(declaredKnots);
             break;
         case CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD:
+            REQUIRE(declaredKnots.front() >= anchor, "MakeCurveDefinition: piecewise-constant forward knots must not precede the anchor");
+            nodeDates = declaredKnots;
+            break;
         case CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD:
             REQUIRE(declaredKnots.front() > anchor, "MakeCurveDefinition: forward knots must be after the anchor");
             nodeDates = declaredKnots;

--- a/dal-cpp/tests/curve/test_calibration.cpp
+++ b/dal-cpp/tests/curve/test_calibration.cpp
@@ -202,6 +202,20 @@ TEST(CalibrationTest, TestValidateCurveCalibrationSpecRejectsZeroRateAnchorKnotW
     }
 }
 
+TEST(CalibrationTest, TestValidateCurveCalibrationSpecRejectsPiecewiseConstantForwardPreAnchorKnotWithSpecificMessage) {
+    CurveCalibrationSpec_ spec = MakeValidSpec();
+    spec.parameterization_ = CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD;
+    spec.knotDates_[0] = spec.today_.AddDays(-1);
+
+    try {
+        ValidateCurveCalibrationSpec(spec);
+        FAIL() << "Expected PIECEWISE_CONSTANT_FWD pre-anchor knot to be rejected";
+    } catch (const Dal::Exception_& e) {
+        ASSERT_TRUE(std::string(e.what()).find("PIECEWISE_CONSTANT_FWD calibration requires knot 0 to be on or after today") != std::string::npos)
+            << e.what();
+    }
+}
+
 TEST(CalibrationTest, TestValidateCurveCalibrationSpecChecksZeroRateGuessAgainstParameterCount) {
     CurveCalibrationSpec_ spec = MakeValidSpec();
     spec.parameterization_ = CurveParameterization_::Value_::ZERO_RATE;

--- a/dal-cpp/tests/curve/test_curveparameterization.cpp
+++ b/dal-cpp/tests/curve/test_curveparameterization.cpp
@@ -48,6 +48,20 @@ TEST(CurveParameterizationTest, TestLayoutsMatchStableSolverColumnOrder) {
     ASSERT_FALSE(pwlLayout.pinnedAnchor_);
 }
 
+TEST(CurveParameterizationTest, TestPiecewiseConstantDefinitionAllowsAnchorBoundaryOnly) {
+    const Date_ anchor(2024, 1, 15);
+    const Date_ maturity(2025, 1, 15);
+    const DayBasis_ dayCount("ACT_365F");
+
+    const auto definition = MakeCurveDefinition("pwc", "USD", CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD,
+                                                LogDfScheme_::Value_::LOG_LINEAR, Vector_<Date_>{anchor, maturity}, anchor, dayCount);
+
+    ASSERT_EQ(definition.nodeDates_, Vector_<Date_>({anchor, maturity}));
+    ASSERT_THROW(MakeCurveDefinition("pwc", "USD", CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, LogDfScheme_::Value_::LOG_LINEAR,
+                                     Vector_<Date_>{anchor.AddDays(-1), maturity}, anchor, dayCount),
+                 Exception_);
+}
+
 TEST(CurveParameterizationTest, TestZeroRateDefinitionPrependsAnchorAndPreservesGeometry) {
     const Date_ anchor(2024, 1, 15);
     const Vector_<Date_> maturities{Date_(2024, 4, 15), Date_(2024, 7, 15), Date_(2025, 1, 15)};

--- a/dal-public/tests/test_curvespec.cpp
+++ b/dal-public/tests/test_curvespec.cpp
@@ -110,6 +110,32 @@ TEST(CurveSpecTest, TestCalibrateSingleCurveExact) {
     ASSERT_LT(result.diagnostics_.rmsResidual_, 1.0e-6);
 }
 
+TEST(CurveSpecTest, TestCalibrateSingleCurvePiecewiseConstantForwardFromToday) {
+    CurveCalibrationSpecBuilder_ builder;
+    builder.today_ = Today();
+    builder.ccy_ = "USD";
+    builder.curveName_ = "pwc_deposits";
+    builder.calibrateDiscountCurve_ = true;
+    builder.parameterization_ = CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD;
+    builder.initialGuess_ = 0.05;
+
+    const Date_ firstMaturity = Dal::Date::AddMonths(Today(), 12);
+    const Date_ secondMaturity = Dal::Date::AddMonths(Today(), 18);
+    const RateIndexConvention_ index = RateIndexConvention_New(PeriodLength_New("3M"), DayBasis_New("ACT_365F"), CollateralType_OIS());
+    builder.knotDates_ = {Today(), firstMaturity, secondMaturity};
+    builder.instruments_ = {
+        DepositNew(Today(), Today(), firstMaturity, 0.04, index),
+        DepositNew(Today(), Today(), secondMaturity, 0.04, index),
+    };
+
+    const CalibrationResult_ result = CalibrateSingleCurve(builder.Build());
+
+    ASSERT_NE(result.curve_, nullptr);
+    ASSERT_EQ(result.diagnostics_.marketRates_.size(), 2);
+    ASSERT_LT(result.diagnostics_.maxAbsResidual_, 1.0e-6);
+    ASSERT_LT(result.diagnostics_.rmsResidual_, 1.0e-6);
+}
+
 // Single-curve calibration with Jacobian
 
 TEST(CurveSpecTest, TestCalibrateSingleCurveWithBumpedJacobian) {

--- a/dal-web/backend/app/schemas/curve_lab.py
+++ b/dal-web/backend/app/schemas/curve_lab.py
@@ -618,6 +618,18 @@ class ParameterAxisEntryV2(CurveLabWireModel):
     display_label: str
 
 
+class CurveViewPointV1(CurveLabWireModel):
+    model_config = ConfigDict(extra="forbid", validate_default=True, frozen=True)
+
+    parameter_id: str
+    component_key: str
+    node_date: date
+    side: Literal["LEFT", "RIGHT"] | None
+    discount_factor: PositiveFiniteFloat
+    zero_rate: FiniteFloat | None
+    one_day_forward_rate: FiniteFloat
+
+
 class CurveLabDependencyManifestEntryV2(CurveLabWireModel):
     version_id: Annotated[str, Field(pattern=r"^[0-9a-f]{32}$")]
     content_hash: Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
@@ -646,6 +658,7 @@ class CurveBuildRunResponse(CurveLabWireModel):
     resolved_plan: dict[str, object]
     quote_axis: tuple[QuoteAxisEntryV2, ...]
     parameter_axis: tuple[ParameterAxisEntryV2, ...]
+    curve_views: tuple[CurveViewPointV1, ...] = ()
     dependency_manifest: tuple[CurveLabDependencyManifestEntryV2, ...]
     diagnostics: dict[str, object] | None
     native_payload_hash: Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")] | None = None

--- a/dal-web/backend/app/services/curve_lab_lifecycle.py
+++ b/dal-web/backend/app/services/curve_lab_lifecycle.py
@@ -482,6 +482,11 @@ def _execute_build_run(
             document,
             native_payload,
         )
+        curve_views = gateway.curve_lab_archive_curve_views(
+            document,
+            native_payload,
+            parameter_coordinates,
+        )
     except Exception:  # noqa: BLE001 - native failure becomes immutable evidence
         error = {
             "code": "NATIVE_BUILD_FAILED",
@@ -553,6 +558,7 @@ def _execute_build_run(
             "quote_count": len(quote_coordinates),
             "parameter_count": len(parameter_coordinates),
             "payload_bytes": len(native_payload),
+            "curve_views": curve_views,
         },
         "error": None,
         "created_at": queued["created_at"],
@@ -722,10 +728,19 @@ def quote_axis(document: dict) -> list[dict]:
 
 def _build_public(store: StoreProtocol, record: dict) -> dict:
     current = get_draft(store, record["draft_id"])
+    diagnostics = record.get("diagnostics")
+    curve_views = diagnostics.get("curve_views", []) if diagnostics else []
+    public_diagnostics = (
+        {key: value for key, value in diagnostics.items() if key != "curve_views"}
+        if diagnostics is not None
+        else None
+    )
     return {
         key: value
         for key, value in {
             **record,
+            "curve_views": curve_views,
+            "diagnostics": public_diagnostics,
             "stale": (
                 current["revision"] != record["draft_revision"]
                 or current["fingerprint"] != record["draft_fingerprint"]

--- a/dal-web/backend/app/services/dal_gateway.py
+++ b/dal-web/backend/app/services/dal_gateway.py
@@ -9,11 +9,12 @@ service module imports ``dal`` directly -- they all go through :class:`DalGatewa
 from __future__ import annotations
 
 import hashlib
+import math
 import threading
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, NamedTuple
 
 from app.native_runtime import load_native_dal
@@ -788,6 +789,107 @@ class DalGateway:
             curves = self._curve_lab_archive_curves(payload, root_kind, document)
             return self._curve_lab_parameter_axis_from_curves(document, curves)
 
+    def curve_lab_archive_curve_views(
+        self,
+        document: Mapping[str, Any],
+        payload: bytes,
+        parameter_axis: Sequence[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Project numerical curve views from the calibrated native archive."""
+
+        root_kind = "DISCOUNT_CURVE" if document["mode"] == "SINGLE" else "CURVE_SET"
+        with self._calibration_lock:
+            curves = self._curve_lab_archive_curves(payload, root_kind, document)
+            return self._curve_lab_curve_views_from_curves(
+                document,
+                curves,
+                parameter_axis,
+            )
+
+    def _curve_lab_curve_views_from_curves(
+        self,
+        document: Mapping[str, Any],
+        curves: Mapping[str, Any],
+        parameter_axis: Sequence[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        as_of = date.fromisoformat(str(document["as_of_date"]))
+        result: list[dict[str, Any]] = []
+        for axis in parameter_axis:
+            node = date.fromisoformat(str(axis["node_date"]))
+            curve = curves[str(axis["component_key"])]
+            discount_factor = self._curve_lab_discount_factor(curve, as_of, node)
+            elapsed_days = (node - as_of).days
+            zero_rate = (
+                None if elapsed_days == 0 else -math.log(discount_factor) * 365.0 / elapsed_days
+            )
+            left_side = axis.get("side") == "LEFT"
+            forward_start = node - timedelta(days=1) if left_side else node
+            forward_end = node if left_side else node + timedelta(days=1)
+            one_day_discount = self._curve_lab_discount_factor(
+                curve,
+                forward_start,
+                forward_end,
+            )
+            result.append(
+                {
+                    "parameter_id": str(axis["parameter_id"]),
+                    "component_key": str(axis["component_key"]),
+                    "node_date": str(axis["node_date"]),
+                    "side": axis.get("side"),
+                    "discount_factor": discount_factor,
+                    "zero_rate": zero_rate,
+                    "one_day_forward_rate": -math.log(one_day_discount) * 365.0,
+                }
+            )
+        return result
+
+    def _curve_lab_discount_factor(
+        self,
+        curve: Any,
+        start: date,
+        end: date,
+    ) -> float:
+        if isinstance(curve, Mapping):
+            return self._curve_lab_mapping_discount_factor(curve, start, end)
+        value = float(curve(self._native_date(start), self._native_date(end)))
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError("Curve Lab numerical view requires positive finite discount factors")
+        return value
+
+    @classmethod
+    def _curve_lab_mapping_discount_factor(
+        cls,
+        curve: Mapping[str, Any],
+        start: date,
+        end: date,
+    ) -> float:
+        if end < start:
+            return 1.0 / cls._curve_lab_mapping_discount_factor(curve, end, start)
+        dates = [
+            date.fromisoformat(str(item)) for item in curve.get("dates", curve.get("knotDates", ()))
+        ]
+        values = [float(item) for item in curve.get("values", curve.get("rightVals", ()))]
+        if not dates or len(dates) != len(values):
+            raise ValueError("Curve Lab test curve requires matching PWC dates and values")
+        integral = 0.0
+        cursor = start
+        while cursor < end:
+            right_index = max(
+                (index for index, knot in enumerate(dates) if knot <= cursor),
+                default=0,
+            )
+            next_knot = min((knot for knot in dates if knot > cursor), default=end)
+            segment_end = min(end, next_knot)
+            integral += (segment_end - cursor).days * values[right_index]
+            cursor = segment_end
+        value = math.exp(-integral / 365.0)
+        base = curve.get("base")
+        if isinstance(base, Mapping):
+            value *= cls._curve_lab_mapping_discount_factor(base, start, end)
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError("Curve Lab numerical view requires positive finite discount factors")
+        return value
+
     def _curve_lab_parameter_axis_from_curves(
         self,
         document: Mapping[str, Any],
@@ -1260,7 +1362,8 @@ class DalGateway:
                 f"Curve Lab declaration {declaration['component_key']!r} has no instruments"
             )
         builder = self._dal.CurveCalibrationSpecBuilder_()
-        builder.today_ = self._native_date(date.fromisoformat(str(document["as_of_date"])))
+        today = self._native_date(date.fromisoformat(str(document["as_of_date"])))
+        builder.today_ = today
         builder.ccy_ = self._dal.String_(str(declaration["currency"]))
         builder.curveName_ = self._dal.String_(str(declaration["component_key"]))
         builder.instruments_ = [
@@ -1270,7 +1373,7 @@ class DalGateway:
             )
             for item in instruments
         ]
-        builder.knotDates_ = [
+        knot_dates = [
             self._native_date(date.fromisoformat(str(item["maturity_date"])))
             for item in sorted(
                 instruments,
@@ -1280,6 +1383,9 @@ class DalGateway:
                 ),
             )
         ]
+        if declaration["parameterization"] == "PIECEWISE_CONSTANT_FWD":
+            knot_dates.insert(0, today)
+        builder.knotDates_ = knot_dates
         route = str(declaration["component_key"]).rsplit("/", 1)[-1]
         builder.targetCollateral_ = self._dal.CollateralType_(
             route if declaration["role"] == "DISCOUNT" else "OIS"

--- a/dal-web/backend/openapi/dal-web.openapi.json
+++ b/dal-web/backend/openapi/dal-web.openapi.json
@@ -659,6 +659,14 @@
             "title": "Created At",
             "type": "string"
           },
+          "curve_views": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CurveViewPointV1"
+            },
+            "title": "Curve Views",
+            "type": "array"
+          },
           "deadline_at": {
             "format": "date-time",
             "title": "Deadline At",
@@ -2568,6 +2576,70 @@
           "created_at"
         ],
         "title": "CurveVersionResponse",
+        "type": "object"
+      },
+      "CurveViewPointV1": {
+        "additionalProperties": false,
+        "properties": {
+          "component_key": {
+            "title": "Component Key",
+            "type": "string"
+          },
+          "discount_factor": {
+            "exclusiveMinimum": 0.0,
+            "title": "Discount Factor",
+            "type": "number"
+          },
+          "node_date": {
+            "format": "date",
+            "title": "Node Date",
+            "type": "string"
+          },
+          "one_day_forward_rate": {
+            "title": "One Day Forward Rate",
+            "type": "number"
+          },
+          "parameter_id": {
+            "title": "Parameter Id",
+            "type": "string"
+          },
+          "side": {
+            "anyOf": [
+              {
+                "enum": [
+                  "LEFT",
+                  "RIGHT"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Side"
+          },
+          "zero_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Zero Rate"
+          }
+        },
+        "required": [
+          "parameter_id",
+          "component_key",
+          "node_date",
+          "side",
+          "discount_factor",
+          "zero_rate",
+          "one_day_forward_rate"
+        ],
+        "title": "CurveViewPointV1",
         "type": "object"
       },
       "DepositInstrumentDTO": {

--- a/dal-web/backend/tests/test_curve_lab_build_modes.py
+++ b/dal-web/backend/tests/test_curve_lab_build_modes.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from copy import deepcopy
+from datetime import date
 from types import SimpleNamespace
 
 import pytest
@@ -407,6 +409,78 @@ def test_multi_curve_calls_native_bundle_with_declaration_local_stages() -> None
     assert curves == {
         DISCOUNT_KEY: {"native": "discount"},
         PROJECTION_KEY: {"native": "projection"},
+    }
+
+
+def test_piecewise_constant_curve_builder_adds_valuation_date_boundary() -> None:
+    from app.services.dal_gateway import DalGateway
+
+    document = _multi_document()
+    document["mode"] = "SINGLE"
+    document["declarations"] = document["declarations"][:1]
+    document["instruments"][1]["terms"]["component_key"] = DISCOUNT_KEY
+    gateway = DalGateway()
+    gateway._dal = _RecordingMultiDal()
+
+    builder = gateway._curve_lab_curve_builder(
+        document,
+        document["declarations"][0],
+        document["instruments"],
+        {},
+    )
+
+    assert builder.knotDates_ == [
+        "2026-01-15",
+        "2027-01-15",
+        "2028-01-15",
+    ]
+
+
+def test_curve_views_project_discount_zero_and_forward_values_on_native_axis() -> None:
+    from app.services.dal_gateway import DalGateway
+
+    class FlatCurve:
+        def __call__(self, start: str, end: str) -> float:
+            days = (date.fromisoformat(end) - date.fromisoformat(start)).days
+            return math.exp(-0.04 * days / 365.0)
+
+    document = _multi_document()
+    document["mode"] = "SINGLE"
+    document["declarations"] = document["declarations"][:1]
+    parameter_axis = [
+        {
+            "parameter_id": f"{DISCOUNT_KEY}:today",
+            "component_key": DISCOUNT_KEY,
+            "node_date": "2026-01-15",
+            "side": "RIGHT",
+        },
+        {
+            "parameter_id": f"{DISCOUNT_KEY}:one-year",
+            "component_key": DISCOUNT_KEY,
+            "node_date": "2027-01-15",
+            "side": "RIGHT",
+        },
+    ]
+    gateway = DalGateway()
+    gateway._dal = _RecordingMultiDal()
+
+    views = gateway._curve_lab_curve_views_from_curves(
+        document,
+        {DISCOUNT_KEY: FlatCurve()},
+        parameter_axis,
+    )
+
+    assert views[0] == {
+        **parameter_axis[0],
+        "discount_factor": 1.0,
+        "zero_rate": None,
+        "one_day_forward_rate": pytest.approx(0.04),
+    }
+    assert views[1] == {
+        **parameter_axis[1],
+        "discount_factor": pytest.approx(math.exp(-0.04)),
+        "zero_rate": pytest.approx(0.04),
+        "one_day_forward_rate": pytest.approx(0.04),
     }
 
 

--- a/dal-web/backend/tests/test_curve_lab_lifecycle_api.py
+++ b/dal-web/backend/tests/test_curve_lab_lifecycle_api.py
@@ -1170,6 +1170,40 @@ def test_native_build_failure_is_persisted_and_restart_readable(client, monkeypa
     assert client.get("/api/curve-lab/versions").json() == []
 
 
+def test_native_parameter_axis_failure_preserves_original_build_error(
+    client,
+    monkeypatch,
+) -> None:
+    import app.services.dal_gateway as gateway_module
+
+    draft = client.post("/api/curve-lab/drafts", json=_document()).json()
+    gateway = gateway_module.get_gateway()
+
+    def fail_parameter_axis(_document, _payload) -> list[dict]:
+        raise ValueError("deliberate parameter-axis failure")
+
+    monkeypatch.setattr(
+        gateway,
+        "curve_lab_archive_parameter_axis",
+        fail_parameter_axis,
+    )
+
+    response = client.post(f"/api/curve-lab/drafts/{draft['id']}/build-runs")
+
+    assert response.status_code == 202
+    run = _wait_for_job(
+        client,
+        "build-runs",
+        response.json()["id"],
+        {"SUCCEEDED", "FAILED", "TIMED_OUT"},
+    )
+    assert run["state"] == "FAILED"
+    assert run["parameter_axis"] == []
+    assert run["diagnostics"]["parameter_count"] == 0
+    assert run["error"]["code"] == "NATIVE_BUILD_FAILED"
+    assert "deliberate parameter-axis failure" not in run["error"]["message"]
+
+
 def test_build_create_acknowledges_queued_before_blocking_native_work(
     client,
     monkeypatch,

--- a/dal-web/backend/tests/test_curve_lab_lifecycle_api.py
+++ b/dal-web/backend/tests/test_curve_lab_lifecycle_api.py
@@ -332,6 +332,17 @@ def test_concurrent_draft_updates_have_exactly_one_cas_winner(client) -> None:
 def test_version_publication_is_cas_idempotent_immutable_and_archivable(client) -> None:
     draft = _create_draft(client)
     run = _completed_build(client, draft["id"])
+    assert run["curve_views"] == [
+        {
+            "parameter_id": run["parameter_axis"][0]["parameter_id"],
+            "component_key": "clab/v1/local/discount/USD/OIS",
+            "node_date": "2026-04-16",
+            "side": "RIGHT",
+            "discount_factor": pytest.approx(0.990077),
+            "zero_rate": pytest.approx(0.04),
+            "one_day_forward_rate": pytest.approx(0.04),
+        }
+    ]
     request = {
         "draft_id": draft["id"],
         "draft_revision": draft["revision"],

--- a/dal-web/frontend/src/api/client.ts
+++ b/dal-web/frontend/src/api/client.ts
@@ -177,6 +177,16 @@ export interface CurveLabAxisEntry {
   node_date?: string;
 }
 
+export interface CurveLabCurveViewPoint {
+  parameter_id: string;
+  component_key: string;
+  node_date: string;
+  side: "LEFT" | "RIGHT" | null;
+  discount_factor: number;
+  zero_rate: number | null;
+  one_day_forward_rate: number;
+}
+
 export interface CurveLabBuildRun {
   id: string;
   draft_id: string;
@@ -188,6 +198,7 @@ export interface CurveLabBuildRun {
   resolved_plan: Record<string, unknown>;
   quote_axis: CurveLabAxisEntry[];
   parameter_axis: CurveLabAxisEntry[];
+  curve_views?: CurveLabCurveViewPoint[];
   dependency_manifest: {
     version_id: string;
     content_hash: string;

--- a/dal-web/frontend/src/components/CurveLabWorkspace.tsx
+++ b/dal-web/frontend/src/components/CurveLabWorkspace.tsx
@@ -13,6 +13,7 @@ import {
   ApiClientError,
   type CurveLabBuildRun,
   type CurveLabCanonicalQuote,
+  type CurveLabCurveViewPoint,
   type CurveLabDraft,
   type CurveLabImportJob,
   type CurveLabMatrix,
@@ -41,6 +42,7 @@ import { css } from "../format";
 
 type WorkspaceTab = "build" | "runs" | "risk" | "versions";
 type CurveLabBuildMode = "SINGLE" | "MULTI_CURVE" | "STAGED_XCCY" | "JOINT_XCCY";
+type CurveView = "discount" | "zero" | "forward";
 
 export interface CurveLabWorkspaceHandle {
   // eslint-disable-next-line no-unused-vars -- core ESLint sees type-only parameter names.
@@ -55,6 +57,20 @@ export interface CurveLabCanonicalTarget {
 interface CurveLabWorkspaceProps {
   // eslint-disable-next-line no-unused-vars -- core ESLint sees type-only parameter names.
   onCanonicalTargetChange?: (...args: [CurveLabCanonicalTarget | null]) => void;
+}
+
+const CURVE_VIEW_LABELS: Record<CurveView, string> = {
+  discount: "Discount factors",
+  zero: "Zero rates",
+  forward: "Forwards",
+};
+
+function curveViewValue(point: CurveLabCurveViewPoint, view: CurveView): string {
+  if (view === "discount") return point.discount_factor.toFixed(10);
+  const value = view === "zero" ? point.zero_rate : point.one_day_forward_rate;
+  return value === null
+    ? "—"
+    : `${value.toFixed(10)} (${(value * 100).toFixed(6)}%)`;
 }
 
 const TABS: { id: WorkspaceTab; label: string; note: string }[] = [
@@ -464,7 +480,7 @@ const CurveLabWorkspace = forwardRef<
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [importManifest, setImportManifest] = useState<Record<string, unknown> | null>(null);
-  const [curveView, setCurveView] = useState<"discount" | "zero" | "forward">("discount");
+  const [curveView, setCurveView] = useState<CurveView>("discount");
   const [selectedInstrumentIndex, setSelectedInstrumentIndex] = useState<number | null>(null);
   const canonicalTargetTokenRef = useRef(0);
   const [canonicalTargetToken, setCanonicalTargetToken] = useState(0);
@@ -1605,21 +1621,29 @@ const CurveLabWorkspace = forwardRef<
                   </div>
                 </div>
                 <p {...css("muted")}>
-                  {curveView === "discount" && "Native discount-factor view on the persisted node axis."}
-                  {curveView === "zero" && "Continuously compounded zero-rate view on the persisted node axis."}
-                  {curveView === "forward" && "Instantaneous forward coordinates in native parameter order."}
+                  {curveView === "discount" && "Native discount factors from valuation date to each persisted node."}
+                  {curveView === "zero" && "Continuously compounded ACT/365F zero rates on the persisted node axis."}
+                  {curveView === "forward" && "One-day continuously compounded ACT/365F forwards; LEFT samples the preceding interval."}
                 </p>
                 <div {...css("table-container")}>
-                  <table>
-                    <thead><tr><th>Node</th><th>Component</th><th>Native coordinate</th></tr></thead>
+                  <table aria-label={`${CURVE_VIEW_LABELS[curveView]} curve values`}>
+                    <thead><tr><th>Node</th><th>Component</th><th>Side</th><th {...css("num")}>Value</th></tr></thead>
                     <tbody>
-                      {build.parameter_axis.map((axis) => (
-                        <tr key={String(axis.parameter_id)}>
-                          <td>{String(axis.node_date)}</td>
-                          <td {...css("mono")}>{String(axis.component_key)}</td>
-                          <td>{String(axis.coordinate_kind)}</td>
+                      {(build.curve_views ?? []).map((point) => (
+                        <tr key={point.parameter_id}>
+                          <td {...css("mono")}>{point.node_date}</td>
+                          <td {...css("mono")}>{point.component_key}</td>
+                          <td>{point.side ?? "—"}</td>
+                          <td {...css("mono", "num")}>{curveViewValue(point, curveView)}</td>
                         </tr>
                       ))}
+                      {(build.curve_views ?? []).length === 0 && (
+                        <tr>
+                          <td colSpan={4} {...css("muted")}>
+                            Numeric curve views are unavailable for this run. Rebuild the curve to populate them.
+                          </td>
+                        </tr>
+                      )}
                     </tbody>
                   </table>
                 </div>

--- a/dal-web/frontend/src/components/CurveLabWorkspace.tsx
+++ b/dal-web/frontend/src/components/CurveLabWorkspace.tsx
@@ -59,11 +59,16 @@ interface CurveLabWorkspaceProps {
   onCanonicalTargetChange?: (...args: [CurveLabCanonicalTarget | null]) => void;
 }
 
-const CURVE_VIEW_LABELS: Record<CurveView, string> = {
-  discount: "Discount factors",
-  zero: "Zero rates",
-  forward: "Forwards",
-};
+function curveViewLabel(view: CurveView): string {
+  switch (view) {
+    case "discount":
+      return "Discount factors";
+    case "zero":
+      return "Zero rates";
+    case "forward":
+      return "Forwards";
+  }
+}
 
 function curveViewValue(point: CurveLabCurveViewPoint, view: CurveView): string {
   if (view === "discount") return point.discount_factor.toFixed(10);
@@ -1626,7 +1631,7 @@ const CurveLabWorkspace = forwardRef<
                   {curveView === "forward" && "One-day continuously compounded ACT/365F forwards; LEFT samples the preceding interval."}
                 </p>
                 <div {...css("table-container")}>
-                  <table aria-label={`${CURVE_VIEW_LABELS[curveView]} curve values`}>
+                  <table aria-label={`${curveViewLabel(curveView)} curve values`}>
                     <thead><tr><th>Node</th><th>Component</th><th>Side</th><th {...css("num")}>Value</th></tr></thead>
                     <tbody>
                       {(build.curve_views ?? []).map((point) => (

--- a/dal-web/frontend/tests/unit/curve_lab_workspace.test.tsx
+++ b/dal-web/frontend/tests/unit/curve_lab_workspace.test.tsx
@@ -227,6 +227,15 @@ describe("Curve Lab V2 workspace", () => {
         coordinate_kind: "PIECEWISE_CONSTANT_FWD",
         node_date: "2027-01-15",
       }],
+      curve_views: [{
+        parameter_id: "parameter-0",
+        component_key: "curve",
+        node_date: "2027-01-15",
+        side: "RIGHT" as const,
+        discount_factor: 0.961,
+        zero_rate: 0.04,
+        one_day_forward_rate: 0.041,
+      }],
       dependency_manifest: [],
       diagnostics: { fit_state: "NATIVE_ARCHIVE_VALIDATED" },
       native_payload_hash: "d".repeat(64),
@@ -269,6 +278,14 @@ describe("Curve Lab V2 workspace", () => {
     const quoteAxis = screen.getByRole("heading", { name: "Quote axis" }).closest("section");
     expect(quoteAxis?.querySelector("th")?.className).toContain("num");
     expect(quoteAxis?.querySelector("tbody td")?.className).toContain("num");
+    expect(screen.getByRole("table", { name: "Discount factors curve values" }).textContent)
+      .toContain("0.9610000000");
+    fireEvent.click(screen.getByRole("button", { name: "Zero rates" }));
+    expect(screen.getByRole("table", { name: "Zero rates curve values" }).textContent)
+      .toContain("0.0400000000 (4.000000%)");
+    fireEvent.click(screen.getByRole("button", { name: "Forwards" }));
+    expect(screen.getByRole("table", { name: "Forwards curve values" }).textContent)
+      .toContain("0.0410000000 (4.100000%)");
     fireEvent.click(screen.getByRole("tab", { name: "Build" }));
     fireEvent.change(screen.getByLabelText("Version name"), {
       target: { value: "USD OIS" },

--- a/docs/curve-lab.md
+++ b/docs/curve-lab.md
@@ -111,8 +111,9 @@ The **Curve Lab** screen has four tabs:
 
 1. **Build** — choose the topology, declare components, add typed instruments
    and version dependencies, then create or save a draft.
-2. **Runs** — start an immutable build snapshot and poll it to `SUCCEEDED`,
-   `FAILED`, or `TIMED_OUT`.
+2. **Runs** — start an immutable build snapshot, poll it to `SUCCEEDED`,
+   `FAILED`, or `TIMED_OUT`, and inspect node-level discount factors,
+   continuously compounded ACT/365F zero rates, and one-day forwards.
 3. **Pricing & Risk** — price typed trades against a published version and
    request PV, DV01, key-rate DV01, and optional diagnostic matrices.
 4. **Versions** — publish a successful, non-stale run; clone a version to a new


### PR DESCRIPTION
## Summary
- allow piecewise-constant forward calibrations to start at the valuation-date anchor while continuing to reject knots before it
- add the required Curve Lab anchor boundary and persist node-level discount factors, continuously compounded ACT/365F zero rates, and one-day forwards
- render the numeric views in the Runs tab with a rebuild message for legacy runs, and update the API contract, documentation, and regression coverage
- use exhaustive curve-view label selection so static analysis does not treat the accessible table label as an object-injection sink
- align PWC validation diagnostics and cover the native parameter-axis failure path identified during review

## Test plan
- [x] DAL C++ core suite: 1160 passed
- [x] DAL public suite: 65 passed
- [x] DAL Web backend suite: 451 passed, 2 deselected
- [x] DAL Web frontend suite: 101 passed
- [x] DAL Web frontend production build
- [x] Focused RED/GREEN validation-message regression
- [x] Focused native parameter-axis failure regression
- [x] `git diff --check`

## Environment note
- The targeted Playwright flow loaded the real page but sandbox Chromium timed out waiting for the visible `Create draft` button to become actionable, before reaching any application assertion.