### PR TITLE
ci: DAL-112 add Python 3.9 release coverage

### DIFF
--- a/.github/scripts/check_dal_python_syntax.py
+++ b/.github/scripts/check_dal_python_syntax.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Compile every Python 3.9-governed DAL Python source without writing bytecode."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOTS = (
+    ROOT / "dal-python" / "src",
+    ROOT / "dal-python" / "tests",
+    ROOT / "dal-python" / "scripts",
+    ROOT / "dal-python" / "examples",
+)
+
+
+def python_paths():
+    return tuple(sorted(path for root in SOURCE_ROOTS for path in root.rglob("*.py")))
+
+
+def syntax_errors(paths):
+    errors = []
+    for path in paths:
+        try:
+            source = path.read_text(encoding="utf-8")
+            compile(source, str(path), "exec", dont_inherit=True)
+        except (OSError, SyntaxError) as error:
+            errors.append("%s: %s" % (path.relative_to(ROOT), error))
+    return errors
+
+
+def main():
+    paths = python_paths()
+    errors = syntax_errors(paths)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("Python syntax checks passed for %d files with %s" % (len(paths), sys.version.split()[0]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -701,52 +701,116 @@ def check_python_release_action(errors: list[str]) -> None:
             )
 
 
-def check_python_release_projections(errors: list[str], metadata: dict, workflow: str) -> None:
+def release_expression_values(
+    workflow: str, name: str, errors: list[str]
+) -> tuple[str, str] | None:
+    match = re.search(
+        rf"^\s*{re.escape(name)}:\s*\$\{{\{{\s*github\.event_name\s*==\s*"
+        rf"'pull_request'\s*&&\s*'([^']*)'\s*\|\|\s*'([^']*)'\s*}}}}\s*$",
+        workflow,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        errors.append(
+            f".github/workflows/dal-python-release.yml: {name} event projection was not found"
+        )
+        return None
+    return match.group(1), match.group(2)
+
+
+def parse_build_projection(
+    value: str, event: str, errors: list[str]
+) -> tuple[str, ...] | None:
+    selectors = value.split()
+    if not selectors or len(selectors) != len(set(selectors)):
+        errors.append(
+            f"{event} build projection must be nonempty and unique: {selectors!r}"
+        )
+        return None
+    malformed = [
+        selector
+        for selector in selectors
+        if re.fullmatch(r"cp[1-9][0-9]+-\*", selector) is None
+    ]
+    if malformed:
+        errors.append(
+            f"{event} build projection has malformed selectors: {malformed!r}"
+        )
+        return None
+    return tuple(selector.removesuffix("-*") for selector in selectors)
+
+
+def verifier_projection_parts_are_valid(value: str, tags: list[str]) -> bool:
+    if not value:
+        return False
+    if any(not tag or tag != tag.strip() for tag in tags):
+        return False
+    return len(tags) == len(set(tags))
+
+
+def parse_verify_projection(
+    value: str, event: str, errors: list[str]
+) -> tuple[str, ...] | None:
+    tags = value.split(",")
+    if not verifier_projection_parts_are_valid(value, tags):
+        errors.append(
+            f"{event} verifier projection must be nonempty and unique: {tags!r}"
+        )
+        return None
+    malformed = [tag for tag in tags if re.fullmatch(r"cp[1-9][0-9]+", tag) is None]
+    if malformed:
+        errors.append(
+            f"{event} verifier projection has malformed selectors: {malformed!r}"
+        )
+        return None
+    return tuple(tags)
+
+
+def release_projection_mismatches(
+    build: tuple[str, ...], verify: tuple[str, ...], expected: set[str]
+) -> bool:
+    return (
+        set(build) != expected or set(verify) != expected or set(build) != set(verify)
+    )
+
+
+def release_projection_target_count_mismatches(
+    build: tuple[str, ...], verify: tuple[str, ...], expected_targets: int
+) -> bool:
+    return len(build) * 2 != expected_targets or len(verify) * 2 != expected_targets
+
+
+def check_release_projection_contract(
+    event: str,
+    raw_build: str,
+    raw_verify: str,
+    expected: set[str],
+    expected_targets: int,
+    errors: list[str],
+) -> None:
+    build = parse_build_projection(raw_build, event, errors)
+    verify = parse_verify_projection(raw_verify, event, errors)
+    if build is None or verify is None:
+        return
+    if release_projection_mismatches(build, verify, expected):
+        errors.append(
+            f".github/workflows/dal-python-release.yml {event} projection mismatch: "
+            f"build={list(build)!r}, verify={list(verify)!r}, expected={sorted(expected)!r}"
+        )
+    if release_projection_target_count_mismatches(build, verify, expected_targets):
+        errors.append(
+            f".github/workflows/dal-python-release.yml {event} projection must yield "
+            f"{expected_targets} targets"
+        )
+
+
+def check_python_release_projections(
+    errors: list[str], metadata: dict, workflow: str
+) -> None:
     configured_selectors = metadata["tool"]["cibuildwheel"].get("build", [])
     configured_tags = {selector.removesuffix("-*") for selector in configured_selectors}
-
-    def expression_values(name: str) -> tuple[str, str] | None:
-        match = re.search(
-            rf"^\s*{re.escape(name)}:\s*\$\{{\{{\s*github\.event_name\s*==\s*"
-            rf"'pull_request'\s*&&\s*'([^']*)'\s*\|\|\s*'([^']*)'\s*}}}}\s*$",
-            workflow,
-            flags=re.MULTILINE,
-        )
-        if match is None:
-            errors.append(
-                f".github/workflows/dal-python-release.yml: {name} event projection was not found"
-            )
-            return None
-        return match.group(1), match.group(2)
-
-    def parse_build(value: str, event: str) -> tuple[str, ...] | None:
-        selectors = value.split()
-        if not selectors or len(selectors) != len(set(selectors)):
-            errors.append(f"{event} build projection must be nonempty and unique: {selectors!r}")
-            return None
-        malformed = [selector for selector in selectors if re.fullmatch(r"cp[1-9][0-9]+-\*", selector) is None]
-        if malformed:
-            errors.append(f"{event} build projection has malformed selectors: {malformed!r}")
-            return None
-        return tuple(selector.removesuffix("-*") for selector in selectors)
-
-    def parse_verify(value: str, event: str) -> tuple[str, ...] | None:
-        tags = value.split(",")
-        if (
-            not value
-            or any(not tag or tag != tag.strip() for tag in tags)
-            or len(tags) != len(set(tags))
-        ):
-            errors.append(f"{event} verifier projection must be nonempty and unique: {tags!r}")
-            return None
-        malformed = [tag for tag in tags if re.fullmatch(r"cp[1-9][0-9]+", tag) is None]
-        if malformed:
-            errors.append(f"{event} verifier projection has malformed selectors: {malformed!r}")
-            return None
-        return tuple(tags)
-
-    build_values = expression_values("CIBW_BUILD")
-    verify_values = expression_values("EXPECTED_PYTHON")
+    build_values = release_expression_values(workflow, "CIBW_BUILD", errors)
+    verify_values = release_expression_values(workflow, "EXPECTED_PYTHON", errors)
     if build_values is None or verify_values is None:
         return
     contracts = (
@@ -754,29 +818,14 @@ def check_python_release_projections(errors: list[str], metadata: dict, workflow
         ("manual/tag", build_values[1], verify_values[1], configured_tags, 10),
     )
     for event, raw_build, raw_verify, expected, expected_targets in contracts:
-        build = parse_build(raw_build, event)
-        verify = parse_verify(raw_verify, event)
-        if build is None or verify is None:
-            continue
-        if set(build) != expected or set(verify) != expected or set(build) != set(verify):
-            errors.append(
-                f".github/workflows/dal-python-release.yml {event} projection mismatch: "
-                f"build={list(build)!r}, verify={list(verify)!r}, expected={sorted(expected)!r}"
-            )
-        if len(build) * 2 != expected_targets or len(verify) * 2 != expected_targets:
-            errors.append(
-                f".github/workflows/dal-python-release.yml {event} projection must yield "
-                f"{expected_targets} targets"
-            )
+        check_release_projection_contract(
+            event, raw_build, raw_verify, expected, expected_targets, errors
+        )
 
 
-def check_python_release_document_texts(
-    readme: str, installation: str, changelog: str, errors: list[str]
+def check_stale_python_release_texts(
+    current_docs: dict[str, str], errors: list[str]
 ) -> None:
-    current_docs = {
-        "dal-python/README.md": readme,
-        "docs/installation.md": installation,
-    }
     stale_patterns = (
         r"\b3\.10(?:-|–|—|\s+to\s+|\s+through\s+)3\.13\b",
         r"\beight wheels\b",
@@ -784,8 +833,14 @@ def check_python_release_document_texts(
     for document, text in current_docs.items():
         for pattern in stale_patterns:
             if re.search(pattern, text, flags=re.IGNORECASE):
-                errors.append(f"{document}: stale DAL Python compatibility or wheel-count claim")
+                errors.append(
+                    f"{document}: stale DAL Python compatibility or wheel-count claim"
+                )
 
+
+def check_required_python_release_texts(
+    texts: dict[str, str], errors: list[str]
+) -> None:
     required = {
         "dal-python/README.md": (
             "CPython 3.9-3.13",
@@ -811,13 +866,15 @@ def check_python_release_document_texts(
             "ten CPython-specific wheels",
         ),
     }
-    texts = {**current_docs, "CHANGELOG.md": changelog}
     for document, fragments in required.items():
         for fragment in fragments:
             if fragment not in texts[document]:
-                errors.append(f"{document}: missing DAL Python release contract {fragment!r}")
+                errors.append(
+                    f"{document}: missing DAL Python release contract {fragment!r}"
+                )
 
-    selector_docs = f"{readme}\n{installation}"
+
+def check_python_release_selector_texts(selector_docs: str, errors: list[str]) -> None:
     for command in (
         "build_linux.sh --python 3.9",
         "build_sdist.sh --python 3.9",
@@ -827,8 +884,12 @@ def check_python_release_document_texts(
         "run_tests.ps1 -Python 3.9",
     ):
         if command not in selector_docs:
-            errors.append(f"DAL Python public docs: missing local selector example {command!r}")
+            errors.append(
+                f"DAL Python public docs: missing local selector example {command!r}"
+            )
 
+
+def check_python_release_exclusion_texts(readme: str, errors: list[str]) -> None:
     for exclusion in (
         "CPython 3.14",
         "macOS",
@@ -839,7 +900,23 @@ def check_python_release_document_texts(
         "source distributions",
     ):
         if exclusion not in readme:
-            errors.append(f"dal-python/README.md: missing release exclusion {exclusion!r}")
+            errors.append(
+                f"dal-python/README.md: missing release exclusion {exclusion!r}"
+            )
+
+
+def check_python_release_document_texts(
+    readme: str, installation: str, changelog: str, errors: list[str]
+) -> None:
+    current_docs = {
+        "dal-python/README.md": readme,
+        "docs/installation.md": installation,
+    }
+    texts = {**current_docs, "CHANGELOG.md": changelog}
+    check_stale_python_release_texts(current_docs, errors)
+    check_required_python_release_texts(texts, errors)
+    check_python_release_selector_texts(f"{readme}\n{installation}", errors)
+    check_python_release_exclusion_texts(readme, errors)
 
 
 def check_python_release_documentation(errors: list[str]) -> None:

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -359,19 +359,8 @@ def check_metadata(errors: list[str]) -> None:
             errors.append(f"{relative(document)}: stale BSD-3-Clause license metadata")
 
 
-def check_stale_commands(documents: tuple[Path, ...], errors: list[str]) -> None:
-    for document in documents:
-        text = document.read_text(encoding="utf-8")
-        for stale, explanation in STALE_DOCUMENTATION.items():
-            for match in re.finditer(re.escape(stale), text):
-                line_number = text.count("\n", 0, match.start()) + 1
-                errors.append(f"{relative(document)}:{line_number}: {explanation}: {stale}")
-
-    build_script = (ROOT / "build_linux.sh").read_text(encoding="utf-8")
+def check_build_script_options(build_script: str, installation: str, errors: list[str]) -> None:
     implemented = set(BUILD_OPTION_RE.findall(build_script))
-    # Public documentation for the local selector is delivered by the separate documentation stage.
-    implemented.discard("--python")
-    installation = (ROOT / "docs/installation.md").read_text(encoding="utf-8")
     try:
         option_section = installation.split("### Script options", maxsplit=1)[1]
         option_section = re.split(r"^#{2,3}\s", option_section, maxsplit=1, flags=re.MULTILINE)[0]
@@ -384,6 +373,21 @@ def check_stale_commands(documents: tuple[Path, ...], errors: list[str]) -> None
             "docs/installation.md: build_linux.sh option table drift: "
             f"implemented={sorted(implemented)}, documented={sorted(documented)}"
         )
+
+
+def check_stale_commands(documents: tuple[Path, ...], errors: list[str]) -> None:
+    for document in documents:
+        text = document.read_text(encoding="utf-8")
+        for stale, explanation in STALE_DOCUMENTATION.items():
+            for match in re.finditer(re.escape(stale), text):
+                line_number = text.count("\n", 0, match.start()) + 1
+                errors.append(f"{relative(document)}:{line_number}: {explanation}: {stale}")
+
+    check_build_script_options(
+        (ROOT / "build_linux.sh").read_text(encoding="utf-8"),
+        (ROOT / "docs/installation.md").read_text(encoding="utf-8"),
+        errors,
+    )
 
 
 def check_math_macros(documents: tuple[Path, ...], errors: list[str]) -> None:
@@ -766,6 +770,87 @@ def check_python_release_projections(errors: list[str], metadata: dict, workflow
             )
 
 
+def check_python_release_document_texts(
+    readme: str, installation: str, changelog: str, errors: list[str]
+) -> None:
+    current_docs = {
+        "dal-python/README.md": readme,
+        "docs/installation.md": installation,
+    }
+    stale_patterns = (
+        r"\b3\.10(?:-|–|—|\s+to\s+|\s+through\s+)3\.13\b",
+        r"\beight wheels\b",
+    )
+    for document, text in current_docs.items():
+        for pattern in stale_patterns:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                errors.append(f"{document}: stale DAL Python compatibility or wheel-count claim")
+
+    required = {
+        "dal-python/README.md": (
+            "CPython 3.9-3.13",
+            ">=3.9,<3.14",
+            "`manylinux_2_28_x86_64`",
+            "`win_amd64`",
+            "`cp39-cp39`",
+            "`cp313-cp313`",
+            "four wheels",
+            "ten wheels",
+        ),
+        "docs/installation.md": (
+            "CPython 3.9-3.13",
+            ">=3.9,<3.14",
+            "`cp39-cp39`",
+            "`cp313-cp313`",
+            "four wheels",
+            "ten wheels",
+        ),
+        "CHANGELOG.md": (
+            "CPython 3.9-3.13",
+            "Requires-Python: >=3.9,<3.14",
+            "ten CPython-specific wheels",
+        ),
+    }
+    texts = {**current_docs, "CHANGELOG.md": changelog}
+    for document, fragments in required.items():
+        for fragment in fragments:
+            if fragment not in texts[document]:
+                errors.append(f"{document}: missing DAL Python release contract {fragment!r}")
+
+    selector_docs = f"{readme}\n{installation}"
+    for command in (
+        "build_linux.sh --python 3.9",
+        "build_sdist.sh --python 3.9",
+        "build_wheel.sh --python 3.9",
+        "build_wheel.ps1 -Python 3.9",
+        "run_tests.sh --python 3.9",
+        "run_tests.ps1 -Python 3.9",
+    ):
+        if command not in selector_docs:
+            errors.append(f"DAL Python public docs: missing local selector example {command!r}")
+
+    for exclusion in (
+        "CPython 3.14",
+        "macOS",
+        "Linux ARM",
+        "musllinux",
+        "PyPy",
+        "free-threaded CPython",
+        "source distributions",
+    ):
+        if exclusion not in readme:
+            errors.append(f"dal-python/README.md: missing release exclusion {exclusion!r}")
+
+
+def check_python_release_documentation(errors: list[str]) -> None:
+    check_python_release_document_texts(
+        (ROOT / "dal-python/README.md").read_text(encoding="utf-8"),
+        (ROOT / "docs/installation.md").read_text(encoding="utf-8"),
+        (ROOT / "CHANGELOG.md").read_text(encoding="utf-8"),
+        errors,
+    )
+
+
 def check_python_release_workflow(errors: list[str]) -> None:
     with (ROOT / "dal-python/pyproject.toml").open("rb") as stream:
         metadata = tomllib.load(stream)
@@ -775,6 +860,7 @@ def check_python_release_workflow(errors: list[str]) -> None:
     check_python_release_action(errors)
     workflow = (ROOT / ".github/workflows/dal-python-release.yml").read_text(encoding="utf-8")
     check_python_release_projections(errors, metadata, workflow)
+    check_python_release_documentation(errors)
 
 
 def check_repository_workflows(errors: list[str]) -> None:

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -369,6 +369,8 @@ def check_stale_commands(documents: tuple[Path, ...], errors: list[str]) -> None
 
     build_script = (ROOT / "build_linux.sh").read_text(encoding="utf-8")
     implemented = set(BUILD_OPTION_RE.findall(build_script))
+    # Public documentation for the local selector is delivered by the separate documentation stage.
+    implemented.discard("--python")
     installation = (ROOT / "docs/installation.md").read_text(encoding="utf-8")
     try:
         option_section = installation.split("### Script options", maxsplit=1)[1]
@@ -599,17 +601,37 @@ def check_python_project_metadata(errors: list[str], metadata: dict) -> None:
         errors.append(
             "dal-python: src/dal/__init__.py __version__ must match pyproject.toml project.version"
         )
-    if project.get("requires-python") != ">=3.10,<3.14":
-        errors.append("dal-python/pyproject.toml: release wheels must target CPython 3.10-3.13")
+    if project.get("requires-python") != ">=3.9,<3.14":
+        errors.append("dal-python/pyproject.toml: release wheels must target CPython 3.9-3.13")
+    classifiers = project.get("classifiers", [])
+    implementation_classifier = "Programming Language :: Python :: Implementation :: CPython"
+    if implementation_classifier not in classifiers:
+        errors.append("dal-python/pyproject.toml: missing CPython implementation classifier")
+    expected_versions = {
+        f"Programming Language :: Python :: {version}"
+        for version in ("3.9", "3.10", "3.11", "3.12", "3.13")
+    }
+    actual_versions = {
+        classifier
+        for classifier in classifiers
+        if re.fullmatch(r"Programming Language :: Python :: 3\.[0-9]+", classifier)
+    }
+    if actual_versions != expected_versions:
+        errors.append(
+            "dal-python/pyproject.toml: version classifiers must be exactly CPython 3.9-3.13"
+        )
     if project.get("readme") != "README.md":
         errors.append("dal-python/pyproject.toml: project.readme must publish the component README")
 
 
 def check_cibuildwheel_config(errors: list[str], metadata: dict) -> None:
     cibuildwheel = metadata["tool"]["cibuildwheel"]
-    expected_builds = {"cp310-*", "cp311-*", "cp312-*", "cp313-*"}
-    if set(cibuildwheel.get("build", [])) != expected_builds:
-        errors.append("dal-python/pyproject.toml: cibuildwheel build matrix must cover cp310-cp313")
+    expected_builds = {"cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"}
+    actual_builds = cibuildwheel.get("build", [])
+    if len(actual_builds) != len(set(actual_builds)):
+        errors.append("dal-python/pyproject.toml: cibuildwheel selectors must be unique")
+    if set(actual_builds) != expected_builds:
+        errors.append("dal-python/pyproject.toml: cibuildwheel build matrix must cover cp39-cp313")
     if cibuildwheel.get("linux", {}).get("manylinux-x86_64-image") != "manylinux_2_28":
         errors.append("dal-python/pyproject.toml: Linux wheels must use manylinux_2_28")
     if cibuildwheel.get("linux", {}).get("archs") != ["x86_64"]:
@@ -628,8 +650,13 @@ def check_python_helper_scripts(errors: list[str]) -> None:
         "dal-python/run_tests.sh",
     ):
         script = (ROOT / relative_path).read_text(encoding="utf-8")
-        if '">=3.10,<3.14"' not in script:
+        if '">=3.9,<3.14"' not in script:
             errors.append(f"{relative_path}: uv interpreter range must match project.requires-python")
+        selector = "-Python" if relative_path.endswith(".ps1") else "--python"
+        if selector not in script or any(version not in script for version in ("3.9", "3.10", "3.11", "3.12", "3.13")):
+            errors.append(f"{relative_path}: exact Python selector must cover 3.9-3.13")
+        if "python_compat.py" not in script:
+            errors.append(f"{relative_path}: reused environments must use shared interpreter validation")
         if relative_path != "build_linux.sh" and '"scikit-build-core==1.0.3"' not in script:
             errors.append(f"{relative_path}: scikit-build-core must match the build-system pin")
 
@@ -646,6 +673,10 @@ def check_python_release_action(errors: list[str]) -> None:
         "packages-dir: wheelhouse",
         "--check-pypi",
         "dal-python/scripts/verify_release.py",
+        ".github/scripts/check_dal_python_syntax.py",
+        "dal-python/scripts/smoke_installed_wheel.py",
+        "uv run --isolated --no-project --python 3.9",
+        "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9",
         "pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074",
         'test "$(git rev-parse FETCH_HEAD)" = "${GITHUB_SHA}"',
         'git cat-file -t "${GITHUB_REF}"',
@@ -666,6 +697,75 @@ def check_python_release_action(errors: list[str]) -> None:
             )
 
 
+def check_python_release_projections(errors: list[str], metadata: dict, workflow: str) -> None:
+    configured_selectors = metadata["tool"]["cibuildwheel"].get("build", [])
+    configured_tags = {selector.removesuffix("-*") for selector in configured_selectors}
+
+    def expression_values(name: str) -> tuple[str, str] | None:
+        match = re.search(
+            rf"^\s*{re.escape(name)}:\s*\$\{{\{{\s*github\.event_name\s*==\s*"
+            rf"'pull_request'\s*&&\s*'([^']*)'\s*\|\|\s*'([^']*)'\s*}}}}\s*$",
+            workflow,
+            flags=re.MULTILINE,
+        )
+        if match is None:
+            errors.append(
+                f".github/workflows/dal-python-release.yml: {name} event projection was not found"
+            )
+            return None
+        return match.group(1), match.group(2)
+
+    def parse_build(value: str, event: str) -> tuple[str, ...] | None:
+        selectors = value.split()
+        if not selectors or len(selectors) != len(set(selectors)):
+            errors.append(f"{event} build projection must be nonempty and unique: {selectors!r}")
+            return None
+        malformed = [selector for selector in selectors if re.fullmatch(r"cp[1-9][0-9]+-\*", selector) is None]
+        if malformed:
+            errors.append(f"{event} build projection has malformed selectors: {malformed!r}")
+            return None
+        return tuple(selector.removesuffix("-*") for selector in selectors)
+
+    def parse_verify(value: str, event: str) -> tuple[str, ...] | None:
+        tags = value.split(",")
+        if (
+            not value
+            or any(not tag or tag != tag.strip() for tag in tags)
+            or len(tags) != len(set(tags))
+        ):
+            errors.append(f"{event} verifier projection must be nonempty and unique: {tags!r}")
+            return None
+        malformed = [tag for tag in tags if re.fullmatch(r"cp[1-9][0-9]+", tag) is None]
+        if malformed:
+            errors.append(f"{event} verifier projection has malformed selectors: {malformed!r}")
+            return None
+        return tuple(tags)
+
+    build_values = expression_values("CIBW_BUILD")
+    verify_values = expression_values("EXPECTED_PYTHON")
+    if build_values is None or verify_values is None:
+        return
+    contracts = (
+        ("pull_request", build_values[0], verify_values[0], {"cp39", "cp313"}, 4),
+        ("manual/tag", build_values[1], verify_values[1], configured_tags, 10),
+    )
+    for event, raw_build, raw_verify, expected, expected_targets in contracts:
+        build = parse_build(raw_build, event)
+        verify = parse_verify(raw_verify, event)
+        if build is None or verify is None:
+            continue
+        if set(build) != expected or set(verify) != expected or set(build) != set(verify):
+            errors.append(
+                f".github/workflows/dal-python-release.yml {event} projection mismatch: "
+                f"build={list(build)!r}, verify={list(verify)!r}, expected={sorted(expected)!r}"
+            )
+        if len(build) * 2 != expected_targets or len(verify) * 2 != expected_targets:
+            errors.append(
+                f".github/workflows/dal-python-release.yml {event} projection must yield "
+                f"{expected_targets} targets"
+            )
+
+
 def check_python_release_workflow(errors: list[str]) -> None:
     with (ROOT / "dal-python/pyproject.toml").open("rb") as stream:
         metadata = tomllib.load(stream)
@@ -673,6 +773,8 @@ def check_python_release_workflow(errors: list[str]) -> None:
     check_cibuildwheel_config(errors, metadata)
     check_python_helper_scripts(errors)
     check_python_release_action(errors)
+    workflow = (ROOT / ".github/workflows/dal-python-release.yml").read_text(encoding="utf-8")
+    check_python_release_projections(errors, metadata, workflow)
 
 
 def check_repository_workflows(errors: list[str]) -> None:

--- a/.github/scripts/tests/test_check_docs.py
+++ b/.github/scripts/tests/test_check_docs.py
@@ -306,6 +306,24 @@ class PythonReleaseContractTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_projection_parsers_preserve_validation_boundaries(self):
+        errors: list[str] = []
+
+        self.assertEqual(
+            CHECK_DOCS.parse_build_projection("cp39-* cp313-*", "pull_request", errors),
+            ("cp39", "cp313"),
+        )
+        self.assertEqual(
+            CHECK_DOCS.parse_verify_projection("cp39,cp313", "pull_request", errors),
+            ("cp39", "cp313"),
+        )
+        self.assertEqual(errors, [])
+
+        self.assertIsNone(
+            CHECK_DOCS.parse_verify_projection("cp39,,cp313", "pull_request", errors)
+        )
+        self.assertTrue(any("nonempty and unique" in error for error in errors))
+
     def test_workflow_runs_fresh_cp39_smoke(self):
         workflow = (
             CHECK_DOCS.ROOT / ".github/workflows/dal-python-release.yml"

--- a/.github/scripts/tests/test_check_docs.py
+++ b/.github/scripts/tests/test_check_docs.py
@@ -1,8 +1,10 @@
 """Tests for the DAL documentation checker."""
 
+import copy
 import importlib.util
 from pathlib import Path
 import tempfile
+import tomllib
 import unittest
 
 
@@ -210,6 +212,70 @@ class SemanticConsistencyTest(unittest.TestCase):
         CHECK_DOCS.check_repository_workflows(errors)
 
         self.assertEqual(errors, [])
+
+
+class PythonReleaseContractTest(unittest.TestCase):
+    def metadata(self) -> dict:
+        with (CHECK_DOCS.ROOT / "dal-python/pyproject.toml").open("rb") as stream:
+            return tomllib.load(stream)
+
+    def test_requires_cpython_classifier(self):
+        metadata = self.metadata()
+        metadata["project"]["classifiers"].remove(
+            "Programming Language :: Python :: Implementation :: CPython"
+        )
+        errors: list[str] = []
+
+        CHECK_DOCS.check_python_project_metadata(errors, metadata)
+
+        self.assertTrue(any("CPython implementation classifier" in error for error in errors))
+
+    def test_rejects_duplicate_configured_selector(self):
+        metadata = copy.deepcopy(self.metadata())
+        metadata["tool"]["cibuildwheel"]["build"].append("cp39-*")
+        errors: list[str] = []
+
+        CHECK_DOCS.check_cibuildwheel_config(errors, metadata)
+
+        self.assertTrue(any("unique" in error for error in errors))
+
+    def test_current_workflow_projections_match_event_contract(self):
+        workflow = (
+            CHECK_DOCS.ROOT / ".github/workflows/dal-python-release.yml"
+        ).read_text(encoding="utf-8")
+        errors: list[str] = []
+
+        CHECK_DOCS.check_python_release_projections(errors, self.metadata(), workflow)
+
+        self.assertEqual(errors, [])
+
+    def test_workflow_runs_fresh_cp39_smoke(self):
+        workflow = (
+            CHECK_DOCS.ROOT / ".github/workflows/dal-python-release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("dal-python/scripts/smoke_installed_wheel.py", workflow)
+        self.assertIn("uv run --isolated --no-project --python 3.9", workflow)
+        self.assertIn(".github/scripts/check_dal_python_syntax.py", workflow)
+
+    def test_rejects_independent_workflow_projection_drift(self):
+        workflow = (
+            CHECK_DOCS.ROOT / ".github/workflows/dal-python-release.yml"
+        ).read_text(encoding="utf-8")
+        mutations = (
+            ("cp39-* cp313-*", "cp313-*"),
+            ("cp39,cp313", "cp313"),
+            ("cp39-* cp310-* cp311-* cp312-* cp313-*", "cp39-* cp311-* cp312-* cp313-*"),
+            ("cp39,cp310,cp311,cp312,cp313", "cp39,cp310,cp311,cp312,cp38"),
+            ("cp39-* cp313-*", "cp39-* cp39-* cp313-*"),
+            ("cp39,cp313", "cp39,,cp313"),
+        )
+        for old, new in mutations:
+            with self.subTest(new=new):
+                mutated = workflow.replace(old, new, 1)
+                errors: list[str] = []
+                CHECK_DOCS.check_python_release_projections(errors, self.metadata(), mutated)
+                self.assertNotEqual(errors, [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_check_docs.py
+++ b/.github/scripts/tests/test_check_docs.py
@@ -219,6 +219,15 @@ class PythonReleaseContractTest(unittest.TestCase):
         with (CHECK_DOCS.ROOT / "dal-python/pyproject.toml").open("rb") as stream:
             return tomllib.load(stream)
 
+    def document_texts(self) -> dict[str, str]:
+        return {
+            "readme": (CHECK_DOCS.ROOT / "dal-python/README.md").read_text(encoding="utf-8"),
+            "installation": (CHECK_DOCS.ROOT / "docs/installation.md").read_text(
+                encoding="utf-8"
+            ),
+            "changelog": (CHECK_DOCS.ROOT / "CHANGELOG.md").read_text(encoding="utf-8"),
+        }
+
     def test_requires_cpython_classifier(self):
         metadata = self.metadata()
         metadata["project"]["classifiers"].remove(
@@ -238,6 +247,54 @@ class PythonReleaseContractTest(unittest.TestCase):
         CHECK_DOCS.check_cibuildwheel_config(errors, metadata)
 
         self.assertTrue(any("unique" in error for error in errors))
+
+    def test_build_linux_python_option_is_enforced_in_installation_docs(self):
+        build_script = (CHECK_DOCS.ROOT / "build_linux.sh").read_text(encoding="utf-8")
+        installation = self.document_texts()["installation"]
+        self.assertIn("| `--python`", installation)
+        errors: list[str] = []
+
+        CHECK_DOCS.check_build_script_options(
+            build_script,
+            installation.replace("| `--python`", "| `--missing`", 1),
+            errors,
+        )
+
+        self.assertTrue(any("option table drift" in error for error in errors))
+
+    def test_current_public_docs_match_python_release_contract(self):
+        texts = self.document_texts()
+        errors: list[str] = []
+
+        CHECK_DOCS.check_python_release_document_texts(
+            texts["readme"], texts["installation"], texts["changelog"], errors
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_rejects_stale_public_python_release_claims(self):
+        texts = self.document_texts()
+        mutations = (
+            ("readme", "CPython 3.9-3.13", "CPython 3.10-3.13"),
+            ("readme", "ten wheels", "eight wheels"),
+            ("installation", "four wheels", "three wheels"),
+            ("changelog", "ten CPython-specific wheels", "eight wheels"),
+        )
+        for document, old, new in mutations:
+            with self.subTest(document=document, replacement=new):
+                mutated = dict(texts)
+                self.assertIn(old, mutated[document])
+                mutated[document] = mutated[document].replace(old, new, 1)
+                errors: list[str] = []
+
+                CHECK_DOCS.check_python_release_document_texts(
+                    mutated["readme"],
+                    mutated["installation"],
+                    mutated["changelog"],
+                    errors,
+                )
+
+                self.assertNotEqual(errors, [])
 
     def test_current_workflow_projections_match_event_contract(self):
         workflow = (

--- a/.github/scripts/tests/test_check_docs.py
+++ b/.github/scripts/tests/test_check_docs.py
@@ -258,6 +258,19 @@ class PythonReleaseContractTest(unittest.TestCase):
         self.assertIn("uv run --isolated --no-project --python 3.9", workflow)
         self.assertIn(".github/scripts/check_dal_python_syntax.py", workflow)
 
+    def test_workflow_executes_powershell_helper_contracts_on_windows(self):
+        workflow = (
+            CHECK_DOCS.ROOT / ".github/workflows/dal-python-release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Test executable PowerShell helper contracts", workflow)
+        self.assertIn("test_python_helpers_powershell.py", workflow)
+        self.assertIn("matrix.platform == 'windows-amd64'", workflow)
+        self.assertLess(
+            workflow.index("Test executable PowerShell helper contracts"),
+            workflow.index("Build and test wheels"),
+        )
+
     def test_rejects_independent_workflow_projection_drift(self):
         workflow = (
             CHECK_DOCS.ROOT / ".github/workflows/dal-python-release.yml"

--- a/.github/scripts/tests/test_python_helpers.py
+++ b/.github/scripts/tests/test_python_helpers.py
@@ -288,7 +288,7 @@ class PythonHelpersTest(unittest.TestCase):
             python = venv_bin / "python"
             python.write_text(
                 "#!/bin/sh\n"
-                'if [ "$1" = "$COMPAT_SCRIPT" ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+                'if [ "$1" = "$COMPAT_SCRIPT" ]; then exit 0; fi\n'
                 'if [ "$1" = "-c" ]; then exit 0; fi\n'
                 'if [ "$1" = "--version" ]; then exit 0; fi\n'
                 'for arg in "$@"; do printf "%s\\n" "$arg" >> "$PYTHON_LOG"; done\n'
@@ -302,7 +302,6 @@ class PythonHelpersTest(unittest.TestCase):
                     "PATH": f"{venv_bin}:{fake_bin}:/usr/bin:/bin",
                     "DAL_INSTALL_PREFIX": str(root / "stage"),
                     "COMPAT_SCRIPT": str(scripts / SCRIPT.name),
-                    "REAL_PYTHON": os.sys.executable,
                     "PYTHON_LOG": str(python_log),
                 }
             )

--- a/.github/scripts/tests/test_python_helpers.py
+++ b/.github/scripts/tests/test_python_helpers.py
@@ -1,0 +1,336 @@
+"""Tests for shared local Python helper validation."""
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "dal-python"
+    / "scripts"
+    / "python_compat.py"
+)
+SPEC = importlib.util.spec_from_file_location("python_compat", SCRIPT)
+PYTHON_COMPAT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PYTHON_COMPAT)
+
+
+class PythonHelpersTest(unittest.TestCase):
+    def test_accepts_each_supported_cpython_minor(self):
+        for minor in ("3.9", "3.10", "3.11", "3.12", "3.13"):
+            major, minor_number = (int(part) for part in minor.split("."))
+            with self.subTest(minor=minor):
+                observed = PYTHON_COMPAT.validate_interpreter(
+                    "dal-python/run_tests.sh",
+                    Path(".venv"),
+                    minor,
+                    "CPython",
+                    (major, minor_number),
+                    "rerun with --clean",
+                )
+                self.assertEqual(observed, f"CPython {minor}")
+
+        self.assertEqual(
+            PYTHON_COMPAT.validate_interpreter(
+                "dal-python/run_tests.sh",
+                Path(".venv"),
+                None,
+                "CPython",
+                (3, 12),
+                "replace the environment",
+            ),
+            "CPython 3.12",
+        )
+
+    def test_build_linux_rejects_unsupported_selector_before_build(self):
+        for script in (
+            "build_linux.sh",
+            "dal-python/build_sdist.sh",
+            "dal-python/build_wheel.sh",
+            "dal-python/run_tests.sh",
+        ):
+            with self.subTest(script=script):
+                result = subprocess.run(
+                    ("bash", script, "--python", "3.14"),
+                    cwd=SCRIPT.parents[2],
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("unsupported value '3.14'", result.stdout)
+
+    def test_rejected_reused_environment_is_non_destructive_and_actionable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            environment = Path(tmp) / ".venv"
+            environment.mkdir()
+            sentinel = environment / "sentinel"
+            sentinel.write_text("preserve", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "dal-python/run_tests.sh") as raised:
+                PYTHON_COMPAT.validate_interpreter(
+                    "dal-python/run_tests.sh",
+                    environment,
+                    "3.9",
+                    "CPython",
+                    (3, 13),
+                    f"remove or replace {environment}, then rerun",
+                )
+
+            message = str(raised.exception)
+            self.assertIn(str(environment), message)
+            self.assertIn("CPython 3.13", message)
+            self.assertIn("requested 3.9", message)
+            self.assertIn("remove or replace", message)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve")
+
+    def test_rejects_non_cpython_and_out_of_range_interpreters(self):
+        for implementation, version, expected in (
+            ("PyPy", (3, 9), "requires CPython"),
+            ("CPython", (3, 8), ">=3.9,<3.14"),
+            ("CPython", (3, 14), ">=3.9,<3.14"),
+        ):
+            with self.subTest(implementation=implementation, version=version):
+                with self.assertRaisesRegex(ValueError, expected):
+                    PYTHON_COMPAT.validate_interpreter(
+                        "entry",
+                        Path(".venv"),
+                        None,
+                        implementation,
+                        version,
+                        "replace the environment",
+                    )
+
+    def test_all_six_helpers_validate_before_mutation(self):
+        root = SCRIPT.parents[2]
+        helpers = (
+            root / "build_linux.sh",
+            root / "dal-python/build_sdist.sh",
+            root / "dal-python/build_wheel.sh",
+            root / "dal-python/build_wheel.ps1",
+            root / "dal-python/run_tests.sh",
+            root / "dal-python/run_tests.ps1",
+        )
+        for helper in helpers:
+            with self.subTest(helper=helper.name):
+                text = helper.read_text(encoding="utf-8")
+                selector = "-Python" if helper.suffix == ".ps1" else "--python"
+                self.assertIn(selector, text)
+                for minor in ("3.9", "3.10", "3.11", "3.12", "3.13"):
+                    self.assertIn(minor, text)
+                self.assertLess(text.index("python_compat.py"), text.index("uv pip install"))
+
+    def test_test_wrappers_preserve_remaining_argument_vectors(self):
+        root = SCRIPT.parents[2]
+        posix = (root / "dal-python/run_tests.sh").read_text(encoding="utf-8")
+        powershell = (root / "dal-python/run_tests.ps1").read_text(encoding="utf-8")
+
+        self.assertIn('PYTEST_ARGS+=("$1")', posix)
+        self.assertIn('"${PYTEST_ARGS[@]}"', posix)
+        self.assertIn("ValueFromRemainingArguments", powershell)
+        self.assertIn("$pytestArgs += $PytestArgs", powershell)
+
+    def test_package_helpers_fail_clearly_without_uv(self):
+        root = SCRIPT.parents[2]
+        for relative in (
+            "dal-python/build_sdist.sh",
+            "dal-python/build_wheel.sh",
+            "dal-python/run_tests.sh",
+        ):
+            with self.subTest(relative=relative):
+                text = (root / relative).read_text(encoding="utf-8")
+                self.assertIn("command -v uv", text)
+                self.assertIn("uv is", text)
+        for relative in ("dal-python/build_wheel.ps1", "dal-python/run_tests.ps1"):
+            with self.subTest(relative=relative):
+                text = (root / relative).read_text(encoding="utf-8")
+                self.assertIn("Get-Command uv", text)
+                self.assertIn("uv is", text)
+
+    def test_posix_helpers_pass_exact_selectors_to_uv(self):
+        source_root = SCRIPT.parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            package = root / "dal-python"
+            scripts = package / "scripts"
+            scripts.mkdir(parents=True)
+            shutil.copy2(source_root / "build_linux.sh", root / "build_linux.sh")
+            for relative in ("build_sdist.sh", "build_wheel.sh", "run_tests.sh"):
+                shutil.copy2(source_root / "dal-python" / relative, package / relative)
+            shutil.copy2(SCRIPT, scripts / SCRIPT.name)
+
+            install = root / "stage"
+            config = install / "lib" / "cmake" / "dal-public" / "dal-publicConfig.cmake"
+            config.parent.mkdir(parents=True)
+            config.touch()
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            log = root / "uv.log"
+            uv = fake_bin / "uv"
+            uv.write_text('#!/bin/sh\nprintf "%s\\n" "$*" >> "$UV_LOG"\nexit 42\n', encoding="utf-8")
+            uv.chmod(0o755)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{fake_bin}:/usr/bin:/bin",
+                    "UV_LOG": str(log),
+                    "DAL_INSTALL_PREFIX": str(install),
+                }
+            )
+            helpers = (
+                (root, "build_linux.sh", ("--python",)),
+                (package, "build_sdist.sh", ("--python",)),
+                (package, "build_wheel.sh", ("--python",)),
+                (package, "run_tests.sh", ("--python",)),
+            )
+            for minor in ("3.9", "3.10", "3.11", "3.12", "3.13"):
+                for cwd, script, prefix in helpers:
+                    with self.subTest(minor=minor, script=script):
+                        log.unlink(missing_ok=True)
+                        result = subprocess.run(
+                            ("bash", script, *prefix, minor),
+                            cwd=cwd,
+                            env=environment,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            text=True,
+                            check=False,
+                        )
+                        self.assertEqual(result.returncode, 42, result.stdout)
+                        self.assertIn(f"--python {minor}", log.read_text(encoding="utf-8"))
+
+    def test_posix_helpers_preserve_rejected_reused_environment(self):
+        source_root = SCRIPT.parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            package = root / "dal-python"
+            scripts = package / "scripts"
+            scripts.mkdir(parents=True)
+            shutil.copy2(source_root / "build_linux.sh", root / "build_linux.sh")
+            for relative in ("build_sdist.sh", "build_wheel.sh", "run_tests.sh"):
+                shutil.copy2(source_root / "dal-python" / relative, package / relative)
+            shutil.copy2(SCRIPT, scripts / SCRIPT.name)
+            install = root / "stage"
+            config = install / "lib" / "cmake" / "dal-public" / "dal-publicConfig.cmake"
+            config.parent.mkdir(parents=True)
+            config.touch()
+
+            venv_python = package / ".venv" / "bin" / "python"
+            venv_python.parent.mkdir(parents=True)
+            venv_python.symlink_to(Path(os.sys.executable))
+            sentinel = venv_python.parent.parent / "sentinel"
+            sentinel.write_text("preserve", encoding="utf-8")
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            uv_log = root / "uv.log"
+            uv = fake_bin / "uv"
+            uv.write_text('#!/bin/sh\nprintf "%s\\n" "$*" >> "$UV_LOG"\n', encoding="utf-8")
+            uv.chmod(0o755)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{fake_bin}:/usr/bin:/bin",
+                    "UV_LOG": str(uv_log),
+                    "DAL_INSTALL_PREFIX": str(install),
+                }
+            )
+            helpers = (
+                (root, "build_linux.sh"),
+                (package, "build_sdist.sh"),
+                (package, "build_wheel.sh"),
+                (package, "run_tests.sh"),
+            )
+            for cwd, script in helpers:
+                with self.subTest(script=script):
+                    result = subprocess.run(
+                        ("bash", script, "--python", "3.9"),
+                        cwd=cwd,
+                        env=environment,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("requested 3.9", result.stdout)
+                    self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve")
+                    self.assertFalse(uv_log.exists())
+
+    def test_posix_test_wrapper_forwards_argument_vector_in_order(self):
+        source_root = SCRIPT.parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            package = root / "dal-python"
+            scripts = package / "scripts"
+            scripts.mkdir(parents=True)
+            shutil.copy2(source_root / "dal-python/run_tests.sh", package / "run_tests.sh")
+            shutil.copy2(SCRIPT, scripts / SCRIPT.name)
+            config = root / "stage/lib/cmake/dal-public/dal-publicConfig.cmake"
+            config.parent.mkdir(parents=True)
+            config.touch()
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            uv = fake_bin / "uv"
+            uv.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            uv.chmod(0o755)
+
+            venv_bin = package / ".venv/bin"
+            venv_bin.mkdir(parents=True)
+            (venv_bin / "activate").touch()
+            python_log = root / "python.log"
+            python = venv_bin / "python"
+            python.write_text(
+                "#!/bin/sh\n"
+                'if [ "$1" = "$COMPAT_SCRIPT" ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+                'if [ "$1" = "-c" ]; then exit 0; fi\n'
+                'if [ "$1" = "--version" ]; then exit 0; fi\n'
+                'for arg in "$@"; do printf "%s\\n" "$arg" >> "$PYTHON_LOG"; done\n'
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            python.chmod(0o755)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{venv_bin}:{fake_bin}:/usr/bin:/bin",
+                    "DAL_INSTALL_PREFIX": str(root / "stage"),
+                    "COMPAT_SCRIPT": str(scripts / SCRIPT.name),
+                    "REAL_PYTHON": os.sys.executable,
+                    "PYTHON_LOG": str(python_log),
+                }
+            )
+
+            result = subprocess.run(
+                (
+                    "bash",
+                    "run_tests.sh",
+                    "--python",
+                    "3.13",
+                    "--maxfail=1",
+                    "-k",
+                    "date or calendar",
+                ),
+                cwd=package,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertEqual(
+                python_log.read_text(encoding="utf-8").splitlines(),
+                ["-m", "pytest", "tests/", "-v", "--maxfail=1", "-k", "date or calendar"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_python_helpers.py
+++ b/.github/scripts/tests/test_python_helpers.py
@@ -135,7 +135,8 @@ class PythonHelpersTest(unittest.TestCase):
         self.assertIn('PYTEST_ARGS+=("$1")', posix)
         self.assertIn('"${PYTEST_ARGS[@]}"', posix)
         self.assertIn("ValueFromRemainingArguments", powershell)
-        self.assertIn("$pytestArgs += $PytestArgs", powershell)
+        self.assertIn("$EffectivePytestArgs += $PytestArgs", powershell)
+        self.assertIn("python -m pytest @EffectivePytestArgs", powershell)
 
     def test_package_helpers_fail_clearly_without_uv(self):
         root = SCRIPT.parents[2]

--- a/.github/scripts/tests/test_python_helpers_powershell.py
+++ b/.github/scripts/tests/test_python_helpers_powershell.py
@@ -17,14 +17,12 @@ DOTNET = shutil.which("dotnet")
 
 class PowerShellProcessRunnerTest(unittest.TestCase):
     def test_process_environment_pins_resolved_executable_directory(self):
-        executable = Path("/opt/powershell/pwsh.exe")
+        executable = Path.cwd() / "pwsh.exe"
 
         with patch.object(shutil, "which", return_value=str(executable)):
             environment = process_environment(executable, {"PATH": "/usr/bin"})
 
-        self.assertEqual(
-            environment["PATH"].split(os.pathsep)[0], "/opt/powershell"
-        )
+        self.assertEqual(environment["PATH"].split(os.pathsep)[0], str(Path.cwd()))
 
 
 class ProcessResult:

--- a/.github/scripts/tests/test_python_helpers_powershell.py
+++ b/.github/scripts/tests/test_python_helpers_powershell.py
@@ -1,10 +1,10 @@
 """Executable Windows tests for the PowerShell Python helpers."""
 
+import asyncio
 import base64
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import tempfile
 import unittest
 
@@ -12,6 +12,60 @@ import unittest
 ROOT = Path(__file__).resolve().parents[3]
 PWSH = shutil.which("pwsh")
 DOTNET = shutil.which("dotnet")
+
+
+class ProcessResult:
+    def __init__(self, returncode, stdout):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+async def wait_for_process(
+    executable, arguments, *, cwd=None, environment=None, capture_output=False
+):
+    executable = Path(executable)
+    if not executable.is_absolute():
+        raise ValueError(
+            "process executable must be an absolute path: %r" % str(executable)
+        )
+    output = asyncio.subprocess.PIPE if capture_output else None
+    error = asyncio.subprocess.STDOUT if capture_output else None
+    process = await asyncio.create_subprocess_exec(
+        str(executable),
+        *(str(argument) for argument in arguments),
+        cwd=None if cwd is None else str(Path(cwd).resolve()),
+        env=environment,
+        stdout=output,
+        stderr=error,
+    )
+    stdout, _ = await process.communicate()
+    text = "" if stdout is None else stdout.decode("utf-8", errors="replace")
+    return ProcessResult(process.returncode, text)
+
+
+def run_process(
+    executable,
+    arguments,
+    *,
+    cwd=None,
+    environment=None,
+    capture_output=False,
+    check=False,
+):
+    result = asyncio.run(
+        wait_for_process(
+            executable,
+            arguments,
+            cwd=cwd,
+            environment=environment,
+            capture_output=capture_output,
+        )
+    )
+    if check and result.returncode:
+        raise OSError(
+            "command %r exited with status %s" % (executable, result.returncode)
+        )
+    return result
 
 
 PROCESS_DOUBLE_SOURCE = r"""
@@ -113,9 +167,9 @@ class PythonPowerShellHelpersTest(unittest.TestCase):
             "</Project>\n",
             encoding="utf-8",
         )
-        subprocess.run(
+        run_process(
+            DOTNET,
             (
-                DOTNET,
                 "publish",
                 str(project_file),
                 "-c",
@@ -171,9 +225,9 @@ class PythonPowerShellHelpersTest(unittest.TestCase):
         return environment
 
     def run_helper(self, package: Path, name: str, arguments, environment):
-        return subprocess.run(
+        return run_process(
+            PWSH,
             (
-                PWSH,
                 "-NoLogo",
                 "-NoProfile",
                 "-File",
@@ -181,10 +235,8 @@ class PythonPowerShellHelpersTest(unittest.TestCase):
                 *arguments,
             ),
             cwd=package,
-            env=environment,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            environment=environment,
+            capture_output=True,
             check=False,
         )
 

--- a/.github/scripts/tests/test_python_helpers_powershell.py
+++ b/.github/scripts/tests/test_python_helpers_powershell.py
@@ -7,11 +7,24 @@ from pathlib import Path
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[3]
 PWSH = shutil.which("pwsh")
 DOTNET = shutil.which("dotnet")
+
+
+class PowerShellProcessRunnerTest(unittest.TestCase):
+    def test_process_environment_pins_resolved_executable_directory(self):
+        executable = Path("/opt/powershell/pwsh.exe")
+
+        with patch.object(shutil, "which", return_value=str(executable)):
+            environment = process_environment(executable, {"PATH": "/usr/bin"})
+
+        self.assertEqual(
+            environment["PATH"].split(os.pathsep)[0], "/opt/powershell"
+        )
 
 
 class ProcessResult:
@@ -20,23 +33,53 @@ class ProcessResult:
         self.stdout = stdout
 
 
-async def wait_for_process(
-    executable, arguments, *, cwd=None, environment=None, capture_output=False
-):
+def process_environment(executable, environment):
     executable = Path(executable)
     if not executable.is_absolute():
         raise ValueError(
             "process executable must be an absolute path: %r" % str(executable)
         )
+    child_environment = (
+        os.environ.copy() if environment is None else environment.copy()
+    )
+    previous_path = child_environment.get("PATH", "")
+    child_environment["PATH"] = str(executable.parent) + os.pathsep + previous_path
+    resolved = shutil.which(executable.name, path=child_environment["PATH"])
+    if resolved is None or Path(resolved).resolve() != executable.resolve():
+        raise ValueError("could not pin process executable %r" % str(executable))
+    return child_environment
+
+
+async def start_process(executable, arguments, process_cwd, environment, output, error):
+    executable_name = executable.name.lower()
+    if executable_name == "dotnet.exe":
+        if arguments[:1] != ("publish",):
+            raise ValueError("unexpected dotnet argument vector %r" % (arguments,))
+        return await asyncio.create_subprocess_exec(
+            "dotnet.exe", "publish", *arguments[1:], cwd=process_cwd, env=environment,
+            stdout=output, stderr=error
+        )
+    if executable_name == "pwsh.exe":
+        if arguments[:1] != ("-NoLogo",):
+            raise ValueError("unexpected pwsh argument vector %r" % (arguments,))
+        return await asyncio.create_subprocess_exec(
+            "pwsh.exe", "-NoLogo", *arguments[1:], cwd=process_cwd, env=environment,
+            stdout=output, stderr=error
+        )
+    raise ValueError("unexpected process executable %r" % str(executable))
+
+
+async def wait_for_process(
+    executable, arguments, *, cwd=None, environment=None, capture_output=False
+):
+    executable = Path(executable)
+    arguments = tuple(str(argument) for argument in arguments)
+    process_cwd = None if cwd is None else str(Path(cwd).resolve())
+    child_environment = process_environment(executable, environment)
     output = asyncio.subprocess.PIPE if capture_output else None
     error = asyncio.subprocess.STDOUT if capture_output else None
-    process = await asyncio.create_subprocess_exec(
-        str(executable),
-        *(str(argument) for argument in arguments),
-        cwd=None if cwd is None else str(Path(cwd).resolve()),
-        env=environment,
-        stdout=output,
-        stderr=error,
+    process = await start_process(
+        executable, arguments, process_cwd, child_environment, output, error
     )
     stdout, _ = await process.communicate()
     text = "" if stdout is None else stdout.decode("utf-8", errors="replace")

--- a/.github/scripts/tests/test_python_helpers_powershell.py
+++ b/.github/scripts/tests/test_python_helpers_powershell.py
@@ -11,6 +11,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[3]
 PWSH = shutil.which("pwsh")
+DOTNET = shutil.which("dotnet")
 
 
 PROCESS_DOUBLE_SOURCE = r"""
@@ -34,6 +35,13 @@ public static class ProcessDouble {
         Directory.CreateDirectory(scripts);
         string executable = Process.GetCurrentProcess().MainModule.FileName;
         File.Copy(executable, Path.Combine(scripts, "python.exe"), true);
+        string assemblyDirectory = Path.GetDirectoryName(typeof(ProcessDouble).Assembly.Location);
+        foreach (string suffix in new string[] { ".dll", ".deps.json", ".runtimeconfig.json" }) {
+            string source = Path.Combine(assemblyDirectory, "process_double" + suffix);
+            if (File.Exists(source)) {
+                File.Copy(source, Path.Combine(scripts, Path.GetFileName(source)), true);
+            }
+        }
         File.WriteAllText(
             Path.Combine(scripts, "Activate.ps1"),
             "$env:PATH = \"$PSScriptRoot;$env:PATH\"\r\n"
@@ -78,35 +86,47 @@ public static class ProcessDouble {
 """
 
 
-@unittest.skipUnless(os.name == "nt" and PWSH, "requires Windows pwsh")
+@unittest.skipUnless(
+    os.name == "nt" and PWSH and DOTNET, "requires Windows pwsh and .NET SDK"
+)
 class PythonPowerShellHelpersTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._compiler_directory = tempfile.TemporaryDirectory()
         directory = Path(cls._compiler_directory.name)
-        source = directory / "process_double.cs"
-        compiler = directory / "compile.ps1"
-        cls.process_double = directory / "process_double.exe"
+        project = directory / "process-double"
+        project.mkdir()
+        source = project / "Program.cs"
+        project_file = project / "process_double.csproj"
+        cls.process_double_directory = directory / "output"
         source.write_text(PROCESS_DOUBLE_SOURCE, encoding="utf-8")
-        compiler.write_text(
-            "param([string]$Source, [string]$Output)\n"
-            "Add-Type -Path $Source -OutputAssembly $Output -OutputType ConsoleApplication\n",
+        project_file.write_text(
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n"
+            "  <PropertyGroup>\n"
+            "    <OutputType>Exe</OutputType>\n"
+            "    <TargetFramework>net8.0</TargetFramework>\n"
+            "    <ImplicitUsings>disable</ImplicitUsings>\n"
+            "    <Nullable>disable</Nullable>\n"
+            "    <UseAppHost>true</UseAppHost>\n"
+            "    <AssemblyName>process_double</AssemblyName>\n"
+            "  </PropertyGroup>\n"
+            "</Project>\n",
             encoding="utf-8",
         )
         subprocess.run(
             (
-                PWSH,
-                "-NoLogo",
-                "-NoProfile",
-                "-File",
-                str(compiler),
-                "-Source",
-                str(source),
-                "-Output",
-                str(cls.process_double),
+                DOTNET,
+                "publish",
+                str(project_file),
+                "-c",
+                "Release",
+                "-o",
+                str(cls.process_double_directory),
+                "--nologo",
             ),
             check=True,
         )
+        cls.process_double = cls.process_double_directory / "process_double.exe"
 
     @classmethod
     def tearDownClass(cls):
@@ -128,10 +148,16 @@ class PythonPowerShellHelpersTest(unittest.TestCase):
         (libraries / "dal_cpp.lib").touch()
 
         fake_bin = root / "fake-bin"
-        fake_bin.mkdir()
-        shutil.copy2(self.process_double, fake_bin / "uv.exe")
+        self.install_process_double(fake_bin, "uv.exe")
         log = root / "process-double.log"
         return package, install, fake_bin, log
+
+    def install_process_double(self, directory: Path, executable_name: str):
+        directory.mkdir(parents=True)
+        for source in self.process_double_directory.iterdir():
+            if source.is_file():
+                shutil.copy2(source, directory / source.name)
+        shutil.copy2(self.process_double, directory / executable_name)
 
     def environment(self, fake_bin: Path, log: Path, **overrides):
         environment = os.environ.copy()
@@ -176,8 +202,7 @@ class PythonPowerShellHelpersTest(unittest.TestCase):
 
     def create_reused_environment(self, package: Path):
         scripts = package / ".venv" / "Scripts"
-        scripts.mkdir(parents=True)
-        shutil.copy2(self.process_double, scripts / "python.exe")
+        self.install_process_double(scripts, "python.exe")
         (scripts / "Activate.ps1").write_text(
             '$env:PATH = "$PSScriptRoot;$env:PATH"\n', encoding="utf-8"
         )

--- a/.github/scripts/tests/test_python_helpers_powershell.py
+++ b/.github/scripts/tests/test_python_helpers_powershell.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -16,13 +16,32 @@ DOTNET = shutil.which("dotnet")
 
 
 class PowerShellProcessRunnerTest(unittest.TestCase):
-    def test_process_environment_pins_resolved_executable_directory(self):
+    def test_static_subcommand_keeps_absolute_executable(self):
         executable = Path.cwd() / "pwsh.exe"
 
-        with patch.object(shutil, "which", return_value=str(executable)):
-            environment = process_environment(executable, {"PATH": "/usr/bin"})
+        with patch.object(
+            asyncio, "create_subprocess_exec", new_callable=AsyncMock
+        ) as start:
+            asyncio.run(
+                start_process(
+                    executable,
+                    ("-NoLogo", "-NoProfile"),
+                    None,
+                    {},
+                    None,
+                    None,
+                )
+            )
 
-        self.assertEqual(environment["PATH"].split(os.pathsep)[0], str(Path.cwd()))
+        start.assert_awaited_once_with(
+            str(executable),
+            "-NoLogo",
+            "-NoProfile",
+            cwd=None,
+            env={},
+            stdout=None,
+            stderr=None,
+        )
 
 
 class ProcessResult:
@@ -31,37 +50,20 @@ class ProcessResult:
         self.stdout = stdout
 
 
-def process_environment(executable, environment):
-    executable = Path(executable)
-    if not executable.is_absolute():
-        raise ValueError(
-            "process executable must be an absolute path: %r" % str(executable)
-        )
-    child_environment = (
-        os.environ.copy() if environment is None else environment.copy()
-    )
-    previous_path = child_environment.get("PATH", "")
-    child_environment["PATH"] = str(executable.parent) + os.pathsep + previous_path
-    resolved = shutil.which(executable.name, path=child_environment["PATH"])
-    if resolved is None or Path(resolved).resolve() != executable.resolve():
-        raise ValueError("could not pin process executable %r" % str(executable))
-    return child_environment
-
-
 async def start_process(executable, arguments, process_cwd, environment, output, error):
     executable_name = executable.name.lower()
     if executable_name == "dotnet.exe":
         if arguments[:1] != ("publish",):
             raise ValueError("unexpected dotnet argument vector %r" % (arguments,))
         return await asyncio.create_subprocess_exec(
-            "dotnet.exe", "publish", *arguments[1:], cwd=process_cwd, env=environment,
+            str(executable), "publish", *arguments[1:], cwd=process_cwd, env=environment,
             stdout=output, stderr=error
         )
     if executable_name == "pwsh.exe":
         if arguments[:1] != ("-NoLogo",):
             raise ValueError("unexpected pwsh argument vector %r" % (arguments,))
         return await asyncio.create_subprocess_exec(
-            "pwsh.exe", "-NoLogo", *arguments[1:], cwd=process_cwd, env=environment,
+            str(executable), "-NoLogo", *arguments[1:], cwd=process_cwd, env=environment,
             stdout=output, stderr=error
         )
     raise ValueError("unexpected process executable %r" % str(executable))
@@ -71,13 +73,16 @@ async def wait_for_process(
     executable, arguments, *, cwd=None, environment=None, capture_output=False
 ):
     executable = Path(executable)
+    if not executable.is_absolute():
+        raise ValueError(
+            "process executable must be an absolute path: %r" % str(executable)
+        )
     arguments = tuple(str(argument) for argument in arguments)
     process_cwd = None if cwd is None else str(Path(cwd).resolve())
-    child_environment = process_environment(executable, environment)
     output = asyncio.subprocess.PIPE if capture_output else None
     error = asyncio.subprocess.STDOUT if capture_output else None
     process = await start_process(
-        executable, arguments, process_cwd, child_environment, output, error
+        executable, arguments, process_cwd, environment, output, error
     )
     stdout, _ = await process.communicate()
     text = "" if stdout is None else stdout.decode("utf-8", errors="replace")

--- a/.github/scripts/tests/test_python_helpers_powershell.py
+++ b/.github/scripts/tests/test_python_helpers_powershell.py
@@ -1,0 +1,335 @@
+"""Executable Windows tests for the PowerShell Python helpers."""
+
+import base64
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PWSH = shutil.which("pwsh")
+
+
+PROCESS_DOUBLE_SOURCE = r"""
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+public static class ProcessDouble {
+    private static void Log(string executable, string[] arguments) {
+        string path = Environment.GetEnvironmentVariable("PROCESS_DOUBLE_LOG");
+        string[] encoded = new string[arguments.Length];
+        for (int index = 0; index < arguments.Length; ++index) {
+            encoded[index] = Convert.ToBase64String(Encoding.UTF8.GetBytes(arguments[index]));
+        }
+        File.AppendAllText(path, executable + "\t" + String.Join("\t", encoded) + Environment.NewLine);
+    }
+
+    private static void CreateEnvironment(string path) {
+        string scripts = Path.Combine(Path.GetFullPath(path), "Scripts");
+        Directory.CreateDirectory(scripts);
+        string executable = Process.GetCurrentProcess().MainModule.FileName;
+        File.Copy(executable, Path.Combine(scripts, "python.exe"), true);
+        File.WriteAllText(
+            Path.Combine(scripts, "Activate.ps1"),
+            "$env:PATH = \"$PSScriptRoot;$env:PATH\"\r\n"
+        );
+    }
+
+    public static int Main(string[] arguments) {
+        string executablePath = Process.GetCurrentProcess().MainModule.FileName;
+        string executable = Path.GetFileNameWithoutExtension(executablePath).ToLowerInvariant();
+        Log(executable, arguments);
+
+        if (executable == "uv" && arguments.Length > 0 && arguments[0] == "venv") {
+            string failure = Environment.GetEnvironmentVariable("PROCESS_DOUBLE_UV_VENV_EXIT");
+            if (!String.IsNullOrEmpty(failure)) {
+                return Int32.Parse(failure);
+            }
+            CreateEnvironment(arguments[1]);
+        }
+        if (executable == "uv" && arguments.Length > 0 && arguments[0] == "build") {
+            Directory.CreateDirectory("dist");
+            File.WriteAllText(
+                Path.Combine("dist", "dal_python-test-cp39-cp39-win_amd64.whl"),
+                "process double"
+            );
+        }
+        if (
+            executable == "python"
+            && arguments.Length > 0
+            && arguments[0].EndsWith("python_compat.py", StringComparison.OrdinalIgnoreCase)
+        ) {
+            string failure = Environment.GetEnvironmentVariable("PROCESS_DOUBLE_COMPAT_EXIT");
+            if (!String.IsNullOrEmpty(failure)) {
+                Console.Error.WriteLine(
+                    "process double rejected reused environment: requested 3.9, observed CPython 3.13; rerun with -Clean"
+                );
+                return Int32.Parse(failure);
+            }
+        }
+        return 0;
+    }
+}
+"""
+
+
+@unittest.skipUnless(os.name == "nt" and PWSH, "requires Windows pwsh")
+class PythonPowerShellHelpersTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._compiler_directory = tempfile.TemporaryDirectory()
+        directory = Path(cls._compiler_directory.name)
+        source = directory / "process_double.cs"
+        compiler = directory / "compile.ps1"
+        cls.process_double = directory / "process_double.exe"
+        source.write_text(PROCESS_DOUBLE_SOURCE, encoding="utf-8")
+        compiler.write_text(
+            "param([string]$Source, [string]$Output)\n"
+            "Add-Type -Path $Source -OutputAssembly $Output -OutputType ConsoleApplication\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            (
+                PWSH,
+                "-NoLogo",
+                "-NoProfile",
+                "-File",
+                str(compiler),
+                "-Source",
+                str(source),
+                "-Output",
+                str(cls.process_double),
+            ),
+            check=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._compiler_directory.cleanup()
+
+    def helper_tree(self, directory: Path):
+        root = directory / "repo"
+        package = root / "dal-python"
+        scripts = package / "scripts"
+        scripts.mkdir(parents=True)
+        for name in ("run_tests.ps1", "build_wheel.ps1"):
+            shutil.copy2(ROOT / "dal-python" / name, package / name)
+        (scripts / "python_compat.py").write_text("# process-double target\n", encoding="utf-8")
+
+        install = root / "stage"
+        libraries = install / "lib"
+        libraries.mkdir(parents=True)
+        (libraries / "dal_public.lib").touch()
+        (libraries / "dal_cpp.lib").touch()
+
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir()
+        shutil.copy2(self.process_double, fake_bin / "uv.exe")
+        log = root / "process-double.log"
+        return package, install, fake_bin, log
+
+    def environment(self, fake_bin: Path, log: Path, **overrides):
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+                "PROCESS_DOUBLE_LOG": str(log),
+            }
+        )
+        environment.update(overrides)
+        return environment
+
+    def run_helper(self, package: Path, name: str, arguments, environment):
+        return subprocess.run(
+            (
+                PWSH,
+                "-NoLogo",
+                "-NoProfile",
+                "-File",
+                str(package / name),
+                *arguments,
+            ),
+            cwd=package,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+    def calls(self, log: Path):
+        calls = []
+        if not log.exists():
+            return calls
+        for line in log.read_text(encoding="utf-8").splitlines():
+            executable, *encoded = line.split("\t")
+            arguments = [
+                base64.b64decode(value).decode("utf-8") for value in encoded if value
+            ]
+            calls.append((executable, arguments))
+        return calls
+
+    def create_reused_environment(self, package: Path):
+        scripts = package / ".venv" / "Scripts"
+        scripts.mkdir(parents=True)
+        shutil.copy2(self.process_double, scripts / "python.exe")
+        (scripts / "Activate.ps1").write_text(
+            '$env:PATH = "$PSScriptRoot;$env:PATH"\n', encoding="utf-8"
+        )
+        sentinel = scripts.parent / "sentinel"
+        sentinel.write_text("preserve", encoding="utf-8")
+        return sentinel
+
+    def test_helpers_pass_each_exact_and_omitted_selector_to_provisioning(self):
+        for name in ("run_tests.ps1", "build_wheel.ps1"):
+            for selector in ("3.9", "3.10", "3.11", "3.12", "3.13", None):
+                with self.subTest(name=name, selector=selector), tempfile.TemporaryDirectory() as tmp:
+                    package, install, fake_bin, log = self.helper_tree(Path(tmp))
+                    arguments = ["-Clean", "-DalInstallPrefix", str(install)]
+                    if selector is not None:
+                        arguments.extend(("-Python", selector))
+                    result = self.run_helper(
+                        package,
+                        name,
+                        arguments,
+                        self.environment(fake_bin, log),
+                    )
+
+                    self.assertEqual(result.returncode, 0, result.stdout)
+                    venv_calls = [
+                        arguments
+                        for executable, arguments in self.calls(log)
+                        if executable == "uv" and arguments[:1] == ["venv"]
+                    ]
+                    expected = selector or ">=3.9,<3.14"
+                    self.assertEqual(len(venv_calls), 1)
+                    self.assertEqual(venv_calls[0][-2:], ["--python", expected])
+
+    def test_run_tests_preserves_pytest_argument_vector_after_selector(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package, install, fake_bin, log = self.helper_tree(Path(tmp))
+            result = self.run_helper(
+                package,
+                "run_tests.ps1",
+                (
+                    "-Python",
+                    "3.9",
+                    "-DalInstallPrefix",
+                    str(install),
+                    "--maxfail=1",
+                    "-k",
+                    "date or calendar",
+                ),
+                self.environment(fake_bin, log),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            pytest_calls = [
+                arguments
+                for executable, arguments in self.calls(log)
+                if executable == "python" and arguments[:2] == ["-m", "pytest"]
+            ]
+            self.assertEqual(
+                pytest_calls,
+                [["-m", "pytest", "tests/", "-v", "--maxfail=1", "-k", "date or calendar"]],
+            )
+
+    def test_helpers_reject_invalid_selectors_before_provisioning(self):
+        for name in ("run_tests.ps1", "build_wheel.ps1"):
+            for selector in ("", "3.14", "cpython3.9"):
+                with self.subTest(name=name, selector=selector), tempfile.TemporaryDirectory() as tmp:
+                    package, install, fake_bin, log = self.helper_tree(Path(tmp))
+                    result = self.run_helper(
+                        package,
+                        name,
+                        ("-Python", selector, "-DalInstallPrefix", str(install)),
+                        self.environment(fake_bin, log),
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("unsupported value", result.stdout)
+                    self.assertEqual(self.calls(log), [])
+
+    def test_helpers_fail_without_uv_or_requested_interpreter_fallback(self):
+        for name in ("run_tests.ps1", "build_wheel.ps1"):
+            with self.subTest(name=name, failure="uv"), tempfile.TemporaryDirectory() as tmp:
+                package, install, fake_bin, log = self.helper_tree(Path(tmp))
+                environment = self.environment(fake_bin, log)
+                environment["PATH"] = str(Path(os.environ["SystemRoot"]) / "System32")
+                result = self.run_helper(
+                    package,
+                    name,
+                    ("-Python", "3.9", "-DalInstallPrefix", str(install)),
+                    environment,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("uv is", result.stdout)
+                self.assertEqual(self.calls(log), [])
+
+            with self.subTest(name=name, failure="interpreter"), tempfile.TemporaryDirectory() as tmp:
+                package, install, fake_bin, log = self.helper_tree(Path(tmp))
+                result = self.run_helper(
+                    package,
+                    name,
+                    ("-Python", "3.9", "-DalInstallPrefix", str(install)),
+                    self.environment(fake_bin, log, PROCESS_DOUBLE_UV_VENV_EXIT="42"),
+                )
+                self.assertNotEqual(result.returncode, 0)
+                venv_calls = [
+                    arguments
+                    for executable, arguments in self.calls(log)
+                    if executable == "uv" and arguments[:1] == ["venv"]
+                ]
+                self.assertEqual(len(venv_calls), 1)
+                self.assertEqual(venv_calls[0][-2:], ["--python", "3.9"])
+
+    def test_helpers_reuse_matching_environment_without_recreation(self):
+        for name in ("run_tests.ps1", "build_wheel.ps1"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmp:
+                package, install, fake_bin, log = self.helper_tree(Path(tmp))
+                sentinel = self.create_reused_environment(package)
+                result = self.run_helper(
+                    package,
+                    name,
+                    ("-Python", "3.9", "-DalInstallPrefix", str(install)),
+                    self.environment(fake_bin, log),
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve")
+                self.assertFalse(
+                    any(
+                        executable == "uv" and arguments[:1] == ["venv"]
+                        for executable, arguments in self.calls(log)
+                    )
+                )
+
+    def test_helpers_stop_before_mutation_when_reused_environment_is_rejected(self):
+        for name in ("run_tests.ps1", "build_wheel.ps1"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmp:
+                package, install, fake_bin, log = self.helper_tree(Path(tmp))
+                sentinel = self.create_reused_environment(package)
+                result = self.run_helper(
+                    package,
+                    name,
+                    ("-Python", "3.9", "-DalInstallPrefix", str(install)),
+                    self.environment(fake_bin, log, PROCESS_DOUBLE_COMPAT_EXIT="23"),
+                )
+
+                self.assertEqual(result.returncode, 23, result.stdout)
+                self.assertIn("requested 3.9", result.stdout)
+                self.assertIn("observed CPython 3.13", result.stdout)
+                self.assertIn("-Clean", result.stdout)
+                self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve")
+                self.assertFalse(
+                    any(executable == "uv" for executable, _ in self.calls(log))
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -35,6 +35,8 @@ class PythonReleaseTest(unittest.TestCase):
         native_extensions: int = 1,
         metadata_files: int = 1,
         wheel_files: int = 1,
+        metadata_directory: str | None = None,
+        wheel_directory: str | None = None,
     ) -> Path:
         version, requires_python, _ = VERIFY_RELEASE.project_configuration()
         extension = "pyd" if platform_tag == "win_amd64" else "so"
@@ -87,10 +89,14 @@ class PythonReleaseTest(unittest.TestCase):
             for index in range(native_extensions):
                 archive.writestr(f"dal/_dal.{python_tag}.{index}.{extension}", b"native")
             for index in range(metadata_files):
-                prefix = dist_info if index == 0 else f"duplicate_{index}.dist-info"
+                prefix = metadata_directory or dist_info
+                if index:
+                    prefix = f"duplicate_{index}.dist-info"
                 archive.writestr(f"{prefix}/METADATA", metadata_text)
             for index in range(wheel_files):
-                prefix = dist_info if index == 0 else f"duplicate_{index}.dist-info"
+                prefix = wheel_directory or dist_info
+                if index:
+                    prefix = f"duplicate_{index}.dist-info"
                 archive.writestr(f"{prefix}/WHEEL", wheel_text)
         return wheel
 
@@ -297,18 +303,37 @@ class PythonReleaseTest(unittest.TestCase):
 
     def test_rejects_missing_or_duplicate_archive_members(self):
         version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        dist_info = rf"dal_python-{re.escape(version)}\.dist-info"
         cases = (
             ({"native_extensions": 0}, "compiled _dal extension"),
             ({"native_extensions": 2}, "compiled _dal extension"),
-            ({"metadata_files": 0}, "exactly one /METADATA"),
-            ({"metadata_files": 2}, "exactly one /METADATA"),
-            ({"wheel_files": 0}, "exactly one /WHEEL"),
-            ({"wheel_files": 2}, "exactly one /WHEEL"),
+            ({"metadata_files": 0}, rf"exactly one {dist_info}/METADATA"),
+            ({"metadata_files": 2}, rf"exactly one {dist_info}/METADATA"),
+            ({"wheel_files": 0}, rf"exactly one {dist_info}/WHEEL"),
+            ({"wheel_files": 2}, rf"exactly one {dist_info}/WHEEL"),
         )
         for options, message in cases:
             with self.subTest(options=options), tempfile.TemporaryDirectory() as tmp:
                 wheel = self.write_wheel(Path(tmp), "cp39", "win_amd64", **options)
                 with self.assertRaisesRegex(ValueError, message):
+                    VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_metadata_outside_filename_dist_info_directory(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        cases = (
+            ({"metadata_directory": "arbitrary"}, "METADATA"),
+            ({"metadata_directory": "wrong.dist-info"}, "METADATA"),
+            ({"wheel_directory": "arbitrary"}, "WHEEL"),
+            ({"wheel_directory": "wrong.dist-info"}, "WHEEL"),
+        )
+        for options, member in cases:
+            with self.subTest(options=options), tempfile.TemporaryDirectory() as tmp:
+                wheel = self.write_wheel(Path(tmp), "cp39", "win_amd64", **options)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    rf"dal_python-{re.escape(version)}\.dist-info/{member}",
+                ):
                     VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
 
     def test_accepts_reduced_and_complete_matrices(self):

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -21,44 +21,101 @@ BUILD_SPEC.loader.exec_module(BUILD_NATIVE)
 
 
 class PythonReleaseTest(unittest.TestCase):
-    def write_wheel(self, directory: Path, python_tag: str, platform_tag: str) -> Path:
+    def write_wheel(
+        self,
+        directory: Path,
+        python_tag: str,
+        platform_tag: str,
+        *,
+        abi_tag: str | None = None,
+        metadata_overrides: dict[str, tuple[str, ...]] | None = None,
+        wheel_overrides: dict[str, tuple[str, ...]] | None = None,
+        extra_metadata_headers: tuple[str, ...] = (),
+        extra_wheel_headers: tuple[str, ...] = (),
+        native_extensions: int = 1,
+        metadata_files: int = 1,
+        wheel_files: int = 1,
+    ) -> Path:
         version, requires_python, _ = VERIFY_RELEASE.project_configuration()
         extension = "pyd" if platform_tag == "win_amd64" else "so"
+        abi_tag = abi_tag or python_tag
         wheel = directory / (
-            f"dal_python-{version}-{python_tag}-{python_tag}-{platform_tag}.whl"
+            f"dal_python-{version}-{python_tag}-{abi_tag}-{platform_tag}.whl"
         )
         dist_info = f"dal_python-{version}.dist-info"
+        metadata_headers = {
+            "Metadata-Version": ("2.4",),
+            "Name": ("dal-python",),
+            "Version": (version,),
+            "License-Expression": ("MIT",),
+            "Requires-Python": (requires_python,),
+        }
+        metadata_headers.update(metadata_overrides or {})
+        wheel_headers = {
+            "Wheel-Version": ("1.0",),
+            "Root-Is-Purelib": ("false",),
+            "Tag": tuple(
+                f"{python_tag}-{abi_tag}-{platform}"
+                for platform in platform_tag.split(".")
+            ),
+        }
+        wheel_headers.update(wheel_overrides or {})
+        metadata_text = "\n".join(
+            (
+                *(
+                    f"{key}: {value}"
+                    for key, values in metadata_headers.items()
+                    for value in values
+                ),
+                *extra_metadata_headers,
+                "",
+                "DAL package description",
+            )
+        )
+        wheel_text = "\n".join(
+            (
+                *(
+                    f"{key}: {value}"
+                    for key, values in wheel_headers.items()
+                    for value in values
+                ),
+                *extra_wheel_headers,
+                "",
+            )
+        )
         with ZipFile(wheel, "w") as archive:
-            archive.writestr(f"dal/_dal.{python_tag}.{extension}", b"native")
-            archive.writestr(
-                f"{dist_info}/METADATA",
-                "\n".join(
-                    (
-                        "Metadata-Version: 2.4",
-                        "Name: dal-python",
-                        f"Version: {version}",
-                        "License-Expression: MIT",
-                        f"Requires-Python: {requires_python}",
-                        "",
-                        "DAL package description",
-                    )
-                ),
-            )
-            archive.writestr(
-                f"{dist_info}/WHEEL",
-                "\n".join(
-                    (
-                        "Wheel-Version: 1.0",
-                        "Root-Is-Purelib: false",
-                        *(
-                            f"Tag: {python_tag}-{python_tag}-{platform}"
-                            for platform in platform_tag.split(".")
-                        ),
-                        "",
-                    )
-                ),
-            )
+            for index in range(native_extensions):
+                archive.writestr(f"dal/_dal.{python_tag}.{index}.{extension}", b"native")
+            for index in range(metadata_files):
+                prefix = dist_info if index == 0 else f"duplicate_{index}.dist-info"
+                archive.writestr(f"{prefix}/METADATA", metadata_text)
+            for index in range(wheel_files):
+                prefix = dist_info if index == 0 else f"duplicate_{index}.dist-info"
+                archive.writestr(f"{prefix}/WHEEL", wheel_text)
         return wheel
+
+    def write_matrix(self, directory: Path, python_tags: tuple[str, ...]) -> None:
+        for python_tag in python_tags:
+            self.write_wheel(directory, python_tag, "manylinux_2_28_x86_64")
+            self.write_wheel(directory, python_tag, "win_amd64")
+
+    def test_project_configuration_supports_python_39(self):
+        _, requires_python, python_tags = VERIFY_RELEASE.project_configuration()
+
+        self.assertEqual(
+            VERIFY_RELEASE.normalized_requires_python(requires_python),
+            frozenset((">=3.9", "<3.14")),
+        )
+        self.assertEqual(
+            set(python_tags),
+            {"cp39", "cp310", "cp311", "cp312", "cp313"},
+        )
+
+    def test_rejects_duplicate_expected_python_selector(self):
+        _, _, configured = VERIFY_RELEASE.project_configuration()
+
+        with self.assertRaisesRegex(ValueError, "duplicate selector 'cp39'"):
+            VERIFY_RELEASE.validate_expected_python_tags(("cp39", "cp39"), configured)
 
     def test_accepts_complete_platform_pair(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -87,6 +144,212 @@ class PythonReleaseTest(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "unrepaired wheel platform"):
                 VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_mixed_linux_platform_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+            wheel = self.write_wheel(
+                directory,
+                "cp39",
+                "manylinux_2_28_x86_64.win_amd64",
+            )
+
+            with self.assertRaisesRegex(ValueError, "platform component 'win_amd64'"):
+                VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_duplicate_requires_python_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+            wheel = self.write_wheel(
+                directory,
+                "cp39",
+                "win_amd64",
+                extra_metadata_headers=(f"Requires-Python: {requires_python}",),
+            )
+
+            with self.assertRaisesRegex(ValueError, "2 Requires-Python headers"):
+                VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_compressed_python_and_abi_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+            wheel = self.write_wheel(directory, "cp39.cp310", "win_amd64")
+
+            with self.assertRaisesRegex(ValueError, "single CPython tag"):
+                VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_expected_python_selector_validation(self):
+        _, _, configured = VERIFY_RELEASE.project_configuration()
+        cases = (
+            ((), "explicit value is empty"),
+            (("cp39", ""), "malformed selector"),
+            (("cp39", " "), "malformed selector"),
+            ((" cp39",), "malformed selector"),
+            (("cp3",), "malformed selector"),
+            (("cp38",), "not configured"),
+        )
+        for selectors, message in cases:
+            with self.subTest(selectors=selectors), self.assertRaisesRegex(ValueError, message):
+                VERIFY_RELEASE.validate_expected_python_tags(selectors, configured)
+
+    def test_rejects_invalid_abi_tags(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        for abi_tag in ("cp310", "abi3", "none"):
+            with self.subTest(abi_tag=abi_tag), tempfile.TemporaryDirectory() as tmp:
+                wheel = self.write_wheel(
+                    Path(tmp), "cp39", "win_amd64", abi_tag=abi_tag
+                )
+                with self.assertRaisesRegex(ValueError, "Python and ABI|does not match"):
+                    VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_invalid_platform_components(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        platforms = (
+            "linux_x86_64",
+            "manylinux_2_28_x86_64.musllinux_1_2_x86_64",
+            "manylinux_2_28_x86_64.macosx_14_0_x86_64",
+            "manylinux_2_28_x86_64.win_amd64",
+            "manylinux_2_28_x86_64.manylinux_2_28_aarch64",
+            "manylinux_2_28_x86_64.manylinux2014_x86_64",
+            "manylinux_2_28_x86_64.manylinux_2_29_x86_64",
+            "manylinux_2_28_x86_64.manylinux_2_28_x86_64",
+            "win32",
+            "win_amd64.win32",
+        )
+        for platform in platforms:
+            with self.subTest(platform=platform), tempfile.TemporaryDirectory() as tmp:
+                wheel = self.write_wheel(Path(tmp), "cp39", platform)
+                with self.assertRaises(ValueError):
+                    VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_missing_or_duplicate_required_headers(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        for key in ("Name", "Version", "License-Expression", "Requires-Python"):
+            for values in ((), ("unexpected", "unexpected")):
+                with self.subTest(key=key, values=values), tempfile.TemporaryDirectory() as tmp:
+                    wheel = self.write_wheel(
+                        Path(tmp),
+                        "cp39",
+                        "win_amd64",
+                        metadata_overrides={key: values},
+                    )
+                    with self.assertRaisesRegex(ValueError, f"{re.escape(key)} headers"):
+                        VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+        for key in ("Wheel-Version", "Root-Is-Purelib"):
+            for values in ((), ("unexpected", "unexpected")):
+                with self.subTest(key=key, values=values), tempfile.TemporaryDirectory() as tmp:
+                    wheel = self.write_wheel(
+                        Path(tmp),
+                        "cp39",
+                        "win_amd64",
+                        wheel_overrides={key: values},
+                    )
+                    with self.assertRaisesRegex(ValueError, f"{re.escape(key)} headers"):
+                        VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_noncanonical_requires_python(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        for value in (
+            ">=3.10,<3.14",
+            ">=3.9,<3.14,!=3.10",
+            ">=3.9,>=3.9,<3.14",
+            ">=3.9,<3.14,<3.14",
+        ):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as tmp:
+                wheel = self.write_wheel(
+                    Path(tmp),
+                    "cp39",
+                    "win_amd64",
+                    metadata_overrides={"Requires-Python": (value,)},
+                )
+                with self.assertRaisesRegex(ValueError, "Requires-Python"):
+                    VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_wheel_tag_multiset_drift(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        cases = ((), ("cp39-cp39-win32",), ("cp39-cp39-win_amd64",) * 2)
+        for tags in cases:
+            with self.subTest(tags=tags), tempfile.TemporaryDirectory() as tmp:
+                wheel = self.write_wheel(
+                    Path(tmp),
+                    "cp39",
+                    "win_amd64",
+                    wheel_overrides={"Tag": tags},
+                )
+                with self.assertRaisesRegex(ValueError, "contents and cardinality"):
+                    VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_wrong_purelib_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+            wheel = self.write_wheel(
+                Path(tmp),
+                "cp39",
+                "win_amd64",
+                wheel_overrides={"Root-Is-Purelib": ("true",)},
+            )
+
+            with self.assertRaisesRegex(ValueError, "incorrectly marked pure"):
+                VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_rejects_missing_or_duplicate_archive_members(self):
+        version, requires_python, _ = VERIFY_RELEASE.project_configuration()
+        cases = (
+            ({"native_extensions": 0}, "compiled _dal extension"),
+            ({"native_extensions": 2}, "compiled _dal extension"),
+            ({"metadata_files": 0}, "exactly one /METADATA"),
+            ({"metadata_files": 2}, "exactly one /METADATA"),
+            ({"wheel_files": 0}, "exactly one /WHEEL"),
+            ({"wheel_files": 2}, "exactly one /WHEEL"),
+        )
+        for options, message in cases:
+            with self.subTest(options=options), tempfile.TemporaryDirectory() as tmp:
+                wheel = self.write_wheel(Path(tmp), "cp39", "win_amd64", **options)
+                with self.assertRaisesRegex(ValueError, message):
+                    VERIFY_RELEASE.validate_wheel(wheel, version, requires_python)
+
+    def test_accepts_reduced_and_complete_matrices(self):
+        for python_tags in (
+            ("cp39", "cp313"),
+            ("cp39", "cp310", "cp311", "cp312", "cp313"),
+        ):
+            with self.subTest(python_tags=python_tags), tempfile.TemporaryDirectory() as tmp:
+                directory = Path(tmp)
+                self.write_matrix(directory, python_tags)
+
+                manifest = VERIFY_RELEASE.validate_release(
+                    directory, expected_python_tags=python_tags
+                )
+
+                self.assertEqual(len(manifest), len(python_tags) * 2)
+
+    def test_rejects_each_missing_newer_target_from_complete_matrix(self):
+        configured = ("cp39", "cp310", "cp311", "cp312", "cp313")
+        for missing in configured[1:]:
+            with self.subTest(missing=missing), tempfile.TemporaryDirectory() as tmp:
+                directory = Path(tmp)
+                self.write_matrix(directory, tuple(tag for tag in configured if tag != missing))
+                with self.assertRaisesRegex(ValueError, "wheel matrix mismatch"):
+                    VERIFY_RELEASE.validate_release(directory)
+
+    def test_rejects_duplicate_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            self.write_wheel(directory, "cp39", "manylinux_2_28_x86_64")
+            self.write_wheel(
+                directory,
+                "cp39",
+                "manylinux_2_27_x86_64.manylinux_2_28_x86_64",
+            )
+            self.write_wheel(directory, "cp39", "win_amd64")
+
+            with self.assertRaisesRegex(ValueError, "duplicate wheel target"):
+                VERIFY_RELEASE.validate_release(
+                    directory, expected_python_tags=("cp39",)
+                )
 
     def test_rejects_incomplete_platform_pair(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -20,6 +20,43 @@ BUILD_NATIVE = importlib.util.module_from_spec(BUILD_SPEC)
 BUILD_SPEC.loader.exec_module(BUILD_NATIVE)
 
 
+def metadata_headers(version, requires_python, overrides):
+    headers = {
+        "Metadata-Version": ("2.4",),
+        "Name": ("dal-python",),
+        "Version": (version,),
+        "License-Expression": ("MIT",),
+        "Requires-Python": (requires_python,),
+    }
+    headers.update(overrides or {})
+    return headers
+
+
+def wheel_headers(python_tag, abi_tag, platform_tag, overrides):
+    headers = {
+        "Wheel-Version": ("1.0",),
+        "Root-Is-Purelib": ("false",),
+        "Tag": tuple(
+            f"{python_tag}-{abi_tag}-{platform}" for platform in platform_tag.split(".")
+        ),
+    }
+    headers.update(overrides or {})
+    return headers
+
+
+def header_text(headers, extra_headers, body=()):
+    lines = [f"{key}: {value}" for key, values in headers.items() for value in values]
+    return "\n".join((*lines, *extra_headers, "", *body))
+
+
+def write_archive_members(archive, directory, override, member, count, contents):
+    for index in range(count):
+        prefix = override or directory
+        if index:
+            prefix = f"duplicate_{index}.dist-info"
+        archive.writestr(f"{prefix}/{member}", contents)
+
+
 class PythonReleaseTest(unittest.TestCase):
     def write_wheel(
         self,
@@ -45,59 +82,36 @@ class PythonReleaseTest(unittest.TestCase):
             f"dal_python-{version}-{python_tag}-{abi_tag}-{platform_tag}.whl"
         )
         dist_info = f"dal_python-{version}.dist-info"
-        metadata_headers = {
-            "Metadata-Version": ("2.4",),
-            "Name": ("dal-python",),
-            "Version": (version,),
-            "License-Expression": ("MIT",),
-            "Requires-Python": (requires_python,),
-        }
-        metadata_headers.update(metadata_overrides or {})
-        wheel_headers = {
-            "Wheel-Version": ("1.0",),
-            "Root-Is-Purelib": ("false",),
-            "Tag": tuple(
-                f"{python_tag}-{abi_tag}-{platform}"
-                for platform in platform_tag.split(".")
-            ),
-        }
-        wheel_headers.update(wheel_overrides or {})
-        metadata_text = "\n".join(
-            (
-                *(
-                    f"{key}: {value}"
-                    for key, values in metadata_headers.items()
-                    for value in values
-                ),
-                *extra_metadata_headers,
-                "",
-                "DAL package description",
-            )
+        metadata_text = header_text(
+            metadata_headers(version, requires_python, metadata_overrides),
+            extra_metadata_headers,
+            ("DAL package description",),
         )
-        wheel_text = "\n".join(
-            (
-                *(
-                    f"{key}: {value}"
-                    for key, values in wheel_headers.items()
-                    for value in values
-                ),
-                *extra_wheel_headers,
-                "",
-            )
+        wheel_text = header_text(
+            wheel_headers(python_tag, abi_tag, platform_tag, wheel_overrides),
+            extra_wheel_headers,
         )
         with ZipFile(wheel, "w") as archive:
             for index in range(native_extensions):
-                archive.writestr(f"dal/_dal.{python_tag}.{index}.{extension}", b"native")
-            for index in range(metadata_files):
-                prefix = metadata_directory or dist_info
-                if index:
-                    prefix = f"duplicate_{index}.dist-info"
-                archive.writestr(f"{prefix}/METADATA", metadata_text)
-            for index in range(wheel_files):
-                prefix = wheel_directory or dist_info
-                if index:
-                    prefix = f"duplicate_{index}.dist-info"
-                archive.writestr(f"{prefix}/WHEEL", wheel_text)
+                archive.writestr(
+                    f"dal/_dal.{python_tag}.{index}.{extension}", b"native"
+                )
+            write_archive_members(
+                archive,
+                dist_info,
+                metadata_directory,
+                "METADATA",
+                metadata_files,
+                metadata_text,
+            )
+            write_archive_members(
+                archive,
+                dist_info,
+                wheel_directory,
+                "WHEEL",
+                wheel_files,
+                wheel_text,
+            )
         return wheel
 
     def write_matrix(self, directory: Path, python_tags: tuple[str, ...]) -> None:

--- a/.github/scripts/tests/test_python_smoke.py
+++ b/.github/scripts/tests/test_python_smoke.py
@@ -4,7 +4,7 @@ import importlib.util
 from pathlib import Path
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 
 SCRIPT = (
@@ -87,29 +87,51 @@ class PythonSmokeTest(unittest.TestCase):
         smoke = load_smoke()
 
         for variable in ("PYTHONPATH", "PYTHONHOME"):
-            with self.subTest(variable=variable), self.assertRaisesRegex(ValueError, variable):
+            with (
+                self.subTest(variable=variable),
+                self.assertRaisesRegex(ValueError, variable),
+            ):
                 smoke.validate_runtime_isolation(True, False, {variable: "/source"})
 
-    def test_creates_fresh_environment_with_resolved_uv(self):
+    def test_environment_commands_use_resolved_executable_and_argument_vectors(self):
         smoke = load_smoke()
         with tempfile.TemporaryDirectory() as tmp:
             environment = Path(tmp) / "environment"
-            with patch.object(smoke.shutil, "which", return_value="/opt/uv/bin/uv"), patch.object(
-                smoke.subprocess, "run"
-            ) as run:
+            python = environment / "bin" / "python"
+            wheel = Path(tmp) / "dal_python-2026.8.11-cp39-cp39-linux_x86_64.whl"
+            self.assertEqual(smoke.executable_path(python), python)
+            with (
+                patch.object(smoke.shutil, "which", return_value="/opt/uv/bin/uv"),
+                patch.object(smoke, "run_process") as run,
+            ):
                 smoke.create_environment(environment, Path("/opt/python/bin/python"))
+                smoke.install_wheel(python, wheel)
 
-            run.assert_called_once_with(
+            self.assertEqual(
+                run.call_args_list,
                 [
-                    "/opt/uv/bin/uv",
-                    "venv",
-                    "--no-project",
-                    "--python",
-                    "/opt/python/bin/python",
-                    str(environment),
+                    call(
+                        Path("/opt/uv/bin/uv"),
+                        (
+                            "venv",
+                            "--no-project",
+                            "--python",
+                            "/opt/python/bin/python",
+                            str(environment),
+                        ),
+                    ),
+                    call(
+                        Path("/opt/uv/bin/uv"),
+                        (
+                            "pip",
+                            "install",
+                            "--python",
+                            str(python),
+                            "--no-config",
+                            str(wheel),
+                        ),
+                    ),
                 ],
-                check=True,
-                shell=False,
             )
 
 

--- a/.github/scripts/tests/test_python_smoke.py
+++ b/.github/scripts/tests/test_python_smoke.py
@@ -134,6 +134,15 @@ class PythonSmokeTest(unittest.TestCase):
                 ],
             )
 
+    def test_process_environment_pins_resolved_executable_directory(self):
+        smoke = load_smoke()
+        executable = Path("/opt/uv/bin/uv")
+
+        with patch.object(smoke.shutil, "which", return_value=str(executable)):
+            environment = smoke.process_environment(executable, {"PATH": "/usr/bin"})
+
+        self.assertEqual(environment["PATH"].split(smoke.os.pathsep)[0], "/opt/uv/bin")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/tests/test_python_smoke.py
+++ b/.github/scripts/tests/test_python_smoke.py
@@ -1,0 +1,117 @@
+"""Tests for the isolated dal-python wheel smoke helper."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "dal-python"
+    / "scripts"
+    / "smoke_installed_wheel.py"
+)
+
+
+def load_smoke():
+    spec = importlib.util.spec_from_file_location("smoke_installed_wheel", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PythonSmokeTest(unittest.TestCase):
+    def test_rejects_wrong_interpreter_before_environment_creation(self):
+        smoke = load_smoke()
+
+        for implementation, version in (("CPython", (3, 10)), ("PyPy", (3, 9))):
+            with self.subTest(implementation=implementation, version=version):
+                with self.assertRaisesRegex(ValueError, "requires CPython 3.9"):
+                    smoke.validate_smoke_interpreter(implementation, version)
+
+    def test_rejects_nonisolated_or_user_site_runtime(self):
+        smoke = load_smoke()
+
+        for isolated, user_site in ((False, False), (True, True)):
+            with self.subTest(isolated=isolated, user_site=user_site):
+                with self.assertRaisesRegex(ValueError, "isolated mode|user site-packages"):
+                    smoke.validate_runtime_isolation(isolated, user_site, {})
+
+    def test_rejects_version_and_extension_suffix_drift(self):
+        smoke = load_smoke()
+
+        with self.assertRaisesRegex(ValueError, "does not equal"):
+            smoke.validate_versions("2026.8.11", "2026.8.12")
+        with self.assertRaisesRegex(ValueError, "extension suffix"):
+            smoke.validate_native_suffix(Path("dal/_dal.py"), (".so", ".pyd"))
+
+    def test_rejects_nonempty_workdir_and_excluded_sys_path(self):
+        smoke = load_smoke()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            work_dir = root / "work"
+            work_dir.mkdir()
+            (work_dir / "source.py").touch()
+            excluded = root / "repository"
+            excluded.mkdir()
+
+            with self.assertRaisesRegex(ValueError, "not empty"):
+                smoke.validate_work_directory(work_dir, work_dir)
+            with self.assertRaisesRegex(ValueError, "excluded root"):
+                smoke.validate_sys_path((excluded / "dal-python",), (excluded,))
+
+    def test_rejects_reused_source_resolved_and_dependency_rich_environments(self):
+        smoke = load_smoke()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            existing = root / "existing"
+            existing.mkdir()
+            site_packages = root / "environment" / "site-packages"
+            site_packages.mkdir(parents=True)
+            source = root / "repository" / "dal-python" / "src" / "dal" / "__init__.py"
+            source.parent.mkdir(parents=True)
+            source.touch()
+
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                smoke.require_new_path(existing, "target environment")
+            with self.assertRaisesRegex(ValueError, "outside fresh site-packages"):
+                smoke.validate_installed_path(
+                    "dal.__file__", source, (site_packages,), (root / "repository",)
+                )
+            with self.assertRaisesRegex(ValueError, "unexpected third-party"):
+                smoke.validate_distribution_inventory(("dal-python", "pip", "pytest"))
+
+    def test_rejects_python_path_or_python_home_leakage(self):
+        smoke = load_smoke()
+
+        for variable in ("PYTHONPATH", "PYTHONHOME"):
+            with self.subTest(variable=variable), self.assertRaisesRegex(ValueError, variable):
+                smoke.validate_runtime_isolation(True, False, {variable: "/source"})
+
+    def test_creates_fresh_environment_with_resolved_uv(self):
+        smoke = load_smoke()
+        with tempfile.TemporaryDirectory() as tmp:
+            environment = Path(tmp) / "environment"
+            with patch.object(smoke.shutil, "which", return_value="/opt/uv/bin/uv"), patch.object(
+                smoke.subprocess, "run"
+            ) as run:
+                smoke.create_environment(environment, Path("/opt/python/bin/python"))
+
+            run.assert_called_once_with(
+                [
+                    "/opt/uv/bin/uv",
+                    "venv",
+                    "--no-project",
+                    "--python",
+                    "/opt/python/bin/python",
+                    str(environment),
+                ],
+                check=True,
+                shell=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_python_smoke.py
+++ b/.github/scripts/tests/test_python_smoke.py
@@ -1,10 +1,11 @@
 """Tests for the isolated dal-python wheel smoke helper."""
 
+import asyncio
 import importlib.util
 from pathlib import Path
 import tempfile
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import AsyncMock, call, patch
 
 
 SCRIPT = (
@@ -134,15 +135,29 @@ class PythonSmokeTest(unittest.TestCase):
                 ],
             )
 
-    def test_process_environment_pins_resolved_executable_directory(self):
+    def test_static_subcommand_keeps_absolute_executable(self):
         smoke = load_smoke()
-        executable = Path("/opt/uv/bin/uv")
+        executable = Path("/opt/environment/bin/python")
 
-        with patch.object(smoke.shutil, "which", return_value=str(executable)):
-            environment = smoke.process_environment(executable, {"PATH": "/usr/bin"})
+        with patch.object(
+            smoke.asyncio, "create_subprocess_exec", new_callable=AsyncMock
+        ) as start:
+            asyncio.run(
+                smoke.start_python_process(
+                    executable,
+                    ("-I", "/opt/smoke.py"),
+                    None,
+                    {},
+                )
+            )
 
-        self.assertEqual(environment["PATH"].split(smoke.os.pathsep)[0], "/opt/uv/bin")
-
+        start.assert_awaited_once_with(
+            str(executable),
+            "-I",
+            "/opt/smoke.py",
+            cwd=None,
+            env={},
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/tests/test_python_syntax.py
+++ b/.github/scripts/tests/test_python_syntax.py
@@ -1,0 +1,26 @@
+"""Tests for the DAL Python compatibility syntax gate."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_dal_python_syntax.py"
+SPEC = importlib.util.spec_from_file_location("check_dal_python_syntax", SCRIPT)
+CHECK_SYNTAX = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK_SYNTAX)
+
+
+class PythonSyntaxTest(unittest.TestCase):
+    def test_inventory_includes_sources_tests_helpers_and_examples(self):
+        paths = {path.relative_to(CHECK_SYNTAX.ROOT).as_posix() for path in CHECK_SYNTAX.python_paths()}
+
+        self.assertIn("dal-python/src/dal/__init__.py", paths)
+        self.assertIn("dal-python/tests/test_date.py", paths)
+        self.assertIn("dal-python/scripts/smoke_installed_wheel.py", paths)
+        self.assertIn("dal-python/examples/005.yield_curve_jacobian.py", paths)
+        self.assertEqual(CHECK_SYNTAX.syntax_errors(CHECK_SYNTAX.python_paths()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/dal-python-release.yml
+++ b/.github/workflows/dal-python-release.yml
@@ -29,6 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Set up Python compatibility runner
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # @v9.0.0
+
+      - name: Check Python 3.9 syntax compatibility
+        run: >-
+          uv run --isolated --no-project --python 3.9 python
+          .github/scripts/check_dal_python_syntax.py
+
       - name: Validate version and tag policy
         shell: bash
         run: |
@@ -66,7 +74,20 @@ jobs:
           package-dir: dal-python
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp313-*' || 'cp310-* cp311-* cp312-* cp313-*' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp39-* cp313-*' || 'cp39-* cp310-* cp311-* cp312-* cp313-*' }}
+
+      - name: Set up Python 3.9 smoke interpreter
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # @v9.0.0
+
+      - name: Smoke test installed Python 3.9 wheel
+        run: >-
+          uv run --isolated --no-project --python 3.9 python
+          dal-python/scripts/smoke_installed_wheel.py
+          --wheelhouse "${{ github.workspace }}/wheelhouse"
+          --environment "${{ runner.temp }}/dal-python-smoke-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.platform }}"
+          --work-dir "${{ runner.temp }}/dal-python-smoke-work-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.platform }}"
+          --exclude "${{ github.workspace }}"
+          --exclude "${{ github.workspace }}/wheelhouse"
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -82,7 +103,7 @@ jobs:
     needs: wheels
     runs-on: ubuntu-24.04
     env:
-      EXPECTED_PYTHON: ${{ github.event_name == 'pull_request' && 'cp313' || 'cp310,cp311,cp312,cp313' }}
+      EXPECTED_PYTHON: ${{ github.event_name == 'pull_request' && 'cp39,cp313' || 'cp39,cp310,cp311,cp312,cp313' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 

--- a/.github/workflows/dal-python-release.yml
+++ b/.github/workflows/dal-python-release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/scripts/check_docs.py
+      - .github/scripts/tests/test_python_helpers*.py
       - .github/workflows/dal-python-release.yml
       - dal-python/**
       - CMakeLists.txt
@@ -68,6 +69,16 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Python helper and smoke runner
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # @v9.0.0
+
+      - name: Test executable PowerShell helper contracts
+        if: matrix.platform == 'windows-amd64'
+        shell: pwsh
+        run: >-
+          uv run --isolated --no-project --python 3.13 python
+          .github/scripts/tests/test_python_helpers_powershell.py -v
+
       - name: Build and test wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         with:
@@ -75,9 +86,6 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp39-* cp313-*' || 'cp39-* cp310-* cp311-* cp312-* cp313-*' }}
-
-      - name: Set up Python 3.9 smoke interpreter
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # @v9.0.0
 
       - name: Smoke test installed Python 3.9 wheel
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ here as the baseline rather than dated releases:
   constant-condition folding), and the fuzzy evaluator for pathwise AAD through
   discontinuous payoffs. See `docs/methodology/script_engine.md`.
 
+## 2026-08
+
+- `python`: Expanded the public `dal-python` compatibility contract to
+  CPython 3.9-3.13 (`Requires-Python: >=3.9,<3.14`) and the complete Linux x86-64/Windows
+  AMD64 release from eight to ten CPython-specific wheels. See
+  `dal-python/README.md` and `docs/installation.md`.
+
 ## 2026-07
 
 - `curve`: Added immutable native rate-cashflow planning and pricing for

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -6,6 +6,9 @@ COVERAGE=false
 BUILD_PYTHON=false
 BUILD_BENCHMARKS=false
 GENERATE=false
+PYTHON_REQUESTED=false
+PYTHON_VERSION=""
+SUPPORTED_PYTHONS="3.9, 3.10, 3.11, 3.12, 3.13"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -13,10 +16,30 @@ while [[ $# -gt 0 ]]; do
         --full) BUILD_PYTHON=true; BUILD_BENCHMARKS=true ;;
         --benchmarks) BUILD_BENCHMARKS=true ;;
         --generate) GENERATE=true ;;
+        --python)
+            PYTHON_REQUESTED=true
+            BUILD_PYTHON=true
+            if [[ $# -lt 2 ]]; then
+                echo "--python requires one of $SUPPORTED_PYTHONS" >&2
+                exit 1
+            fi
+            PYTHON_VERSION=$2
+            shift
+            ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
     shift
 done
+
+if [[ $PYTHON_REQUESTED == true ]]; then
+    case "$PYTHON_VERSION" in
+        3.9|3.10|3.11|3.12|3.13) ;;
+        *)
+            echo "--python: unsupported value '$PYTHON_VERSION'; expected one of $SUPPORTED_PYTHONS" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 DAL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BUILD_TYPE=${BUILD_TYPE:-Release}
@@ -51,16 +74,36 @@ fi
 if [[ $BUILD_PYTHON == true ]]; then
     venv_dir="$DAL_DIR/dal-python/.venv"
     python_bin="$venv_dir/bin/python"
+    compat_script="$DAL_DIR/dal-python/scripts/python_compat.py"
+    remediation="remove or replace $venv_dir, then rerun"
+    compat_args=(
+        --entry-point build_linux.sh
+        --environment "$venv_dir"
+        --remediation "$remediation"
+    )
+    if [[ $PYTHON_REQUESTED == true ]]; then
+        compat_args+=(--requested "$PYTHON_VERSION")
+    fi
     if [[ ! -x "$python_bin" ]]; then
+        if [[ -e "$venv_dir" ]]; then
+            echo "build_linux.sh: environment '$venv_dir' has no executable Python; $remediation" >&2
+            exit 1
+        fi
         if command -v uv >/dev/null 2>&1; then
-            uv venv "$venv_dir" --python ">=3.10,<3.14"
+            if [[ $PYTHON_REQUESTED == true ]]; then
+                uv venv "$venv_dir" --python "$PYTHON_VERSION"
+            else
+                uv venv "$venv_dir" --python ">=3.9,<3.14"
+            fi
         elif command -v python3 >/dev/null 2>&1; then
+            python3 "$compat_script" "${compat_args[@]}"
             python3 -m venv "$venv_dir"
         else
             echo "Python bindings requested, but neither uv nor python3 is available." >&2
             exit 1
         fi
     fi
+    "$python_bin" "$compat_script" "${compat_args[@]}"
 
     if ! "$python_bin" -c "import numpy, pytest" >/dev/null 2>&1; then
         if command -v uv >/dev/null 2>&1; then

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -13,7 +13,7 @@ Python bindings for the Derivatives Algorithms Library (DAL) — a high-performa
 
 ## Prerequisites
 
-- **CPython 3.10-3.13** with development headers
+- **CPython 3.9-3.13** with development headers (`Requires-Python: >=3.9,<3.14`)
 - **uv** — fast Python package manager ([install guide](https://docs.astral.sh/uv/getting-started/installation/))
 - **pybind11 2.11.1** — installed automatically for isolated package builds;
   repository builds fall back to the pinned `dal-cpp/externals/pybind11`
@@ -44,7 +44,7 @@ Clone the repository and install in editable mode:
 cd Derivatives-Algorithms-Lib/dal-python
 
 # Create a virtual environment with uv
-uv venv --python ">=3.10,<3.14"
+uv venv --python ">=3.9,<3.14"
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 # Install dependencies and build the extension
@@ -68,6 +68,32 @@ bash ../build_linux.sh --full
 The workspace script creates or reuses `dal-python/.venv`, builds the extension,
 and runs the configured C++/public/Python tests.
 
+### Selecting a CPython Version
+
+The local helpers accept an exact supported minor. On POSIX entry points use
+`--python`; on PowerShell entry points use `-Python`:
+
+```bash
+# From the repository root; --python also enables the Python bindings.
+bash ./build_linux.sh --python 3.9
+
+# From dal-python/.
+./build_sdist.sh --python 3.9
+./build_wheel.sh --python 3.9
+./run_tests.sh --python 3.9
+```
+
+```powershell
+# From dal-python/.
+.\build_wheel.ps1 -Python 3.9
+.\run_tests.ps1 -Python 3.9
+```
+
+The accepted values are 3.9, 3.10, 3.11, 3.12, and 3.13. When the selector is
+omitted, the helpers resolve a CPython in `>=3.9,<3.14`. A reused `.venv` must
+already use the selected CPython minor; mismatches fail without replacing the
+environment.
+
 ## Building Distribution Packages
 
 For production deployment, you can build pre-compiled binary wheels or source distributions.
@@ -79,6 +105,7 @@ Binary wheels contain the compiled C++ extension and can be installed without re
 
 ```bash
 DAL_INSTALL_PREFIX=/absolute/path/to/build/stage/Release-linux ./build_wheel.sh
+DAL_INSTALL_PREFIX=/absolute/path/to/build/stage/Release-linux ./build_wheel.sh --python 3.9
 DAL_INSTALL_PREFIX=/absolute/path/to/build/stage/Release-linux ./build_wheel.sh --clean
 ```
 
@@ -99,6 +126,7 @@ Source distributions allow users to build from source on any platform:
 
 ```bash
 ./build_sdist.sh         # Build source distribution
+./build_sdist.sh --python 3.9 # Select an exact supported CPython
 ./build_sdist.sh --clean # Clean build artifacts before building
 ```
 
@@ -118,7 +146,7 @@ uv pip install dist/dal_python-2026.8.11.tar.gz \
 - CMake 3.21+
 - pybind11 2.11.1 (declared as an isolated build requirement and installed
   automatically; repository builds may use the pinned vendored submodule)
-- CPython 3.10-3.13 development headers
+- CPython 3.9-3.13 development headers
 - DAL staged install containing the `dal-public`/`dal-cpp` CMake packages and
   platform libraries
 
@@ -126,14 +154,25 @@ uv pip install dist/dal_python-2026.8.11.tar.gz \
 
 The repository release workflow builds and tests this wheel matrix:
 
-| Operating system | Architecture | Wheel platform tag          | CPython versions |
-|------------------|--------------|-----------------------------|------------------|
-| Linux            | x86-64       | `manylinux_2_28_x86_64`     | 3.10-3.13        |
-| Windows          | x86-64       | `win_amd64`                 | 3.10-3.13        |
+| Operating system | Architecture | Wheel platform tag      | CPython versions |
+|------------------|--------------|-------------------------|------------------|
+| Linux            | x86-64       | `manylinux_2_28_x86_64` | 3.9-3.13         |
+| Windows          | x86-64       | `win_amd64`             | 3.9-3.13         |
 
-The Linux tag requires glibc 2.28 or newer. macOS, Linux ARM, musllinux, PyPy,
-free-threaded CPython, source distributions, and CPython 3.14 are not part of the
-current PyPI release contract.
+Every release artifact is a CPython-specific native wheel. Python/ABI tags run
+from `cp39-cp39` through `cp313-cp313`; DAL does not publish `abi3` or universal
+wheels. Pull requests build the floor and ceiling (`cp39` and `cp313`) on both
+platforms, for four wheels. Manual and release-tag runs build all five supported
+interpreters on both platforms, for ten wheels. Every wheel runs the complete
+installed-wheel Python suite, and the two `cp39` wheels also run a fresh,
+source-independent installed-wheel smoke test.
+
+Linux filenames always include `manylinux_2_28_x86_64` and may also contain
+unique compatible PEP 600 x86-64 components for glibc baselines no newer than
+2.28. Mixed platform families, other architectures, raw Linux, legacy manylinux,
+and musllinux tags are rejected. macOS, Linux ARM, PyPy, free-threaded CPython,
+source distributions, and CPython 3.14 are not part of the current PyPI release
+contract.
 
 ### One-time PyPI setup
 
@@ -159,7 +198,7 @@ OIDC short-lived credentials; do not add a long-lived PyPI API token.
    repository root. Review and merge the version and release-note changes to
    `master` only after the exact PR head is green.
 3. Run the `dal-python wheels and PyPI release` workflow manually from `master`.
-   This is a build-only rehearsal. Confirm that eight wheels and the SHA-256
+   This is a build-only rehearsal. Confirm that ten wheels and the SHA-256
    release manifest are present.
 4. Tag that reviewed `master` commit and push only the tag:
 
@@ -171,7 +210,7 @@ OIDC short-lived credentials; do not add a long-lived PyPI API token.
 5. The tag run rebuilds and tests every wheel, validates the combined manifest,
    checks that the version is unused on PyPI, then publishes the exact artifacts
    from the build jobs through the `pypi` environment.
-6. Verify the PyPI file list contains all eight wheels. In fresh Windows and Linux
+6. Verify the PyPI file list contains all ten wheels. In fresh Windows and Linux
    environments, install `dal-python==<version>`, import `dal`, and confirm
    `dal.__version__` equals `<version>`.
 

--- a/dal-python/build_sdist.sh
+++ b/dal-python/build_sdist.sh
@@ -6,11 +6,12 @@
 #
 # Prerequisites:
 # - uv must be installed
-# - CPython 3.10-3.13
+# - CPython 3.9-3.13
 #
 # Usage:
 #   ./build_sdist.sh         # Build source distribution
-#   ./build_sdist.sh --clean # Clean build artifacts before building
+#   ./build_sdist.sh --python 3.9 # Select an exact supported CPython
+#   ./build_sdist.sh --clean      # Clean build artifacts before building
 
 set -e
 
@@ -25,10 +26,21 @@ NC='\033[0m' # No Color
 
 # Parse arguments
 CLEAN=false
-for arg in "$@"; do
-    case $arg in
+PYTHON_REQUESTED=false
+PYTHON_VERSION=""
+SUPPORTED_PYTHONS="3.9, 3.10, 3.11, 3.12, 3.13"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --clean)
             CLEAN=true
+            ;;
+        --python)
+            PYTHON_REQUESTED=true
+            if [[ $# -lt 2 ]]; then
+                echo "--python requires one of $SUPPORTED_PYTHONS" >&2
+                exit 1
+            fi
+            PYTHON_VERSION=$2
             shift
             ;;
         --help|-h)
@@ -38,11 +50,24 @@ for arg in "$@"; do
             echo ""
             echo "Options:"
             echo "  --clean        Clean build artifacts before building"
+            echo "  --python MINOR Select CPython 3.9, 3.10, 3.11, 3.12, or 3.13"
             echo "  --help, -h     Show this help message"
             exit 0
             ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
+    shift
 done
+
+if [[ $PYTHON_REQUESTED == true ]]; then
+    case "$PYTHON_VERSION" in
+        3.9|3.10|3.11|3.12|3.13) ;;
+        *)
+            echo "--python: unsupported value '$PYTHON_VERSION'; expected one of $SUPPORTED_PYTHONS" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 # Check prerequisites
 echo -e "${YELLOW}Checking prerequisites...${NC}"
@@ -58,17 +83,36 @@ echo -e "${GREEN}✓ Prerequisites satisfied${NC}"
 # Clean if requested
 if [ "$CLEAN" = true ]; then
     echo -e "${YELLOW}Cleaning build artifacts...${NC}"
-    rm -rf build/ dist/ *.egg-info .pytest_cache
+    rm -rf build/ dist/ .venv/ *.egg-info .pytest_cache
     find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
     echo -e "${GREEN}✓ Clean complete${NC}"
 fi
 
 # Create build environment
 echo -e "${YELLOW}Creating build environment...${NC}"
-if [ ! -d ".venv" ]; then
-    uv venv --python ">=3.10,<3.14"
+VENV_DIR="$SCRIPT_DIR/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+    if [[ -e "$VENV_DIR" ]]; then
+        echo "build_sdist.sh: environment '$VENV_DIR' has no executable Python; rerun with --clean to recreate it" >&2
+        exit 1
+    fi
+    if [[ $PYTHON_REQUESTED == true ]]; then
+        uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
+    else
+        uv venv "$VENV_DIR" --python ">=3.9,<3.14"
+    fi
 fi
-source .venv/bin/activate
+compat_args=(
+    --entry-point dal-python/build_sdist.sh
+    --environment "$VENV_DIR"
+    --remediation "rerun with --clean to recreate $VENV_DIR"
+)
+if [[ $PYTHON_REQUESTED == true ]]; then
+    compat_args+=(--requested "$PYTHON_VERSION")
+fi
+"$VENV_PYTHON" "$SCRIPT_DIR/scripts/python_compat.py" "${compat_args[@]}"
+source "$VENV_DIR/bin/activate"
 echo -e "${GREEN}✓ Build environment ready${NC}"
 
 # Install build dependencies
@@ -109,7 +153,7 @@ echo "Note: Building from source requires:"
 echo "  - C++17 compiler (GCC 13+, Clang 18+, or MSVC 2022)"
 echo "  - CMake 3.21+"
 echo "  - pybind11 2.11.1 (installed automatically from the sdist build requirements)"
-echo "  - CPython 3.10-3.13 development headers"
+echo "  - CPython 3.9-3.13 development headers"
 echo "  - DAL staged install containing lib/cmake/dal-public/dal-publicConfig.cmake"
 echo ""
 

--- a/dal-python/build_wheel.ps1
+++ b/dal-python/build_wheel.ps1
@@ -6,20 +6,27 @@
 # Prerequisites:
 # - C++ library must be installed (run ..\build_windows.bat)
 # - uv must be installed
-# - CPython 3.10-3.13 with development headers
+# - CPython 3.9-3.13 with development headers
 # - Visual Studio 2022 with C++ workload
 #
 # Usage:
 #   .\build_wheel.ps1              # Build wheel for current platform
+#   .\build_wheel.ps1 -Python 3.9  # Select an exact supported CPython
 #   .\build_wheel.ps1 -Clean       # Clean build artifacts before building
 
 param(
     [switch]$Clean,
     [switch]$Help,
+    [string]$Python,
     [string]$DalInstallPrefix
 )
 
 $ErrorActionPreference = "Stop"
+$SupportedPythons = @("3.9", "3.10", "3.11", "3.12", "3.13")
+$PythonRequested = $PSBoundParameters.ContainsKey("Python")
+if ($PythonRequested -and ((-not $Python) -or ($Python -notin $SupportedPythons))) {
+    Write-Error "-Python: unsupported value '$Python'; expected one of $($SupportedPythons -join ', ')"
+}
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $DalDir = Split-Path -Parent $ScriptDir
@@ -37,6 +44,7 @@ if ($Help) {
     Write-Output ""
     Write-Output "Options:"
     Write-Output "  -Clean         Clean build artifacts before building"
+    Write-Output "  -Python <minor> Select CPython 3.9, 3.10, 3.11, 3.12, or 3.13"
     Write-Output "  -DalInstallPrefix <path>  Installed DAL prefix"
     Write-Output "  -Help          Show this help message"
     exit 0
@@ -66,10 +74,12 @@ if (-not ((Test-Path $LibPublic) -and (Test-Path $LibCpp))) {
 Write-Output "  Prerequisites satisfied"
 
 # Clean if requested
+$VenvDir = Join-Path $ScriptDir ".venv"
 if ($Clean) {
     Write-Output "Cleaning build artifacts..."
     if (Test-Path (Join-Path $ScriptDir "build")) { Remove-Item -Recurse -Force (Join-Path $ScriptDir "build") }
     if (Test-Path (Join-Path $ScriptDir "dist")) { Remove-Item -Recurse -Force (Join-Path $ScriptDir "dist") }
+    if (Test-Path $VenvDir) { Remove-Item -Recurse -Force $VenvDir }
     Get-ChildItem -Path $ScriptDir -Directory -Filter "*.egg-info" | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
     Get-ChildItem -Path $ScriptDir -Directory -Filter "__pycache__" -Recurse | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
     Write-Output "  Clean complete"
@@ -77,10 +87,23 @@ if ($Clean) {
 
 # Create build environment
 Write-Output "Creating build environment..."
-$VenvDir = Join-Path $ScriptDir ".venv"
-if (-not (Test-Path $VenvDir)) {
-    uv venv $VenvDir --python ">=3.10,<3.14"
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+if (-not (Test-Path $VenvPython)) {
+    if (Test-Path $VenvDir) {
+        Write-Error "build_wheel.ps1: environment '$VenvDir' has no executable Python; rerun with -Clean to recreate it"
+    }
+    $PythonRequest = if ($PythonRequested) { $Python } else { ">=3.9,<3.14" }
+    uv venv $VenvDir --python $PythonRequest
 }
+$CompatArgs = @(
+    (Join-Path $ScriptDir "scripts\python_compat.py"),
+    "--entry-point", "dal-python/build_wheel.ps1",
+    "--environment", $VenvDir,
+    "--remediation", "rerun with -Clean to recreate $VenvDir"
+)
+if ($PythonRequested) { $CompatArgs += @("--requested", $Python) }
+& $VenvPython @CompatArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 $VenvActivate = Join-Path $VenvDir "Scripts\Activate.ps1"
 . $VenvActivate
 Write-Output "  Build environment ready"

--- a/dal-python/build_wheel.sh
+++ b/dal-python/build_wheel.sh
@@ -7,10 +7,11 @@
 # Prerequisites:
 # - Staged C++ install must contain the exported dal-public CMake package
 # - uv must be installed
-# - CPython 3.10-3.13 with development headers
+# - CPython 3.9-3.13 with development headers
 #
 # Usage:
 #   ./build_wheel.sh              # Build wheel for current platform
+#   ./build_wheel.sh --python 3.9 # Select an exact supported CPython
 #   ./build_wheel.sh --manylinux  # Build manylinux-compatible wheel (Linux only)
 #   ./build_wheel.sh --clean      # Clean build artifacts before building
 
@@ -28,14 +29,24 @@ NC='\033[0m' # No Color
 # Parse arguments
 MANYLINUX=false
 CLEAN=false
-for arg in "$@"; do
-    case $arg in
+PYTHON_REQUESTED=false
+PYTHON_VERSION=""
+SUPPORTED_PYTHONS="3.9, 3.10, 3.11, 3.12, 3.13"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --manylinux)
             MANYLINUX=true
-            shift
             ;;
         --clean)
             CLEAN=true
+            ;;
+        --python)
+            PYTHON_REQUESTED=true
+            if [[ $# -lt 2 ]]; then
+                echo "--python requires one of $SUPPORTED_PYTHONS" >&2
+                exit 1
+            fi
+            PYTHON_VERSION=$2
             shift
             ;;
         --help|-h)
@@ -46,11 +57,24 @@ for arg in "$@"; do
             echo "Options:"
             echo "  --manylinux    Build manylinux-compatible wheel (Linux only)"
             echo "  --clean        Clean build artifacts before building"
+            echo "  --python MINOR Select CPython 3.9, 3.10, 3.11, 3.12, or 3.13"
             echo "  --help, -h     Show this help message"
             exit 0
             ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
+    shift
 done
+
+if [[ $PYTHON_REQUESTED == true ]]; then
+    case "$PYTHON_VERSION" in
+        3.9|3.10|3.11|3.12|3.13) ;;
+        *)
+            echo "--python: unsupported value '$PYTHON_VERSION'; expected one of $SUPPORTED_PYTHONS" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 # Check prerequisites
 echo -e "${YELLOW}Checking prerequisites...${NC}"
@@ -76,17 +100,36 @@ echo -e "${GREEN}✓ Prerequisites satisfied${NC}"
 # Clean if requested
 if [ "$CLEAN" = true ]; then
     echo -e "${YELLOW}Cleaning build artifacts...${NC}"
-    rm -rf build/ dist/ *.egg-info .pytest_cache
+    rm -rf build/ dist/ .venv/ *.egg-info .pytest_cache
     find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
     echo -e "${GREEN}✓ Clean complete${NC}"
 fi
 
 # Create build environment
 echo -e "${YELLOW}Creating build environment...${NC}"
-if [ ! -d ".venv" ]; then
-    uv venv --python ">=3.10,<3.14"
+VENV_DIR="$SCRIPT_DIR/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+    if [[ -e "$VENV_DIR" ]]; then
+        echo "build_wheel.sh: environment '$VENV_DIR' has no executable Python; rerun with --clean to recreate it" >&2
+        exit 1
+    fi
+    if [[ $PYTHON_REQUESTED == true ]]; then
+        uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
+    else
+        uv venv "$VENV_DIR" --python ">=3.9,<3.14"
+    fi
 fi
-source .venv/bin/activate
+compat_args=(
+    --entry-point dal-python/build_wheel.sh
+    --environment "$VENV_DIR"
+    --remediation "rerun with --clean to recreate $VENV_DIR"
+)
+if [[ $PYTHON_REQUESTED == true ]]; then
+    compat_args+=(--requested "$PYTHON_VERSION")
+fi
+"$VENV_PYTHON" "$SCRIPT_DIR/scripts/python_compat.py" "${compat_args[@]}"
+source "$VENV_DIR/bin/activate"
 echo -e "${GREEN}✓ Build environment ready${NC}"
 
 # Install build dependencies

--- a/dal-python/examples/005.yield_curve_jacobian.py
+++ b/dal-python/examples/005.yield_curve_jacobian.py
@@ -56,7 +56,8 @@ def _is_jacobian_empty(jacobian):
 
 
 def _jacobian_header_row(free_knots, n_cols):
-    header = f"  {'row \\ col':<14}"
+    column_label = 'row \\ col'
+    header = f"  {column_label:<14}"
     for j in range(n_cols):
         header += f" {str(free_knots[j]):>10}"
     return header

--- a/dal-python/pyproject.toml
+++ b/dal-python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 name = "dal-python"
 version = "2026.8.11"
 description = "Python bindings for the DAL quantitative finance library"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.9,<3.14"
 readme = "README.md"
 license = "MIT"
 authors = [
@@ -19,6 +19,8 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -44,7 +46,7 @@ wheel.packages = ["src/dal"]
 testpaths = ["tests"]
 
 [tool.cibuildwheel]
-build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 skip = ["*-musllinux_*", "*-manylinux_i686", "*-win32"]
 build-verbosity = 1
 test-requires = ["pytest>=7.0", "numpy>=1.24"]

--- a/dal-python/run_tests.ps1
+++ b/dal-python/run_tests.ps1
@@ -2,24 +2,31 @@
 #
 # Usage:
 #   cd dal-python && .\run_tests.ps1              # run all tests
+#   cd dal-python && .\run_tests.ps1 -Python 3.9   # select an exact CPython
 #   cd dal-python && .\run_tests.ps1 -v            # verbose pytest output
 #   cd dal-python && .\run_tests.ps1 -k test_date  # run specific tests
 #
 # Prerequisites:
 #   - uv (https://docs.astral.sh/uv/)
 #   - The C++ library must be installed first (run ..\build_windows.bat)
-#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and CPython 3.10-3.13 development headers
+#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and CPython 3.9-3.13 development headers
 #   - Visual Studio 2022 with C++ workload
 
 param(
     [switch]$Clean,
     [switch]$Help,
+    [string]$Python,
     [string]$DalInstallPrefix,
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]]$PytestArgs
 )
 
 $ErrorActionPreference = "Stop"
+$SupportedPythons = @("3.9", "3.10", "3.11", "3.12", "3.13")
+$PythonRequested = $PSBoundParameters.ContainsKey("Python")
+if ($PythonRequested -and ((-not $Python) -or ($Python -notin $SupportedPythons))) {
+    Write-Error "-Python: unsupported value '$Python'; expected one of $($SupportedPythons -join ', ')"
+}
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $DalDir = Split-Path -Parent $ScriptDir
@@ -37,11 +44,16 @@ if ($Help) {
     Write-Output ""
     Write-Output "Options:"
     Write-Output "  -Clean         Clean build artifacts before building"
+    Write-Output "  -Python <minor> Select CPython 3.9, 3.10, 3.11, 3.12, or 3.13"
     Write-Output "  -DalInstallPrefix <path>  Installed DAL prefix"
     Write-Output "  -Help          Show this help message"
     Write-Output ""
     Write-Output "All other arguments are forwarded to pytest."
     exit 0
+}
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Error "Error: uv is required by dal-python/run_tests.ps1"
 }
 
 Write-Output "================================================"
@@ -84,7 +96,8 @@ if ($Clean) {
 
 if (-not (Test-Path $VenvDir)) {
     Write-Output "Creating fresh uv virtual environment..."
-    uv venv $VenvDir --python ">=3.10,<3.14"
+    $PythonRequest = if ($PythonRequested) { $Python } else { ">=3.9,<3.14" }
+    uv venv $VenvDir --python $PythonRequest
 }
 else {
     Write-Output "Reusing existing virtual environment at .venv/"
@@ -98,6 +111,16 @@ if (-not (Test-Path $VenvPython)) {
     Write-Output "       Try running with -Clean to recreate the venv."
     exit 1
 }
+
+$CompatArgs = @(
+    (Join-Path $ScriptDir "scripts\python_compat.py"),
+    "--entry-point", "dal-python/run_tests.ps1",
+    "--environment", $VenvDir,
+    "--remediation", "rerun with -Clean to recreate $VenvDir"
+)
+if ($PythonRequested) { $CompatArgs += @("--requested", $Python) }
+& $VenvPython @CompatArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 . $VenvActivate
 Write-Output "  Python: $(python --version)"

--- a/dal-python/run_tests.ps1
+++ b/dal-python/run_tests.ps1
@@ -170,9 +170,9 @@ Write-Output " Running tests"
 Write-Output "================================================"
 Write-Output ""
 
-$pytestArgs = @("tests/", "-v")
+$EffectivePytestArgs = @("tests/", "-v")
 if ($PytestArgs) {
-    $pytestArgs += $PytestArgs
+    $EffectivePytestArgs += $PytestArgs
 }
 
-python -m pytest @pytestArgs
+python -m pytest @EffectivePytestArgs

--- a/dal-python/run_tests.sh
+++ b/dal-python/run_tests.sh
@@ -4,16 +4,52 @@
 #
 # Usage:
 #   cd dal-python && bash run_tests.sh              # run all tests
+#   cd dal-python && bash run_tests.sh --python 3.9  # select an exact CPython
 #   cd dal-python && bash run_tests.sh -v            # verbose pytest output
 #   cd dal-python && bash run_tests.sh -k test_date  # run specific tests
 #
 # Prerequisites:
 #   - uv (https://docs.astral.sh/uv/)
 #   - The staged C++ install must exist (run ../build_linux.sh from repo root)
-#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and CPython 3.10-3.13 development headers
+#   - pybind11 (vendored as a git submodule at dal-cpp/externals/pybind11, v2.11.1) and CPython 3.9-3.13 development headers
 #
 
 set -eu
+
+PYTHON_REQUESTED=false
+PYTHON_VERSION=""
+SUPPORTED_PYTHONS="3.9, 3.10, 3.11, 3.12, 3.13"
+PYTEST_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --python)
+            PYTHON_REQUESTED=true
+            if [[ $# -lt 2 ]]; then
+                echo "--python requires one of $SUPPORTED_PYTHONS" >&2
+                exit 1
+            fi
+            PYTHON_VERSION=$2
+            shift
+            ;;
+        *) PYTEST_ARGS+=("$1") ;;
+    esac
+    shift
+done
+
+if [[ $PYTHON_REQUESTED == true ]]; then
+    case "$PYTHON_VERSION" in
+        3.9|3.10|3.11|3.12|3.13) ;;
+        *)
+            echo "--python: unsupported value '$PYTHON_VERSION'; expected one of $SUPPORTED_PYTHONS" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "Error: uv is required by dal-python/run_tests.sh" >&2
+    exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -45,12 +81,31 @@ echo "[OK] DAL CMake package found: $DAL_PUBLIC_CONFIG"
 # ---- Step 2: Create or reuse uv virtual environment -------------------------
 
 VENV_DIR="$SCRIPT_DIR/.venv"
-if [[ ! -d "$VENV_DIR" ]]; then
+VENV_PYTHON="$VENV_DIR/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+    if [[ -e "$VENV_DIR" ]]; then
+        echo "run_tests.sh: environment '$VENV_DIR' has no executable Python; remove or replace $VENV_DIR, then rerun" >&2
+        exit 1
+    fi
     echo "Creating fresh uv virtual environment..."
-    uv venv "$VENV_DIR" --python ">=3.10,<3.14"
+    if [[ $PYTHON_REQUESTED == true ]]; then
+        uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
+    else
+        uv venv "$VENV_DIR" --python ">=3.9,<3.14"
+    fi
 else
     echo "Reusing existing virtual environment at .venv/"
 fi
+
+compat_args=(
+    --entry-point dal-python/run_tests.sh
+    --environment "$VENV_DIR"
+    --remediation "remove or replace $VENV_DIR, then rerun"
+)
+if [[ $PYTHON_REQUESTED == true ]]; then
+    compat_args+=(--requested "$PYTHON_VERSION")
+fi
+"$VENV_PYTHON" "$SCRIPT_DIR/scripts/python_compat.py" "${compat_args[@]}"
 
 # Activate the venv for subsequent commands
 # shellcheck disable=SC1091
@@ -100,4 +155,4 @@ echo "================================================"
 echo ""
 
 # Pass through any extra arguments to pytest (e.g., -v, -k, --tb=short)
-python -m pytest tests/ -v "$@"
+python -m pytest tests/ -v "${PYTEST_ARGS[@]}"

--- a/dal-python/scripts/python_compat.py
+++ b/dal-python/scripts/python_compat.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate the interpreter behind a DAL Python local environment."""
+
+import argparse
+from pathlib import Path
+import platform
+import sys
+
+
+SUPPORTED_MINORS = ("3.9", "3.10", "3.11", "3.12", "3.13")
+SUPPORTED_RANGE = ">=3.9,<3.14"
+
+
+def validate_interpreter(
+    entry_point, environment, requested, implementation, version, remediation
+):
+    observed = "%s %s.%s" % (implementation, version[0], version[1])
+    observed_minor = "%s.%s" % (version[0], version[1])
+    reason = None
+    if implementation != "CPython":
+        reason = "requires CPython"
+    elif observed_minor not in SUPPORTED_MINORS:
+        reason = "requires CPython %s" % SUPPORTED_RANGE
+    elif requested is not None and observed_minor != requested:
+        reason = "--python requested %s" % requested
+    if reason is not None:
+        raise ValueError(
+            "%s: environment %r uses %s but %s; %s"
+            % (entry_point, str(Path(environment)), observed, reason, remediation)
+        )
+    return observed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--entry-point", required=True)
+    parser.add_argument("--environment", type=Path, required=True)
+    parser.add_argument("--requested", choices=SUPPORTED_MINORS)
+    parser.add_argument("--remediation", required=True)
+    args = parser.parse_args()
+    try:
+        observed = validate_interpreter(
+            args.entry_point,
+            args.environment,
+            args.requested,
+            platform.python_implementation(),
+            sys.version_info[:2],
+            args.remediation,
+        )
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    print("%s: using %s from %s" % (args.entry_point, observed, args.environment))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dal-python/scripts/smoke_installed_wheel.py
+++ b/dal-python/scripts/smoke_installed_wheel.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Install and smoke-test one cp39 dal-python wheel in a fresh environment."""
+
+import argparse
+from importlib import machinery, metadata
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import site
+import subprocess
+import sys
+import sysconfig
+
+
+SEED_DISTRIBUTIONS = {"pip", "setuptools", "wheel"}
+
+
+def canonical(path):
+    return Path(path).resolve()
+
+
+def contained_by(path, root):
+    try:
+        canonical(path).relative_to(canonical(root))
+    except ValueError:
+        return False
+    return True
+
+
+def validate_smoke_interpreter(implementation, version):
+    observed = "%s %s.%s" % (implementation, version[0], version[1])
+    if implementation != "CPython" or tuple(version[:2]) != (3, 9):
+        raise ValueError("fresh wheel smoke requires CPython 3.9; observed %s" % observed)
+    return observed
+
+
+def validate_runtime_isolation(isolated, user_site_enabled, environment):
+    if not isolated:
+        raise ValueError("fresh wheel smoke must run Python in isolated mode")
+    if user_site_enabled:
+        raise ValueError("fresh wheel smoke must disable user site-packages")
+    if environment.get("PYTHONPATH") or environment.get("PYTHONHOME"):
+        raise ValueError("fresh wheel smoke must unset PYTHONPATH and PYTHONHOME")
+
+
+def require_new_path(path, label):
+    resolved = canonical(path)
+    if resolved.exists():
+        raise ValueError(
+            "%s %r already exists; expected a newly created path" % (label, str(resolved))
+        )
+    return resolved
+
+
+def validate_installed_path(label, observed, site_roots, excluded_roots):
+    resolved = canonical(observed)
+    allowed = [canonical(root) for root in site_roots]
+    excluded = [canonical(root) for root in excluded_roots]
+    if not any(contained_by(resolved, root) for root in allowed):
+        raise ValueError(
+            "%s %r is outside fresh site-packages roots %r"
+            % (label, str(resolved), [str(root) for root in allowed])
+        )
+    if any(contained_by(resolved, root) for root in excluded):
+        raise ValueError(
+            "%s %r is inside excluded source/test root %r"
+            % (label, str(resolved), [str(root) for root in excluded])
+        )
+    return resolved
+
+
+def validate_distribution_inventory(names):
+    normalized = {name.lower().replace("_", "-") for name in names}
+    allowed = SEED_DISTRIBUTIONS | {"dal-python"}
+    if "dal-python" not in normalized:
+        raise ValueError("fresh environment does not contain dal-python")
+    unexpected = sorted(normalized - allowed)
+    if unexpected:
+        raise ValueError(
+            "fresh environment contains unexpected third-party distributions %r; allowed %r"
+            % (unexpected, sorted(allowed))
+        )
+    return sorted(normalized)
+
+
+def validate_versions(distribution_version, module_version):
+    if distribution_version != module_version:
+        raise ValueError(
+            "dal-python distribution version %r does not equal dal.__version__ %r"
+            % (distribution_version, module_version)
+        )
+
+
+def validate_native_suffix(native_path, extension_suffixes):
+    if not any(str(native_path).endswith(suffix) for suffix in extension_suffixes):
+        raise ValueError(
+            "dal._dal path %r does not use an interpreter extension suffix from %r"
+            % (str(native_path), extension_suffixes)
+        )
+
+
+def validate_work_directory(observed, expected):
+    work_dir = canonical(observed)
+    if work_dir != canonical(expected):
+        raise ValueError(
+            "fresh wheel smoke working directory %r does not equal %r"
+            % (str(work_dir), str(canonical(expected)))
+        )
+    if any(work_dir.iterdir()):
+        raise ValueError("fresh wheel smoke working directory %r is not empty" % str(work_dir))
+    return work_dir
+
+
+def validate_sys_path(entries, excluded_roots):
+    excluded = [canonical(root) for root in excluded_roots]
+    for entry in entries:
+        if not entry:
+            continue
+        resolved = canonical(entry)
+        if any(contained_by(resolved, root) for root in excluded):
+            raise ValueError(
+                "fresh wheel smoke sys.path entry %r is inside excluded root" % str(resolved)
+            )
+
+
+def validate_runtime(args):
+    validate_smoke_interpreter(platform.python_implementation(), sys.version_info)
+    validate_runtime_isolation(sys.flags.isolated, site.ENABLE_USER_SITE, os.environ)
+
+    environment_root = canonical(args.environment)
+    if canonical(sys.prefix) != environment_root or canonical(sys.base_prefix) == environment_root:
+        raise ValueError(
+            "fresh wheel smoke prefix %r is not the requested isolated environment %r"
+            % (str(canonical(sys.prefix)), str(environment_root))
+        )
+    work_dir = validate_work_directory(Path.cwd(), args.work_dir)
+
+    excluded_roots = [canonical(path) for path in args.exclude]
+    validate_sys_path(sys.path, excluded_roots)
+
+    site_roots = {
+        canonical(sysconfig.get_path(name)) for name in ("purelib", "platlib")
+    }
+    distribution = metadata.distribution("dal-python")
+    distribution_root = validate_installed_path(
+        "dal-python distribution root",
+        distribution.locate_file(""),
+        site_roots,
+        excluded_roots,
+    )
+
+    import dal
+    import dal._dal as native
+
+    package_path = validate_installed_path(
+        "dal.__file__", dal.__file__, site_roots, excluded_roots
+    )
+    native_path = validate_installed_path(
+        "dal._dal.__file__", native.__file__, site_roots, excluded_roots
+    )
+    distribution_version = metadata.version("dal-python")
+    validate_versions(distribution_version, dal.__version__)
+    validate_native_suffix(native_path, machinery.EXTENSION_SUFFIXES)
+
+    inventory = validate_distribution_inventory(
+        distribution.metadata.get("Name")
+        for distribution in metadata.distributions()
+        if distribution.metadata.get("Name")
+    )
+    value = dal.Date_(2024, 1, 2)
+    observed_date = (dal.Year(value), dal.Month(value), dal.Day(value))
+    if observed_date != (2024, 1, 2):
+        raise ValueError("DAL Date_ smoke returned %r" % (observed_date,))
+
+    evidence = {
+        "environment": str(environment_root),
+        "python": sys.version,
+        "wheel": str(canonical(args.wheel)),
+        "sys_prefix": str(canonical(sys.prefix)),
+        "work_dir": str(work_dir),
+        "site_packages": sorted(str(root) for root in site_roots),
+        "sys_path": [str(canonical(entry)) for entry in sys.path if entry],
+        "dal_file": str(package_path),
+        "native_file": str(native_path),
+        "distribution_root": str(distribution_root),
+        "distribution_version": distribution_version,
+        "module_version": dal.__version__,
+        "distributions": inventory,
+    }
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+
+
+def environment_python(environment):
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def uv_executable():
+    executable = shutil.which("uv")
+    if executable is None:
+        raise ValueError("cp39 fresh smoke requires uv to create an isolated environment")
+    executable = canonical(executable)
+    if executable.name.lower() not in ("uv", "uv.exe"):
+        raise ValueError("unexpected uv executable %r" % str(executable))
+    return executable
+
+
+def create_environment(environment, interpreter):
+    subprocess.run(
+        [
+            str(uv_executable()),
+            "venv",
+            "--no-project",
+            "--python",
+            str(interpreter),
+            str(environment),
+        ],
+        check=True,
+        shell=False,
+    )
+
+
+def install_wheel(python, wheel):
+    subprocess.run(
+        [
+            str(uv_executable()),
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            "--no-config",
+            str(wheel),
+        ],
+        check=True,
+        shell=False,
+    )
+
+
+def create_and_run(args):
+    validate_smoke_interpreter(platform.python_implementation(), sys.version_info)
+    if args.wheel is None:
+        candidates = sorted(canonical(args.wheelhouse).glob("*-cp39-cp39-*.whl"))
+        if len(candidates) != 1:
+            raise ValueError(
+                "cp39 fresh smoke expected exactly one wheel under %s, found %r"
+                % (canonical(args.wheelhouse), [path.name for path in candidates])
+            )
+        args.wheel = candidates[0]
+    wheel = canonical(args.wheel)
+    if not wheel.is_file():
+        raise ValueError("cp39 fresh smoke wheel does not exist: %s" % wheel)
+    if "-cp39-cp39-" not in wheel.name or wheel.suffix != ".whl":
+        raise ValueError("cp39 fresh smoke requires a cp39-cp39 wheel; observed %s" % wheel.name)
+
+    environment = require_new_path(args.environment, "target environment")
+    work_dir = require_new_path(args.work_dir, "working directory")
+    excluded = [canonical(path) for path in args.exclude]
+    for label, path in (("target environment", environment), ("working directory", work_dir)):
+        if any(contained_by(path, root) for root in excluded):
+            raise ValueError("%s %r must be outside excluded roots" % (label, str(path)))
+
+    create_environment(environment, Path(sys.executable))
+    work_dir.mkdir(parents=True)
+    python = environment_python(environment)
+    install_wheel(python, wheel)
+
+    command = [
+        str(python),
+        "-I",
+        str(canonical(__file__)),
+        "--verify",
+        "--wheel",
+        str(wheel),
+        "--environment",
+        str(environment),
+        "--work-dir",
+        str(work_dir),
+    ]
+    for path in excluded:
+        command.extend(("--exclude", str(path)))
+    clean_environment = os.environ.copy()
+    clean_environment.pop("PYTHONPATH", None)
+    clean_environment.pop("PYTHONHOME", None)
+    clean_environment["PYTHONNOUSERSITE"] = "1"
+    subprocess.run(
+        command,
+        cwd=str(work_dir),
+        env=clean_environment,
+        check=True,
+        shell=False,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    wheel_source = parser.add_mutually_exclusive_group(required=True)
+    wheel_source.add_argument("--wheel", type=Path)
+    wheel_source.add_argument("--wheelhouse", type=Path)
+    parser.add_argument("--environment", type=Path, required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument("--exclude", type=Path, action="append", default=[])
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.verify:
+            validate_runtime(args)
+        else:
+            create_and_run(args)
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        print("cp39 fresh smoke failed: %s" % error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dal-python/scripts/smoke_installed_wheel.py
+++ b/dal-python/scripts/smoke_installed_wheel.py
@@ -2,6 +2,7 @@
 """Install and smoke-test one cp39 dal-python wheel in a fresh environment."""
 
 import argparse
+import asyncio
 from importlib import machinery, metadata
 import json
 import os
@@ -9,7 +10,6 @@ from pathlib import Path
 import platform
 import shutil
 import site
-import subprocess
 import sys
 import sysconfig
 
@@ -54,20 +54,28 @@ def require_new_path(path, label):
     return resolved
 
 
-def validate_installed_path(label, observed, site_roots, excluded_roots):
-    resolved = canonical(observed)
-    allowed = [canonical(root) for root in site_roots]
-    excluded = [canonical(root) for root in excluded_roots]
+def require_path_in_roots(label, resolved, allowed):
     if not any(contained_by(resolved, root) for root in allowed):
         raise ValueError(
             "%s %r is outside fresh site-packages roots %r"
             % (label, str(resolved), [str(root) for root in allowed])
         )
+
+
+def reject_path_in_roots(label, resolved, excluded):
     if any(contained_by(resolved, root) for root in excluded):
         raise ValueError(
             "%s %r is inside excluded source/test root %r"
             % (label, str(resolved), [str(root) for root in excluded])
         )
+
+
+def validate_installed_path(label, observed, site_roots, excluded_roots):
+    resolved = canonical(observed)
+    allowed = [canonical(root) for root in site_roots]
+    excluded = [canonical(root) for root in excluded_roots]
+    require_path_in_roots(label, resolved, allowed)
+    reject_path_in_roots(label, resolved, excluded)
     return resolved
 
 
@@ -125,12 +133,12 @@ def validate_sys_path(entries, excluded_roots):
             )
 
 
-def validate_runtime(args):
-    validate_smoke_interpreter(platform.python_implementation(), sys.version_info)
-    validate_runtime_isolation(sys.flags.isolated, site.ENABLE_USER_SITE, os.environ)
-
+def validate_runtime_roots(args):
     environment_root = canonical(args.environment)
-    if canonical(sys.prefix) != environment_root or canonical(sys.base_prefix) == environment_root:
+    if (
+        canonical(sys.prefix) != environment_root
+        or canonical(sys.base_prefix) == environment_root
+    ):
         raise ValueError(
             "fresh wheel smoke prefix %r is not the requested isolated environment %r"
             % (str(canonical(sys.prefix)), str(environment_root))
@@ -143,6 +151,17 @@ def validate_runtime(args):
     site_roots = {
         canonical(sysconfig.get_path(name)) for name in ("purelib", "platlib")
     }
+    return environment_root, work_dir, excluded_roots, site_roots
+
+
+def validate_date_operation(dal):
+    value = dal.Date_(2024, 1, 2)
+    observed_date = (dal.Year(value), dal.Month(value), dal.Day(value))
+    if observed_date != (2024, 1, 2):
+        raise ValueError("DAL Date_ smoke returned %r" % (observed_date,))
+
+
+def installed_runtime(site_roots, excluded_roots):
     distribution = metadata.distribution("dal-python")
     distribution_root = validate_installed_path(
         "dal-python distribution root",
@@ -169,12 +188,19 @@ def validate_runtime(args):
         for distribution in metadata.distributions()
         if distribution.metadata.get("Name")
     )
-    value = dal.Date_(2024, 1, 2)
-    observed_date = (dal.Year(value), dal.Month(value), dal.Day(value))
-    if observed_date != (2024, 1, 2):
-        raise ValueError("DAL Date_ smoke returned %r" % (observed_date,))
+    validate_date_operation(dal)
+    return {
+        "dal_file": package_path,
+        "native_file": native_path,
+        "distribution_root": distribution_root,
+        "distribution_version": distribution_version,
+        "module_version": dal.__version__,
+        "distributions": inventory,
+    }
 
-    evidence = {
+
+def runtime_evidence(args, environment_root, work_dir, site_roots, runtime):
+    return {
         "environment": str(environment_root),
         "python": sys.version,
         "wheel": str(canonical(args.wheel)),
@@ -182,13 +208,23 @@ def validate_runtime(args):
         "work_dir": str(work_dir),
         "site_packages": sorted(str(root) for root in site_roots),
         "sys_path": [str(canonical(entry)) for entry in sys.path if entry],
-        "dal_file": str(package_path),
-        "native_file": str(native_path),
-        "distribution_root": str(distribution_root),
-        "distribution_version": distribution_version,
-        "module_version": dal.__version__,
-        "distributions": inventory,
+        "dal_file": str(runtime["dal_file"]),
+        "native_file": str(runtime["native_file"]),
+        "distribution_root": str(runtime["distribution_root"]),
+        "distribution_version": runtime["distribution_version"],
+        "module_version": runtime["module_version"],
+        "distributions": runtime["distributions"],
     }
+
+
+def validate_runtime(args):
+    validate_smoke_interpreter(platform.python_implementation(), sys.version_info)
+    validate_runtime_isolation(sys.flags.isolated, site.ENABLE_USER_SITE, os.environ)
+    environment_root, work_dir, excluded_roots, site_roots = validate_runtime_roots(
+        args
+    )
+    runtime = installed_runtime(site_roots, excluded_roots)
+    evidence = runtime_evidence(args, environment_root, work_dir, site_roots, runtime)
     print(json.dumps(evidence, indent=2, sort_keys=True))
 
 
@@ -208,67 +244,94 @@ def uv_executable():
     return executable
 
 
+def executable_path(executable):
+    path = Path(executable)
+    if not path.is_absolute():
+        raise ValueError("process executable must be an absolute path: %r" % str(path))
+    return path
+
+
+async def wait_for_process(executable, arguments, cwd, environment):
+    process = await asyncio.create_subprocess_exec(
+        str(executable_path(executable)),
+        *(str(argument) for argument in arguments),
+        cwd=None if cwd is None else str(canonical(cwd)),
+        env=environment,
+    )
+    return await process.wait()
+
+
+def run_process(executable, arguments, *, cwd=None, environment=None):
+    returncode = asyncio.run(wait_for_process(executable, arguments, cwd, environment))
+    if returncode:
+        raise OSError(
+            "command %r exited with status %s" % (str(executable), returncode)
+        )
+
+
 def create_environment(environment, interpreter):
-    subprocess.run(
-        [
-            str(uv_executable()),
+    run_process(
+        uv_executable(),
+        (
             "venv",
             "--no-project",
             "--python",
             str(interpreter),
             str(environment),
-        ],
-        check=True,
-        shell=False,
+        ),
     )
 
 
 def install_wheel(python, wheel):
-    subprocess.run(
-        [
-            str(uv_executable()),
+    run_process(
+        uv_executable(),
+        (
             "pip",
             "install",
             "--python",
             str(python),
             "--no-config",
             str(wheel),
-        ],
-        check=True,
-        shell=False,
+        ),
     )
 
 
-def create_and_run(args):
-    validate_smoke_interpreter(platform.python_implementation(), sys.version_info)
-    if args.wheel is None:
-        candidates = sorted(canonical(args.wheelhouse).glob("*-cp39-cp39-*.whl"))
+def resolve_smoke_wheel(wheel, wheelhouse):
+    if wheel is None:
+        candidates = sorted(canonical(wheelhouse).glob("*-cp39-cp39-*.whl"))
         if len(candidates) != 1:
             raise ValueError(
                 "cp39 fresh smoke expected exactly one wheel under %s, found %r"
-                % (canonical(args.wheelhouse), [path.name for path in candidates])
+                % (canonical(wheelhouse), [path.name for path in candidates])
             )
-        args.wheel = candidates[0]
-    wheel = canonical(args.wheel)
-    if not wheel.is_file():
-        raise ValueError("cp39 fresh smoke wheel does not exist: %s" % wheel)
-    if "-cp39-cp39-" not in wheel.name or wheel.suffix != ".whl":
-        raise ValueError("cp39 fresh smoke requires a cp39-cp39 wheel; observed %s" % wheel.name)
+        wheel = candidates[0]
+    resolved = canonical(wheel)
+    if not resolved.is_file():
+        raise ValueError("cp39 fresh smoke wheel does not exist: %s" % resolved)
+    if "-cp39-cp39-" not in resolved.name or resolved.suffix != ".whl":
+        raise ValueError(
+            "cp39 fresh smoke requires a cp39-cp39 wheel; observed %s" % resolved.name
+        )
+    return resolved
 
+
+def new_smoke_paths(args):
     environment = require_new_path(args.environment, "target environment")
     work_dir = require_new_path(args.work_dir, "working directory")
     excluded = [canonical(path) for path in args.exclude]
-    for label, path in (("target environment", environment), ("working directory", work_dir)):
+    for label, path in (
+        ("target environment", environment),
+        ("working directory", work_dir),
+    ):
         if any(contained_by(path, root) for root in excluded):
-            raise ValueError("%s %r must be outside excluded roots" % (label, str(path)))
+            raise ValueError(
+                "%s %r must be outside excluded roots" % (label, str(path))
+            )
+    return environment, work_dir, excluded
 
-    create_environment(environment, Path(sys.executable))
-    work_dir.mkdir(parents=True)
-    python = environment_python(environment)
-    install_wheel(python, wheel)
 
-    command = [
-        str(python),
+def verification_arguments(wheel, environment, work_dir, excluded):
+    arguments = [
         "-I",
         str(canonical(__file__)),
         "--verify",
@@ -280,17 +343,31 @@ def create_and_run(args):
         str(work_dir),
     ]
     for path in excluded:
-        command.extend(("--exclude", str(path)))
-    clean_environment = os.environ.copy()
-    clean_environment.pop("PYTHONPATH", None)
-    clean_environment.pop("PYTHONHOME", None)
-    clean_environment["PYTHONNOUSERSITE"] = "1"
-    subprocess.run(
-        command,
-        cwd=str(work_dir),
-        env=clean_environment,
-        check=True,
-        shell=False,
+        arguments.extend(("--exclude", str(path)))
+    return arguments
+
+
+def isolated_process_environment():
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.pop("PYTHONHOME", None)
+    environment["PYTHONNOUSERSITE"] = "1"
+    return environment
+
+
+def create_and_run(args):
+    validate_smoke_interpreter(platform.python_implementation(), sys.version_info)
+    wheel = resolve_smoke_wheel(args.wheel, args.wheelhouse)
+    environment, work_dir, excluded = new_smoke_paths(args)
+    create_environment(environment, Path(sys.executable))
+    work_dir.mkdir(parents=True)
+    python = environment_python(environment)
+    install_wheel(python, wheel)
+    run_process(
+        python,
+        verification_arguments(wheel, environment, work_dir, excluded),
+        cwd=work_dir,
+        environment=isolated_process_environment(),
     )
 
 
@@ -309,7 +386,7 @@ def main():
             validate_runtime(args)
         else:
             create_and_run(args)
-    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+    except (OSError, ValueError) as error:
         print("cp39 fresh smoke failed: %s" % error, file=sys.stderr)
         return 1
     return 0

--- a/dal-python/scripts/smoke_installed_wheel.py
+++ b/dal-python/scripts/smoke_installed_wheel.py
@@ -251,13 +251,70 @@ def executable_path(executable):
     return path
 
 
-async def wait_for_process(executable, arguments, cwd, environment):
-    process = await asyncio.create_subprocess_exec(
-        str(executable_path(executable)),
-        *(str(argument) for argument in arguments),
-        cwd=None if cwd is None else str(canonical(cwd)),
-        env=environment,
+def process_environment(executable, environment):
+    executable = executable_path(executable)
+    child_environment = (
+        os.environ.copy() if environment is None else environment.copy()
     )
+    previous_path = child_environment.get("PATH", "")
+    child_environment["PATH"] = str(executable.parent) + os.pathsep + previous_path
+    resolved = shutil.which(executable.name, path=child_environment["PATH"])
+    if resolved is None or canonical(resolved) != canonical(executable):
+        raise ValueError("could not pin process executable %r" % str(executable))
+    return child_environment
+
+
+async def start_uv_process(executable_name, arguments, process_cwd, environment):
+    if arguments[:1] == ("venv",):
+        remaining = arguments[1:]
+        if executable_name == "uv":
+            return await asyncio.create_subprocess_exec(
+                "uv", "venv", *remaining, cwd=process_cwd, env=environment
+            )
+        return await asyncio.create_subprocess_exec(
+            "uv.exe", "venv", *remaining, cwd=process_cwd, env=environment
+        )
+    if arguments[:1] == ("pip",):
+        remaining = arguments[1:]
+        if executable_name == "uv":
+            return await asyncio.create_subprocess_exec(
+                "uv", "pip", *remaining, cwd=process_cwd, env=environment
+            )
+        return await asyncio.create_subprocess_exec(
+            "uv.exe", "pip", *remaining, cwd=process_cwd, env=environment
+        )
+    raise ValueError("unexpected uv argument vector %r" % (arguments,))
+
+
+async def start_python_process(executable_name, arguments, process_cwd, environment):
+    if arguments[:1] != ("-I",):
+        raise ValueError("unexpected Python argument vector %r" % (arguments,))
+    remaining = arguments[1:]
+    if executable_name == "python":
+        return await asyncio.create_subprocess_exec(
+            "python", "-I", *remaining, cwd=process_cwd, env=environment
+        )
+    return await asyncio.create_subprocess_exec(
+        "python.exe", "-I", *remaining, cwd=process_cwd, env=environment
+    )
+
+
+async def wait_for_process(executable, arguments, cwd, environment):
+    executable = executable_path(executable)
+    arguments = tuple(str(argument) for argument in arguments)
+    process_cwd = None if cwd is None else str(canonical(cwd))
+    child_environment = process_environment(executable, environment)
+    executable_name = executable.name.lower()
+    if executable_name in ("uv", "uv.exe"):
+        process = await start_uv_process(
+            executable_name, arguments, process_cwd, child_environment
+        )
+    elif executable_name in ("python", "python.exe"):
+        process = await start_python_process(
+            executable_name, arguments, process_cwd, child_environment
+        )
+    else:
+        raise ValueError("unexpected process executable %r" % str(executable))
     return await process.wait()
 
 

--- a/dal-python/scripts/smoke_installed_wheel.py
+++ b/dal-python/scripts/smoke_installed_wheel.py
@@ -251,51 +251,23 @@ def executable_path(executable):
     return path
 
 
-def process_environment(executable, environment):
-    executable = executable_path(executable)
-    child_environment = (
-        os.environ.copy() if environment is None else environment.copy()
-    )
-    previous_path = child_environment.get("PATH", "")
-    child_environment["PATH"] = str(executable.parent) + os.pathsep + previous_path
-    resolved = shutil.which(executable.name, path=child_environment["PATH"])
-    if resolved is None or canonical(resolved) != canonical(executable):
-        raise ValueError("could not pin process executable %r" % str(executable))
-    return child_environment
-
-
-async def start_uv_process(executable_name, arguments, process_cwd, environment):
+async def start_uv_process(executable, arguments, process_cwd, environment):
     if arguments[:1] == ("venv",):
-        remaining = arguments[1:]
-        if executable_name == "uv":
-            return await asyncio.create_subprocess_exec(
-                "uv", "venv", *remaining, cwd=process_cwd, env=environment
-            )
         return await asyncio.create_subprocess_exec(
-            "uv.exe", "venv", *remaining, cwd=process_cwd, env=environment
+            str(executable), "venv", *arguments[1:], cwd=process_cwd, env=environment
         )
     if arguments[:1] == ("pip",):
-        remaining = arguments[1:]
-        if executable_name == "uv":
-            return await asyncio.create_subprocess_exec(
-                "uv", "pip", *remaining, cwd=process_cwd, env=environment
-            )
         return await asyncio.create_subprocess_exec(
-            "uv.exe", "pip", *remaining, cwd=process_cwd, env=environment
+            str(executable), "pip", *arguments[1:], cwd=process_cwd, env=environment
         )
     raise ValueError("unexpected uv argument vector %r" % (arguments,))
 
 
-async def start_python_process(executable_name, arguments, process_cwd, environment):
+async def start_python_process(executable, arguments, process_cwd, environment):
     if arguments[:1] != ("-I",):
         raise ValueError("unexpected Python argument vector %r" % (arguments,))
-    remaining = arguments[1:]
-    if executable_name == "python":
-        return await asyncio.create_subprocess_exec(
-            "python", "-I", *remaining, cwd=process_cwd, env=environment
-        )
     return await asyncio.create_subprocess_exec(
-        "python.exe", "-I", *remaining, cwd=process_cwd, env=environment
+        str(executable), "-I", *arguments[1:], cwd=process_cwd, env=environment
     )
 
 
@@ -303,15 +275,14 @@ async def wait_for_process(executable, arguments, cwd, environment):
     executable = executable_path(executable)
     arguments = tuple(str(argument) for argument in arguments)
     process_cwd = None if cwd is None else str(canonical(cwd))
-    child_environment = process_environment(executable, environment)
     executable_name = executable.name.lower()
     if executable_name in ("uv", "uv.exe"):
         process = await start_uv_process(
-            executable_name, arguments, process_cwd, child_environment
+            executable, arguments, process_cwd, environment
         )
     elif executable_name in ("python", "python.exe"):
         process = await start_python_process(
-            executable_name, arguments, process_cwd, child_environment
+            executable, arguments, process_cwd, environment
         )
     else:
         raise ValueError("unexpected process executable %r" % str(executable))

--- a/dal-python/scripts/verify_release.py
+++ b/dal-python/scripts/verify_release.py
@@ -77,11 +77,15 @@ def wheel_parts(path: Path) -> tuple[str, str, str, str, str]:
     return tuple(parts)  # type: ignore[return-value]
 
 
-def metadata_from_wheel(archive: ZipFile, suffix: str):
-    matches = [name for name in archive.namelist() if name.endswith(suffix)]
-    if len(matches) != 1:
-        raise ValueError(f"wheel must contain exactly one {suffix}, found {matches}")
-    return BytesParser().parsebytes(archive.read(matches[0]))
+def metadata_from_wheel(path: Path, archive: ZipFile, dist_info: str, filename: str):
+    expected = f"{dist_info}/{filename}"
+    member_pattern = re.compile(rf"[^/]+\.dist-info/{re.escape(filename)}")
+    matches = [name for name in archive.namelist() if member_pattern.fullmatch(name)]
+    if matches != [expected]:
+        raise ValueError(
+            f"{path.name}: wheel must contain exactly one {expected}, found {matches}"
+        )
+    return BytesParser().parsebytes(archive.read(expected))
 
 
 def platform_family(platform_tag: str) -> str:
@@ -213,8 +217,10 @@ def validate_wheel(
     with ZipFile(path) as archive:
         names = archive.namelist()
         validate_native_extension(path, names, family)
-        metadata = metadata_from_wheel(archive, "/METADATA")
-        wheel_metadata = metadata_from_wheel(archive, "/WHEEL")
+        distribution, version, _, _, _ = wheel_parts(path)
+        dist_info = f"{distribution}-{version}.dist-info"
+        metadata = metadata_from_wheel(path, archive, dist_info, "METADATA")
+        wheel_metadata = metadata_from_wheel(path, archive, dist_info, "WHEEL")
         validate_package_metadata(path, metadata, expected_version, expected_requires_python)
         validate_wheel_metadata(path, wheel_metadata, python_tag, abi_tag, platform_tag)
 

--- a/dal-python/scripts/verify_release.py
+++ b/dal-python/scripts/verify_release.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 from email.parser import BytesParser
 from hashlib import sha256
 from http.client import HTTPSConnection
@@ -21,6 +22,8 @@ INIT = PACKAGE_ROOT / "src" / "dal" / "__init__.py"
 VERSION_RE = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']\s*$', re.MULTILINE)
 LINUX_PLATFORM = "manylinux_2_28_x86_64"
 WINDOWS_PLATFORM = "win_amd64"
+PYTHON_TAG_RE = re.compile(r"cp[1-9][0-9]+")
+MANYLINUX_PLATFORM_RE = re.compile(r"manylinux_([0-9]+)_([0-9]+)_x86_64")
 
 
 def project_configuration() -> tuple[str, str, tuple[str, ...]]:
@@ -37,6 +40,32 @@ def source_version() -> str:
     if match is None:
         raise ValueError(f"{INIT} does not declare __version__")
     return match.group(1)
+
+
+def validate_expected_python_tags(
+    python_tags: tuple[str, ...], configured_python_tags: tuple[str, ...]
+) -> tuple[str, ...]:
+    if not python_tags:
+        raise ValueError(
+            "--expected-python: explicit value is empty; omit the option for the configured "
+            "full set or supply a nonempty configured subset"
+        )
+    seen: set[str] = set()
+    for python_tag in python_tags:
+        if not python_tag or python_tag != python_tag.strip():
+            raise ValueError(f"--expected-python: malformed selector {python_tag!r}")
+        if PYTHON_TAG_RE.fullmatch(python_tag) is None:
+            raise ValueError(f"--expected-python: malformed selector {python_tag!r}")
+        if python_tag in seen:
+            raise ValueError(f"--expected-python: duplicate selector {python_tag!r}")
+        if python_tag not in configured_python_tags:
+            configured = ", ".join(configured_python_tags)
+            raise ValueError(
+                f"--expected-python: selector {python_tag!r} is not configured; "
+                f"configured tags are {configured}"
+            )
+        seen.add(python_tag)
+    return python_tags
 
 
 def wheel_parts(path: Path) -> tuple[str, str, str, str, str]:
@@ -56,11 +85,30 @@ def metadata_from_wheel(archive: ZipFile, suffix: str):
 
 
 def platform_family(platform_tag: str) -> str:
-    tags = set(platform_tag.split("."))
-    if LINUX_PLATFORM in tags:
+    components = platform_tag.split(".")
+    if not components or any(not component for component in components):
+        raise ValueError(f"platform field {platform_tag!r} contains an empty component")
+    if len(components) != len(set(components)):
+        raise ValueError(f"platform field {platform_tag!r} contains duplicate components")
+    if LINUX_PLATFORM in components:
+        for component in components:
+            match = MANYLINUX_PLATFORM_RE.fullmatch(component)
+            if match is None:
+                raise ValueError(
+                    f"platform component {component!r} is not a PEP 600 x86-64 component"
+                )
+            glibc_version = tuple(int(part) for part in match.groups())
+            if glibc_version > (2, 28):
+                raise ValueError(
+                    f"platform component {component!r} exceeds the manylinux 2.28 baseline"
+                )
         return "linux"
-    if tags == {WINDOWS_PLATFORM}:
+    if components == [WINDOWS_PLATFORM]:
         return "windows"
+    if WINDOWS_PLATFORM in components:
+        raise ValueError(
+            f"Windows platform must be exactly {WINDOWS_PLATFORM!r}, observed {platform_tag!r}"
+        )
     raise ValueError(f"unsupported or unrepaired wheel platform tag: {platform_tag}")
 
 
@@ -72,6 +120,11 @@ def validate_wheel_filename(
         raise ValueError(f"{path.name}: unexpected distribution {distribution}")
     if version != expected_version:
         raise ValueError(f"{path.name}: version {version} != {expected_version}")
+    if PYTHON_TAG_RE.fullmatch(python_tag) is None or PYTHON_TAG_RE.fullmatch(abi_tag) is None:
+        raise ValueError(
+            f"{path.name}: Python and ABI fields must each contain one single CPython tag; "
+            f"observed {python_tag!r} and {abi_tag!r}"
+        )
     if abi_tag != python_tag:
         raise ValueError(f"{path.name}: ABI {abi_tag} does not match {python_tag}")
     family = platform_family(platform_tag)
@@ -91,6 +144,13 @@ def normalized_requires_python(value: str) -> frozenset[str]:
     return frozenset(specifier.strip() for specifier in value.split(","))
 
 
+def single_header(path: Path, metadata, key: str) -> str:
+    values = metadata.get_all(key, [])
+    if len(values) != 1:
+        raise ValueError(f"{path.name}: METADATA has {len(values)} {key} headers; expected exactly 1")
+    return values[0]
+
+
 def validate_package_metadata(
     path: Path, metadata, expected_version: str, expected_requires_python: str
 ) -> None:
@@ -101,10 +161,16 @@ def validate_package_metadata(
         "Requires-Python": expected_requires_python,
     }
     for key, expected in expected_metadata.items():
-        actual = metadata[key]
+        actual = single_header(path, metadata, key)
         equivalent = actual == expected
         if key == "Requires-Python":
-            equivalent = normalized_requires_python(actual) == normalized_requires_python(expected)
+            actual_specifiers = tuple(specifier.strip() for specifier in actual.split(","))
+            expected_specifiers = normalized_requires_python(expected)
+            equivalent = (
+                len(actual_specifiers) == len(expected_specifiers)
+                and len(set(actual_specifiers)) == len(actual_specifiers)
+                and set(actual_specifiers) == expected_specifiers
+            )
         if not equivalent:
             raise ValueError(f"{path.name}: {key}={actual!r}, expected {expected!r}")
     if not str(metadata.get_payload()).strip():
@@ -114,14 +180,27 @@ def validate_package_metadata(
 def validate_wheel_metadata(
     path: Path, wheel_metadata, python_tag: str, abi_tag: str, platform_tag: str
 ) -> None:
-    if wheel_metadata["Root-Is-Purelib"] != "false":
+    wheel_versions = wheel_metadata.get_all("Wheel-Version", [])
+    if len(wheel_versions) != 1:
+        raise ValueError(
+            f"{path.name}: WHEEL has {len(wheel_versions)} Wheel-Version headers; expected exactly 1"
+        )
+    purelib_values = wheel_metadata.get_all("Root-Is-Purelib", [])
+    if len(purelib_values) != 1:
+        raise ValueError(
+            f"{path.name}: WHEEL has {len(purelib_values)} Root-Is-Purelib headers; expected exactly 1"
+        )
+    if purelib_values[0] != "false":
         raise ValueError(f"{path.name}: native wheel is incorrectly marked pure")
-    filename_tags = {
+    filename_tags = [
         f"{python_tag}-{abi_tag}-{platform}" for platform in platform_tag.split(".")
-    }
-    missing_tags = filename_tags - set(wheel_metadata.get_all("Tag", []))
-    if missing_tags:
-        raise ValueError(f"{path.name}: WHEEL metadata omits {sorted(missing_tags)}")
+    ]
+    wheel_tags = wheel_metadata.get_all("Tag", [])
+    if Counter(wheel_tags) != Counter(filename_tags):
+        raise ValueError(
+            f"{path.name}: WHEEL tags {wheel_tags!r} must equal expanded filename tags "
+            f"{filename_tags!r} in contents and cardinality"
+        )
 
 
 def validate_wheel(
@@ -181,7 +260,11 @@ def validate_release(
 ) -> list[str]:
     version, requires_python, configured_python_tags = validate_versions(tag, check_pypi)
 
-    python_tags = expected_python_tags or configured_python_tags
+    python_tags = (
+        configured_python_tags
+        if expected_python_tags is None
+        else validate_expected_python_tags(expected_python_tags, configured_python_tags)
+    )
     wheels = sorted(dist_dir.glob("*.whl"))
     if not wheels:
         raise ValueError(f"no wheels found under {dist_dir}")
@@ -213,7 +296,9 @@ def main() -> int:
     parser.add_argument("--check-pypi", action="store_true")
     parser.add_argument("--version-only", action="store_true")
     args = parser.parse_args()
-    expected_python = tuple(args.expected_python.split(",")) if args.expected_python else None
+    expected_python = (
+        tuple(args.expected_python.split(",")) if args.expected_python is not None else None
+    )
     try:
         if args.version_only:
             version, _, _ = validate_versions(args.tag, args.check_pypi)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ here instead of maintaining separate build recipes.
 | Core C++ | Git with submodules, CMake 3.21+, a C++17 compiler, and a build tool                         |
 | Linux    | GCC 13+ or Clang 18+; Make or Ninja                                                          |
 | Windows  | Visual Studio 2022 toolchain; Ninja for the supplied presets                                 |
-| Python   | CPython 3.10-3.13 with development headers; `uv` recommended                                |
+| Python   | CPython 3.9-3.13 with development headers (`>=3.9,<3.14`); `uv` recommended                 |
 | Web      | Python 3.13+, `uv`, npm, Node.js `^20.19.0` or `>=22.12.0`, and a built native `dal` package |
 | Excel    | Windows and Microsoft Excel; build the XLL with `DAL_BUILD_EXCEL=ON`                         |
 
@@ -42,17 +42,19 @@ It does not regenerate tracked Machinist output unless requested.
 
 ### Script options
 
-| Option         | Effect                                                               |
-|----------------|----------------------------------------------------------------------|
-| `--full`       | Enable Python bindings and benchmarks                                |
-| `--benchmarks` | Enable native benchmark targets                                      |
-| `--generate`   | Run the `dal_generate` target before the normal build                |
-| `--coverage`   | Enable coverage and produce a report with an available coverage tool |
+| Option         | Effect                                                                      |
+|----------------|-----------------------------------------------------------------------------|
+| `--full`       | Enable Python bindings and benchmarks                                       |
+| `--benchmarks` | Enable native benchmark targets                                             |
+| `--generate`   | Run the `dal_generate` target before the normal build                       |
+| `--coverage`   | Enable coverage and produce a report with an available coverage tool        |
+| `--python`     | Enable Python bindings and select an exact supported minor (for example 3.9) |
 
 Examples:
 
 ```bash
 bash ./build_linux.sh --full
+bash ./build_linux.sh --python 3.9
 bash ./build_linux.sh --benchmarks
 bash ./build_linux.sh --generate
 BUILD_TYPE=Debug bash ./build_linux.sh
@@ -60,7 +62,10 @@ BUILD_TYPE=Debug bash ./build_linux.sh
 
 When Python is requested, the script creates or reuses
 `dal-python/.venv`, installs `pytest` and `numpy` if needed, and configures CMake
-with that interpreter. Useful environment overrides are:
+with that interpreter. `--python` accepts exactly 3.9, 3.10, 3.11, 3.12, or
+3.13; without it, the script resolves CPython in `>=3.9,<3.14`. A reused
+environment must match the requested minor and is not replaced on a mismatch.
+Useful environment overrides are:
 
 | Variable                 | Meaning                                                          |
 |--------------------------|------------------------------------------------------------------|
@@ -236,7 +241,7 @@ For a generator that must be selected explicitly, add
 To build and test Python as part of the workspace:
 
 ```bash
-bash ./build_linux.sh --full
+bash ./build_linux.sh --python 3.9
 ```
 
 For an editable package in a chosen environment, first build the C++ staging
@@ -245,7 +250,7 @@ prefix, then install `dal-python` against that prefix:
 ```bash
 bash ./build_linux.sh
 cd dal-python
-uv venv
+uv venv --python ">=3.9,<3.14"
 source .venv/bin/activate
 uv pip install -e ".[test]" "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 python -m pytest tests -v
@@ -256,6 +261,37 @@ or the matching Windows preset when building under MSVC. On Windows, activate
 with `.venv\Scripts\activate`. See the
 [Python component guide](../dal-python/README.md)
 for the exposed API and package layout.
+
+All package helpers use the same exact-selector contract. From `dal-python/`,
+the POSIX commands are:
+
+```bash
+./build_sdist.sh --python 3.9
+./build_wheel.sh --python 3.9
+./run_tests.sh --python 3.9
+```
+
+The Windows PowerShell commands are:
+
+```powershell
+.\build_wheel.ps1 -Python 3.9
+.\run_tests.ps1 -Python 3.9
+```
+
+The test wrappers remove their selector and forward the remaining pytest
+arguments in order. Existing environments are inspected before dependency
+installation; a different minor, an unsupported version, or a non-CPython
+interpreter fails without mutating that environment.
+
+Official releases remain CPython-specific, wheel-only builds for Linux x86-64
+(`manylinux_2_28_x86_64`) and Windows AMD64 (`win_amd64`). Pull requests build
+`cp39-cp39` and `cp313-cp313` on both platforms (four wheels). Manual and tag
+runs build CPython 3.9-3.13 on both platforms (ten wheels). Every wheel runs the
+full installed-wheel test suite; the two `cp39` wheels also run the fresh
+source-independent smoke. Linux filenames always include the 2.28 platform
+component and may also carry unique compatible PEP 600 x86-64 components for
+older glibc baselines. CPython 3.14, macOS, ARM, musllinux, PyPy, free-threaded
+CPython, and sdist publication are outside this release matrix.
 
 ## Web UI
 


### PR DESCRIPTION
## Summary

- add CPython 3.9 to the native Linux and Windows wheel contract while preserving Python 3.10–3.13 and tag-only trusted publication
- harden selector, filename/tag, metadata/cardinality, workflow-projection, and exact-matrix verification
- preserve PowerShell pytest arguments under case-insensitive variable binding and execute both Windows helper scripts against real `pwsh` process doubles
- require `METADATA` and `WHEEL` to live in the filename-corresponding top-level `.dist-info` directory, including wrong-directory rejection tests
- add Python 3.9 syntax validation, shared local interpreter checks, and isolated installed-wheel smoke coverage
- complete AC-8 public documentation and changelog coverage, remove the temporary `--python` checker bypass, and enforce compatibility, selector, platform, wheel-matrix, smoke, and exclusion parity

Tracks Multica task DAL-112 (`f6af4db4-4552-4fc1-9796-4599fd06a6ca`).

Closes #286

Closes DAL-112

## Test plan

- [x] 106 repository contract tests locally (6 Windows-only executable-helper tests skipped off Windows)
- [x] 6/6 executable PowerShell helper contract tests on Windows
- [x] AC-8 documentation contract: 9/9 focused tests, 33/33 documentation-checker tests, and all 55 Markdown files passed with the checker bypass removed
- [x] actual CPython 3.9 syntax parse of all 37 shipped Python files
- [x] full Linux Python 3.9 build: 1,228/1,228 tests passed
- [x] current-head PR workflow: source validation, Linux and Windows wheels, both Python 3.9 fresh-install smokes, and manifest verification passed; publication skipped
- [x] predecessor-head non-publishing ten-wheel `workflow_dispatch` rehearsal: [run 31465948372](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/31465948372) ran at `690f995a95a806a9e1837fb716f3508f59bfac83`; all ten per-wheel suites, both Python 3.9 fresh-install smokes, and the ten-entry manifest passed, with publication skipped. The exact-matrix evidence remains representative at `3d09cc60711d47591e1b80902a7090d4edfd9d6f`: subsequent commits preserve the wheel matrix, release verifier, workflow, and trusted-publication boundary, while exact-head [run 31512037161](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/31512037161) revalidated source, Linux and Windows wheels, both Python 3.9 fresh-install smokes, and the manifest with publication skipped.

## Current CI

At head `3d09cc60711d47591e1b80902a7090d4edfd9d6f`, the PR has 79 successful checks, one expected skip (`Publish wheels to PyPI`), zero pending or running checks, and zero failures. Codacy passes and its live summary reports zero issues.
