### PR TITLE
docs: DAL-92 reconcile documentation contracts

### DIFF
--- a/.claude/api-notes/joint-aad-gradient.md
+++ b/.claude/api-notes/joint-aad-gradient.md
@@ -1,5 +1,11 @@
 # Joint Multi-Curve AAD Analytic Jacobian (Phase B) - API Note
 
+> **Artifact status: implemented history.** The API decisions in this note have shipped.
+> Current supported behavior is documented in
+> `docs/methodology/yield_curve.md` and
+> `docs/methodology/yield_curve_jacobian.md`. Paths, line citations, and staged
+> hand-offs below describe the implementation baseline and are retained as historical evidence.
+
 > Status: **REVISED (third pass) — 2026-06-20.** This pass DROPS the
 > second-pass CP4 / critique-B5 decision (reject `OISSwap_`, switch the
 > example to vanilla `Swap_`, defer `Tape::OisSwapRate_<T_>` to Phase B+1).

--- a/.claude/critiques/pde-framework-reimplementation.md
+++ b/.claude/critiques/pde-framework-reimplementation.md
@@ -1,5 +1,9 @@
 # PDE Solver Framework Reimplementation - Critic Critique
 
+> **Artifact status: implemented history.** The reviewed PDE reimplementation has shipped.
+> Current supported behavior is documented in `docs/methodology/pde.md`.
+> References to the retired PDE stack below describe the critique baseline and are intentionally historical.
+
 ## Target
 - Spec: `.claude/specs/pde-framework-reimplementation.md` (including the API Design section added by `dal-api-designer`)
 

--- a/.claude/designs/api-shape-dedup.md
+++ b/.claude/designs/api-shape-dedup.md
@@ -1,5 +1,11 @@
 # dal-public Spec Builder API-Shape Deduplication -- Design
 
+> **Artifact status: implemented history.** The accepted design shipped as the
+> brace-initialized `Build()` implementations and shared `CurveSolverOptions_`
+> vocabulary in `dal-public/src/curvespec.hpp`, `dal-public/src/curvespec.cpp`,
+> `dal-public/src/xccycalibration.hpp`, and `dal-public/src/xccycalibration.cpp`.
+> The analysis below is retained as design history, not pending work.
+
 ## Source
 
 - User request on 2026-06-27: design (do not implement) two API-shape duplications in the
@@ -7,8 +13,6 @@
 - Read-only sweep of `dal-public/src/`, `dal-public/tests/`, `dal-python/src/`,
   `dal-python/tests/`, `dal-python/examples/`, `dal-excel/src/`, `dal-excel/auto/`,
   `dal-cpp/examples/`, `dal-cpp/tests/`, and `docs/` on 2026-06-27.
-
-**STATUS: Design only. No code changes. Awaiting user approval of the recommendation.**
 
 ## Problem Statement
 

--- a/.claude/designs/joint-aad-gradient.md
+++ b/.claude/designs/joint-aad-gradient.md
@@ -1,5 +1,11 @@
 # Joint Multi-Curve AAD Analytic Jacobian (Phase B) - Design
 
+> **Artifact status: implemented history.** The joint analytic-Jacobian design has shipped.
+> Current supported behavior is documented in
+> `docs/methodology/yield_curve.md` and
+> `docs/methodology/yield_curve_jacobian.md`. Paths, line citations, and staged
+> decisions below describe the implementation baseline and are retained as historical evidence.
+
 > Status: **REVISED (third pass) — 2026-06-20.** This pass DROPS the second-pass
 > CP4 / critique-B5 decision (reject `OISSwap_`, switch the example to vanilla
 > `Swap_`, defer `Tape::OisSwapRate_<T_>`). The lead re-verified

--- a/.claude/skills/dal-unit-test-write/SKILL.md
+++ b/.claude/skills/dal-unit-test-write/SKILL.md
@@ -64,13 +64,13 @@ Every `TEST()` block is self-contained — set up its own data, exercise the API
 
 **Assertions by type:**
 
