### PR TITLE
ci: harden dal-python release verification and syntax gate

### DIFF
--- a/.github/scripts/check_dal_python_syntax.py
+++ b/.github/scripts/check_dal_python_syntax.py
@@ -6,6 +6,7 @@ interpreter's grammar, so only a 3.9 host enforces the 3.9 grammar floor.
 """
 
 from pathlib import Path
+import platform
 import sys
 
 
@@ -35,13 +36,15 @@ def syntax_errors(paths):
 
 
 def main():
-    if sys.version_info[:2] != GRAMMAR_FLOOR:
+    implementation = platform.python_implementation()
+    if implementation != "CPython" or sys.version_info[:2] != GRAMMAR_FLOOR:
         floor = "%d.%d" % GRAMMAR_FLOOR
+        observed = "%s %s" % (implementation, sys.version.split()[0])
         print(
             "Python %s syntax gate must run under CPython %s exactly (observed %s); "
             "run: uv run --isolated --no-project --python %s python "
             ".github/scripts/check_dal_python_syntax.py"
-            % (floor, floor, sys.version.split()[0], floor),
+            % (floor, floor, observed, floor),
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/check_dal_python_syntax.py
+++ b/.github/scripts/check_dal_python_syntax.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-"""Compile every Python 3.9-governed DAL Python source without writing bytecode."""
+"""Compile every Python 3.9-governed DAL Python source without writing bytecode.
+
+Must run under CPython 3.9 exactly: compile() applies the running
+interpreter's grammar, so only a 3.9 host enforces the 3.9 grammar floor.
+"""
 
 from pathlib import Path
 import sys
 
 
 ROOT = Path(__file__).resolve().parents[2]
+GRAMMAR_FLOOR = (3, 9)
 SOURCE_ROOTS = (
     ROOT / "dal-python" / "src",
     ROOT / "dal-python" / "tests",
@@ -30,6 +35,16 @@ def syntax_errors(paths):
 
 
 def main():
+    if sys.version_info[:2] != GRAMMAR_FLOOR:
+        floor = "%d.%d" % GRAMMAR_FLOOR
+        print(
+            "Python %s syntax gate must run under CPython %s exactly (observed %s); "
+            "run: uv run --isolated --no-project --python %s python "
+            ".github/scripts/check_dal_python_syntax.py"
+            % (floor, floor, sys.version.split()[0], floor),
+            file=sys.stderr,
+        )
+        return 1
     paths = python_paths()
     errors = syntax_errors(paths)
     if errors:

--- a/.github/scripts/tests/test_python_helpers.py
+++ b/.github/scripts/tests/test_python_helpers.py
@@ -209,6 +209,9 @@ class PythonHelpersTest(unittest.TestCase):
 
     def test_posix_helpers_preserve_rejected_reused_environment(self):
         source_root = SCRIPT.parents[2]
+        # The reused environment wraps the host interpreter, so request a
+        # supported minor that always differs from the host's.
+        requested = "3.10" if "%d.%d" % os.sys.version_info[:2] == "3.9" else "3.9"
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"
             package = root / "dal-python"
@@ -251,7 +254,7 @@ class PythonHelpersTest(unittest.TestCase):
             for cwd, script in helpers:
                 with self.subTest(script=script):
                     result = subprocess.run(
-                        ("bash", script, "--python", "3.9"),
+                        ("bash", script, "--python", requested),
                         cwd=cwd,
                         env=environment,
                         stdout=subprocess.PIPE,
@@ -260,7 +263,7 @@ class PythonHelpersTest(unittest.TestCase):
                         check=False,
                     )
                     self.assertNotEqual(result.returncode, 0)
-                    self.assertIn("requested 3.9", result.stdout)
+                    self.assertIn(f"requested {requested}", result.stdout)
                     self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve")
                     self.assertFalse(uv_log.exists())
 

--- a/.github/scripts/tests/test_python_release.py
+++ b/.github/scripts/tests/test_python_release.py
@@ -433,6 +433,12 @@ class PythonReleaseTest(unittest.TestCase):
                 BUILD_NATIVE.cmake_executable(), Path("/opt/cmake/bin/cmake")
             )
 
+    def test_cmake_executable_accepts_versioned_cmake3_symlink_target(self):
+        with patch.object(BUILD_NATIVE, "which", return_value="/usr/bin/cmake3"):
+            self.assertEqual(
+                BUILD_NATIVE.cmake_executable(), Path("/usr/bin/cmake3")
+            )
+
     def test_cmake_executable_rejects_unexpected_name(self):
         with patch.object(BUILD_NATIVE, "which", return_value="/tmp/not-cmake"):
             with self.assertRaisesRegex(RuntimeError, "unexpected cmake executable"):

--- a/.github/scripts/tests/test_python_syntax.py
+++ b/.github/scripts/tests/test_python_syntax.py
@@ -2,8 +2,10 @@
 
 import importlib.util
 from pathlib import Path
+import platform
 import sys
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "check_dal_python_syntax.py"
@@ -23,9 +25,16 @@ class PythonSyntaxTest(unittest.TestCase):
         self.assertEqual(CHECK_SYNTAX.syntax_errors(CHECK_SYNTAX.python_paths()), [])
 
     def test_main_runs_only_under_the_grammar_floor(self):
-        if sys.version_info[:2] == CHECK_SYNTAX.GRAMMAR_FLOOR:
-            self.assertEqual(CHECK_SYNTAX.main(), 0)
-        else:
+        is_gate_interpreter = (
+            platform.python_implementation() == "CPython"
+            and sys.version_info[:2] == CHECK_SYNTAX.GRAMMAR_FLOOR
+        )
+        self.assertEqual(CHECK_SYNTAX.main(), 0 if is_gate_interpreter else 1)
+
+    def test_main_rejects_non_cpython_interpreters(self):
+        with mock.patch.object(
+            CHECK_SYNTAX.platform, "python_implementation", return_value="PyPy"
+        ):
             self.assertEqual(CHECK_SYNTAX.main(), 1)
 
 

--- a/.github/scripts/tests/test_python_syntax.py
+++ b/.github/scripts/tests/test_python_syntax.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 from pathlib import Path
+import sys
 import unittest
 
 
@@ -20,6 +21,12 @@ class PythonSyntaxTest(unittest.TestCase):
         self.assertIn("dal-python/scripts/smoke_installed_wheel.py", paths)
         self.assertIn("dal-python/examples/005.yield_curve_jacobian.py", paths)
         self.assertEqual(CHECK_SYNTAX.syntax_errors(CHECK_SYNTAX.python_paths()), [])
+
+    def test_main_runs_only_under_the_grammar_floor(self):
+        if sys.version_info[:2] == CHECK_SYNTAX.GRAMMAR_FLOOR:
+            self.assertEqual(CHECK_SYNTAX.main(), 0)
+        else:
+            self.assertEqual(CHECK_SYNTAX.main(), 1)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/dal-python-release.yml
+++ b/.github/workflows/dal-python-release.yml
@@ -3,8 +3,13 @@ name: dal-python wheels and PyPI release
 on:
   pull_request:
     paths:
+      - .github/scripts/check_dal_python_syntax.py
       - .github/scripts/check_docs.py
+      - .github/scripts/tests/test_check_docs.py
       - .github/scripts/tests/test_python_helpers*.py
+      - .github/scripts/tests/test_python_release.py
+      - .github/scripts/tests/test_python_smoke.py
+      - .github/scripts/tests/test_python_syntax.py
       - .github/workflows/dal-python-release.yml
       - dal-python/**
       - CMakeLists.txt
@@ -161,6 +166,19 @@ jobs:
           pattern: wheels-*
           path: wheelhouse
           merge-multiple: true
+
+      - name: Download release manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dal-python-release-manifest
+          path: manifest
+
+      - name: Verify wheels against the release manifest
+        shell: bash
+        run: |
+          cd wheelhouse
+          sha256sum --check ../manifest/release-manifest.txt
+          test "$(ls -1 *.whl | wc -l)" -eq "$(wc -l < ../manifest/release-manifest.txt)"
 
       - name: Publish exact wheel artifacts
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -174,6 +174,12 @@ and musllinux tags are rejected. macOS, Linux ARM, PyPy, free-threaded CPython,
 source distributions, and CPython 3.14 are not part of the current PyPI release
 contract.
 
+The SHA-256 release manifest records the exact verified bytes of every wheel,
+and the publish job re-checks the downloaded artifacts against it before
+upload. The toolchain is pinned (full action SHAs, exact build dependency
+versions, named manylinux/runner images), but byte-for-byte reproducibility
+across independent rebuilds is not currently enforced.
+
 ### One-time PyPI setup
 
 Configure a Trusted Publisher on the existing `dal-python` PyPI project with:

--- a/dal-python/build_wheel.ps1
+++ b/dal-python/build_wheel.ps1
@@ -22,6 +22,20 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+if ($Help) {
+    Write-Output "Usage: .\build_wheel.ps1 [OPTIONS]"
+    Write-Output ""
+    Write-Output "Build Python wheel package for dal-python"
+    Write-Output ""
+    Write-Output "Options:"
+    Write-Output "  -Clean         Clean build artifacts before building"
+    Write-Output "  -Python <minor> Select CPython 3.9, 3.10, 3.11, 3.12, or 3.13"
+    Write-Output "  -DalInstallPrefix <path>  Installed DAL prefix"
+    Write-Output "  -Help          Show this help message"
+    exit 0
+}
+
 $SupportedPythons = @("3.9", "3.10", "3.11", "3.12", "3.13")
 $PythonRequested = $PSBoundParameters.ContainsKey("Python")
 if ($PythonRequested -and ((-not $Python) -or ($Python -notin $SupportedPythons))) {
@@ -35,19 +49,6 @@ if (-not $DalInstallPrefix) {
 }
 if (-not $DalInstallPrefix) {
     $DalInstallPrefix = Join-Path $DalDir "build\stage\Release-windows"
-}
-
-if ($Help) {
-    Write-Output "Usage: .\build_wheel.ps1 [OPTIONS]"
-    Write-Output ""
-    Write-Output "Build Python wheel package for dal-python"
-    Write-Output ""
-    Write-Output "Options:"
-    Write-Output "  -Clean         Clean build artifacts before building"
-    Write-Output "  -Python <minor> Select CPython 3.9, 3.10, 3.11, 3.12, or 3.13"
-    Write-Output "  -DalInstallPrefix <path>  Installed DAL prefix"
-    Write-Output "  -Help          Show this help message"
-    exit 0
 }
 
 # Check prerequisites

--- a/dal-python/run_tests.ps1
+++ b/dal-python/run_tests.ps1
@@ -22,20 +22,6 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$SupportedPythons = @("3.9", "3.10", "3.11", "3.12", "3.13")
-$PythonRequested = $PSBoundParameters.ContainsKey("Python")
-if ($PythonRequested -and ((-not $Python) -or ($Python -notin $SupportedPythons))) {
-    Write-Error "-Python: unsupported value '$Python'; expected one of $($SupportedPythons -join ', ')"
-}
-
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$DalDir = Split-Path -Parent $ScriptDir
-if (-not $DalInstallPrefix) {
-    $DalInstallPrefix = $env:DAL_INSTALL_PREFIX
-}
-if (-not $DalInstallPrefix) {
-    $DalInstallPrefix = Join-Path $DalDir "build\stage\Release-windows"
-}
 
 if ($Help) {
     Write-Output "Usage: .\run_tests.ps1 [OPTIONS] [-- pytest_args...]"
@@ -50,6 +36,21 @@ if ($Help) {
     Write-Output ""
     Write-Output "All other arguments are forwarded to pytest."
     exit 0
+}
+
+$SupportedPythons = @("3.9", "3.10", "3.11", "3.12", "3.13")
+$PythonRequested = $PSBoundParameters.ContainsKey("Python")
+if ($PythonRequested -and ((-not $Python) -or ($Python -notin $SupportedPythons))) {
+    Write-Error "-Python: unsupported value '$Python'; expected one of $($SupportedPythons -join ', ')"
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DalDir = Split-Path -Parent $ScriptDir
+if (-not $DalInstallPrefix) {
+    $DalInstallPrefix = $env:DAL_INSTALL_PREFIX
+}
+if (-not $DalInstallPrefix) {
+    $DalInstallPrefix = Join-Path $DalDir "build\stage\Release-windows"
 }
 
 if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {

--- a/dal-python/scripts/build_native.py
+++ b/dal-python/scripts/build_native.py
@@ -27,7 +27,7 @@ def cmake_executable() -> Path:
     if discovered is None:
         raise RuntimeError("cmake executable was not found on PATH")
     executable = Path(discovered).resolve()
-    if executable.name.lower() not in {"cmake", "cmake.exe"}:
+    if executable.name.lower() not in {"cmake", "cmake.exe", "cmake3", "cmake3.exe"}:
         raise RuntimeError(f"unexpected cmake executable path: {executable}")
     return executable
 
@@ -60,7 +60,6 @@ def generator_configuration(is_windows: bool) -> tuple[list[str], list[str]]:
                 "-A",
                 "x64",
                 "-DMSVC_RUNTIME=static",
-                "-DXAD_STATIC_MSVC_RUNTIME=ON",
             ],
             ["--config", "Release"],
         )

--- a/dal-python/scripts/verify_release.py
+++ b/dal-python/scripts/verify_release.py
@@ -117,7 +117,7 @@ def platform_family(platform_tag: str) -> str:
 
 
 def validate_wheel_filename(
-    path: Path, expected_version: str, expected_requires_python: str
+    path: Path, expected_version: str
 ) -> tuple[str, str, str, str]:
     distribution, version, python_tag, abi_tag, platform_tag = wheel_parts(path)
     if distribution != "dal_python":
@@ -211,7 +211,7 @@ def validate_wheel(
     path: Path, expected_version: str, expected_requires_python: str
 ) -> tuple[str, str, str]:
     python_tag, abi_tag, platform_tag, family = validate_wheel_filename(
-        path, expected_version, expected_requires_python
+        path, expected_version
     )
 
     with ZipFile(path) as archive:


### PR DESCRIPTION
## Summary
- Gate `check_dal_python_syntax.py` on the exact CPython 3.9 interpreter so it cannot silently validate the wrong grammar outside the pinned CI runner (with a clear remediation message)
- Trigger the release workflow on every CI script/test file it governs (`check_dal_python_syntax.py`, `test_check_docs.py`, `test_python_release.py`, `test_python_smoke.py`, `test_python_syntax.py`)
- Re-verify downloaded wheels against the SHA-256 release manifest (`sha256sum --check` + wheel-count equality) in the publish job before the PyPI upload
- Document the release posture honestly: verified manifest and pinned toolchain, no enforced byte-for-byte reproducibility
- Accept resolved `cmake3` executable names in `build_native.py`; drop the dead `-DXAD_STATIC_MSVC_RUNTIME=ON` define (XAD is never configured in this build)
- Drop the unused `expected_requires_python` parameter from `validate_wheel_filename`
- Show `-Help` output before `-Python` validation in `run_tests.ps1` / `build_wheel.ps1`
- Make `test_posix_helpers_preserve_rejected_reused_environment` independent of the host interpreter minor version

## Test plan
- [x] `python3 -m unittest discover -s .github/scripts/tests` — 111 tests pass (2 new), 6 Windows-only skips
- [x] `python3 .github/scripts/check_docs.py` — all 55 Markdown files pass the docs/workflow contract checks
- [x] `uv run --isolated --no-project --python 3.9 python .github/scripts/check_dal_python_syntax.py` — passes under real CPython 3.9.25; fails with guidance under 3.13
- [x] Manifest `sha256sum --check` + wheel-count logic simulated locally, including the extra-wheel rejection case
- [ ] Release workflow rehearsal (4-wheel PR matrix) passes on this PR