### PR TITLE
ci: run tests in parallel and build with all cores

### DIFF
--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -406,10 +406,15 @@ def check_current_state_doc_locations(errors: list[str], root: Path = ROOT) -> N
 def check_ci_compiler_inventory(errors: list[str]) -> None:
     workflow = (ROOT / ".github/workflows/cmake-linux.yml").read_text(encoding="utf-8")
     match = re.search(r"^\s*compiler:\s*\[([^]]+)\]", workflow, flags=re.MULTILINE)
-    if match is None:
+    if match is not None:
+        compilers = {value.strip() for value in match.group(1).split(",")}
+    else:
+        # The matrix is produced by the define-matrix job; the compiler
+        # inventory lives in its generator table as "compiler": "<name>".
+        compilers = set(re.findall(r'"compiler":\s*"([^"]+)"', workflow))
+    if not compilers:
         errors.append(".github/workflows/cmake-linux.yml: compiler matrix was not found")
         return
-    compilers = {value.strip() for value in match.group(1).split(",")}
     copilot = (ROOT / ".github/copilot-instructions.md").read_text(encoding="utf-8")
     missing = sorted(compiler for compiler in compilers if compiler not in copilot)
     if missing:

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -8,48 +8,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The matrix is generated rather than declared inline for two reasons:
+  #
+  # 1. Push events (master merges, direct branch pushes) run a lean subset --
+  #    gcc-14 and clang-20 across all four AAD backends (8 legs) -- because
+  #    pull requests already ran the full 6 x 4 matrix before merge. Pull
+  #    requests still get every compiler x backend combination.
+  # 2. Coverage is consolidated onto the single gcc-14/aadet leg, the only
+  #    one Coveralls consumes. Every backend is still fully compiled and
+  #    tested; the dropped legs only repeated gcov-instrumented builds whose
+  #    lcov output nobody read.
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - id: generate
+        run: |
+          python3 - "${{ github.event_name }}" <<'PYEOF' >> "$GITHUB_OUTPUT"
+          import json
+          import sys
+
+          event = sys.argv[1]
+
+          compilers = [
+              {"compiler": "clang-18", "cc": "clang-18", "cxx": "clang++-18",
+               "packages": "clang-18 libomp-18-dev libstdc++-14-dev"},
+              {"compiler": "clang-19", "cc": "clang-19", "cxx": "clang++-19",
+               "packages": "clang-19 libomp-19-dev libstdc++-14-dev"},
+              {"compiler": "clang-20", "cc": "clang-20", "cxx": "clang++-20",
+               "packages": "clang-20 libomp-20-dev libstdc++-14-dev"},
+              {"compiler": "gcc-13", "cc": "gcc-13", "cxx": "g++-13",
+               "packages": "gcc-13 g++-13"},
+              {"compiler": "gcc-14", "cc": "gcc-14", "cxx": "g++-14",
+               "packages": "gcc-14 g++-14"},
+              # gcc-15 comes from ppa:ubuntu-toolchain-r/test, not the Ubuntu
+              # 24.04 archive; the build job adds the PPA for this leg.
+              {"compiler": "gcc-15", "cc": "gcc-15", "cxx": "g++-15",
+               "packages": "gcc-15 g++-15"},
+          ]
+          backends = ["aadet", "xad", "codipack", "adept"]
+          push_compilers = {"gcc-14", "clang-20"}
+
+          include = []
+          for entry in compilers:
+              if event == "push" and entry["compiler"] not in push_compilers:
+                  continue
+              for backend in backends:
+                  leg = dict(entry)
+                  leg["aad-backend"] = backend
+                  leg["coverage"] = (
+                      entry["compiler"] == "gcc-14" and backend == "aadet")
+                  if leg["coverage"]:
+                      leg["gcov"] = "gcov-14"
+                  include.append(leg)
+
+          print(f"matrix={json.dumps({'include': include})}")
+          PYEOF
+
   build:
