### PR TITLE
chore: release dal-python 2026.8.14

### DIFF
--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -134,10 +134,10 @@ The source archive is created under `dist/`.
 
 Install from source (requires C++ build tools):
 ```bash
-pip install dist/dal_python-2026.8.11.tar.gz \
+pip install dist/dal_python-2026.8.14.tar.gz \
   "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 # or
-uv pip install dist/dal_python-2026.8.11.tar.gz \
+uv pip install dist/dal_python-2026.8.14.tar.gz \
   "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 ```
 

--- a/dal-python/pyproject.toml
+++ b/dal-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "dal-python"
-version = "2026.8.11"
+version = "2026.8.14"
 description = "Python bindings for the DAL quantitative finance library"
 requires-python = ">=3.9,<3.14"
 readme = "README.md"

--- a/dal-python/src/dal/__init__.py
+++ b/dal-python/src/dal/__init__.py
@@ -8,4 +8,4 @@ from .api import *
 
 __author__ = 'The Derivatives Algorithms Group'
 __email__ = 'wegamekinglc@hotmail.com'
-__version__ = "2026.8.11"
+__version__ = "2026.8.14"


### PR DESCRIPTION
## Summary
- Bump dal-python version 2026.8.11 -> 2026.8.14 in `pyproject.toml` and `src/dal/__init__.py` (kept in lockstep per the release policy gate)
- Refresh the README sdist example filenames to the new version
- No library behavior changes since dal-python-v2026.8.11 (only CI hardening #287, #288), so no CHANGELOG entry

## Test plan
- [x] `python3 dal-python/scripts/verify_release.py --version-only --tag dal-python-v2026.8.14 --check-pypi` passes (version not on PyPI, tag policy OK)
- [x] `check_dal_python_syntax.py` (Python 3.9) and `check_docs.py` gates pass locally
- [ ] `bash ./build_linux.sh --full` local build + CTest (running)
- [ ] CI green on the exact PR head (cmake-linux + dal-python-release wheel checks)

After merge: run the `dal-python wheels and PyPI release` workflow manually from master (10-wheel rehearsal), then tag the master commit `dal-python-v2026.8.14` and push the tag to publish.