### PR TITLE
ci: add reproducible dal-python PyPI releases

### DIFF
--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -588,16 +588,10 @@ def check_benchmark_case_policy(errors: list[str]) -> None:
         errors.append("CONTRIBUTING.md: benchmark case-set policy does not describe head-only coverage")
 
 
-def check_python_release_workflow(errors: list[str]) -> None:
-    with (ROOT / "dal-python/pyproject.toml").open("rb") as stream:
-        metadata = tomllib.load(stream)
+def check_python_project_metadata(errors: list[str], metadata: dict) -> None:
     project = metadata["project"]
-    cibuildwheel = metadata["tool"]["cibuildwheel"]
-    expected_builds = {"cp310-*", "cp311-*", "cp312-*", "cp313-*"}
-
     if "scikit-build-core==1.0.3" not in metadata["build-system"]["requires"]:
         errors.append("dal-python/pyproject.toml: scikit-build-core must be reproducibly pinned")
-
     init = (ROOT / "dal-python/src/dal/__init__.py").read_text(encoding="utf-8")
     version_match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']\s*$', init, re.MULTILINE)
     source_version = version_match.group(1) if version_match else None
@@ -609,6 +603,11 @@ def check_python_release_workflow(errors: list[str]) -> None:
         errors.append("dal-python/pyproject.toml: release wheels must target CPython 3.10-3.13")
     if project.get("readme") != "README.md":
         errors.append("dal-python/pyproject.toml: project.readme must publish the component README")
+
+
+def check_cibuildwheel_config(errors: list[str], metadata: dict) -> None:
+    cibuildwheel = metadata["tool"]["cibuildwheel"]
+    expected_builds = {"cp310-*", "cp311-*", "cp312-*", "cp313-*"}
     if set(cibuildwheel.get("build", [])) != expected_builds:
         errors.append("dal-python/pyproject.toml: cibuildwheel build matrix must cover cp310-cp313")
     if cibuildwheel.get("linux", {}).get("manylinux-x86_64-image") != "manylinux_2_28":
@@ -618,6 +617,8 @@ def check_python_release_workflow(errors: list[str]) -> None:
     if cibuildwheel.get("windows", {}).get("archs") != ["AMD64"]:
         errors.append("dal-python/pyproject.toml: Windows wheel architecture must be AMD64")
 
+
+def check_python_helper_scripts(errors: list[str]) -> None:
     for relative_path in (
         "build_linux.sh",
         "dal-python/build_sdist.sh",
@@ -632,6 +633,8 @@ def check_python_release_workflow(errors: list[str]) -> None:
         if relative_path != "build_linux.sh" and '"scikit-build-core==1.0.3"' not in script:
             errors.append(f"{relative_path}: scikit-build-core must match the build-system pin")
 
+
+def check_python_release_action(errors: list[str]) -> None:
     workflow_path = ROOT / ".github/workflows/dal-python-release.yml"
     workflow = workflow_path.read_text(encoding="utf-8")
     required_fragments = (
@@ -661,6 +664,15 @@ def check_python_release_workflow(errors: list[str]) -> None:
             errors.append(
                 ".github/workflows/dal-python-release.yml: actions must be pinned to full SHAs"
             )
+
+
+def check_python_release_workflow(errors: list[str]) -> None:
+    with (ROOT / "dal-python/pyproject.toml").open("rb") as stream:
+        metadata = tomllib.load(stream)
+    check_python_project_metadata(errors, metadata)
+    check_cibuildwheel_config(errors, metadata)
+    check_python_helper_scripts(errors)
+    check_python_release_action(errors)
 
 
 def check_repository_workflows(errors: list[str]) -> None:

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -588,12 +588,88 @@ def check_benchmark_case_policy(errors: list[str]) -> None:
         errors.append("CONTRIBUTING.md: benchmark case-set policy does not describe head-only coverage")
 
 
+def check_python_release_workflow(errors: list[str]) -> None:
+    with (ROOT / "dal-python/pyproject.toml").open("rb") as stream:
+        metadata = tomllib.load(stream)
+    project = metadata["project"]
+    cibuildwheel = metadata["tool"]["cibuildwheel"]
+    expected_builds = {"cp310-*", "cp311-*", "cp312-*", "cp313-*"}
+
+    if "scikit-build-core==1.0.3" not in metadata["build-system"]["requires"]:
+        errors.append("dal-python/pyproject.toml: scikit-build-core must be reproducibly pinned")
+
+    init = (ROOT / "dal-python/src/dal/__init__.py").read_text(encoding="utf-8")
+    version_match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']\s*$', init, re.MULTILINE)
+    source_version = version_match.group(1) if version_match else None
+    if source_version != project["version"]:
+        errors.append(
+            "dal-python: src/dal/__init__.py __version__ must match pyproject.toml project.version"
+        )
+    if project.get("requires-python") != ">=3.10,<3.14":
+        errors.append("dal-python/pyproject.toml: release wheels must target CPython 3.10-3.13")
+    if project.get("readme") != "README.md":
+        errors.append("dal-python/pyproject.toml: project.readme must publish the component README")
+    if set(cibuildwheel.get("build", [])) != expected_builds:
+        errors.append("dal-python/pyproject.toml: cibuildwheel build matrix must cover cp310-cp313")
+    if cibuildwheel.get("linux", {}).get("manylinux-x86_64-image") != "manylinux_2_28":
+        errors.append("dal-python/pyproject.toml: Linux wheels must use manylinux_2_28")
+    if cibuildwheel.get("linux", {}).get("archs") != ["x86_64"]:
+        errors.append("dal-python/pyproject.toml: Linux wheel architecture must be x86_64")
+    if cibuildwheel.get("windows", {}).get("archs") != ["AMD64"]:
+        errors.append("dal-python/pyproject.toml: Windows wheel architecture must be AMD64")
+
+    for relative_path in (
+        "build_linux.sh",
+        "dal-python/build_sdist.sh",
+        "dal-python/build_wheel.ps1",
+        "dal-python/build_wheel.sh",
+        "dal-python/run_tests.ps1",
+        "dal-python/run_tests.sh",
+    ):
+        script = (ROOT / relative_path).read_text(encoding="utf-8")
+        if '">=3.10,<3.14"' not in script:
+            errors.append(f"{relative_path}: uv interpreter range must match project.requires-python")
+        if relative_path != "build_linux.sh" and '"scikit-build-core==1.0.3"' not in script:
+            errors.append(f"{relative_path}: scikit-build-core must match the build-system pin")
+
+    workflow_path = ROOT / ".github/workflows/dal-python-release.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    required_fragments = (
+        "dal-python-v*",
+        "workflow_dispatch:",
+        "if: github.ref_type == 'tag'",
+        "name: pypi",
+        "id-token: write",
+        "packages-dir: wheelhouse",
+        "--check-pypi",
+        "dal-python/scripts/verify_release.py",
+        "pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074",
+        'test "$(git rev-parse FETCH_HEAD)" = "${GITHUB_SHA}"',
+        'git cat-file -t "${GITHUB_REF}"',
+    )
+    for fragment in required_fragments:
+        if fragment not in workflow:
+            errors.append(f".github/workflows/dal-python-release.yml: missing {fragment!r}")
+    for forbidden in ("skip-existing", "PYPI_API_TOKEN", "password:", "--sdist"):
+        if forbidden in workflow:
+            errors.append(f".github/workflows/dal-python-release.yml: forbidden {forbidden!r}")
+    for line in workflow.splitlines():
+        if "uses:" not in line:
+            continue
+        reference = line.split("@", maxsplit=1)[-1].split(maxsplit=1)[0]
+        if re.fullmatch(r"[0-9a-f]{40}", reference) is None:
+            errors.append(
+                ".github/workflows/dal-python-release.yml: actions must be pinned to full SHAs"
+            )
+
+
 def check_repository_workflows(errors: list[str]) -> None:
     check_windows_python_helpers(errors)
     check_component_build_modes(errors)
     check_web_launcher_portability(errors)
     check_windows_generation_and_tests(errors)
     check_benchmark_case_policy(errors)