+    # Explicit name keeps the historical "build (<compiler>, <backend>)"
+    # check names stable for branch protection and log searching.
+    name: build (${{ matrix.compiler }}, ${{ matrix.aad-backend }})
+    needs: define-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        compiler: [clang-18, clang-19, clang-20, gcc-13, gcc-14, gcc-15]
-        aad-backend: [aadet, xad, codipack, adept]
-        include:
-          - compiler: clang-18
-            cc: clang-18
-            cxx: clang++-18
-            packages: clang-18 libomp-18-dev libstdc++-14-dev
-            coverage: false
-          - compiler: clang-19
-            cc: clang-19
-            cxx: clang++-19
-            packages: clang-19 libomp-19-dev libstdc++-14-dev
-            coverage: false
-          - compiler: clang-20
-            cc: clang-20
-            cxx: clang++-20
-            packages: clang-20 libomp-20-dev libstdc++-14-dev
-            coverage: false
-          - compiler: gcc-13
-            cc: gcc-13
-            cxx: g++-13
-            packages: gcc-13 g++-13
-            coverage: true
-            gcov: gcov-13
-          - compiler: gcc-14
-            cc: gcc-14
-            cxx: g++-14
-            packages: gcc-14 g++-14
-            coverage: true
-            gcov: gcov-14
-          # gcc-15 comes from ppa:ubuntu-toolchain-r/test (not in the Ubuntu
-          # 24.04 archive); coverage stays on gcc-13/gcc-14 to keep gcov legs lean.
-          - compiler: gcc-15
-            cc: gcc-15
-            cxx: g++-15
-            packages: gcc-15 g++-15
-            coverage: false
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -58,8 +83,8 @@ jobs:
 
       # The action's key gets only a "ccache-" prefix and a trailing
       # timestamp, so the key itself must carry every matrix dimension
-      # (OS, compiler, backend) to keep the 24 jobs from colliding.
-      # Coverage legs are excluded: cache hits skip compilation, and the
+      # (OS, compiler, backend) to keep the matrix legs from colliding.
+      # The coverage leg is excluded: cache hits skip compilation, and the
       # .gcno notes gcov needs are only emitted when the compiler runs.
       - name: Setup ccache
         if: matrix.coverage == false
@@ -104,7 +129,7 @@ jobs:
               FLAGS="-DDAL_USE_XAD_AAD=off -DDAL_USE_CODIPACK_AAD=off -DDAL_USE_ADEPT_AAD=on" ;;
           esac
           # Python bindings are backend-agnostic — tested separately in
-          # the build-extended job so the 24-job matrix stays lean.
+          # the build-extended job so the matrix stays lean.
           FLAGS="$FLAGS -DDAL_BUILD_PYTHON=OFF"
           echo "ADDITIONAL_CMAKE_FLAGS=$FLAGS" >> $GITHUB_ENV
 
@@ -146,8 +171,9 @@ jobs:
             lcov --list coverage/lcov.info --ignore-errors empty
           fi
 
+      # Only one leg carries coverage (gcc-14/aadet) — see define-matrix.
       - name: Coveralls
-        if: matrix.coverage && matrix.compiler == 'gcc-14' && matrix.aad-backend == 'aadet'
+        if: matrix.coverage
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -193,9 +219,9 @@ jobs:
           ctest --test-dir build/Release-codipack --output-on-failure --parallel "$(nproc)" -LE benchmark
 
   # Extended build: dal-cpp + dal-public + dal-python.
-  # Lives in a separate job so the main 24-job compiler×backend matrix
-  # stays lean — the Python bindings are backend-agnostic, so testing
-  # them against one representative configuration is sufficient.
+  # Lives in a separate job so the main compiler×backend matrix stays
+  # lean — the Python bindings are backend-agnostic, so testing them
+  # against one representative configuration is sufficient.
   build-extended:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Build CoDiPack
         run: |
-          cmake --build build/Release-codipack --parallel 2
+          cmake --build build/Release-codipack --parallel "$(nproc)"
 
       - name: Test CoDiPack thread isolation
         run: |
@@ -190,7 +190,7 @@ jobs:
 
       - name: Test CoDiPack suite
         run: |