-| Situation                        | Macro                                      | Example                                        |
-|----------------------------------|--------------------------------------------|------------------------------------------------|
-| Float (tolerant)                 | `ASSERT_NEAR(actual, expected, tol)`       | `ASSERT_NEAR(price, 8.5359, 1e-10)`            |
-| Float (exact, e.g. knot points)  | `ASSERT_DOUBLE_EQ(expected, actual)`       | `ASSERT_DOUBLE_EQ(f[2], interp(x[2]))`         |
-| Integer / size / object equality | `ASSERT_EQ(expected, actual)`              | `ASSERT_EQ(Year(dt), yyyy)`                    |
-| Boolean condition                | `ASSERT_TRUE(expr)` / `ASSERT_FALSE(expr)` | `ASSERT_TRUE(dt.IsValid())`                    |
-| Expected exception               | `ASSERT_THROW(stmt, Dal::Exception_)`      | `ASSERT_THROW(Mesher(0,0,5), Dal::Exception_)` |
+| Situation                        | Macro                                      | Example                                                                 |
+|----------------------------------|--------------------------------------------|-------------------------------------------------------------------------|
+| Float (tolerant)                 | `ASSERT_NEAR(actual, expected, tol)`       | `ASSERT_NEAR(price, 8.5359, 1e-10)`                                     |
+| Float (exact, e.g. knot points)  | `ASSERT_DOUBLE_EQ(expected, actual)`       | `ASSERT_DOUBLE_EQ(f[2], interp(x[2]))`                                  |
+| Integer / size / object equality | `ASSERT_EQ(expected, actual)`              | `ASSERT_EQ(Year(dt), yyyy)`                                             |
+| Boolean condition                | `ASSERT_TRUE(expr)` / `ASSERT_FALSE(expr)` | `ASSERT_TRUE(dt.IsValid())`                                             |
+| Expected exception               | `ASSERT_THROW(stmt, Dal::Exception_)`      | `ASSERT_THROW(Dal::PDE::MakeUniformGrid(1.0, 0.0, 5), Dal::Exception_)` |
 
 - Never use `EXPECT_*` — always `ASSERT_*` for fail-fast.
 - Tolerance for `ASSERT_NEAR`: `1e-10` is most common in this repo, followed by `1e-8` and `1e-6`. Use `1e-4` for Monte Carlo or iterative

--- a/.claude/specs/dal-web-db-persistence.md
+++ b/.claude/specs/dal-web-db-persistence.md
@@ -1,5 +1,9 @@
 # dal-web database persistence
 
+> **Artifact status: implemented history.** Database-backed storage and migrations have shipped.
+> Current setup and restart behavior are documented in `dal-web/README.md` and
+> `docs/architecture.md`. The proposal language below describes the pre-implementation baseline.
+
 ## Goal
 
 Give the dal-web backend real persistent storage backed by a database, with

--- a/.claude/specs/joint-aad-gradient.md
+++ b/.claude/specs/joint-aad-gradient.md
@@ -1,5 +1,11 @@
 # Joint Multi-Curve AAD Analytic Jacobian (Phase B) - Specification
 
+> **Artifact status: implemented history.** This specification has shipped.
+> Current supported behavior is documented in
+> `docs/methodology/yield_curve.md` and
+> `docs/methodology/yield_curve_jacobian.md`. Paths, line citations, acceptance
+> checkboxes, and hand-offs below describe the implementation baseline and are retained as historical evidence.
+
 > Status: **REVISED (third pass) — 2026-06-20.** This pass DROPS the second-pass
 > CP4 / critique-B5 scope reduction (reject `OISSwap_`, switch the example to
 > vanilla `Swap_`, defer `Tape::OisSwapRate_<T_>`). The lead re-verified
@@ -19,10 +25,10 @@
 > is priced through a NEW `Tape::JointRate_<T_>` base whose `operator()` takes a
 > `const JointCurveBlock_<T_>&` (CP3) — NOT through Phase A's `Tape::Rate_<T_>` virtual
 > (which is bound to `YCCtx_<T_>` and reads a single curve). The OIS-discount slice
-> (`forecast == discount`) rides the inherited `Swap_::PrecomputeT<T_>`. This is a
-> DESIGN-ONLY spec. No code, no headers, no test scaffolding. Implementation is the
-> `dal-implementer`'s job; API shape is `dal-api-designer`'s job; algorithm selection
-> is the architect's job.
+> (`forecast == discount`) rides the inherited `Swap_::PrecomputeT<T_>`. This is the
+> original design-only spec. No code, headers, or test scaffolding were authored in
+> this artifact. Implementation was the `dal-implementer`'s job; API shape is
+> `dal-api-designer`'s job; algorithm selection is the architect's job.
 
 ## Source
 