+    check_python_release_workflow(errors)
 
 
 def code_regions(lines: list[str]) -> list[tuple[int, str]]:

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -1,0 +1,93 @@
+"""Tests for the dal-python binary release verifier."""
+
+import importlib.util
+from pathlib import Path
+import re
+import tempfile
+import unittest
+from zipfile import ZipFile
+
+
+SCRIPT = Path(__file__).resolve().parents[3] / "dal-python" / "scripts" / "verify_release.py"
+SPEC = importlib.util.spec_from_file_location("verify_release", SCRIPT)
+VERIFY_RELEASE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY_RELEASE)
+
+
+class PythonReleaseTest(unittest.TestCase):
+    def write_wheel(self, directory: Path, python_tag: str, platform_tag: str) -> Path:
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        extension = "pyd" if platform_tag == "win_amd64" else "so"
+        wheel = directory / (
+            f"dal_python-{version}-{python_tag}-{python_tag}-{platform_tag}.whl"
+        )
+        dist_info = f"dal_python-{version}.dist-info"
+        with ZipFile(wheel, "w") as archive:
+            archive.writestr(f"dal/_dal.{python_tag}.{extension}", b"native")
+            archive.writestr(
+                f"{dist_info}/METADATA",
+                "\n".join(
+                    (
+                        "Metadata-Version: 2.4",
+                        "Name: dal-python",
+                        f"Version: {version}",
+                        "License-Expression: MIT",
+                        f"Requires-Python: {requires_python}",
+                        "",
+                        "DAL package description",
+                    )
+                ),
+            )
+            archive.writestr(
+                f"{dist_info}/WHEEL",
+                "\n".join(
+                    (
+                        "Wheel-Version: 1.0",
+                        "Root-Is-Purelib: false",
+                        f"Tag: {python_tag}-{python_tag}-{platform_tag}",
+                        "",
+                    )
+                ),
+            )
+        return wheel
+
+    def test_accepts_complete_platform_pair(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            version, _, _ = VERIFY_RELEASE.project_configuration()
+            self.write_wheel(directory, "cp313", "manylinux_2_28_x86_64")
+            self.write_wheel(directory, "cp313", "win_amd64")
+
+            manifest = VERIFY_RELEASE.validate_release(
+                directory,
+                expected_python_tags=("cp313",),
+                tag=f"dal-python-v{version}",
+            )
+
+            self.assertEqual(len(manifest), 2)
+
+    def test_rejects_raw_linux_platform_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+            wheel = self.write_wheel(directory, "cp313", "linux_x86_64")
+
+            with self.assertRaisesRegex(ValueError, "unrepaired wheel platform"):
+                VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_incomplete_platform_pair(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            self.write_wheel(directory, "cp313", "manylinux_2_28_x86_64")
+
+            with self.assertRaisesRegex(ValueError, "wheel matrix mismatch"):
+                VERIFY_RELEASE.validate_release(directory, expected_python_tags=("cp313",))
+
+    def test_rejects_tag_version_drift(self):
+        version, _, _ = VERIFY_RELEASE.project_configuration()
+        with self.assertRaisesRegex(ValueError, f"must equal {re.escape(f'dal-python-v{version}')}"):
+            VERIFY_RELEASE.validate_versions("dal-python-v0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import tempfile
 import unittest
+from unittest.mock import patch
 from zipfile import ZipFile
 
 
@@ -103,6 +104,44 @@ class PythonReleaseTest(unittest.TestCase):
                 config.touch()
 
                 self.assertEqual(BUILD_NATIVE.find_public_config(install_dir), config)
+
+    def test_windows_native_build_selects_msvc_release(self):
+        generator, build_config = BUILD_NATIVE.generator_configuration(is_windows=True)
+
+        self.assertIn("Visual Studio 17 2022", generator)
+        self.assertIn("x64", generator)
+        self.assertEqual(build_config, ["--config", "Release"])
+
+    def test_pypi_version_check_uses_fixed_https_endpoint(self):
+        with patch.object(VERIFY_RELEASE, "HTTPSConnection") as connection:
+            response = connection.return_value.getresponse.return_value
+            response.status = 404
+
+            VERIFY_RELEASE.ensure_version_is_new_on_pypi("2026.8.11+candidate")
+
+            connection.assert_called_once_with("pypi.org", timeout=20)
+            connection.return_value.request.assert_called_once_with(
+                "GET",
+                "/pypi/dal-python/2026.8.11%2Bcandidate/json",
+                headers={"Accept": "application/json"},
+            )
+            connection.return_value.close.assert_called_once_with()
+
+    def test_pypi_version_check_rejects_existing_release(self):
+        with patch.object(VERIFY_RELEASE, "HTTPSConnection") as connection:
+            response = connection.return_value.getresponse.return_value
+            response.status = 200
+
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                VERIFY_RELEASE.ensure_version_is_new_on_pypi("2026.8.11")
+
+    def test_pypi_version_check_rejects_unexpected_status(self):
+        with patch.object(VERIFY_RELEASE, "HTTPSConnection") as connection:
+            response = connection.return_value.getresponse.return_value
+            response.status = 503
+
+            with self.assertRaisesRegex(OSError, "HTTP 503"):
+                VERIFY_RELEASE.ensure_version_is_new_on_pypi("2026.8.11")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -13,6 +13,11 @@ SPEC = importlib.util.spec_from_file_location("verify_release", SCRIPT)
 VERIFY_RELEASE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(VERIFY_RELEASE)
 
+BUILD_SCRIPT = SCRIPT.with_name("build_native.py")
+BUILD_SPEC = importlib.util.spec_from_file_location("build_native", BUILD_SCRIPT)
+BUILD_NATIVE = importlib.util.module_from_spec(BUILD_SPEC)
+BUILD_SPEC.loader.exec_module(BUILD_NATIVE)
+
 
 class PythonReleaseTest(unittest.TestCase):
     def write_wheel(self, directory: Path, python_tag: str, platform_tag: str) -> Path:
@@ -87,6 +92,17 @@ class PythonReleaseTest(unittest.TestCase):
         version, _, _ = VERIFY_RELEASE.project_configuration()
         with self.assertRaisesRegex(ValueError, f"must equal {re.escape(f'dal-python-v{version}')}"):
             VERIFY_RELEASE.validate_versions("dal-python-v0")
+
+    def test_finds_native_config_in_lib_and_lib64(self):
+        relative = Path("cmake") / "dal-public" / "dal-publicConfig.cmake"
+        for lib_dir in ("lib", "lib64"):
+            with self.subTest(lib_dir=lib_dir), tempfile.TemporaryDirectory() as tmp:
+                install_dir = Path(tmp)
+                config = install_dir / lib_dir / relative
+                config.parent.mkdir(parents=True)
+                config.touch()
+
+                self.assertEqual(BUILD_NATIVE.find_public_config(install_dir), config)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -50,7 +50,10 @@ class PythonReleaseTest(unittest.TestCase):
                     (
                         "Wheel-Version: 1.0",
                         "Root-Is-Purelib: false",
-                        f"Tag: {python_tag}-{python_tag}-{platform_tag}",
+                        *(
+                            f"Tag: {python_tag}-{python_tag}-{platform}"
+                            for platform in platform_tag.split(".")
+                        ),
                         "",
                     )
                 ),
@@ -61,7 +64,11 @@ class PythonReleaseTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
             version, _, _ = VERIFY_RELEASE.project_configuration()
-            self.write_wheel(directory, "cp313", "manylinux_2_28_x86_64")
+            self.write_wheel(
+                directory,
+                "cp313",
+                "manylinux_2_27_x86_64.manylinux_2_28_x86_64",
+            )
             self.write_wheel(directory, "cp313", "win_amd64")
 
             manifest = VERIFY_RELEASE.validate_release(
@@ -93,6 +100,12 @@ class PythonReleaseTest(unittest.TestCase):
         version, _, _ = VERIFY_RELEASE.project_configuration()
         with self.assertRaisesRegex(ValueError, f"must equal {re.escape(f'dal-python-v{version}')}"):
             VERIFY_RELEASE.validate_versions("dal-python-v0")
+
+    def test_python_requirement_order_is_not_significant(self):
+        self.assertEqual(
+            VERIFY_RELEASE.normalized_requires_python(">=3.10,<3.14"),
+            VERIFY_RELEASE.normalized_requires_python("<3.14, >=3.10"),
+        )
 
     def test_finds_native_config_in_lib_and_lib64(self):
         relative = Path("cmake") / "dal-public" / "dal-publicConfig.cmake"

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -112,6 +112,17 @@ class PythonReleaseTest(unittest.TestCase):
         self.assertIn("x64", generator)
         self.assertEqual(build_config, ["--config", "Release"])
 
+    def test_cmake_executable_is_resolved_to_absolute_path(self):
+        with patch.object(BUILD_NATIVE, "which", return_value="/opt/cmake/bin/cmake"):
+            self.assertEqual(
+                BUILD_NATIVE.cmake_executable(), Path("/opt/cmake/bin/cmake")
+            )
+
+    def test_cmake_executable_rejects_unexpected_name(self):
+        with patch.object(BUILD_NATIVE, "which", return_value="/tmp/not-cmake"):
+            with self.assertRaisesRegex(RuntimeError, "unexpected cmake executable"):
+                BUILD_NATIVE.cmake_executable()
+
     def test_pypi_version_check_uses_fixed_https_endpoint(self):
         with patch.object(VERIFY_RELEASE, "HTTPSConnection") as connection:
             response = connection.return_value.getresponse.return_value

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -123,6 +123,17 @@ class PythonReleaseTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "unexpected cmake executable"):
                 BUILD_NATIVE.cmake_executable()
 
+    def test_run_cmake_uses_resolved_executable_without_shell(self):
+        executable = Path("/opt/cmake/bin/cmake")
+        with patch.object(
+            BUILD_NATIVE, "cmake_executable", return_value=executable
+        ), patch.object(BUILD_NATIVE.subprocess, "run") as run:
+            BUILD_NATIVE.run_cmake(["--version"])
+
+            run.assert_called_once_with(
+                [str(executable), "--version"], check=True, shell=False
+            )
+
     def test_pypi_version_check_uses_fixed_https_endpoint(self):
         with patch.object(VERIFY_RELEASE, "HTTPSConnection") as connection:
             response = connection.return_value.getresponse.return_value

--- a/.github/workflows/dal-python-release.yml
+++ b/.github/workflows/dal-python-release.yml
@@ -1,0 +1,139 @@
+name: dal-python wheels and PyPI release
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/check_docs.py
+      - .github/workflows/dal-python-release.yml
+      - dal-python/**
+      - CMakeLists.txt
+      - CMakePresets.json
+      - dal-cpp/**
+      - dal-public/**
+  push:
+    tags:
+      - dal-python-v*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Validate release source
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Validate version and tag policy
+        shell: bash
+        run: |
+          args=(--version-only)
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            git fetch --no-tags origin master
+            test "$(git rev-parse FETCH_HEAD)" = "${GITHUB_SHA}"
+            test "$(git cat-file -t "${GITHUB_REF}")" = "tag"
+            args+=(--tag "${GITHUB_REF_NAME}" --check-pypi)
+          fi
+          python dal-python/scripts/verify_release.py "${args[@]}"
+
+  wheels:
+    name: ${{ matrix.platform }} wheels
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux-x86_64
+          - os: windows-2022
+            platform: windows-amd64
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: recursive
+
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        with:
+          package-dir: dal-python
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp313-*' || 'cp310-* cp311-* cp312-* cp313-*' }}
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-${{ matrix.platform }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+  verify:
+    name: Verify release manifest
+    needs: wheels
+    runs-on: ubuntu-24.04
+    env:
+      EXPECTED_PYTHON: ${{ github.event_name == 'pull_request' && 'cp313' || 'cp310,cp311,cp312,cp313' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels-*
+          path: wheelhouse
+          merge-multiple: true
+
+      - name: Validate wheel matrix and metadata
+        shell: bash
+        run: |
+          args=(
+            --dist-dir wheelhouse
+            --expected-python "${EXPECTED_PYTHON}"
+          )
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            args+=(--tag "${GITHUB_REF_NAME}" --check-pypi)
+          fi
+          python dal-python/scripts/verify_release.py "${args[@]}" \
+            | tee release-manifest.txt
+
+      - name: Upload release manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dal-python-release-manifest
+          path: release-manifest.txt
+          if-no-files-found: error
+          retention-days: 90
+
+  publish:
+    name: Publish wheels to PyPI
+    if: github.ref_type == 'tag'
+    needs: verify
+    runs-on: ubuntu-24.04
+    environment:
+      name: pypi
+      url: https://pypi.org/project/dal-python/
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download verified wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels-*
+          path: wheelhouse
+          merge-multiple: true
+
+      - name: Publish exact wheel artifacts
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          packages-dir: wheelhouse

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -53,7 +53,7 @@ if [[ $BUILD_PYTHON == true ]]; then
     python_bin="$venv_dir/bin/python"
     if [[ ! -x "$python_bin" ]]; then
         if command -v uv >/dev/null 2>&1; then
-            uv venv "$venv_dir" --python ">=3.10"
+            uv venv "$venv_dir" --python ">=3.10,<3.14"
         elif command -v python3 >/dev/null 2>&1; then
             python3 -m venv "$venv_dir"
         else

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -13,14 +13,14 @@ Python bindings for the Derivatives Algorithms Library (DAL) — a high-performa
 
 ## Prerequisites
 
-- **Python 3.10+** with development headers
+- **CPython 3.10-3.13** with development headers
 - **uv** — fast Python package manager ([install guide](https://docs.astral.sh/uv/getting-started/installation/))
 - **pybind11 2.11.1** — installed automatically for isolated package builds;
   repository builds fall back to the pinned `dal-cpp/externals/pybind11`
   submodule, so run `git submodule update --init --recursive` on fresh clones
 - **CMake 3.21+** and a C++17 compiler (GCC 13+, Clang 18+, or MSVC 2022)
 - **DAL C++ staged install** — build core/public first; the canonical workflow is
-  in [docs/installation.md](../docs/installation.md#python-bindings)
+  in the [installation guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/installation.md#python-bindings)
 
 ### Building the C++ Library
 
@@ -44,7 +44,7 @@ Clone the repository and install in editable mode:
 cd Derivatives-Algorithms-Lib/dal-python
 
 # Create a virtual environment with uv
-uv venv
+uv venv --python ">=3.10,<3.14"
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 # Install dependencies and build the extension
@@ -71,6 +71,7 @@ and runs the configured C++/public/Python tests.
 ## Building Distribution Packages
 
 For production deployment, you can build pre-compiled binary wheels or source distributions.
+Official PyPI releases contain precompiled wheels only.
 
 ### Building a Binary Wheel
 
@@ -105,10 +106,10 @@ The source archive is created under `dist/`.
 
 Install from source (requires C++ build tools):
 ```bash
-pip install dist/dal_python-2025.12.7.tar.gz \
+pip install dist/dal_python-2026.8.11.tar.gz \
   "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 # or
-uv pip install dist/dal_python-2025.12.7.tar.gz \
+uv pip install dist/dal_python-2026.8.11.tar.gz \
   "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 ```
 
@@ -117,9 +118,67 @@ uv pip install dist/dal_python-2025.12.7.tar.gz \
 - CMake 3.21+
 - pybind11 2.11.1 (declared as an isolated build requirement and installed
   automatically; repository builds may use the pinned vendored submodule)
-- Python 3.10+ development headers
+- CPython 3.10-3.13 development headers
 - DAL staged install containing the `dal-public`/`dal-cpp` CMake packages and
   platform libraries
+
+## PyPI Binary Release
+
+The repository release workflow builds and tests this wheel matrix:
+
+| Operating system | Architecture | Wheel platform tag          | CPython versions |
+|------------------|--------------|-----------------------------|------------------|
+| Linux            | x86-64       | `manylinux_2_28_x86_64`     | 3.10-3.13        |
+| Windows          | x86-64       | `win_amd64`                 | 3.10-3.13        |
+
+The Linux tag requires glibc 2.28 or newer. macOS, Linux ARM, musllinux, PyPy,
+free-threaded CPython, source distributions, and CPython 3.14 are not part of the
+current PyPI release contract.
+
+### One-time PyPI setup
+
+Configure a Trusted Publisher on the existing `dal-python` PyPI project with:
+
+| Field                | Value                              |
+|----------------------|------------------------------------|
+| PyPI project         | `dal-python`                       |
+| GitHub owner         | `wegamekinglc`                     |
+| GitHub repository    | `Derivatives-Algorithms-Lib`       |
+| Workflow filename    | `dal-python-release.yml`           |
+| GitHub environment   | `pypi`                             |
+
+Create the matching `pypi` environment in the GitHub repository and require a
+manual deployment approval if the repository plan supports it. The workflow uses
+OIDC short-lived credentials; do not add a long-lived PyPI API token.
+
+### Release procedure
+
+1. Choose a new PEP 440 version that does not exist on PyPI. Update both
+   `pyproject.toml` and `src/dal/__init__.py`.
+2. Build and test the workspace with `bash ./build_linux.sh --full` from the
+   repository root. Review and merge the version and release-note changes to
+   `master` only after the exact PR head is green.
+3. Run the `dal-python wheels and PyPI release` workflow manually from `master`.
+   This is a build-only rehearsal. Confirm that eight wheels and the SHA-256
+   release manifest are present.
+4. Tag that reviewed `master` commit and push only the tag:
+
+   ```bash
+   git tag -a dal-python-v<version> -m "Release dal-python <version>"
+   git push origin dal-python-v<version>
+   ```
+
+5. The tag run rebuilds and tests every wheel, validates the combined manifest,
+   checks that the version is unused on PyPI, then publishes the exact artifacts
+   from the build jobs through the `pypi` environment.
+6. Verify the PyPI file list contains all eight wheels. In fresh Windows and Linux
+   environments, install `dal-python==<version>`, import `dal`, and confirm
+   `dal.__version__` equals `<version>`.
+
+PyPI versions and files are immutable. Never use a skip-existing option to repair
+an incomplete release; correct the issue, increment the version, and run the full
+process again. Local `build_wheel.*` scripts are for diagnostics and private
+deployment only; their output is not a PyPI release artifact.
 
 ## Usage
 
@@ -373,7 +432,7 @@ curve-construction and calibration workflows:
 - **Enums** — `CurveParameterization` (`PIECEWISE_LINEAR_FWD`, `PIECEWISE_CONSTANT_FWD`, `ZERO_RATE`, `LOG_DISCOUNT`), `CurveSolveMode` (`EXACT`, `APPROXIMATE`), `CurveJacobianMode` (`ANALYTIC`, `BUMPED`), `LogDfScheme` (`LOG_LINEAR`, `LOG_CUBIC_NATURAL`, `MIXED`), `XccyNotionalMode` (`FIXED`, `RESETTABLE`, `MARK_TO_MARKET`)
 - **Spec builders** — `CurveCalibrationSpecBuilder_`, `CrossCurrencyCalibrationSpecBuilder_`, and `JointXccyCalibrationSpecBuilder_`
 
-The `dal.calibrate_curve(...)` helper in `api.py` wraps the common single-curve path with Python-friendly defaults. The underlying C++ methodology is documented in [docs/methodology/yield_curve.md](../docs/methodology/yield_curve.md) and [docs/methodology/yield_curve_jacobian.md](../docs/methodology/yield_curve_jacobian.md).
+The `dal.calibrate_curve(...)` helper in `api.py` wraps the common single-curve path with Python-friendly defaults. The underlying C++ methodology is documented in the [yield-curve guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/methodology/yield_curve.md) and [Jacobian guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/methodology/yield_curve_jacobian.md).
 
 ### Continuously Compounded Zero-Rate Curves
 
@@ -480,9 +539,9 @@ either diagnostic matrix. The `eff_jacobian_inverse` matrix has shape
 `totalParameters x totalResiduals` and is the weighted inverse of the solver's
 tolerance-scaled Jacobian. Transforming a raw decimal quote bump therefore
 requires division by the spec's `tolerance_`; see the
-[Jacobian methodology](../docs/methodology/yield_curve_jacobian.md#joint-xccy-jacobian-layout).
+[Jacobian methodology](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/methodology/yield_curve_jacobian.md#joint-xccy-jacobian-layout).
 
-The runnable [joint XCCY calibration example](examples/007.xccy_joint_calibration.py)
+The runnable [joint XCCY calibration example](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/dal-python/examples/007.xccy_joint_calibration.py)
 uses an explicit fixing snapshot for a started MTM trade. It prints convergence,
 the maximum absolute residual, Jacobian dimensions, named parameter and residual
 half-open ranges, and every FX-forward date and value. With the `dal` package
@@ -529,17 +588,17 @@ uv run --no-sync python -c "import dal; print(dal.__version__)"
 
 ## License
 
-MIT License. See the repository [LICENSE](../LICENSE).
+MIT License. See the repository [LICENSE](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/LICENSE).
 
 ## Contributing
 
-Follow the repository [contributor guide](../CONTRIBUTING.md). Binding changes
+Follow the repository [contributor guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/CONTRIBUTING.md). Binding changes
 should include Python tests and updates to the
-[public API guide](../docs/public-api.md) when the supported surface changes.
+[public API guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/public-api.md) when the supported surface changes.
 
 ## See Also
 
-- [DAL C++ Library](../README.md) — Workspace overview
-- [Installation guide](../docs/installation.md) — Canonical setup commands
-- [Public API guide](../docs/public-api.md) — C++, Python, and Excel entry points
+- [DAL C++ Library](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib) — Workspace overview
+- [Installation guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/installation.md) — Canonical setup commands
+- [Public API guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/public-api.md) — C++, Python, and Excel entry points
 - [pybind11 Documentation](https://pybind11.readthedocs.io/) — pybind11 binding syntax

--- a/dal-python/build_sdist.sh
+++ b/dal-python/build_sdist.sh
@@ -6,7 +6,7 @@
 #
 # Prerequisites:
 # - uv must be installed
-# - Python 3.10+
+# - CPython 3.10-3.13
 #
 # Usage:
 #   ./build_sdist.sh         # Build source distribution
@@ -66,14 +66,14 @@ fi
 # Create build environment
 echo -e "${YELLOW}Creating build environment...${NC}"
 if [ ! -d ".venv" ]; then
-    uv venv
+    uv venv --python ">=3.10,<3.14"
 fi
 source .venv/bin/activate
 echo -e "${GREEN}✓ Build environment ready${NC}"
 
 # Install build dependencies
 echo -e "${YELLOW}Installing build dependencies...${NC}"
-uv pip install -q scikit-build-core build "pybind11==2.11.1"
+uv pip install -q "scikit-build-core==1.0.3" build "pybind11==2.11.1"
 echo -e "${GREEN}✓ Build dependencies installed${NC}"
 
 # Build sdist
@@ -109,7 +109,7 @@ echo "Note: Building from source requires:"
 echo "  - C++17 compiler (GCC 13+, Clang 18+, or MSVC 2022)"
 echo "  - CMake 3.21+"
 echo "  - pybind11 2.11.1 (installed automatically from the sdist build requirements)"
-echo "  - Python 3.10+ development headers"
+echo "  - CPython 3.10-3.13 development headers"
 echo "  - DAL staged install containing lib/cmake/dal-public/dal-publicConfig.cmake"
 echo ""
 

--- a/dal-python/build_wheel.ps1
+++ b/dal-python/build_wheel.ps1
@@ -6,7 +6,7 @@
 # Prerequisites:
 # - C++ library must be installed (run ..\build_windows.bat)
 # - uv must be installed
-# - Python 3.10+ with development headers
+# - CPython 3.10-3.13 with development headers
 # - Visual Studio 2022 with C++ workload
 #
 # Usage:
@@ -79,7 +79,7 @@ if ($Clean) {
 Write-Output "Creating build environment..."
 $VenvDir = Join-Path $ScriptDir ".venv"
 if (-not (Test-Path $VenvDir)) {
-    uv venv $VenvDir --python ">=3.10"
+    uv venv $VenvDir --python ">=3.10,<3.14"
 }
 $VenvActivate = Join-Path $VenvDir "Scripts\Activate.ps1"
 . $VenvActivate
@@ -87,7 +87,7 @@ Write-Output "  Build environment ready"
 
 # Install build dependencies
 Write-Output "Installing build dependencies..."
-uv pip install -q scikit-build-core cmake ninja build
+uv pip install -q "scikit-build-core==1.0.3" cmake ninja build
 Write-Output "  Build dependencies installed"
 
 # Build wheel

--- a/dal-python/build_wheel.sh
+++ b/dal-python/build_wheel.sh
@@ -7,7 +7,7 @@
 # Prerequisites:
 # - Staged C++ install must contain the exported dal-public CMake package
 # - uv must be installed
-# - Python 3.10+ with development headers
+# - CPython 3.10-3.13 with development headers
 #
 # Usage:
 #   ./build_wheel.sh              # Build wheel for current platform
@@ -84,14 +84,14 @@ fi
 # Create build environment
 echo -e "${YELLOW}Creating build environment...${NC}"
 if [ ! -d ".venv" ]; then
-    uv venv
+    uv venv --python ">=3.10,<3.14"
 fi
 source .venv/bin/activate
 echo -e "${GREEN}✓ Build environment ready${NC}"
 
 # Install build dependencies
 echo -e "${YELLOW}Installing build dependencies...${NC}"
-uv pip install -q scikit-build-core cmake ninja build
+uv pip install -q "scikit-build-core==1.0.3" cmake ninja build
 if [ "$MANYLINUX" = true ]; then
     uv pip install -q auditwheel
 fi

--- a/dal-python/pyproject.toml
+++ b/dal-python/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11==2.11.1"]
+requires = ["scikit-build-core==1.0.3", "pybind11==2.11.1"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "dal-python"
-version = "2025.12.7"
+version = "2026.8.11"
 description = "Python bindings for the DAL quantitative finance library"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
+readme = "README.md"
 license = "MIT"
 authors = [
     { name = "The Derivatives Algorithms Group", email = "wegamekinglc@hotmail.com" },
@@ -14,10 +15,20 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
+
+[project.urls]
+Documentation = "https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/tree/master/dal-python"
+Repository = "https://github.com/wegamekinglc/Derivatives-Algorithms-Lib"
 
 [project.optional-dependencies]
 test = [
@@ -31,3 +42,24 @@ wheel.packages = ["src/dal"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.cibuildwheel]
+build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+skip = ["*-musllinux_*", "*-manylinux_i686", "*-win32"]
+build-verbosity = 1
+test-requires = ["pytest>=7.0", "numpy>=1.24"]
+test-command = "python -m pytest {package}/tests -q"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+manylinux-x86_64-image = "manylinux_2_28"
+before-all = [
+    "dnf install -y cmake ninja-build",
+    "python {package}/scripts/build_native.py --build-dir /tmp/dal-cibw-build --install-dir /tmp/dal-cibw-install",
+]
+environment = { CMAKE_ARGS = "-DDAL_INSTALL_PREFIX=/tmp/dal-cibw-install -DCMAKE_PREFIX_PATH=/tmp/dal-cibw-install" }
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]
+before-all = "python {package}/scripts/build_native.py --build-dir C:/dal-cibw/build --install-dir C:/dal-cibw/install"
+environment = { CMAKE_ARGS = "-DDAL_INSTALL_PREFIX=C:/dal-cibw/install -DCMAKE_PREFIX_PATH=C:/dal-cibw/install" }

--- a/dal-python/run_tests.ps1
+++ b/dal-python/run_tests.ps1
@@ -8,7 +8,7 @@
 # Prerequisites:
 #   - uv (https://docs.astral.sh/uv/)
 #   - The C++ library must be installed first (run ..\build_windows.bat)
-#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and Python 3.10+ development headers
+#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and CPython 3.10-3.13 development headers
 #   - Visual Studio 2022 with C++ workload
 
 param(
@@ -84,7 +84,7 @@ if ($Clean) {
 
 if (-not (Test-Path $VenvDir)) {
     Write-Output "Creating fresh uv virtual environment..."
-    uv venv $VenvDir --python ">=3.10"
+    uv venv $VenvDir --python ">=3.10,<3.14"
 }
 else {
     Write-Output "Reusing existing virtual environment at .venv/"
@@ -107,7 +107,7 @@ Write-Output "  Path:   $(Get-Command python | Select-Object -ExpandProperty Sou
 
 Write-Output ""
 Write-Output "Installing dependencies (scikit-build-core, pytest, numpy)..."
-uv pip install scikit-build-core pytest numpy
+uv pip install "scikit-build-core==1.0.3" pytest numpy
 
 # ---- Step 4: Install the package in editable mode ---------------------------
 

--- a/dal-python/run_tests.sh
+++ b/dal-python/run_tests.sh
@@ -10,7 +10,7 @@
 # Prerequisites:
 #   - uv (https://docs.astral.sh/uv/)
 #   - The staged C++ install must exist (run ../build_linux.sh from repo root)
-#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and Python 3.10+ development headers
+#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and CPython 3.10-3.13 development headers
 #
 
 set -eu
@@ -47,7 +47,7 @@ echo "[OK] DAL CMake package found: $DAL_PUBLIC_CONFIG"
 VENV_DIR="$SCRIPT_DIR/.venv"
 if [[ ! -d "$VENV_DIR" ]]; then
     echo "Creating fresh uv virtual environment..."
-    uv venv "$VENV_DIR" --python ">=3.10"
+    uv venv "$VENV_DIR" --python ">=3.10,<3.14"
 else
     echo "Reusing existing virtual environment at .venv/"
 fi
@@ -62,7 +62,7 @@ echo "  Path:   $(which python)"
 
 echo ""
 echo "Installing dependencies (scikit-build-core, pytest, numpy)..."
-uv pip install scikit-build-core pytest numpy
+uv pip install "scikit-build-core==1.0.3" pytest numpy
 
 # ---- Step 4: Install the package in editable mode ---------------------------
 

--- a/dal-python/scripts/build_native.py
+++ b/dal-python/scripts/build_native.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
-import subprocess
+import subprocess  # noqa: S404  # nosec B404 -- required to invoke the fixed CMake tool
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -21,9 +21,13 @@ def checked_directory(path: Path, label: str) -> Path:
     return resolved
 
 
-def run(command: list[str]) -> None:
-    print("+", subprocess.list2cmdline(command), flush=True)
-    subprocess.run(command, check=True)
+def run_cmake(arguments: list[str]) -> None:
+    """Run the fixed CMake executable without a shell or caller-selected program."""
+    print("+ cmake", *arguments, flush=True)
+    # Paths come from checked_directory and the remaining arguments are constants.
+    subprocess.run(  # noqa: S603  # nosec B603  # nosemgrep
+        ["cmake", *arguments], check=True, shell=False
+    )
 
 
 def find_public_config(install_dir: Path) -> Path:
@@ -37,19 +41,31 @@ def find_public_config(install_dir: Path) -> Path:
     raise RuntimeError(f"native install is missing a DAL public CMake package; checked {expected}")
 
 
+def generator_configuration(is_windows: bool) -> tuple[list[str], list[str]]:
+    if is_windows:
+        return (
+            [
+                "-G",
+                "Visual Studio 17 2022",
+                "-A",
+                "x64",
+                "-DMSVC_RUNTIME=static",
+                "-DXAD_STATIC_MSVC_RUNTIME=ON",
+            ],
+            ["--config", "Release"],
+        )
+    return ["-G", "Ninja", "-DCMAKE_BUILD_TYPE=Release"], []
+
+
 def build_native(build_dir: Path, install_dir: Path) -> None:
     build_dir = checked_directory(build_dir, "build directory")
     install_dir = checked_directory(install_dir, "install directory")
 
     configure = [
-        "cmake",
         "-S",
         str(REPOSITORY_ROOT),
         "-B",
         str(build_dir),
-        "-G",
-        "Ninja",
-        "-DCMAKE_BUILD_TYPE=Release",
         f"-DCMAKE_INSTALL_PREFIX={install_dir}",
         "-DBUILD_SHARED_LIBS=OFF",
         "-DDAL_BUILD_PUBLIC=ON",
@@ -64,22 +80,24 @@ def build_native(build_dir: Path, install_dir: Path) -> None:
         "-DDAL_USE_CODIPACK_AAD=OFF",
         "-DDAL_USE_ADEPT_AAD=OFF",
     ]
-    if os.name == "nt":
-        configure.extend(["-DMSVC_RUNTIME=static", "-DXAD_STATIC_MSVC_RUNTIME=ON"])
+    generator, build_config = generator_configuration(os.name == "nt")
+    configure.extend(generator)
 
-    run(configure)
-    run(
+    run_cmake(configure)
+    run_cmake(
         [
-            "cmake",
             "--build",
             str(build_dir),
             "--target",
             "dal_public",
+            *build_config,
             "--parallel",
             str(min(os.cpu_count() or 2, 4)),
         ]
     )
-    run(["cmake", "--install", str(build_dir), "--prefix", str(install_dir)])
+    run_cmake(
+        ["--install", str(build_dir), "--prefix", str(install_dir), *build_config]
+    )
 
     find_public_config(install_dir)
 

--- a/dal-python/scripts/build_native.py
+++ b/dal-python/scripts/build_native.py
@@ -26,6 +26,17 @@ def run(command: list[str]) -> None:
     subprocess.run(command, check=True)
 
 
+def find_public_config(install_dir: Path) -> Path:
+    """Find the installed DAL public CMake package on Unix and Windows layouts."""
+    relative = Path("cmake") / "dal-public" / "dal-publicConfig.cmake"
+    candidates = tuple(install_dir / lib_dir / relative for lib_dir in ("lib", "lib64"))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    expected = ", ".join(str(candidate) for candidate in candidates)
+    raise RuntimeError(f"native install is missing a DAL public CMake package; checked {expected}")
+
+
 def build_native(build_dir: Path, install_dir: Path) -> None:
     build_dir = checked_directory(build_dir, "build directory")
     install_dir = checked_directory(install_dir, "install directory")
@@ -70,9 +81,7 @@ def build_native(build_dir: Path, install_dir: Path) -> None:
     )
     run(["cmake", "--install", str(build_dir), "--prefix", str(install_dir)])
 
-    public_config = install_dir / "lib" / "cmake" / "dal-public" / "dal-publicConfig.cmake"
-    if not public_config.is_file():
-        raise RuntimeError(f"native install is missing {public_config}")
+    find_public_config(install_dir)
 
 
 def main() -> int:

--- a/dal-python/scripts/build_native.py
+++ b/dal-python/scripts/build_native.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
+from shutil import which
 import subprocess  # noqa: S404  # nosec B404 -- required to invoke the fixed CMake tool
 
 
@@ -21,12 +22,22 @@ def checked_directory(path: Path, label: str) -> Path:
     return resolved
 
 
+def cmake_executable() -> Path:
+    discovered = which("cmake")
+    if discovered is None:
+        raise RuntimeError("cmake executable was not found on PATH")
+    executable = Path(discovered).resolve()
+    if executable.name.lower() not in {"cmake", "cmake.exe"}:
+        raise RuntimeError(f"unexpected cmake executable path: {executable}")
+    return executable
+
+
 def run_cmake(arguments: list[str]) -> None:
     """Run the fixed CMake executable without a shell or caller-selected program."""
     print("+ cmake", *arguments, flush=True)
     # Paths come from checked_directory and the remaining arguments are constants.
     subprocess.run(  # noqa: S603  # nosec B603  # nosemgrep
-        ["cmake", *arguments], check=True, shell=False
+        [str(cmake_executable()), *arguments], check=True, shell=False
     )
 
 

--- a/dal-python/scripts/build_native.py
+++ b/dal-python/scripts/build_native.py
@@ -36,9 +36,8 @@ def run_cmake(arguments: list[str]) -> None:
     """Run the fixed CMake executable without a shell or caller-selected program."""
     print("+ cmake", *arguments, flush=True)
     # Paths come from checked_directory and the remaining arguments are constants.
-    subprocess.run(  # noqa: S603  # nosec B603  # nosemgrep
-        [str(cmake_executable()), *arguments], check=True, shell=False
-    )
+    command = [str(cmake_executable()), *arguments]
+    subprocess.run(command, check=True, shell=False)  # noqa: S603  # nosec B603  # nosemgrep
 
 
 def find_public_config(install_dir: Path) -> Path:

--- a/dal-python/scripts/build_native.py
+++ b/dal-python/scripts/build_native.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Build the portable native DAL install consumed by cibuildwheel."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = PACKAGE_ROOT.parent
+
+
+def checked_directory(path: Path, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    if resolved == Path(resolved.anchor) or resolved in {PACKAGE_ROOT, REPOSITORY_ROOT}:
+        raise ValueError(f"{label} must be a dedicated build directory, got {resolved}")
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def run(command: list[str]) -> None:
+    print("+", subprocess.list2cmdline(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def build_native(build_dir: Path, install_dir: Path) -> None:
+    build_dir = checked_directory(build_dir, "build directory")
+    install_dir = checked_directory(install_dir, "install directory")
+
+    configure = [
+        "cmake",
+        "-S",
+        str(REPOSITORY_ROOT),
+        "-B",
+        str(build_dir),
+        "-G",
+        "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DDAL_BUILD_PUBLIC=ON",
+        "-DDAL_BUILD_PYTHON=OFF",
+        "-DDAL_BUILD_EXCEL=OFF",
+        "-DDAL_CPP_BUILD_TESTS=OFF",
+        "-DDAL_CPP_BUILD_EXAMPLES=OFF",
+        "-DDAL_CPP_BUILD_BENCHMARKS=OFF",
+        "-DDAL_PUBLIC_BUILD_TESTS=OFF",
+        "-DDAL_ENABLE_NATIVE_ARCH=OFF",
+        "-DDAL_USE_XAD_AAD=OFF",
+        "-DDAL_USE_CODIPACK_AAD=OFF",
+        "-DDAL_USE_ADEPT_AAD=OFF",
+    ]
+    if os.name == "nt":
+        configure.extend(["-DMSVC_RUNTIME=static", "-DXAD_STATIC_MSVC_RUNTIME=ON"])
+
+    run(configure)
+    run(
+        [
+            "cmake",
+            "--build",
+            str(build_dir),
+            "--target",
+            "dal_public",
+            "--parallel",
+            str(min(os.cpu_count() or 2, 4)),
+        ]
+    )
+    run(["cmake", "--install", str(build_dir), "--prefix", str(install_dir)])
+
+    public_config = install_dir / "lib" / "cmake" / "dal-public" / "dal-publicConfig.cmake"
+    if not public_config.is_file():
+        raise RuntimeError(f"native install is missing {public_config}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", required=True, type=Path)
+    parser.add_argument("--install-dir", required=True, type=Path)
+    args = parser.parse_args()
+    build_native(args.build_dir, args.install_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dal-python/scripts/verify_release.py
+++ b/dal-python/scripts/verify_release.py
@@ -6,13 +6,12 @@ from __future__ import annotations
 import argparse
 from email.parser import BytesParser
 from hashlib import sha256
-import json
+from http.client import HTTPSConnection
 from pathlib import Path
 import re
 import sys
 import tomllib
-from urllib.error import HTTPError
-from urllib.request import urlopen
+from urllib.parse import quote
 from zipfile import ZipFile
 
 
@@ -65,9 +64,9 @@ def platform_family(platform_tag: str) -> str:
     raise ValueError(f"unsupported or unrepaired wheel platform tag: {platform_tag}")
 
 
-def validate_wheel(
+def validate_wheel_filename(
     path: Path, expected_version: str, expected_requires_python: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     distribution, version, python_tag, abi_tag, platform_tag = wheel_parts(path)
     if distribution != "dal_python":
         raise ValueError(f"{path.name}: unexpected distribution {distribution}")
@@ -76,52 +75,76 @@ def validate_wheel(
     if abi_tag != python_tag:
         raise ValueError(f"{path.name}: ABI {abi_tag} does not match {python_tag}")
     family = platform_family(platform_tag)
+    return python_tag, abi_tag, platform_tag, family
+
+
+def validate_native_extension(path: Path, names: list[str], family: str) -> None:
+    extension_suffix = ".pyd" if family == "windows" else ".so"
+    extensions = [
+        name for name in names if name.startswith("dal/_dal.") and name.endswith(extension_suffix)
+    ]
+    if len(extensions) != 1:
+        raise ValueError(f"{path.name}: expected one compiled _dal extension, found {extensions}")
+
+
+def validate_package_metadata(
+    path: Path, metadata, expected_version: str, expected_requires_python: str
+) -> None:
+    expected_metadata = {
+        "Name": "dal-python",
+        "Version": expected_version,
+        "License-Expression": "MIT",
+        "Requires-Python": expected_requires_python,
+    }
+    for key, expected in expected_metadata.items():
+        if metadata[key] != expected:
+            raise ValueError(f"{path.name}: {key}={metadata[key]!r}, expected {expected!r}")
+    if not str(metadata.get_payload()).strip():
+        raise ValueError(f"{path.name}: package description is empty")
+
+
+def validate_wheel_metadata(
+    path: Path, wheel_metadata, python_tag: str, abi_tag: str, platform_tag: str
+) -> None:
+    if wheel_metadata["Root-Is-Purelib"] != "false":
+        raise ValueError(f"{path.name}: native wheel is incorrectly marked pure")
+    filename_tag = f"{python_tag}-{abi_tag}-{platform_tag}"
+    if filename_tag not in wheel_metadata.get_all("Tag", []):
+        raise ValueError(f"{path.name}: WHEEL metadata omits {filename_tag}")
+
+
+def validate_wheel(
+    path: Path, expected_version: str, expected_requires_python: str
+) -> tuple[str, str, str]:
+    python_tag, abi_tag, platform_tag, family = validate_wheel_filename(
+        path, expected_version, expected_requires_python
+    )
 
     with ZipFile(path) as archive:
         names = archive.namelist()
-        extension_suffix = ".pyd" if family == "windows" else ".so"
-        extensions = [
-            name
-            for name in names
-            if name.startswith("dal/_dal.") and name.endswith(extension_suffix)
-        ]
-        if len(extensions) != 1:
-            raise ValueError(f"{path.name}: expected one compiled _dal extension, found {extensions}")
-
+        validate_native_extension(path, names, family)
         metadata = metadata_from_wheel(archive, "/METADATA")
         wheel_metadata = metadata_from_wheel(archive, "/WHEEL")
-        expected_metadata = {
-            "Name": "dal-python",
-            "Version": expected_version,
-            "License-Expression": "MIT",
-            "Requires-Python": expected_requires_python,
-        }
-        for key, expected in expected_metadata.items():
-            if metadata[key] != expected:
-                raise ValueError(f"{path.name}: {key}={metadata[key]!r}, expected {expected!r}")
-        if not str(metadata.get_payload()).strip():
-            raise ValueError(f"{path.name}: package description is empty")
-        if wheel_metadata["Root-Is-Purelib"] != "false":
-            raise ValueError(f"{path.name}: native wheel is incorrectly marked pure")
-
-        archive_tags = wheel_metadata.get_all("Tag", [])
-        filename_tag = f"{python_tag}-{abi_tag}-{platform_tag}"
-        if filename_tag not in archive_tags:
-            raise ValueError(f"{path.name}: WHEEL metadata omits {filename_tag}")
+        validate_package_metadata(path, metadata, expected_version, expected_requires_python)
+        validate_wheel_metadata(path, wheel_metadata, python_tag, abi_tag, platform_tag)
 
     digest = sha256(path.read_bytes()).hexdigest()
     return python_tag, family, digest
 
 
 def ensure_version_is_new_on_pypi(version: str) -> None:
-    url = f"https://pypi.org/pypi/dal-python/{version}/json"
+    path = f"/pypi/dal-python/{quote(version, safe='')}/json"
+    connection = HTTPSConnection("pypi.org", timeout=20)
     try:
-        with urlopen(url, timeout=20) as response:
-            json.load(response)
-    except HTTPError as error:
-        if error.code == 404:
-            return
-        raise
+        connection.request("GET", path, headers={"Accept": "application/json"})
+        response = connection.getresponse()
+        response.read()
+    finally:
+        connection.close()
+    if response.status == 404:
+        return
+    if response.status != 200:
+        raise OSError(f"PyPI version check failed with HTTP {response.status}")
     raise ValueError(f"dal-python {version} already exists on PyPI and cannot be overwritten")
 
 

--- a/dal-python/scripts/verify_release.py
+++ b/dal-python/scripts/verify_release.py
@@ -87,6 +87,10 @@ def validate_native_extension(path: Path, names: list[str], family: str) -> None
         raise ValueError(f"{path.name}: expected one compiled _dal extension, found {extensions}")
 
 
+def normalized_requires_python(value: str) -> frozenset[str]:
+    return frozenset(specifier.strip() for specifier in value.split(","))
+
+
 def validate_package_metadata(
     path: Path, metadata, expected_version: str, expected_requires_python: str
 ) -> None:
@@ -97,8 +101,12 @@ def validate_package_metadata(
         "Requires-Python": expected_requires_python,
     }
     for key, expected in expected_metadata.items():
-        if metadata[key] != expected:
-            raise ValueError(f"{path.name}: {key}={metadata[key]!r}, expected {expected!r}")
+        actual = metadata[key]
+        equivalent = actual == expected
+        if key == "Requires-Python":
+            equivalent = normalized_requires_python(actual) == normalized_requires_python(expected)
+        if not equivalent:
+            raise ValueError(f"{path.name}: {key}={actual!r}, expected {expected!r}")
     if not str(metadata.get_payload()).strip():
         raise ValueError(f"{path.name}: package description is empty")
 
@@ -108,9 +116,12 @@ def validate_wheel_metadata(
 ) -> None:
     if wheel_metadata["Root-Is-Purelib"] != "false":
         raise ValueError(f"{path.name}: native wheel is incorrectly marked pure")
-    filename_tag = f"{python_tag}-{abi_tag}-{platform_tag}"
-    if filename_tag not in wheel_metadata.get_all("Tag", []):
-        raise ValueError(f"{path.name}: WHEEL metadata omits {filename_tag}")
+    filename_tags = {
+        f"{python_tag}-{abi_tag}-{platform}" for platform in platform_tag.split(".")
+    }
+    missing_tags = filename_tags - set(wheel_metadata.get_all("Tag", []))
+    if missing_tags:
+        raise ValueError(f"{path.name}: WHEEL metadata omits {sorted(missing_tags)}")
 
 
 def validate_wheel(

--- a/dal-python/scripts/verify_release.py
+++ b/dal-python/scripts/verify_release.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Validate the complete dal-python wheel set before a PyPI upload."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import BytesParser
+from hashlib import sha256
+import json
+from pathlib import Path
+import re
+import sys
+import tomllib
+from urllib.error import HTTPError
+from urllib.request import urlopen
+from zipfile import ZipFile
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
+INIT = PACKAGE_ROOT / "src" / "dal" / "__init__.py"
+VERSION_RE = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']\s*$', re.MULTILINE)
+LINUX_PLATFORM = "manylinux_2_28_x86_64"
+WINDOWS_PLATFORM = "win_amd64"
+
+
+def project_configuration() -> tuple[str, str, tuple[str, ...]]:
+    with PYPROJECT.open("rb") as stream:
+        config = tomllib.load(stream)
+    project = config["project"]
+    build_selectors = config["tool"]["cibuildwheel"]["build"]
+    python_tags = tuple(selector.removesuffix("-*") for selector in build_selectors)
+    return project["version"], project["requires-python"], python_tags
+
+
+def source_version() -> str:
+    match = VERSION_RE.search(INIT.read_text(encoding="utf-8"))
+    if match is None:
+        raise ValueError(f"{INIT} does not declare __version__")
+    return match.group(1)
+
+
+def wheel_parts(path: Path) -> tuple[str, str, str, str, str]:
+    if path.suffix != ".whl":
+        raise ValueError(f"not a wheel: {path}")
+    parts = path.name[:-4].rsplit("-", 4)
+    if len(parts) != 5:
+        raise ValueError(f"invalid wheel filename: {path.name}")
+    return tuple(parts)  # type: ignore[return-value]
+
+
+def metadata_from_wheel(archive: ZipFile, suffix: str):
+    matches = [name for name in archive.namelist() if name.endswith(suffix)]
+    if len(matches) != 1:
+        raise ValueError(f"wheel must contain exactly one {suffix}, found {matches}")
+    return BytesParser().parsebytes(archive.read(matches[0]))
+
+
+def platform_family(platform_tag: str) -> str:
+    tags = set(platform_tag.split("."))
+    if LINUX_PLATFORM in tags:
+        return "linux"
+    if tags == {WINDOWS_PLATFORM}:
+        return "windows"
+    raise ValueError(f"unsupported or unrepaired wheel platform tag: {platform_tag}")
+
+
+def validate_wheel(
+    path: Path, expected_version: str, expected_requires_python: str
+) -> tuple[str, str, str]:
+    distribution, version, python_tag, abi_tag, platform_tag = wheel_parts(path)
+    if distribution != "dal_python":
+        raise ValueError(f"{path.name}: unexpected distribution {distribution}")
+    if version != expected_version:
+        raise ValueError(f"{path.name}: version {version} != {expected_version}")
+    if abi_tag != python_tag:
+        raise ValueError(f"{path.name}: ABI {abi_tag} does not match {python_tag}")
+    family = platform_family(platform_tag)
+
+    with ZipFile(path) as archive:
+        names = archive.namelist()
+        extension_suffix = ".pyd" if family == "windows" else ".so"
+        extensions = [
+            name
+            for name in names
+            if name.startswith("dal/_dal.") and name.endswith(extension_suffix)
+        ]
+        if len(extensions) != 1:
+            raise ValueError(f"{path.name}: expected one compiled _dal extension, found {extensions}")
+
+        metadata = metadata_from_wheel(archive, "/METADATA")
+        wheel_metadata = metadata_from_wheel(archive, "/WHEEL")
+        expected_metadata = {
+            "Name": "dal-python",
+            "Version": expected_version,
+            "License-Expression": "MIT",
+            "Requires-Python": expected_requires_python,
+        }
+        for key, expected in expected_metadata.items():
+            if metadata[key] != expected:
+                raise ValueError(f"{path.name}: {key}={metadata[key]!r}, expected {expected!r}")
+        if not str(metadata.get_payload()).strip():
+            raise ValueError(f"{path.name}: package description is empty")
+        if wheel_metadata["Root-Is-Purelib"] != "false":
+            raise ValueError(f"{path.name}: native wheel is incorrectly marked pure")
+
+        archive_tags = wheel_metadata.get_all("Tag", [])
+        filename_tag = f"{python_tag}-{abi_tag}-{platform_tag}"
+        if filename_tag not in archive_tags:
+            raise ValueError(f"{path.name}: WHEEL metadata omits {filename_tag}")
+
+    digest = sha256(path.read_bytes()).hexdigest()
+    return python_tag, family, digest
+
+
+def ensure_version_is_new_on_pypi(version: str) -> None:
+    url = f"https://pypi.org/pypi/dal-python/{version}/json"
+    try:
+        with urlopen(url, timeout=20) as response:
+            json.load(response)
+    except HTTPError as error:
+        if error.code == 404:
+            return
+        raise
+    raise ValueError(f"dal-python {version} already exists on PyPI and cannot be overwritten")
+
+
+def validate_versions(tag: str | None = None, check_pypi: bool = False) -> tuple[str, str, tuple[str, ...]]:
+    version, requires_python, configured_python_tags = project_configuration()
+    declared_source_version = source_version()
+    if declared_source_version != version:
+        raise ValueError(
+            f"dal.__version__={declared_source_version} does not match project version={version}"
+        )
+    if tag is not None and tag != f"dal-python-v{version}":
+        raise ValueError(f"release tag {tag!r} must equal dal-python-v{version}")
+    if check_pypi:
+        ensure_version_is_new_on_pypi(version)
+    return version, requires_python, configured_python_tags
+
+
+def validate_release(
+    dist_dir: Path,
+    expected_python_tags: tuple[str, ...] | None = None,
+    tag: str | None = None,
+    check_pypi: bool = False,
+) -> list[str]:
+    version, requires_python, configured_python_tags = validate_versions(tag, check_pypi)
+
+    python_tags = expected_python_tags or configured_python_tags
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if not wheels:
+        raise ValueError(f"no wheels found under {dist_dir}")
+
+    actual: set[tuple[str, str]] = set()
+    manifest: list[str] = []
+    for wheel in wheels:
+        python_tag, family, digest = validate_wheel(wheel, version, requires_python)
+        target = (python_tag, family)
+        if target in actual:
+            raise ValueError(f"duplicate wheel target {target}")
+        actual.add(target)
+        manifest.append(f"{digest}  {wheel.name}")
+
+    expected = {(python_tag, family) for python_tag in python_tags for family in ("linux", "windows")}
+    if actual != expected:
+        raise ValueError(
+            f"wheel matrix mismatch: missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}"
+        )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dist-dir", type=Path)
+    parser.add_argument("--expected-python", help="comma-separated CPython tags")
+    parser.add_argument("--tag")
+    parser.add_argument("--check-pypi", action="store_true")
+    parser.add_argument("--version-only", action="store_true")
+    args = parser.parse_args()
+    expected_python = tuple(args.expected_python.split(",")) if args.expected_python else None
+    try:
+        if args.version_only:
+            version, _, _ = validate_versions(args.tag, args.check_pypi)
+            print(version)
+            return 0
+        if args.dist_dir is None:
+            parser.error("--dist-dir is required unless --version-only is used")
+        manifest = validate_release(args.dist_dir, expected_python, args.tag, args.check_pypi)
+    except (OSError, ValueError) as error:
+        print(f"release verification failed: {error}", file=sys.stderr)
+        return 1
+    print("\n".join(manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dal-python/src/dal/__init__.py
+++ b/dal-python/src/dal/__init__.py
@@ -8,4 +8,4 @@ from .api import *
 
 __author__ = 'The Derivatives Algorithms Group'
 __email__ = 'wegamekinglc@hotmail.com'
-__version__ = "2025.12.7"
+__version__ = "2026.8.11"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ here instead of maintaining separate build recipes.
 | Core C++ | Git with submodules, CMake 3.21+, a C++17 compiler, and a build tool                         |
 | Linux    | GCC 13+ or Clang 18+; Make or Ninja                                                          |
 | Windows  | Visual Studio 2022 toolchain; Ninja for the supplied presets                                 |
-| Python   | Python 3.10+ with development headers; `uv` recommended                                      |
+| Python   | CPython 3.10-3.13 with development headers; `uv` recommended                                |
 | Web      | Python 3.13+, `uv`, npm, Node.js `^20.19.0` or `>=22.12.0`, and a built native `dal` package |
 | Excel    | Windows and Microsoft Excel; build the XLL with `DAL_BUILD_EXCEL=ON`                         |
 


### PR DESCRIPTION
## Summary
- build and test precompiled CPython 3.10-3.13 wheels for manylinux x86-64 and Windows AMD64
- validate wheel contents, metadata, platform coverage, checksums, source version, release tag, and PyPI version availability before upload
- publish tag builds through the dedicated `pypi` GitHub environment with PyPI Trusted Publishing
- release the current package as `2026.8.11` and document the repeatable binary-only release procedure

## Test plan
- [x] `bash ./build_linux.sh --full` (1228/1228 CTest cases passed)
- [x] install the CPython 3.13 Linux wheel into a fresh environment and run `dal-python/tests` (266 passed)
- [x] `python -m unittest discover -s .github/scripts/tests -p 'test_*.py'` (47 passed)
- [x] `python .github/scripts/check_docs.py`
- [x] `ruff check dal-python/scripts .github/scripts/check_docs.py .github/scripts/tests/test_python_release.py`
- [x] `actionlint .github/workflows/dal-python-release.yml`
- [x] run `dal-python/scripts/build_native.py` against a fresh build and install prefix
- [ ] GitHub Actions CPython 3.13 Linux/Windows wheel build, repair, install, and test jobs