-          ctest --test-dir build/Release-codipack --output-on-failure -LE benchmark
+          ctest --test-dir build/Release-codipack --output-on-failure --parallel "$(nproc)" -LE benchmark
 
   # Extended build: dal-cpp + dal-public + dal-python.
   # Lives in a separate job so the main 24-job compiler×backend matrix
@@ -244,7 +244,7 @@ jobs:
 
       - name: Verify generated sources
         run: |
-          cmake --build build/Release-linux --target dal_check_generated --parallel 2
+          cmake --build build/Release-linux --target dal_check_generated --parallel "$(nproc)"
 
   documentation:
     name: Documentation integrity
@@ -304,7 +304,7 @@ jobs:
             -DDAL_USE_XAD_AAD=OFF \
             -DDAL_USE_CODIPACK_AAD=OFF \
             -DDAL_USE_ADEPT_AAD=OFF
-          cmake --build "$build_dir" --target dal_cpp dal_public --parallel 2
+          cmake --build "$build_dir" --target dal_cpp dal_public --parallel "$(nproc)"
 
   sanitizers:
     name: ${{ matrix.label }}
@@ -367,7 +367,7 @@ jobs:
           if [ -n '${{ matrix.public-filter }}' ]; then
             targets+=(dal_public_tests)
           fi
-          cmake --build "$build_dir" --target "${targets[@]}" --parallel 2
+          cmake --build "$build_dir" --target "${targets[@]}" --parallel "$(nproc)"
           echo "SANITIZER_BUILD_DIR=$build_dir" >> "$GITHUB_ENV"
 
       - name: Run focused core tests

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          ctest --test-dir build/Release-windows --output-on-failure --verbose -C Release
+          ctest --test-dir build/Release-windows --output-on-failure --parallel -C Release
 
       - name: Test installed CMake consumer
         shell: pwsh

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -142,7 +142,10 @@ cmake --install "$BUILD_DIR" --prefix "$INSTALL_DIR"
 
 # Benchmarks are registered as CTest tests (label "benchmark") so CI can discover
 # them; never run them in the default test pass, even under --benchmarks/--full.
-ctest_flags=(--test-dir "$BUILD_DIR" --output-on-failure -LE benchmark)
+# Tests are registered per gtest case via gtest_discover_tests; each case is an
+# independent process, so ctest can run them in parallel. The few file-writing
+# tests (src.csv / src.json / bad.json) use distinct filenames.
+ctest_flags=(--test-dir "$BUILD_DIR" --output-on-failure --parallel "$NUM_CORES" -LE benchmark)
 if [[ "${VERBOSE:-0}" == "1" ]]; then
     ctest_flags+=(--verbose)
 fi


### PR DESCRIPTION
## Summary
- Run ctest with `--parallel` in `build_linux.sh` and both CI workflows — the 1345 gtest cases are registered individually via `gtest_discover_tests` (independent processes), so they parallelize safely
- Replace hardcoded `cmake --build --parallel 2` with `--parallel $(nproc)` in the codipack-isolation, build-extended, warning-clean, and sanitizer jobs (ubuntu-latest runners have 4 vCPUs)
- Windows test step: drop `--verbose` in favor of `--output-on-failure --parallel`
- Generate the compiler × backend matrix via a `define-matrix` job: **push** events run a lean 8-leg subset (gcc-14 + clang-20 × 4 backends), **pull requests** still run the full 24-leg matrix
- Consolidate coverage from 8 gcov-instrumented legs to the single gcc-14/aadet leg that Coveralls consumes; all backends remain fully compiled and tested

## Test plan
- [x] Full parallel `ctest --parallel 8 -LE benchmark` run locally: 1345/1345 passed
- [x] Verified the only file-writing tests use distinct filenames (`src.csv`, `src.json`, `bad.json`) — no parallel collisions
- [x] Matrix generator simulated locally: push → 8 legs, pull_request → 24 legs, exactly one coverage leg in both
- [x] `bash -n build_linux.sh` and YAML syntax validation pass
- [x] First-round CI on this PR all green; wall-clock: Linux 13.6 → 11.5 min, Windows 13.8 → 8.9 min vs master baseline
- [ ] Second-round CI (this push) green with the generated matrix