--- a/.claude/specs/multi-curve-simultaneous-example.md
+++ b/.claude/specs/multi-curve-simultaneous-example.md
@@ -1,5 +1,9 @@
 # Joint Multi-Curve Calibration + Example - Specification
 
+> **Artifact status: implemented history.** Joint simultaneous calibration and its example have shipped.
+> Current supported behavior is documented in `docs/methodology/yield_curve.md`.
+> Paths, measured baselines, acceptance checkboxes, and staged hand-offs below are retained as historical evidence.
+
 ## Amendment (2026-06-20): optional base layering for the joint forward curves
 
 The capability gained an opt-in `JointCurveDeclaration_::baseLayeredOverDiscount_` flag (forward

--- a/.claude/specs/pde-framework-reimplementation.md
+++ b/.claude/specs/pde-framework-reimplementation.md
@@ -1,5 +1,9 @@
 # PDE Solver Framework Reimplementation - Specification
 
+> **Artifact status: implemented history.** The PDE framework reimplementation has shipped.
+> Current supported behavior is documented in `docs/methodology/pde.md`.
+> References to the retired PDE stack and staged acceptance plan below describe the implementation baseline.
+
 ## Source
 - Issue: user request on 2026-07-07 (clean-room reimplementation of the PDE solver framework)
 - Related methodology: `docs/methodology/pde.md` (meshers, coordinate maps, boundary-null convention)

--- a/.claude/specs/script-compiled-evaluator-alignment.md
+++ b/.claude/specs/script-compiled-evaluator-alignment.md
@@ -1,6 +1,11 @@
 # Script Engine — Compiled Evaluator Alignment
 
-Plan-only document (no implementation yet). Covers: aligning the compiled
+> **Artifact status: implemented history.** Compiled/tree-walk parity, public
+> compiled selection, and compiled fuzzy evaluation have shipped. Current
+> supported behavior is documented in `docs/methodology/script_engine.md`.
+> Paths, line citations, defects, and phases below describe the planning baseline.
+
+This planning document covers aligning the compiled
 bytecode evaluator with the tree-walk evaluator, the parity test harness that
 makes that alignment regression-proof, and the path to making `compiled=true`
 a safe default. This is candidate #1 in

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -37,7 +37,8 @@ Create durable artifacts only when they control active work. Remove completed ar
 their current-state outcome is documented and Git history preserves implementation and review
 history.
 
-No tracked artifact currently controls active work.
+The active DAL-92 documentation audit is recorded under
+`.codex/artifacts/DAL-92/doc-writer/` until independent review is complete.
 
 ## Preserved Claude Sources
 

--- a/.codex/artifacts/DAL-92/doc-writer/audit.md
+++ b/.codex/artifacts/DAL-92/doc-writer/audit.md
@@ -1,0 +1,255 @@
+# DAL-92 Documentation and Agent-Contract Audit
+
+Review date: 2026-08-09.
+
+This artifact controls the independent-review handoff for DAL-92. Retire it after the
+review outcome is represented in current documentation and Git history.
+
+## Baseline
+
+- Repository: `wegamekinglc/Derivatives-Algorithms-Lib`.
+- Task branch: `agent/dal-doc-writer/4dc6ba07`.
+- `git fetch --prune origin master` completed successfully.
+- Audited `HEAD` and fetched `origin/master` both resolve to
+  `512e3dcfb4cb6dbaa3cf6c4db5a057ae838bef86`.
+- Baseline commit date and subject: 2026-08-04,
+  `fix: reconcile repository workflows and documentation (#282)`.
+
+## Scope
+
+The baseline inventory was regenerated with `git ls-files`, not copied from an earlier audit.
+It contains 96 tracked contract files:
+
+- 84 Markdown files;
+- 10 `.codex/agents/*.toml` registrations; and
+- 2 `.codex/skills/**/agents/openai.yaml` interfaces.
+
+This audit adds this Markdown artifact, so the final validated scope is 97 files:
+85 Markdown, 10 TOML, and 2 YAML.
+
+Baseline Markdown distribution:
+
+- root: 5;
+- component READMEs: 6;
+- `docs/`: 24;
+- `.github/`: 2;
+- `.claude/`: 30; and
+- `.codex/`: 17.
+
+Final Markdown distribution differs only in `.codex/`, which increases to 18.
+
+## Exhaustive Markdown Inventory
+
+### Root and component documentation — current, except canonical history
+
+```text
+AGENTS.md
+CHANGELOG.md
+CLAUDE.md
+CONTRIBUTING.md
+README.md
+dal-cpp/README.md
+dal-excel/README.md
+dal-public/README.md
+dal-python/README.md
+dal-web/README.md
+dal-web/backend/README.md
+```
+
+`CHANGELOG.md` is canonical history. The other files in this group are current guides or contracts.
+
+### Published documentation — current
+
+```text
+docs/README.md
+docs/architecture.md
+docs/curve-lab.md
+docs/installation.md
+docs/public-api.md
+docs/methodology/_cpp-example-style.md
+docs/methodology/aad.md
+docs/methodology/black_scholes.md
+docs/methodology/dates.md
+docs/methodology/dupire.md
+docs/methodology/index_parsing.md
+docs/methodology/interpolation.md
+docs/methodology/log_discount_curve.md
+docs/methodology/matrix.md
+docs/methodology/pde.md
+docs/methodology/quadrature.md
+docs/methodology/random.md
+docs/methodology/script_engine.md
+docs/methodology/underdetermined_search.md
+docs/methodology/xccy_calibration.md
+docs/methodology/yield_curve.md
+docs/methodology/yield_curve_jacobian.md
+```
+
+`_cpp-example-style.md` is a maintainer contract. The other methodology pages describe
+supported current behavior.
+
+### Experimental documentation — explicitly non-normative
+
+```text
+docs/experimental/aad-analytic-jacobian-curve-calibration.md
+docs/experimental/replicate-ptirds-single-currency-curve.md
+```
+
+### GitHub contracts — current
+
+```text
+.github/copilot-instructions.md
+.github/pull_request_template.md
+```
+
+### Claude contracts — current
+
+```text
+.claude/agents/README.md
+.claude/agents/dal-api-designer.md
+.claude/agents/dal-critic.md
+.claude/agents/dal-doc-writer.md
+.claude/agents/dal-implementer.md
+.claude/agents/dal-orchestrator.md
+.claude/agents/dal-performancer.md
+.claude/agents/dal-reviewer.md
+.claude/agents/dal-simplifier.md
+.claude/agents/dal-spec-writer.md
+.claude/agents/dal-tester.md
+.claude/rules/code-style.md
+.claude/rules/dal-web-code-style.md
+.claude/rules/dal-web-design.md
+.claude/rules/git-commit-pr.md
+.claude/rules/unit-test-style.md
+.claude/skills/dal-code-style-review/SKILL.md
+.claude/skills/dal-commit-and-pr/SKILL.md
+.claude/skills/dal-unit-test-skill/SKILL.md
+.claude/skills/dal-unit-test-write/SKILL.md
+.claude/skills/dal-web-setup/SKILL.md
+```
+
+### Claude retained implementation history
+
+```text
+.claude/api-notes/joint-aad-gradient.md
+.claude/critiques/pde-framework-reimplementation.md
+.claude/designs/api-shape-dedup.md
+.claude/designs/joint-aad-gradient.md
+.claude/specs/dal-web-db-persistence.md
+.claude/specs/joint-aad-gradient.md
+.claude/specs/multi-curve-simultaneous-example.md
+.claude/specs/pde-framework-reimplementation.md
+.claude/specs/script-compiled-evaluator-alignment.md
+```
+
+These files record implemented work. Their source line citations, retired paths, measured
+baselines, unchecked acceptance boxes, and staged commands are retained as historical evidence,
+not current instructions. Each file now states that boundary and points to current authority.
+
+### Codex contracts — current
+
+```text
+.codex/README.md
+.codex/artifacts/README.md
+.codex/references/benchmark-workflow.md
+.codex/references/code-style.md
+.codex/references/git-commit-pr.md
+.codex/references/run-tests.md
+.codex/references/style-review.md
+.codex/references/unit-test-style.md
+.codex/references/write-tests.md
+.codex/skills/dal-agent-team/references/shared-rules.md
+.codex/skills/dal-git-pr/SKILL.md
+.codex/skills/dal-git-pr/references/publish-workflow.md
+.codex/skills/dal-web/SKILL.md
+.codex/skills/dal-web/references/backend-style.md
+.codex/skills/dal-web/references/design-system.md
+.codex/skills/dal-web/references/operations.md
+.codex/skills/dal-web/references/web-standards.md
+```
+
+This file, `.codex/artifacts/DAL-92/doc-writer/audit.md`, is the one active review artifact.
+
+## Findings and Corrections
+
+### Current benchmark acceptance language
+
+`CONTRIBUTING.md` said the paired regression gate reduces each confirmation round with
+the median. The executable gate in `.github/scripts/check_benchmark_regressions.py` and
+the canonical `.codex/references/benchmark-workflow.md` both reduce with the best-of-N
+minimum. The contributor guide now states the implemented minimum rule.
+
+### Historical artifact status
+
+Nine retained Claude artifacts described completed work without a durable current/history
+boundary. The API-shape design and script-evaluator specification also explicitly claimed that
+implementation was still pending after the implementation had shipped. Each retained artifact
+now identifies itself as implemented history and points to the current methodology, source, or
+application guide. Historical body content was not rewritten as if it were current evidence.
+
+### Active artifact indexes
+
+`.codex/README.md` and `.codex/artifacts/README.md` previously said that no artifact controlled
+active work. They now identify this DAL-92 handoff while independent review is pending.
+
+## Agent and Platform Reconciliation
+
+- The DAL squad contains exactly the same 10 names as `.codex/agents/*.toml` and
+  `.claude/agents/dal-*.md`.
+- Every Multica DAL agent `description` and `instructions` value exactly matches the
+  authoritative TOML `description` and `developer_instructions` after whitespace normalization.
+- Every authoritative description is within the 255-Unicode-code-point limit.
+- No Multica agent field was changed.
+- Claude and Codex preserve the same role coverage and stage order. Claude keeps verbose
+  frontmatter, `EnterWorktree` and tool vocabulary, and `.claude/{specs,api-notes,critiques}`
+  artifact roots. Codex keeps compact TOML contracts, explicit delegation authorization,
+  repository-runtime branch handling, and `.codex/artifacts/` roots. These are justified
+  platform differences rather than drift.
+- The Claude orchestrator's restricted tool surface and report-driven handoff remain
+  Claude-specific. Multica squad routing and status authority remain workspace-specific.
+- Both surfaces require explicit authorization before side-effecting review, publication,
+  or merge actions. DAL-92 authorizes a draft PR but explicitly forbids merge.
+
+## Changelog Decision
+
+No `CHANGELOG.md` entry is warranted. The patch corrects documentation and artifact status;
+it introduces no breaking public API, numerical method, significant capability, methodology
+shift, removal, or deprecation.
+
+## Modified Files and Reasons
+
+- `CONTRIBUTING.md` — match the benchmark gate's best-of-N minimum reduction.
+- Nine files under `.claude/{api-notes,critiques,designs,specs}/` — mark shipped work as
+  implemented history and identify current authority.
+- `.codex/README.md` and `.codex/artifacts/README.md` — index the active DAL-92 review artifact.
+- `.codex/artifacts/DAL-92/doc-writer/audit.md` — preserve exhaustive scope, evidence,
+  decisions, checks, and handoff risk for independent review.
+
+No methodology document was added, removed, or renamed, so `docs/README.md` and the
+`CLAUDE.md` methodology list require no edit.
+
+## Validation Record
+
+- `python3 .github/scripts/check_docs.py` — passed for 55 curated Markdown files.
+- `python3 -m unittest discover -s .github/scripts/tests -p 'test_check_docs.py' -v`
+  — 24 tests passed.
+- Full tracked-Markdown link, anchor, table, math-macro, whitespace, and final-newline audit
+  — 85 files passed.
+- TOML, skill YAML, and `SKILL.md` frontmatter parsing — 10 TOML, 2 YAML, and 7 skill
+  frontmatters passed.
+- Methodology-index reconciliation — both indexes exactly cover all 16 normative pages.
+- Claude/Codex/Multica agent-set and exact Multica text reconciliation — 10 roles passed.
+- Current-document path audit — no unexpected missing path; 18 runtime-created or illustrative
+  path occurrences were classified explicitly.
+- `git diff --check` — passed.
+
+## Preserved Differences, Risks, and Blockers
+
+- Retained implementation-history files intentionally keep historical source line citations,
+  paths later retired from the tree, and pre-implementation commands. Their new status blocks
+  those records from being mistaken for current usage guidance.
+- Runtime-created paths such as `.server.pid`, `.server.log`, and `dal-python/.venv/`, plus
+  illustrative placeholders in agent examples, are intentionally absent from Git.
+- No C++ build or numerical test suite is required for this Markdown-only patch. Repository
+  documentation checks and parser/static consistency checks are the acceptance surface.
+- No blocker remains for independent review. The draft PR must not be merged by this stage.

--- a/.codex/artifacts/DAL-92/doc-writer/audit.md
+++ b/.codex/artifacts/DAL-92/doc-writer/audit.md
@@ -14,6 +14,8 @@ review outcome is represented in current documentation and Git history.
   `512e3dcfb4cb6dbaa3cf6c4db5a057ae838bef86`.
 - Baseline commit date and subject: 2026-08-04,
   `fix: reconcile repository workflows and documentation (#282)`.
+- Reviewer remediation starts from the exact first-stage head
+  `05f29abca7522aada9a647bf02c08ad068b03924`.
 
 ## Scope
 
@@ -192,6 +194,18 @@ application guide. Historical body content was not rewritten as if it were curre
 `.codex/README.md` and `.codex/artifacts/README.md` previously said that no artifact controlled
 active work. They now identify this DAL-92 handoff while independent review is pending.
 
+### Current PDE terminology and exception examples
+
+Independent review found four current-contract occurrences that the first audit had missed.
+`README.md` and `CLAUDE.md` still presented the removed finite-difference mesher family as a
+current PDE surface, while `.codex/references/write-tests.md` and
+`.claude/skills/dal-unit-test-write/SKILL.md` used a nonexistent `Mesher(0,0,5)` exception
+example. The current index language now names the PDE framework, grid construction, and
+coordinate maps. Both test-writing contracts now use
+`Dal::PDE::MakeUniformGrid(1.0, 0.0, 5)`, whose reversed bounds are rejected by the
+`REQUIRE(points.yHigh_ > points.yLow_, ...)` precondition and are covered by
+`dal-cpp/tests/math/pde/test_pdegrid.cpp` as a `Dal::Exception_` case.
+
 ## Agent and Platform Reconciliation
 
 - The DAL squad contains exactly the same 10 names as `.codex/agents/*.toml` and
@@ -222,19 +236,28 @@ shift, removal, or deprecation.
 - Nine files under `.claude/{api-notes,critiques,designs,specs}/` — mark shipped work as
   implemented history and identify current authority.
 - `.codex/README.md` and `.codex/artifacts/README.md` — index the active DAL-92 review artifact.
+- `README.md` and `CLAUDE.md` — replace retired mesher wording with the current PDE framework,
+  grid-construction, and coordinate-map surface.
+- `.codex/references/write-tests.md` and `.claude/skills/dal-unit-test-write/SKILL.md` — replace
+  the nonexistent `Mesher(...)` exception example with a source- and test-backed
+  `Dal::PDE::MakeUniformGrid(...)` precondition failure.
 - `.codex/artifacts/DAL-92/doc-writer/audit.md` — preserve exhaustive scope, evidence,
-  decisions, checks, and handoff risk for independent review.
+  reviewer remediation, decisions, checks, and handoff risk for independent re-review.
 
 No methodology document was added, removed, or renamed, so `docs/README.md` and the
 `CLAUDE.md` methodology list require no edit.
 
 ## Validation Record
 
-- `python3 .github/scripts/check_docs.py` — passed for 55 curated Markdown files.
+- `python3 .github/scripts/check_docs.py` — passed for its 55 curated Markdown files.
 - `python3 -m unittest discover -s .github/scripts/tests -p 'test_check_docs.py' -v`
   — 24 tests passed.
 - Full tracked-Markdown link, anchor, table, math-macro, whitespace, and final-newline audit
   — 85 files passed.
+- Current API, symbol, and example re-audit — all 85 Markdown files were rechecked; current
+  contracts contain no retired Mesher API or example. Outside this remediation record, remaining
+  mesher references are confined to `CHANGELOG.md` and clearly bounded implemented-history
+  artifacts.
 - TOML, skill YAML, and `SKILL.md` frontmatter parsing — 10 TOML, 2 YAML, and 7 skill
   frontmatters passed.
 - Methodology-index reconciliation — both indexes exactly cover all 16 normative pages.
@@ -250,6 +273,10 @@ No methodology document was added, removed, or renamed, so `docs/README.md` and 
   those records from being mistaken for current usage guidance.
 - Runtime-created paths such as `.server.pid`, `.server.log`, and `dal-python/.venv/`, plus
   illustrative placeholders in agent examples, are intentionally absent from Git.
+- `.github/scripts/check_docs.py` intentionally remains unchanged in this remediation. Its
+  55-of-85 Markdown coverage is a non-blocking follow-up because the independent full-tree
+  checks cover all 85 tracked Markdown files for DAL-92.
 - No C++ build or numerical test suite is required for this Markdown-only patch. Repository
   documentation checks and parser/static consistency checks are the acceptance surface.
-- No blocker remains for independent review. The draft PR must not be merged by this stage.
+- The identified reviewer blocker is corrected; independent re-review remains required. The
+  draft PR must not be merged by this stage.

--- a/.codex/artifacts/README.md
+++ b/.codex/artifacts/README.md
@@ -3,6 +3,6 @@
 This directory is the durable output surface for active DAL specifications, designs, API notes,
 critiques, reviews, plans, and performance reports.
 
-No implementation-controlling artifact is currently active. Add new work under the appropriate
-subdirectory only while it controls ongoing work, then retire it after documenting the
-current-state outcome.
+The DAL-92 documentation audit under `DAL-92/doc-writer/` controls the current independent-review
+handoff. Add other work under the appropriate subdirectory only while it controls ongoing work,
+then retire it after documenting the current-state outcome.

--- a/.codex/references/write-tests.md
+++ b/.codex/references/write-tests.md
@@ -65,13 +65,13 @@ Every `TEST()` block is self-contained — set up its own data, exercise the API
 
 **Assertions by type:**
 
-| Situation                        | Macro                                      | Example                                        |
-|----------------------------------|--------------------------------------------|------------------------------------------------|
-| Float (tolerant)                 | `ASSERT_NEAR(actual, expected, tol)`       | `ASSERT_NEAR(price, 8.5359, 1e-10)`            |
-| Float (exact, e.g. knot points)  | `ASSERT_DOUBLE_EQ(expected, actual)`       | `ASSERT_DOUBLE_EQ(f[2], interp(x[2]))`         |
-| Integer / size / object equality | `ASSERT_EQ(expected, actual)`              | `ASSERT_EQ(Year(dt), yyyy)`                    |
-| Boolean condition                | `ASSERT_TRUE(expr)` / `ASSERT_FALSE(expr)` | `ASSERT_TRUE(dt.IsValid())`                    |
-| Expected exception               | `ASSERT_THROW(stmt, Dal::Exception_)`      | `ASSERT_THROW(Mesher(0,0,5), Dal::Exception_)` |
+| Situation                        | Macro                                      | Example                                                                 |
+|----------------------------------|--------------------------------------------|-------------------------------------------------------------------------|
+| Float (tolerant)                 | `ASSERT_NEAR(actual, expected, tol)`       | `ASSERT_NEAR(price, 8.5359, 1e-10)`                                     |
+| Float (exact, e.g. knot points)  | `ASSERT_DOUBLE_EQ(expected, actual)`       | `ASSERT_DOUBLE_EQ(f[2], interp(x[2]))`                                  |
+| Integer / size / object equality | `ASSERT_EQ(expected, actual)`              | `ASSERT_EQ(Year(dt), yyyy)`                                             |
+| Boolean condition                | `ASSERT_TRUE(expr)` / `ASSERT_FALSE(expr)` | `ASSERT_TRUE(dt.IsValid())`                                             |
+| Expected exception               | `ASSERT_THROW(stmt, Dal::Exception_)`      | `ASSERT_THROW(Dal::PDE::MakeUniformGrid(1.0, 0.0, 5), Dal::Exception_)` |
 
 - Never use `EXPECT_*` — always `ASSERT_*` for fail-fast.
 - Tolerance for `ASSERT_NEAR`: `1e-10` is most common in this repo, followed by `1e-8` and `1e-6`. Use `1e-4` for Monte Carlo or iterative

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Interpolation** — [Interpolation](docs/methodology/interpolation.md)
 - **Matrix and Linear Algebra** — [Matrix and linear algebra](docs/methodology/matrix.md)
 - **Log-Discount Curve** — [Log-discount curve](docs/methodology/log_discount_curve.md)
-- **PDE Finite-Difference Meshers and Coordinate Maps** — [PDE meshers](docs/methodology/pde.md)
+- **PDE Framework, Grid Construction, and Coordinate Maps** — [PDE framework](docs/methodology/pde.md)
 - **Yield-Curve Jacobian and Inverse-Jacobian Risk** — [Yield-curve Jacobian](docs/methodology/yield_curve_jacobian.md)
 - **Script Engine** — [Script engine](docs/methodology/script_engine.md), including tree-walk, fuzzy AAD, compiled evaluation, parity coverage, and benchmarks
 - **Dupire Local Volatility** — [Dupire local volatility](docs/methodology/dupire.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,10 @@ bash ./build_linux.sh --benchmarks
 Linux pull requests compare base and head builds on the same runner with GCC 14,
 Release mode, native CPU tuning, the native AAD backend, and
 `DAL_NUM_THREADS=4`. The gate runs two independent rounds of ten interleaved
-process-level samples per side. A comparable case fails only when its head/base
-median exceeds `+4%` in both rounds, which requires a repeated regression rather
-than a single noisy measurement. Base-only cases fail as removals or renames.
+process-level samples per side. A comparable case fails only when the head
+best-of-N minimum is more than `4%` above the base minimum in both rounds,
+which requires a repeated regression rather than a single noisy measurement.
+Base-only cases fail as removals or renames.
 Head-only cases are reported as new informational coverage; the explicit Sobol
 precise-policy migration remains validated separately, and the head Sobol
 precise/fast ratio has a `10x` ceiling. The Windows benchmark job remains

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Methodology notes (see the index above for the full list):
 - [Yield Curve](docs/methodology/yield_curve.md) and [Yield-Curve Jacobian](docs/methodology/yield_curve_jacobian.md) — discount curves, calibration, Jacobian / inverse-Jacobian risk
 - [Cross-Currency Pricing and Calibration](docs/methodology/xccy_calibration.md) — fixed, resettable, and MTM swaps; immutable fixing snapshots; staged basis and simultaneous domestic/foreign/basis calibration
 - [Interpolation](docs/methodology/interpolation.md) — linear, log-linear, cubic interpolators
-- [PDE](docs/methodology/pde.md) — finite-difference meshers and coordinate maps
+- [PDE](docs/methodology/pde.md) — PDE framework, grid construction, and coordinate maps
 - [Script Engine](docs/methodology/script_engine.md) — expression scripting, fuzzy AAD evaluation, and compiled evaluator parity
 - [Random](docs/methodology/random.md) — random number generation and path construction
 - [Black / Bachelier](docs/methodology/black_scholes.md) — vanilla option pricing


### PR DESCRIPTION
## Summary

- align contributor benchmark guidance with the executable best-of-N minimum gate
- classify nine shipped Claude work products as implemented history and point readers to current authority
- replace retired PDE Mesher wording and examples with the current framework, grid-construction, and coordinate-map API
- record the exhaustive DAL-92 Markdown and agent-contract audit, including the reviewer remediation and retained 55/85 checker gap
- verify the Multica DAL roster still matches all ten authoritative Codex TOML contracts, with no workspace mutation

## Test plan

- [x] `python3 .github/scripts/check_docs.py` — 55 curated Markdown files passed
- [x] `python3 -m unittest discover -s .github/scripts/tests -p 'test_check_docs.py' -v` — 24 tests passed
- [x] Full tracked-Markdown link, anchor, table, math-macro, whitespace, final-newline, and current stale-command audit — 85/85 files passed
- [x] Current PDE API/example audit — four corrected contracts match `MakeUniformGrid`, its `REQUIRE` precondition, and `test_pdegrid.cpp`
- [x] Parsed 10 agent TOMLs, 2 skill YAMLs, and 7 `SKILL.md` frontmatters
- [x] Reconciled both methodology indexes against all 16 normative pages
- [x] Reconciled Claude, Codex, Multica workspace, and DAL squad role sets — 10 exact mappings, no writes
- [x] `git diff --check`

`.github/scripts/check_docs.py` remains unchanged and covers 55 of 85 tracked Markdown files; the independent full-tree audit covers all 85 for DAL-92. No C++ build or numerical test suite applies to this Markdown-only change.
