### PR TITLE
fix: restore Windows excelwriter build

### DIFF
--- a/dal-cpp/examples/excelwriter/CMakeLists.txt
+++ b/dal-cpp/examples/excelwriter/CMakeLists.txt
@@ -1,4 +1,7 @@
 file(GLOB_RECURSE EXCELWRITER_FILES CONFIGURE_DEPENDS "*.hpp" "*.cpp")
+# ExcelDriver_ is excluded from dal_library unless USE_EXCEL_REPORT is defined.
+# Compile its implementation in this target, where the Office imports are enabled.
+list(APPEND EXCELWRITER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../../dal/io/exceldriverlite.cpp")
 add_executable(excelwriter ${EXCELWRITER_FILES})
 
 target_link_libraries(excelwriter dal_library)


### PR DESCRIPTION
## Summary

- Compile the Excel driver implementation in the Windows excelwriter target.
- Keep Office import definitions scoped to the example while restoring missing COM method definitions at link time.

## Test plan

- [x] Built excelwriter with the Windows Release preset.
- [x] Built the complete Windows Release workspace.
- [x] Ran the Windows Release CTest suite (1248/1248 passed).