### PR TITLE
feat: add script product JSON and tree debug dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ here as the baseline rather than dated releases:
 
 ## 2026-08
 
+- `script`: Added two script-product debug dumps alongside the legacy
+  s-expression one: `DebugScriptProductJson` / `Product_DebugJson` emit a
+  versioned JSON AST (schema `dal.script-product/1`) for machine consumers
+  such as web front ends, and `DebugScriptProductTree` / `Product_DebugTree`
+  render a width-aware Unicode (or ASCII) tree for humans. Both include past
+  events and resolved variable/constant tables. See
+  `docs/methodology/script_engine.md` § Product Debug Outputs.
+
 - `web`: Removed `dal-web/` from this repository. The portfolio management web
   UI now lives at [wegamekinglc/dal-web](https://github.com/wegamekinglc/dal-web)
   and depends on the published `dal-python` PyPI package. The

--- a/dal-cpp/dal/script/event.cpp
+++ b/dal-cpp/dal/script/event.cpp
@@ -126,6 +126,103 @@ namespace Dal::Script {
         }
     }
 
+    void ScriptProduct_::DebugJson(std::ostream& ost) const {
+        ost << "{\"schema\":\"dal.script-product/1\"";
+        if (!variables_.empty()) {
+            ost << ",\"variables\":[";
+            for (size_t i = 0; i < variables_.size(); ++i) {
+                if (i)
+                    ost << ',';
+                ost << "{\"index\":" << i << ",\"name\":";
+                JsonWriteString(variables_[i], ost);
+                ost << '}';
+            }
+            ost << "],\"payoff_index\":" << payoffIdx_;
+        }
+        if (!consVariables_.empty()) {
+            ost << ",\"constants\":[";
+            for (size_t i = 0; i < consVariables_.size(); ++i) {
+                if (i)
+                    ost << ',';
+                ost << "{\"index\":" << i << ",\"name\":";
+                JsonWriteString(consVariables_[i], ost);
+                ost << ",\"value\":" << DebugNumber(consVariablesValues_[i]) << '}';
+            }
+            ost << ']';
+        }
+        ost << ",\"events\":[";
+        size_t eventId = 0;
+        size_t nodeId = 0;
+        bool firstEvent = true;
+        const auto dump = [&](const Vector_<Date_>& dates, const Vector_<Event_>& events, const char* phase) {
+            for (size_t i = 0; i < events.size(); ++i) {
+                if (!firstEvent)
+                    ost << ',';
+                firstEvent = false;
+                ost << "{\"index\":" << eventId++ << ",\"date\":\"" << Date::ToString(dates[i])
+                    << "\",\"phase\":\"" << phase << "\",\"statements\":[";
+                Debugger_ d;
+                for (size_t s = 0; s < events[i].size(); ++s) {
+                    if (s)
+                        ost << ',';
+                    events[i][s]->Accept(d);
+                    DebugNodeJson(d.Top(), nodeId, ost);
+                }
+                ost << "]}";
+            }
+        };
+        dump(pastEventDates_, pastEvents_, "past");
+        dump(eventDates_, events_, "future");
+        ost << "]}";
+    }
+
+    void ScriptProduct_::DebugTree(std::ostream& ost, bool ascii, int width) const {
+        const TreeStyle_& st = TreeStyle(ascii);
+        if (!variables_.empty()) {
+            ost << "Variables:";
+            for (size_t i = 0; i < variables_.size(); ++i) {
+                if (i)
+                    ost << ',';
+                ost << ' ' << variables_[i];
+                if (i == payoffIdx_)
+                    ost << '*';
+            }
+            ost << '\n';
+            if (!consVariables_.empty()) {
+                ost << "Constants:";
+                for (size_t i = 0; i < consVariables_.size(); ++i) {
+                    if (i)
+                        ost << ',';
+                    ost << ' ' << consVariables_[i] << '=' << DebugNumber(consVariablesValues_[i]);
+                }
+                ost << '\n';
+            }
+            ost << '\n';
+        }
+        size_t eventId = 0;
+        const auto dump = [&](const Vector_<Date_>& dates, const Vector_<Event_>& events, const char* phase) {
+            for (size_t i = 0; i < events.size(); ++i) {
+                const auto& statements = events[i];
+                ost << st.eventS << ' ' << ++eventId << ' ' << st.dotS << ' ' << Date::ToString(dates[i]) << ' '
+                    << st.dotS << ' ' << phase << '\n';
+                Debugger_ d;
+                for (size_t s = 0; s < statements.size(); ++s) {
+                    statements[s]->Accept(d);
+                    Vector_<String_> lines;
+                    const String_ first =
+                        String_(s + 1 == statements.size() ? st.elbow : st.tee) + "(" + String_(std::to_string(s + 1)) + ") ";
+                    const String_ cont = String_(s + 1 == statements.size() ? st.blank : st.pipe);
+                    DebugNodeTree(d.Top(), first, cont, st, width, lines);
+                    for (const auto& line : lines)
+                        ost << line << '\n';
+                }
+                ost << '\n';
+            }
+        };
+        dump(pastEventDates_, pastEvents_, "past");
+        dump(eventDates_, events_, "future");
+    }
+
     ScriptCompiled_ ScriptProduct_::Compile(bool fuzzy) const {
         REQUIRE2(preProcessed_, "product is not pre-processed: call PreProcess() before Compile()", ScriptError_);
 

--- a/dal-cpp/dal/script/event.cpp
+++ b/dal-cpp/dal/script/event.cpp
@@ -107,18 +107,75 @@ namespace Dal::Script {
         return maxNestedIfs;
     }
 
+    namespace {
+        //  A fresh debugger per statement: the IR of previous statements would
+        //  otherwise stay on the stack and grow the dump's footprint
+        void DumpEventsJson(const Vector_<Date_>& dates,
+                            const Vector_<Event_>& events,
+                            const char* phase,
+                            size_t& eventId,
+                            size_t& nodeId,
+                            bool& firstEvent,
+                            std::ostream& ost) {
+            for (size_t i = 0; i < events.size(); ++i) {
+                if (!firstEvent)
+                    ost << ',';
+                firstEvent = false;
+                ost << "{\"index\":" << eventId++ << ",\"date\":\"" << Date::ToString(dates[i])
+                    << "\",\"phase\":\"" << phase << "\",\"statements\":[";
+                for (size_t s = 0; s < events[i].size(); ++s) {
+                    if (s)
+                        ost << ',';
+                    Debugger_ d;
+                    events[i][s]->Accept(d);
+                    DebugNodeJson(d.Top(), nodeId, ost);
+                }
+                ost << "]}";
+            }
+        }
+
+        void DumpStatementTree(const Event_& statements, const TreeStyle_& st, int width, std::ostream& ost) {
+            for (size_t s = 0; s < statements.size(); ++s) {
+                Debugger_ d;
+                statements[s]->Accept(d);
+                Vector_<String_> lines;
+                const String_ first =
+                    String_(s + 1 == statements.size() ? st.elbow : st.tee) + "(" + String_(std::to_string(s + 1)) + ") ";
+                const String_ cont = String_(s + 1 == statements.size() ? st.blank : st.pipe);
+                DebugNodeTree(d.Top(), first, cont, st, width, lines);
+                for (const auto& line : lines)
+                    ost << line << '\n';
+            }
+        }
+
+        void DumpEventsTree(const Vector_<Date_>& dates,
+                            const Vector_<Event_>& events,
+                            const char* phase,
+                            size_t& eventId,
+                            const TreeStyle_& st,
+                            int width,
+                            std::ostream& ost) {
+            for (size_t i = 0; i < events.size(); ++i) {
+                ost << st.eventS << ' ' << ++eventId << ' ' << st.dotS << ' ' << Date::ToString(dates[i]) << ' '
+                    << st.dotS << ' ' << phase << '\n';
+                DumpStatementTree(events[i], st, width, ost);
+                ost << '\n';
+            }
+        }
+    } // namespace
+
     void ScriptProduct_::Debug(std::ostream& ost) const {
         size_t v = 0;
         for (auto& variable : variables_)
             ost << "Var[" << v++ << "] = " << variable << std::endl;
 
-        Debugger_ d;
         size_t e = 0;
         for (auto i = 0; i < events_.size(); ++i) {
             auto& evtIt = events_[i];
             ost << "EventTime_: " << Date::ToString(eventDates_[i]) << "\tEvent_: " << ++e << std::endl;
             unsigned s = 0;
             for (const auto& stat : evtIt) {
+                Debugger_ d;
                 stat->Accept(d);
                 ost << "Statement_: " << ++s << std::endl;
                 ost << d.String() << std::endl;
@@ -154,25 +211,8 @@ namespace Dal::Script {
         size_t eventId = 0;
         size_t nodeId = 0;
         bool firstEvent = true;
-        const auto dump = [&](const Vector_<Date_>& dates, const Vector_<Event_>& events, const char* phase) {
-            for (size_t i = 0; i < events.size(); ++i) {
-                if (!firstEvent)
-                    ost << ',';
-                firstEvent = false;
-                ost << "{\"index\":" << eventId++ << ",\"date\":\"" << Date::ToString(dates[i])
-                    << "\",\"phase\":\"" << phase << "\",\"statements\":[";
-                Debugger_ d;
-                for (size_t s = 0; s < events[i].size(); ++s) {
-                    if (s)
-                        ost << ',';
-                    events[i][s]->Accept(d);
-                    DebugNodeJson(d.Top(), nodeId, ost);
-                }
-                ost << "]}";
-            }
-        };
-        dump(pastEventDates_, pastEvents_, "past");
-        dump(eventDates_, events_, "future");
+        DumpEventsJson(pastEventDates_, pastEvents_, "past", eventId, nodeId, firstEvent, ost);
+        DumpEventsJson(eventDates_, events_, "future", eventId, nodeId, firstEvent, ost);
         ost << "]}";
     }
 
@@ -200,27 +240,8 @@ namespace Dal::Script {
             ost << '\n';
         }
         size_t eventId = 0;
-        const auto dump = [&](const Vector_<Date_>& dates, const Vector_<Event_>& events, const char* phase) {
-            for (size_t i = 0; i < events.size(); ++i) {
-                const auto& statements = events[i];
-                ost << st.eventS << ' ' << ++eventId << ' ' << st.dotS << ' ' << Date::ToString(dates[i]) << ' '
-                    << st.dotS << ' ' << phase << '\n';
-                Debugger_ d;
-                for (size_t s = 0; s < statements.size(); ++s) {
-                    statements[s]->Accept(d);
-                    Vector_<String_> lines;
-                    const String_ first =
-                        String_(s + 1 == statements.size() ? st.elbow : st.tee) + "(" + String_(std::to_string(s + 1)) + ") ";
-                    const String_ cont = String_(s + 1 == statements.size() ? st.blank : st.pipe);
-                    DebugNodeTree(d.Top(), first, cont, st, width, lines);
-                    for (const auto& line : lines)
-                        ost << line << '\n';
-                }
-                ost << '\n';
-            }
-        };
-        dump(pastEventDates_, pastEvents_, "past");
-        dump(eventDates_, events_, "future");
+        DumpEventsTree(pastEventDates_, pastEvents_, "past", eventId, st, width, ost);
+        DumpEventsTree(eventDates_, events_, "future", eventId, st, width, ost);
     }
 
     ScriptCompiled_ ScriptProduct_::Compile(bool fuzzy) const {

--- a/dal-cpp/dal/script/event.hpp
+++ b/dal-cpp/dal/script/event.hpp
@@ -157,6 +157,10 @@ namespace Dal::Script {
 
         size_t PreProcess(bool fuzzy, bool skip_domain);
         void Debug(std::ostream& ost = std::cout) const;
+        //  Machine-friendly JSON dump, schema dal.script-product/1; includes past events
+        void DebugJson(std::ostream& ost = std::cout) const;
+        //  Human-friendly tree dump; `width` caps the line width, `ascii` selects the fallback style
+        void DebugTree(std::ostream& ost = std::cout, bool ascii = false, int width = 125) const;
         [[nodiscard]] ScriptCompiled_ Compile(bool fuzzy = false) const;
 
         [[nodiscard]] auto PayOffIdx() const { return payoffIdx_; }

--- a/dal-cpp/dal/script/visitor/debugger.hpp
+++ b/dal-cpp/dal/script/visitor/debugger.hpp
@@ -6,7 +6,9 @@
 
 #include <cmath>
 #include <iomanip>
+#include <map>
 #include <sstream>
+#include <utility>
 
 #include <dal/platform/platform.hpp>
 #include <dal/math/stacks.hpp>
@@ -71,74 +73,99 @@ namespace Dal::Script {
         static const char* HEX = "0123456789abcdef";
         ost << '"';
         for (const char raw : src) {
-            switch (raw) {
+            const auto byte = static_cast<unsigned char>(raw);
+            switch (byte) {
             case '"': ost << "\\\""; break;
             case '\\': ost << "\\\\"; break;
             case '\n': ost << "\\n"; break;
             case '\r': ost << "\\r"; break;
             case '\t': ost << "\\t"; break;
             default:
-                if (raw >= 0x20)
+                //  Bytes from 0x20 up pass through: JSON strings are UTF-8, so
+                //  multi-byte sequences must not be \u-escaped byte by byte
+                if (byte >= 0x20)
                     ost << raw;
-                else {
-                    const auto val = static_cast<unsigned char>(raw);
-                    ost << "\\u00" << HEX[val >> 4] << HEX[val & 0xf];
-                }
+                else
+                    ost << "\\u00" << HEX[byte >> 4] << HEX[byte & 0xf];
                 break;
             }
         }
         ost << '"';
     }
 
-    //  Machine-friendly JSON; ids are pre-order and unique per dump.
-    inline void DebugNodeJson(const DebugNode_& node, size_t& id, std::ostream& ost) {
-        ost << "{\"id\":\"n" << id++ << "\",\"kind\":";
-        JsonWriteString(node.kind, ost);
+    inline void DebugNodeJson(const DebugNode_& node, size_t& id, std::ostream& ost);
+
+    inline void JsonWriteChildren(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        ost << ",\"children\":[";
+        for (size_t i = 0; i < node.children.size(); ++i) {
+            if (i)
+                ost << ',';
+            DebugNodeJson(node.children[i], id, ost);
+        }
+        ost << ']';
+    }
+
+    inline void JsonWriteIf(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
+        ost << ",\"condition\":";
+        DebugNodeJson(node.children[0], id, ost);
+        ost << ",\"then\":[";
+        for (size_t i = 1; i < firstElse; ++i) {
+            if (i > 1)
+                ost << ',';
+            DebugNodeJson(node.children[i], id, ost);
+        }
+        ost << "],\"else\":[";
+        for (size_t i = firstElse; i < node.children.size(); ++i) {
+            if (i > firstElse)
+                ost << ',';
+            DebugNodeJson(node.children[i], id, ost);
+        }
+        ost << ']';
+    }
+
+    //  Writes the kind-specific fields; returns false when the kind takes only children
+    inline bool JsonWriteFields(const DebugNode_& node, size_t& id, std::ostream& ost) {
         const String_& k = node.kind;
         if (k == "if") {
-            const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
-            ost << ",\"condition\":";
-            DebugNodeJson(node.children[0], id, ost);
-            ost << ",\"then\":[";
-            for (size_t i = 1; i < firstElse; ++i) {
-                if (i > 1)
-                    ost << ',';
-                DebugNodeJson(node.children[i], id, ost);
-            }
-            ost << "],\"else\":[";
-            for (size_t i = firstElse; i < node.children.size(); ++i) {
-                if (i > firstElse)
-                    ost << ',';
-                DebugNodeJson(node.children[i], id, ost);
-            }
-            ost << ']';
-        } else if (k == "assign" || k == "pays") {
+            JsonWriteIf(node, id, ost);
+            return true;
+        }
+        if (k == "assign" || k == "pays") {
             ost << ",\"target\":";
             DebugNodeJson(node.children[0], id, ost);
             ost << ",\"value\":";
             DebugNodeJson(node.children[1], id, ost);
-        } else if (k == "var" || k == "const_var") {
+            return true;
+        }
+        if (k == "var" || k == "const_var") {
             ost << ",\"name\":";
             JsonWriteString(node.name, ost);
             ost << ",\"index\":" << node.index << (k == "var" ? ",\"const_value\":" : ",\"value\":")
                 << DebugNumber(node.number);
-        } else if (k == "const") {
+            return true;
+        }
+        if (k == "const") {
             ost << ",\"value\":" << DebugNumber(node.number);
-        } else if (k == "eq0" || k == "gt0" || k == "ge0") {
+            return true;
+        }
+        if (k == "eq0" || k == "gt0" || k == "ge0") {
             if (node.discrete)
                 ost << ",\"mode\":\"discrete\",\"lb\":" << DebugNumber(node.lb) << ",\"rb\":" << DebugNumber(node.rb);
             else
                 ost << ",\"mode\":\"continuous\",\"eps\":" << DebugNumber(node.number);
+            JsonWriteChildren(node, id, ost);
+            return true;
         }
-        if (k != "if" && k != "assign" && k != "pays" && !node.children.empty()) {
-            ost << ",\"children\":[";
-            for (size_t i = 0; i < node.children.size(); ++i) {
-                if (i)
-                    ost << ',';
-                DebugNodeJson(node.children[i], id, ost);
-            }
-            ost << ']';
-        }
+        return false;
+    }
+
+    //  Machine-friendly JSON; ids are pre-order and unique per dump.
+    inline void DebugNodeJson(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        ost << "{\"id\":\"n" << id++ << "\",\"kind\":";
+        JsonWriteString(node.kind, ost);
+        if (!JsonWriteFields(node, id, ost) && !node.children.empty())
+            JsonWriteChildren(node, id, ost);
         ost << '}';
     }
 
@@ -193,6 +220,16 @@ namespace Dal::Script {
     }
 
     //  UTF-8 aware display width, doubling the CJK and emoji ranges.
+    inline bool IsWideCodePoint(unsigned codePoint) {
+        static const std::pair<unsigned, unsigned> WIDE[] = {{0x1100, 0x115F}, {0x2E80, 0xA4CF}, {0xAC00, 0xD7A3},
+                                                             {0xF900, 0xFAFF}, {0xFE30, 0xFE6F}, {0xFF00, 0xFF60},
+                                                             {0x1F300, 0x1F64F}, {0x1F900, 0x1F9FF}};
+        for (const auto& range : WIDE)
+            if (codePoint >= range.first && codePoint <= range.second)
+                return true;
+        return false;
+    }
+
     inline size_t DisplayWidth(const String_& src) {
         size_t width = 0;
         for (size_t i = 0; i < src.size();) {
@@ -215,41 +252,28 @@ namespace Dal::Script {
             for (size_t j = 1; j < length && i + j < src.size(); ++j)
                 codePoint = (codePoint << 6) | (static_cast<unsigned char>(src[i + j]) & 0x3F);
             i += length;
-            const bool wide = (codePoint >= 0x1100 && codePoint <= 0x115F) || (codePoint >= 0x2E80 && codePoint <= 0xA4CF) ||
-                              (codePoint >= 0xAC00 && codePoint <= 0xD7A3) || (codePoint >= 0xF900 && codePoint <= 0xFAFF) ||
-                              (codePoint >= 0xFE30 && codePoint <= 0xFE6F) || (codePoint >= 0xFF00 && codePoint <= 0xFF60) ||
-                              (codePoint >= 0x1F300 && codePoint <= 0x1F64F) ||
-                              (codePoint >= 0x1F900 && codePoint <= 0x1F9FF);
-            width += wide ? 2 : 1;
+            width += IsWideCodePoint(codePoint) ? 2 : 1;
         }
         return width;
     }
 
     inline int TreePrec(const String_& kind) {
-        if (kind == "assign" || kind == "pays" || kind == "if" || kind == "collect")
-            return 0;
-        if (kind == "or")
-            return 1;
-        if (kind == "and")
-            return 2;
-        if (kind == "eq0" || kind == "gt0" || kind == "ge0")
-            return 3;
-        if (kind == "add" || kind == "sub")
-            return 4;
-        if (kind == "mul" || kind == "div")
-            return 5;
-        if (kind == "not" || kind == "neg" || kind == "uplus")
-            return 6;
-        if (kind == "pow")
-            return 7;
-        return 8;
+        static const std::map<String_, int> PRECEDENCE = {
+            {"assign", 0}, {"pays", 0},     {"if", 0},      {"collect", 0}, {"or", 1},   {"and", 2},
+            {"eq0", 3},    {"gt0", 3},      {"ge0", 3},     {"add", 4},     {"sub", 4},  {"mul", 5},
+            {"div", 5},    {"not", 6},      {"neg", 6},     {"uplus", 6},   {"pow", 7}};
+        const auto found = PRECEDENCE.find(kind);
+        return found == PRECEDENCE.end() ? 8 : found->second;
     }
 
     inline String_ TreeInline(const DebugNode_& node, const TreeStyle_& st);
 
     inline String_ TreeParen(const DebugNode_& child, const TreeStyle_& st, int context) {
         const String_ inner = TreeInline(child, st);
-        return TreePrec(child.kind) < context ? String_("(") + inner + ")" : inner;
+        //  An if/return keeps both branches String_ — a ternary would mix base_t and String_
+        if (TreePrec(child.kind) >= context)
+            return inner;
+        return String_("(") + inner + ")";
     }
 
     inline String_ FuzzySuffix(const DebugNode_& node, const TreeStyle_& st) {
@@ -261,59 +285,106 @@ namespace Dal::Script {
         return String_();
     }
 
-    inline String_ TreeInline(const DebugNode_& node, const TreeStyle_& st) {
+    inline bool TreeInlineLeaf(const DebugNode_& node, const TreeStyle_& st, String_& out) {
+        if (node.kind == "const")
+            out = DebugNumber(node.number);
+        else if (node.kind == "var" || node.kind == "const_var")
+            out = node.name;
+        else if (node.kind == "spot")
+            out = String_("spot()");
+        else if (node.kind == "true" || node.kind == "false")
+            out = String_(node.kind == "true" ? st.trueS : st.falseS);
+        else
+            return false;
+        return true;
+    }
+
+    inline bool TreeInlineUnary(const DebugNode_& node, const TreeStyle_& st, String_& out) {
         const String_& k = node.kind;
-        if (k == "const")
-            return DebugNumber(node.number);
-        if (k == "var" || k == "const_var")
-            return node.name;
-        if (k == "spot")
-            return String_("spot()");
-        if (k == "true" || k == "false")
-            return String_(k == "true" ? st.trueS : st.falseS);
-        if (k == "uplus")
-            return TreeParen(node.children[0], st, 6);
-        if (k == "neg") {
-            const String_ operand = TreeInline(node.children[0], st);
-            return node.children[0].kind == "neg" ? String_(st.negate) + "(" + operand + ")"
-                                                  : String_(st.negate) + TreeParen(node.children[0], st, 7);
+        if (k == "log" || k == "exp" || k == "sqrt") {
+            out = String_(k == "log" ? st.logS : k == "exp" ? st.expS : st.sqrtS) + "(" +
+                  TreeInline(node.children[0], st) + ")";
+            return true;
         }
-        if (k == "log" || k == "exp" || k == "sqrt")
-            return String_(k == "log" ? st.logS : k == "exp" ? st.expS : st.sqrtS) + "(" +
-                   TreeInline(node.children[0], st) + ")";
-        if (k == "add" || k == "sub" || k == "mul" || k == "div" || k == "pow") {
-            const char* op = k == "add" ? st.plus : k == "sub" ? st.minus : k == "mul" ? st.times
-                          : k == "div" ? st.over : st.power;
-            const int prec = TreePrec(k);
-            //  Context bumps keep a − (b − c), a ÷ (b ÷ c) and (a ^ b) ^ c unambiguous
-            const int leftContext = k == "pow" ? 8 : prec;
-            return TreeParen(node.children[0], st, leftContext) + " " + op + " " +
-                   TreeParen(node.children[1], st, prec + 1);
+        if (k == "uplus") {
+            out = TreeParen(node.children[0], st, 6);
+            return true;
         }
-        if (k == "max" || k == "min") {
-            String_ rtn = String_(k == "max" ? st.maxS : st.minS) + "(" + TreeInline(node.children[0], st);
-            for (size_t i = 1; i < node.children.size(); ++i)
-                rtn += ", " + TreeInline(node.children[i], st);
-            return rtn + ")";
+        if (k != "neg")
+            return false;
+        //  Parenthesize a nested neg (avoid "−−x") and a pow operand (avoid the
+        //  "−a ^ b" ambiguity between −(a ^ b) and (−a) ^ b)
+        if (node.children[0].kind == "neg")
+            out = String_(st.negate) + "(" + TreeInline(node.children[0], st) + ")";
+        else
+            out = String_(st.negate) + TreeParen(node.children[0], st, 8);
+        return true;
+    }
+
+    inline bool TreeInlineCall(const DebugNode_& node, const TreeStyle_& st, String_& out) {
+        if (node.kind != "max" && node.kind != "min")
+            return false;
+        out = String_(node.kind == "max" ? st.maxS : st.minS) + "(" + TreeInline(node.children[0], st);
+        for (size_t i = 1; i < node.children.size(); ++i)
+            out += ", " + TreeInline(node.children[i], st);
+        out += ")";
+        return true;
+    }
+
+    inline const char* BinarySymbol(const String_& kind, const TreeStyle_& st) {
+        if (kind == "add")
+            return st.plus;
+        if (kind == "sub")
+            return st.minus;
+        if (kind == "mul")
+            return st.times;
+        return kind == "div" ? st.over : st.power;
+    }
+
+    inline bool TreeInlineBinary(const DebugNode_& node, const TreeStyle_& st, String_& out) {
+        const String_& k = node.kind;
+        if (k != "add" && k != "sub" && k != "mul" && k != "div" && k != "pow")
+            return false;
+        const int prec = TreePrec(k);
+        //  Context bumps keep a − (b − c), a ÷ (b ÷ c) and (a ^ b) ^ c unambiguous
+        const int leftContext = k == "pow" ? 8 : prec;
+        out = TreeParen(node.children[0], st, leftContext) + " " + BinarySymbol(k, st) + " " +
+              TreeParen(node.children[1], st, prec + 1);
+        return true;
+    }
+
+    inline bool TreeInlineLogical(const DebugNode_& node, const TreeStyle_& st, String_& out) {
+        const String_& k = node.kind;
+        if (k == "not") {
+            out = String_(st.notS) + TreeParen(node.children[0], st, 7);
+            return true;
         }
-        if (k == "eq0" || k == "gt0" || k == "ge0") {
-            const char* op = k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS;
-            const DebugNode_& operand = node.children[0];
-            //  Comparisons are normalized to expr OP 0; fold the subtraction back to lhs OP rhs
-            const String_ comparison = operand.kind == "sub"
-                ? TreeParen(operand.children[0], st, 3) + " " + op + " " + TreeParen(operand.children[1], st, 3)
-                : TreeParen(operand, st, 3) + " " + op + " 0";
-            return comparison + FuzzySuffix(node, st);
-        }
-        if (k == "and" || k == "or") {
-            const int prec = TreePrec(k);
-            String_ rtn = TreeParen(node.children[0], st, prec);
-            for (size_t i = 1; i < node.children.size(); ++i)
-                rtn += String_(" ") + (k == "and" ? st.andS : st.orS) + " " + TreeParen(node.children[i], st, prec);
-            return rtn;
-        }
-        if (k == "not")
-            return String_(st.notS) + TreeParen(node.children[0], st, 7);
+        if (k != "and" && k != "or")
+            return false;
+        const int prec = TreePrec(k);
+        out = TreeParen(node.children[0], st, prec);
+        for (size_t i = 1; i < node.children.size(); ++i)
+            out += String_(" ") + (k == "and" ? st.andS : st.orS) + " " + TreeParen(node.children[i], st, prec);
+        return true;
+    }
+
+    inline bool TreeInlineCompare(const DebugNode_& node, const TreeStyle_& st, String_& out) {
+        const String_& k = node.kind;
+        if (k != "eq0" && k != "gt0" && k != "ge0")
+            return false;
+        const char* op = k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS;
+        const DebugNode_& operand = node.children[0];
+        //  Comparisons are normalized to expr OP 0; fold the subtraction back to lhs OP rhs
+        if (operand.kind == "sub")
+            out = TreeParen(operand.children[0], st, 3) + " " + op + " " + TreeParen(operand.children[1], st, 3);
+        else
+            out = TreeParen(operand, st, 3) + " " + op + " 0";
+        out += FuzzySuffix(node, st);
+        return true;
+    }
+
+    inline String_ TreeInlineStatement(const DebugNode_& node, const TreeStyle_& st) {
+        const String_& k = node.kind;
         if (k == "assign" || k == "pays")
             return TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS) + " " +
                    TreeInline(node.children[1], st);
@@ -336,75 +407,115 @@ namespace Dal::Script {
         return rtn;
     }
 
+    //  Best-effort single-line form; parens follow minimal-precedence rules.
+    inline String_ TreeInline(const DebugNode_& node, const TreeStyle_& st) {
+        String_ out;
+        if (TreeInlineLeaf(node, st, out) || TreeInlineUnary(node, st, out) || TreeInlineCall(node, st, out) ||
+            TreeInlineBinary(node, st, out) || TreeInlineLogical(node, st, out) || TreeInlineCompare(node, st, out))
+            return out;
+        return TreeInlineStatement(node, st);
+    }
+
+    //  A child of an overflowing node, with its branch prefix and connector mode
+    struct TreeBranch_ {
+        const DebugNode_* node;
+        String_ marker;
+        bool connected;
+    };
+
+    //  Fills the statement-family header (assign, pays, if); false for other kinds
+    inline bool TreeBranchStatement(const DebugNode_& node, const String_& first, const TreeStyle_& st, size_t width,
+                                    String_& header, Vector_<TreeBranch_>& branches) {
+        const String_& k = node.kind;
+        if (k == "assign" || k == "pays") {
+            header = first + TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS);
+            branches.push_back(TreeBranch_{&node.children[1], String_(), true});
+            return true;
+        }
+        if (k != "if")
+            return false;
+        const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
+        const String_ condInline = TreeInline(node.children[0], st);
+        if (DisplayWidth(first + "if " + condInline + " then") <= width)
+            header = first + "if " + condInline + " then";
+        else {
+            header = first + "if";
+            branches.push_back(TreeBranch_{&node.children[0], String_(st.condS), false});
+        }
+        for (size_t i = 1; i < firstElse; ++i)
+            branches.push_back(TreeBranch_{&node.children[i], String_(st.thenS), false});
+        for (size_t i = firstElse; i < node.children.size(); ++i)
+            branches.push_back(TreeBranch_{&node.children[i], String_(st.elseS), false});
+        return true;
+    }
+
+    inline const char* UnarySymbol(const String_& kind, const TreeStyle_& st) {
+        if (kind == "not")
+            return st.notS;
+        if (kind == "neg")
+            return st.negate;
+        if (kind == "uplus")
+            return "+";
+        if (kind == "log")
+            return st.logS;
+        if (kind == "exp")
+            return st.expS;
+        return st.sqrtS;
+    }
+
+    //  Fills the single-operand header (comparisons and unary operators); false for other kinds
+    inline bool TreeBranchValue(const DebugNode_& node, const String_& first, const TreeStyle_& st, String_& header,
+                                Vector_<TreeBranch_>& branches) {
+        const String_& k = node.kind;
+        if (k == "eq0" || k == "gt0" || k == "ge0")
+            header = first + (k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS) + FuzzySuffix(node, st);
+        else if (k == "not" || k == "neg" || k == "uplus" || k == "log" || k == "exp" || k == "sqrt")
+            header = first + UnarySymbol(k, st);
+        else
+            return false;
+        branches.push_back(TreeBranch_{&node.children[0], String_(), true});
+        return true;
+    }
+
+    //  Fills the header for everything else: binary operators, max/min, collect
+    inline void TreeBranchOperators(const DebugNode_& node, const String_& first, const TreeStyle_& st, String_& header,
+                                    Vector_<TreeBranch_>& branches) {
+        const String_& k = node.kind;
+        if (k == "max" || k == "min")
+            header = first + (k == "max" ? st.maxS : st.minS);
+        else if (k == "collect")
+            header = first;
+        else if (k == "add" || k == "sub" || k == "mul" || k == "div" || k == "pow")
+            header = first + BinarySymbol(k, st);
+        else
+            header = first + k;
+        for (const auto& child : node.children)
+            branches.push_back(TreeBranch_{&child, String_(), true});
+    }
+
     //  Human-friendly tree block: inline while it fits the width budget, branches below otherwise.
     //  `first` prefixes the node's own line, `cont` prefixes every continuation line.
     inline void DebugNodeTree(const DebugNode_& node, const String_& first, const String_& cont, const TreeStyle_& st,
                               size_t width, Vector_<String_>& out) {
         const String_ whole = first + TreeInline(node, st);
-        if (DisplayWidth(whole) <= width) {
-            out.push_back(whole);
-            return;
-        }
-        if (node.children.empty()) {
-            //  An oversized leaf has nothing to branch on
+        //  Inline when it fits; an oversized leaf has nothing to branch on
+        if (DisplayWidth(whole) <= width || node.children.empty()) {
             out.push_back(whole);
             return;
         }
 
-        struct Branch_ {
-            const DebugNode_* node;
-            String_ marker;
-            bool connected;
-        };
-        const String_& k = node.kind;
         String_ header = first;
-        Vector_<Branch_> branches;
-        const auto add = [&](const DebugNode_& child, const char* marker, bool connected) {
-            branches.push_back(Branch_{&child, String_(marker), connected});
-        };
-
-        if (k == "assign" || k == "pays") {
-            header = first + TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS);
-            add(node.children[1], "", true);
-        } else if (k == "if") {
-            const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
-            const String_ condInline = TreeInline(node.children[0], st);
-            if (DisplayWidth(first + "if " + condInline + " then") <= width)
-                header = first + "if " + condInline + " then";
-            else {
-                header = first + "if";
-                add(node.children[0], st.condS, false);
-            }
-            for (size_t i = 1; i < firstElse; ++i)
-                add(node.children[i], st.thenS, false);
-            for (size_t i = firstElse; i < node.children.size(); ++i)
-                add(node.children[i], st.elseS, false);
-        } else if (k == "eq0" || k == "gt0" || k == "ge0") {
-            const char* op = k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS;
-            header = first + op + FuzzySuffix(node, st);
-            add(node.children[0], "", true);
-        } else if (k == "not" || k == "neg" || k == "uplus" || k == "log" || k == "exp" || k == "sqrt") {
-            header = first + (k == "not" ? st.notS : k == "neg" ? st.negate : k == "uplus" ? "+" : k == "log" ? st.logS
-                             : k == "exp" ? st.expS : st.sqrtS);
-            add(node.children[0], "", true);
-        } else if (k == "max" || k == "min" || k == "collect") {
-            header = first + (k == "max" ? st.maxS : k == "min" ? st.minS : "");
-            for (const auto& child : node.children)
-                add(child, "", true);
-        } else {
-            //  Binary operators and any unlisted interior kind
-            header = first + (k == "add" ? st.plus : k == "sub" ? st.minus : k == "mul" ? st.times
-                        : k == "div" ? st.over : k == "pow" ? st.power : k.c_str());
-            for (const auto& child : node.children)
-                add(child, "", true);
-        }
+        Vector_<TreeBranch_> branches;
+        if (!TreeBranchStatement(node, first, st, width, header, branches) &&
+            !TreeBranchValue(node, first, st, header, branches))
+            TreeBranchOperators(node, first, st, header, branches);
 
         out.push_back(header);
         for (size_t i = 0; i < branches.size(); ++i) {
             const bool last = i + 1 == branches.size();
-            const Branch_& branch = branches[i];
-            const String_ branchFirst = branch.connected ? cont + (last ? st.elbow : st.tee) + branch.marker
-                                                         : cont + branch.marker;
+            const TreeBranch_& branch = branches[i];
+            const String_ branchFirst =
+                branch.connected ? cont + (last ? st.elbow : st.tee) + branch.marker : cont + branch.marker;
             const String_ branchCont =
                 branch.connected ? cont + (last ? st.blank : st.pipe) : cont + String_(DisplayWidth(branch.marker), ' ');
             DebugNodeTree(*branch.node, branchFirst, branchCont, st, width, out);

--- a/dal-cpp/dal/script/visitor/debugger.hpp
+++ b/dal-cpp/dal/script/visitor/debugger.hpp
@@ -4,133 +4,526 @@
 
 #pragma once
 
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
 #include <dal/platform/platform.hpp>
 #include <dal/math/stacks.hpp>
 #include <dal/script/node.hpp>
 #include <dal/script/visitor.hpp>
 
-
 namespace Dal::Script {
+    //  Debug IR: one entry per AST node, produced by Debugger_.  The legacy
+    //  s-expression label feeds the text renderer; kind and the structured
+    //  fields feed the JSON and tree renderers.
+    struct DebugNode_ {
+        String_ label;
+        String_ kind;
+        String_ name;          //  var, const_var
+        int index = -1;        //  var, const_var
+        int firstElse = -1;    //  if
+        double number = 0.0;   //  const / const_var value, comparison eps
+        double lb = 0.0;       //  discrete comparison bounds
+        double rb = 0.0;
+        bool discrete = false; //  comparison mode
+        Vector_<DebugNode_> children;
+    };
+
+    //  Shortest decimal representation that round-trips.
+    inline String_ DebugNumber(double src) {
+        if (!std::isfinite(src))
+            return String_("null");
+        for (int precision : {6, 9, 12, 17}) {
+            std::ostringstream ost;
+            ost << std::setprecision(precision) << src;
+            const String_ text(ost.str());
+            if (String::IsNumber(text) && String::ToDouble(text) == src)
+                return text;
+        }
+        return String_(std::to_string(src));
+    }
+
+    //  Legacy s-expression text, byte-identical with the pre-IR debugger.
+    inline void DebugNodeText(const DebugNode_& node, size_t depth, std::ostream& ost) {
+        for (size_t i = 0; i < depth; ++i)
+            ost << '\t';
+        ost << node.label;
+        if (node.children.empty()) {
+            ost << '\n';
+            return;
+        }
+        ost << "(\n";
+        for (size_t i = 0; i < node.children.size(); ++i) {
+            DebugNodeText(node.children[i], depth + 1, ost);
+            if (i + 1 < node.children.size()) {
+                for (size_t d = 0; d < depth; ++d)
+                    ost << '\t';
+                ost << ",\n";
+            }
+        }
+        for (size_t i = 0; i < depth; ++i)
+            ost << '\t';
+        ost << ")\n";
+    }
+
+    inline void JsonWriteString(const String_& src, std::ostream& ost) {
+        static const char* HEX = "0123456789abcdef";
+        ost << '"';
+        for (const char raw : src) {
+            switch (raw) {
+            case '"': ost << "\\\""; break;
+            case '\\': ost << "\\\\"; break;
+            case '\n': ost << "\\n"; break;
+            case '\r': ost << "\\r"; break;
+            case '\t': ost << "\\t"; break;
+            default:
+                if (raw >= 0x20)
+                    ost << raw;
+                else {
+                    const auto val = static_cast<unsigned char>(raw);
+                    ost << "\\u00" << HEX[val >> 4] << HEX[val & 0xf];
+                }
+                break;
+            }
+        }
+        ost << '"';
+    }
+
+    //  Machine-friendly JSON; ids are pre-order and unique per dump.
+    inline void DebugNodeJson(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        ost << "{\"id\":\"n" << id++ << "\",\"kind\":";
+        JsonWriteString(node.kind, ost);
+        const String_& k = node.kind;
+        if (k == "if") {
+            const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
+            ost << ",\"condition\":";
+            DebugNodeJson(node.children[0], id, ost);
+            ost << ",\"then\":[";
+            for (size_t i = 1; i < firstElse; ++i) {
+                if (i > 1)
+                    ost << ',';
+                DebugNodeJson(node.children[i], id, ost);
+            }
+            ost << "],\"else\":[";
+            for (size_t i = firstElse; i < node.children.size(); ++i) {
+                if (i > firstElse)
+                    ost << ',';
+                DebugNodeJson(node.children[i], id, ost);
+            }
+            ost << ']';
+        } else if (k == "assign" || k == "pays") {
+            ost << ",\"target\":";
+            DebugNodeJson(node.children[0], id, ost);
+            ost << ",\"value\":";
+            DebugNodeJson(node.children[1], id, ost);
+        } else if (k == "var" || k == "const_var") {
+            ost << ",\"name\":";
+            JsonWriteString(node.name, ost);
+            ost << ",\"index\":" << node.index << (k == "var" ? ",\"const_value\":" : ",\"value\":")
+                << DebugNumber(node.number);
+        } else if (k == "const") {
+            ost << ",\"value\":" << DebugNumber(node.number);
+        } else if (k == "eq0" || k == "gt0" || k == "ge0") {
+            if (node.discrete)
+                ost << ",\"mode\":\"discrete\",\"lb\":" << DebugNumber(node.lb) << ",\"rb\":" << DebugNumber(node.rb);
+            else
+                ost << ",\"mode\":\"continuous\",\"eps\":" << DebugNumber(node.number);
+        }
+        if (k != "if" && k != "assign" && k != "pays" && !node.children.empty()) {
+            ost << ",\"children\":[";
+            for (size_t i = 0; i < node.children.size(); ++i) {
+                if (i)
+                    ost << ',';
+                DebugNodeJson(node.children[i], id, ost);
+            }
+            ost << ']';
+        }
+        ost << '}';
+    }
+
+    //  Tree rendering symbols; the ascii set keeps constrained consoles readable.
+    struct TreeStyle_ {
+        const char* tee;     //  "├── "
+        const char* elbow;   //  "└── "
+        const char* pipe;    //  "│   "
+        const char* blank;   //  "    "
+        const char* plus;    //  "+"
+        const char* minus;   //  "−"
+        const char* times;   //  "×"
+        const char* over;    //  "÷"
+        const char* power;   //  "^"
+        const char* negate;  //  "−"
+        const char* logS;    //  "ln"
+        const char* expS;    //  "exp"
+        const char* sqrtS;   //  "√"
+        const char* maxS;    //  "max"
+        const char* minS;    //  "min"
+        const char* eqS;     //  "="
+        const char* gtS;     //  ">"
+        const char* geS;     //  "≥"
+        const char* andS;    //  "∧"
+        const char* orS;     //  "∨"
+        const char* notS;    //  "¬"
+        const char* trueS;   //  "⊤"
+        const char* falseS;  //  "⊥"
+        const char* assignS; //  "←"
+        const char* paysS;   //  "⇐"
+        const char* thenS;   //  "▶ "
+        const char* elseS;   //  "▷ "
+        const char* condS;   //  "? "
+        const char* eventS;  //  "📅"
+        const char* dotS;    //  "·"
+        const char* lAng;    //  "⟨"
+        const char* rAng;    //  "⟩"
+        const char* epsS;    //  "ε"
+    };
+
+    inline const TreeStyle_& TreeStyle(bool ascii) {
+        struct Styles_ {
+            TreeStyle_ unicode{"├── ", "└── ", "│   ", "    ", "+",  "−", "×", "÷", "^",  "−",  "ln",   "exp", "√",
+                               "max", "min", "=",   ">",   "≥",  "∧", "∨", "¬", "⊤", "⊥",  "←",   "⇐",   "▶ ",
+                               "▷ ",  "? ",  "📅",  "·",   "⟨",  "⟩", "ε"};
+            TreeStyle_ ascii{"|-- ", "`-- ", "|   ", "    ", "+", "-", "*", "/", "^", "-", "ln", "exp", "sqrt",
+                             "max", "min", "=", ">", ">=", "and", "or", "not", "true", "false", "<-", "<=", "> ",
+                             ". ", "? ", "#", "@", "<", ">", "eps"};
+        };
+        static const Styles_ styles;
+        return ascii ? styles.ascii : styles.unicode;
+    }
+
+    //  UTF-8 aware display width, doubling the CJK and emoji ranges.
+    inline size_t DisplayWidth(const String_& src) {
+        size_t width = 0;
+        for (size_t i = 0; i < src.size();) {
+            const auto lead = static_cast<unsigned char>(src[i]);
+            unsigned codePoint;
+            size_t length;
+            if (lead < 0x80) {
+                codePoint = lead;
+                length = 1;
+            } else if ((lead & 0xE0) == 0xC0) {
+                codePoint = lead & 0x1F;
+                length = 2;
+            } else if ((lead & 0xF0) == 0xE0) {
+                codePoint = lead & 0x0F;
+                length = 3;
+            } else {
+                codePoint = lead & 0x07;
+                length = 4;
+            }
+            for (size_t j = 1; j < length && i + j < src.size(); ++j)
+                codePoint = (codePoint << 6) | (static_cast<unsigned char>(src[i + j]) & 0x3F);
+            i += length;
+            const bool wide = (codePoint >= 0x1100 && codePoint <= 0x115F) || (codePoint >= 0x2E80 && codePoint <= 0xA4CF) ||
+                              (codePoint >= 0xAC00 && codePoint <= 0xD7A3) || (codePoint >= 0xF900 && codePoint <= 0xFAFF) ||
+                              (codePoint >= 0xFE30 && codePoint <= 0xFE6F) || (codePoint >= 0xFF00 && codePoint <= 0xFF60) ||
+                              (codePoint >= 0x1F300 && codePoint <= 0x1F64F) ||
+                              (codePoint >= 0x1F900 && codePoint <= 0x1F9FF);
+            width += wide ? 2 : 1;
+        }
+        return width;
+    }
+
+    inline int TreePrec(const String_& kind) {
+        if (kind == "assign" || kind == "pays" || kind == "if" || kind == "collect")
+            return 0;
+        if (kind == "or")
+            return 1;
+        if (kind == "and")
+            return 2;
+        if (kind == "eq0" || kind == "gt0" || kind == "ge0")
+            return 3;
+        if (kind == "add" || kind == "sub")
+            return 4;
+        if (kind == "mul" || kind == "div")
+            return 5;
+        if (kind == "not" || kind == "neg" || kind == "uplus")
+            return 6;
+        if (kind == "pow")
+            return 7;
+        return 8;
+    }
+
+    inline String_ TreeInline(const DebugNode_& node, const TreeStyle_& st);
+
+    inline String_ TreeParen(const DebugNode_& child, const TreeStyle_& st, int context) {
+        const String_ inner = TreeInline(child, st);
+        return TreePrec(child.kind) < context ? String_("(") + inner + ")" : inner;
+    }
+
+    inline String_ FuzzySuffix(const DebugNode_& node, const TreeStyle_& st) {
+        if (node.discrete)
+            return String_(" ") + st.lAng + "[" + DebugNumber(node.lb) + ", " + DebugNumber(node.rb) + "]" + st.rAng;
+        //  eps is only a smoothing hint when positive; the parser marks unset with -1
+        if (node.number > 0.0)
+            return String_(" ") + st.lAng + st.epsS + "=" + DebugNumber(node.number) + st.rAng;
+        return String_();
+    }
+
+    inline String_ TreeInline(const DebugNode_& node, const TreeStyle_& st) {
+        const String_& k = node.kind;
+        if (k == "const")
+            return DebugNumber(node.number);
+        if (k == "var" || k == "const_var")
+            return node.name;
+        if (k == "spot")
+            return String_("spot()");
+        if (k == "true" || k == "false")
+            return String_(k == "true" ? st.trueS : st.falseS);
+        if (k == "uplus")
+            return TreeParen(node.children[0], st, 6);
+        if (k == "neg") {
+            const String_ operand = TreeInline(node.children[0], st);
+            return node.children[0].kind == "neg" ? String_(st.negate) + "(" + operand + ")"
+                                                  : String_(st.negate) + TreeParen(node.children[0], st, 7);
+        }
+        if (k == "log" || k == "exp" || k == "sqrt")
+            return String_(k == "log" ? st.logS : k == "exp" ? st.expS : st.sqrtS) + "(" +
+                   TreeInline(node.children[0], st) + ")";
+        if (k == "add" || k == "sub" || k == "mul" || k == "div" || k == "pow") {
+            const char* op = k == "add" ? st.plus : k == "sub" ? st.minus : k == "mul" ? st.times
+                          : k == "div" ? st.over : st.power;
+            const int prec = TreePrec(k);
+            //  Context bumps keep a − (b − c), a ÷ (b ÷ c) and (a ^ b) ^ c unambiguous
+            const int leftContext = k == "pow" ? 8 : prec;
+            return TreeParen(node.children[0], st, leftContext) + " " + op + " " +
+                   TreeParen(node.children[1], st, prec + 1);
+        }
+        if (k == "max" || k == "min") {
+            String_ rtn = String_(k == "max" ? st.maxS : st.minS) + "(" + TreeInline(node.children[0], st);
+            for (size_t i = 1; i < node.children.size(); ++i)
+                rtn += ", " + TreeInline(node.children[i], st);
+            return rtn + ")";
+        }
+        if (k == "eq0" || k == "gt0" || k == "ge0") {
+            const char* op = k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS;
+            const DebugNode_& operand = node.children[0];
+            //  Comparisons are normalized to expr OP 0; fold the subtraction back to lhs OP rhs
+            const String_ comparison = operand.kind == "sub"
+                ? TreeParen(operand.children[0], st, 3) + " " + op + " " + TreeParen(operand.children[1], st, 3)
+                : TreeParen(operand, st, 3) + " " + op + " 0";
+            return comparison + FuzzySuffix(node, st);
+        }
+        if (k == "and" || k == "or") {
+            const int prec = TreePrec(k);
+            String_ rtn = TreeParen(node.children[0], st, prec);
+            for (size_t i = 1; i < node.children.size(); ++i)
+                rtn += String_(" ") + (k == "and" ? st.andS : st.orS) + " " + TreeParen(node.children[i], st, prec);
+            return rtn;
+        }
+        if (k == "not")
+            return String_(st.notS) + TreeParen(node.children[0], st, 7);
+        if (k == "assign" || k == "pays")
+            return TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS) + " " +
+                   TreeInline(node.children[1], st);
+        if (k == "if") {
+            const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
+            String_ rtn = String_("if ") + TreeInline(node.children[0], st) + " then";
+            for (size_t i = 1; i < firstElse; ++i)
+                rtn += " " + TreeInline(node.children[i], st);
+            for (size_t i = firstElse; i < node.children.size(); ++i)
+                rtn += " else " + TreeInline(node.children[i], st);
+            return rtn;
+        }
+        //  collect
+        String_ rtn;
+        for (size_t i = 0; i < node.children.size(); ++i) {
+            if (i)
+                rtn += "; ";
+            rtn += TreeInline(node.children[i], st);
+        }
+        return rtn;
+    }
+
+    //  Human-friendly tree block: inline while it fits the width budget, branches below otherwise.
+    //  `first` prefixes the node's own line, `cont` prefixes every continuation line.
+    inline void DebugNodeTree(const DebugNode_& node, const String_& first, const String_& cont, const TreeStyle_& st,
+                              size_t width, Vector_<String_>& out) {
+        const String_ whole = first + TreeInline(node, st);
+        if (DisplayWidth(whole) <= width) {
+            out.push_back(whole);
+            return;
+        }
+        if (node.children.empty()) {
+            //  An oversized leaf has nothing to branch on
+            out.push_back(whole);
+            return;
+        }
+
+        struct Branch_ {
+            const DebugNode_* node;
+            String_ marker;
+            bool connected;
+        };
+        const String_& k = node.kind;
+        String_ header = first;
+        Vector_<Branch_> branches;
+        const auto add = [&](const DebugNode_& child, const char* marker, bool connected) {
+            branches.push_back(Branch_{&child, String_(marker), connected});
+        };
+
+        if (k == "assign" || k == "pays") {
+            header = first + TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS);
+            add(node.children[1], "", true);
+        } else if (k == "if") {
+            const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
+            const String_ condInline = TreeInline(node.children[0], st);
+            if (DisplayWidth(first + "if " + condInline + " then") <= width)
+                header = first + "if " + condInline + " then";
+            else {
+                header = first + "if";
+                add(node.children[0], st.condS, false);
+            }
+            for (size_t i = 1; i < firstElse; ++i)
+                add(node.children[i], st.thenS, false);
+            for (size_t i = firstElse; i < node.children.size(); ++i)
+                add(node.children[i], st.elseS, false);
+        } else if (k == "eq0" || k == "gt0" || k == "ge0") {
+            const char* op = k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS;
+            header = first + op + FuzzySuffix(node, st);
+            add(node.children[0], "", true);
+        } else if (k == "not" || k == "neg" || k == "uplus" || k == "log" || k == "exp" || k == "sqrt") {
+            header = first + (k == "not" ? st.notS : k == "neg" ? st.negate : k == "uplus" ? "+" : k == "log" ? st.logS
+                             : k == "exp" ? st.expS : st.sqrtS);
+            add(node.children[0], "", true);
+        } else if (k == "max" || k == "min" || k == "collect") {
+            header = first + (k == "max" ? st.maxS : k == "min" ? st.minS : "");
+            for (const auto& child : node.children)
+                add(child, "", true);
+        } else {
+            //  Binary operators and any unlisted interior kind
+            header = first + (k == "add" ? st.plus : k == "sub" ? st.minus : k == "mul" ? st.times
+                        : k == "div" ? st.over : k == "pow" ? st.power : k.c_str());
+            for (const auto& child : node.children)
+                add(child, "", true);
+        }
+
+        out.push_back(header);
+        for (size_t i = 0; i < branches.size(); ++i) {
+            const bool last = i + 1 == branches.size();
+            const Branch_& branch = branches[i];
+            const String_ branchFirst = branch.connected ? cont + (last ? st.elbow : st.tee) + branch.marker
+                                                         : cont + branch.marker;
+            const String_ branchCont =
+                branch.connected ? cont + (last ? st.blank : st.pipe) : cont + String_(DisplayWidth(branch.marker), ' ');
+            DebugNodeTree(*branch.node, branchFirst, branchCont, st, width, out);
+        }
+    }
+
     class Debugger_ : public ConstVisitor_<Debugger_> {
-        String_ prefix_;
-        Stack_<String_> stack_;
+        Stack_<DebugNode_> stack_;
 
         // The main function call from every node visitor
-        void Debug(const Node_& node, const String_& nodeId) {
-            // One more tab
-            prefix_ += '\t';
-
+        void Debug(const Node_& node, DebugNode_ ir) {
             // Visit arguments_, right to left
             for (auto it = node.arguments_.rbegin(); it != node.arguments_.rend(); ++it)
                 (*it)->Accept(*this);
 
-            // One less tab
-            prefix_.pop_back();
-
-            String_ str(prefix_ + nodeId);
-            if (!node.arguments_.empty()) {
-                str += "(\n";
-
-                // First argument, pushed last
-                str += stack_.Top();
-                stack_.Pop();
-                if (node.arguments_.size() > 1)
-                    str += prefix_ + ",\n";
-
-                // Args 2 to n-1
-                for (size_t i = 1; i < node.arguments_.size() - 1; ++i) {
-                    str += stack_.Top() + prefix_ + ",\n";
-                    stack_.Pop();
-                }
-
-                if (node.arguments_.size() > 1) {
-                    // Last argument, pushed first
-                    str += stack_.Top();
-                    stack_.Pop();
-                }
-
-                // Close ')'
-                str += prefix_ + ')';
-            }
-
-            str += '\n';
-            stack_.Push(std::move(str));
+            ir.children.Resize(node.arguments_.size());
+            for (size_t i = 0; i < node.arguments_.size(); ++i)
+                ir.children[i] = stack_.TopAndPop();
+            stack_.Push(std::move(ir));
         }
 
-        void DebugComp(const CompNode_& node, const char* label) {
-            String_ s = label;
+        void DebugComp(const CompNode_& node, const char* label, const char* kind) {
+            DebugNode_ ir;
+            ir.label = label;
+            ir.kind = kind;
             if (!node.isDiscrete_) {
-                s += String_("[CONT,EPS=" + std::to_string(node.eps_) + "]");
+                ir.label += String_("[CONT,EPS=" + std::to_string(node.eps_) + "]");
+                ir.number = node.eps_;
             } else {
-                s += "[DISCRETE,";
-                s += String_("BOUNDS=" + std::to_string(node.lb_) + "," + std::to_string(node.rb_) + "]");
+                ir.label += String_("[DISCRETE,BOUNDS=" + std::to_string(node.lb_) + "," + std::to_string(node.rb_) + "]");
+                ir.discrete = true;
+                ir.lb = node.lb_;
+                ir.rb = node.rb_;
             }
-            Debug(node, s);
+            Debug(node, std::move(ir));
         }
 
     public:
         using ConstVisitor_::Visit;
 
-        // Access the Top of the stack, contains the functional form after the tree is traversed
-        [[nodiscard]] const String_& String() const { return stack_.Top(); }
+        //  IR of the last accepted statement
+        [[nodiscard]] const DebugNode_& Top() const { return stack_.Top(); }
+
+        //  Legacy s-expression text of the last accepted statement
+        [[nodiscard]] String_ String() const {
+            std::ostringstream ost;
+            DebugNodeText(Top(), 0, ost);
+            return String_(ost.str());
+        }
 
         // All concrete node visitors, Visit arguments_ by default unless overridden
 
-        void Visit(const NodeCollect_& node) { Debug(node, "COLLECT"); }
+        void Visit(const NodeCollect_& node) { Debug(node, {"COLLECT", "collect"}); }
 
-        void Visit(const NodeUPlus_& node) { Debug(node, "UPLUS"); }
-        void Visit(const NodeUMinus_& node) { Debug(node, "UMINUS"); }
-        void Visit(const NodeAdd_& node) { Debug(node, "ADD"); }
-        void Visit(const NodeSub_& node) { Debug(node, "SUBTRACT"); }
-        void Visit(const NodeMulti_& node) { Debug(node, "MULT"); }
-        void Visit(const NodeDiv_& node) { Debug(node, "DIV"); }
-        void Visit(const NodePow_& node) { Debug(node, "POW"); }
-        void Visit(const NodeLog_& node) { Debug(node, "LOG"); }
-        void Visit(const NodeExp_& node) { Debug(node, "EXP"); }
-        void Visit(const NodeSqrt_& node) { Debug(node, "SQRT"); }
-        void Visit(const NodeMax_& node) { Debug(node, "MAX"); }
-        void Visit(const NodeMin_& node) { Debug(node, "MIN"); }
+        void Visit(const NodeUPlus_& node) { Debug(node, {"UPLUS", "uplus"}); }
+        void Visit(const NodeUMinus_& node) { Debug(node, {"UMINUS", "neg"}); }
+        void Visit(const NodeAdd_& node) { Debug(node, {"ADD", "add"}); }
+        void Visit(const NodeSub_& node) { Debug(node, {"SUBTRACT", "sub"}); }
+        void Visit(const NodeMulti_& node) { Debug(node, {"MULT", "mul"}); }
+        void Visit(const NodeDiv_& node) { Debug(node, {"DIV", "div"}); }
+        void Visit(const NodePow_& node) { Debug(node, {"POW", "pow"}); }
+        void Visit(const NodeLog_& node) { Debug(node, {"LOG", "log"}); }
+        void Visit(const NodeExp_& node) { Debug(node, {"EXP", "exp"}); }
+        void Visit(const NodeSqrt_& node) { Debug(node, {"SQRT", "sqrt"}); }
+        void Visit(const NodeMax_& node) { Debug(node, {"MAX", "max"}); }
+        void Visit(const NodeMin_& node) { Debug(node, {"MIN", "min"}); }
 
-        void Visit(const NodeEqual_& node) { DebugComp(node, "EQUALZERO"); }
+        void Visit(const NodeEqual_& node) { DebugComp(node, "EQUALZERO", "eq0"); }
 
-        void Visit(const NodeNot_& node) {
-            const String_ s = "NOT";
-            Debug(node, s);
-        }
+        void Visit(const NodeNot_& node) { Debug(node, {"NOT", "not"}); }
 
-        void Visit(const NodeSup_& node) { DebugComp(node, "GTZERO"); }
+        void Visit(const NodeSup_& node) { DebugComp(node, "GTZERO", "gt0"); }
+        void Visit(const NodeSupEqual_& node) { DebugComp(node, "GTEQUALZERO", "ge0"); }
 
-        void Visit(const NodeSupEqual_& node) { DebugComp(node, "GTEQUALZERO"); }
-
-        void Visit(const NodeAnd_& node) {
-            const String_ s = "AND";
-            Debug(node, s);
-        }
-
-        void Visit(const NodeOr_& node) {
-            const String_ s = "OR";
-            Debug(node, s);
-        }
-
-        void Visit(const NodeAssign_& node) { Debug(node, "ASSIGN"); }
-        void Visit(const NodePays_& node) { Debug(node, "PAYS"); }
-        void Visit(const NodeSpot_& node) { Debug(node, "SPOT"); }
+        void Visit(const NodeAnd_& node) { Debug(node, {"AND", "and"}); }
+        void Visit(const NodeOr_& node) { Debug(node, {"OR", "or"}); }
+        void Visit(const NodeAssign_& node) { Debug(node, {"ASSIGN", "assign"}); }
+        void Visit(const NodePays_& node) { Debug(node, {"PAYS", "pays"}); }
+        void Visit(const NodeSpot_& node) { Debug(node, {"SPOT", "spot"}); }
 
         void Visit(const NodeIf_& node) {
-            String_ s = "IF";
-            s += String_("[FIRSTELSE=" + std::to_string(node.firstElse_) + "]");
-
-            Debug(node, s);
+            DebugNode_ ir;
+            ir.label = String_("IF[FIRSTELSE=" + std::to_string(node.firstElse_) + "]");
+            ir.kind = "if";
+            ir.firstElse = node.firstElse_;
+            Debug(node, std::move(ir));
         }
 
-        void Visit(const NodeTrue_& node) { Debug(node, "TRUE"); }
-        void Visit(const NodeFalse_& node) { Debug(node, "FALSE"); }
+        void Visit(const NodeTrue_& node) { Debug(node, {"TRUE", "true"}); }
+        void Visit(const NodeFalse_& node) { Debug(node, {"FALSE", "false"}); }
 
         void Visit(const NodeConst_& node) {
-            Debug(node, String_("CONST[") + String_(std::to_string(node.constVal_) + ']')); }
+            DebugNode_ ir;
+            ir.label = String_("CONST[" + std::to_string(node.constVal_) + "]");
+            ir.kind = "const";
+            ir.number = node.constVal_;
+            Debug(node, std::move(ir));
+        }
+
         void Visit(const NodeVar_& node) {
-            Debug(node, String_("VAR[") + node.name_ + String_(',' + std::to_string(node.index_)) + ',' + String::FromDouble(node.constVal_) + ']'); }
+            DebugNode_ ir;
+            ir.label = String_("VAR[") + node.name_ + String_(',' + std::to_string(node.index_)) + ',' +
+                       String_(String::FromDouble(node.constVal_)) + ']';
+            ir.kind = "var";
+            ir.name = node.name_;
+            ir.index = node.index_;
+            ir.number = node.constVal_;
+            Debug(node, std::move(ir));
+        }
+
         void Visit(const NodeConstVar_& node) {
-            Debug(node, String_("CONST_VAR[") + node.name_ + String_(',' + std::to_string(node.index_)) + ',' + String::FromDouble( node.constVal_) + ']'); }
+            DebugNode_ ir;
+            ir.label = String_("CONST_VAR[") + node.name_ + String_(',' + std::to_string(node.index_)) + ',' +
+                       String_(String::FromDouble(node.constVal_)) + ']';
+            ir.kind = "const_var";
+            ir.name = node.name_;
+            ir.index = node.index_;
+            ir.number = node.constVal_;
+            Debug(node, std::move(ir));
+        }
     };
 } // namespace Dal::Script

--- a/dal-cpp/dal/script/visitor/debugger.hpp
+++ b/dal-cpp/dal/script/visitor/debugger.hpp
@@ -105,7 +105,9 @@ namespace Dal::Script {
         ost << ']';
     }
 
-    inline void JsonWriteIf(const DebugNode_& node, size_t& id, std::ostream& ost) {
+    inline bool JsonWriteIf(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        if (node.kind != "if")
+            return false;
         const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
         ost << ",\"condition\":";
         DebugNodeJson(node.children[0], id, ost);
@@ -122,42 +124,51 @@ namespace Dal::Script {
             DebugNodeJson(node.children[i], id, ost);
         }
         ost << ']';
+        return true;
     }
 
-    //  Writes the kind-specific fields; returns false when the kind takes only children
+    inline bool JsonWriteAssign(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        if (node.kind != "assign" && node.kind != "pays")
+            return false;
+        ost << ",\"target\":";
+        DebugNodeJson(node.children[0], id, ost);
+        ost << ",\"value\":";
+        DebugNodeJson(node.children[1], id, ost);
+        return true;
+    }
+
+    inline bool JsonWriteNamed(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        if (node.kind != "var" && node.kind != "const_var")
+            return false;
+        ost << ",\"name\":";
+        JsonWriteString(node.name, ost);
+        ost << ",\"index\":" << node.index << (node.kind == "var" ? ",\"const_value\":" : ",\"value\":")
+            << DebugNumber(node.number);
+        return true;
+    }
+
+    inline bool JsonWriteConst(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        if (node.kind != "const")
+            return false;
+        ost << ",\"value\":" << DebugNumber(node.number);
+        return true;
+    }
+
+    inline bool JsonWriteCompare(const DebugNode_& node, size_t& id, std::ostream& ost) {
+        if (node.kind != "eq0" && node.kind != "gt0" && node.kind != "ge0")
+            return false;
+        if (node.discrete)
+            ost << ",\"mode\":\"discrete\",\"lb\":" << DebugNumber(node.lb) << ",\"rb\":" << DebugNumber(node.rb);
+        else
+            ost << ",\"mode\":\"continuous\",\"eps\":" << DebugNumber(node.number);
+        JsonWriteChildren(node, id, ost);
+        return true;
+    }
+
+    //  Writes the kind-specific fields; false when the kind takes only children
     inline bool JsonWriteFields(const DebugNode_& node, size_t& id, std::ostream& ost) {
-        const String_& k = node.kind;
-        if (k == "if") {
-            JsonWriteIf(node, id, ost);
-            return true;
-        }
-        if (k == "assign" || k == "pays") {
-            ost << ",\"target\":";
-            DebugNodeJson(node.children[0], id, ost);
-            ost << ",\"value\":";
-            DebugNodeJson(node.children[1], id, ost);
-            return true;
-        }
-        if (k == "var" || k == "const_var") {
-            ost << ",\"name\":";
-            JsonWriteString(node.name, ost);
-            ost << ",\"index\":" << node.index << (k == "var" ? ",\"const_value\":" : ",\"value\":")
-                << DebugNumber(node.number);
-            return true;
-        }
-        if (k == "const") {
-            ost << ",\"value\":" << DebugNumber(node.number);
-            return true;
-        }
-        if (k == "eq0" || k == "gt0" || k == "ge0") {
-            if (node.discrete)
-                ost << ",\"mode\":\"discrete\",\"lb\":" << DebugNumber(node.lb) << ",\"rb\":" << DebugNumber(node.rb);
-            else
-                ost << ",\"mode\":\"continuous\",\"eps\":" << DebugNumber(node.number);
-            JsonWriteChildren(node, id, ost);
-            return true;
-        }
-        return false;
+        return JsonWriteIf(node, id, ost) || JsonWriteAssign(node, id, ost) || JsonWriteNamed(node, id, ost) ||
+               JsonWriteConst(node, id, ost) || JsonWriteCompare(node, id, ost);
     }
 
     //  Machine-friendly JSON; ids are pre-order and unique per dump.
@@ -299,25 +310,36 @@ namespace Dal::Script {
         return true;
     }
 
+    inline const char* FunctionSymbol(const String_& kind, const TreeStyle_& st) {
+        if (kind == "log")
+            return st.logS;
+        if (kind == "exp")
+            return st.expS;
+        return st.sqrtS;
+    }
+
+    inline String_ TreeInlineNeg(const DebugNode_& node, const TreeStyle_& st) {
+        //  Parenthesize a nested neg (avoid "−−x") and a pow operand (avoid the
+        //  "−a ^ b" ambiguity between −(a ^ b) and (−a) ^ b)
+        if (node.children[0].kind == "neg")
+            return String_(st.negate) + "(" + TreeInline(node.children[0], st) + ")";
+        return String_(st.negate) + TreeParen(node.children[0], st, 8);
+    }
+
     inline bool TreeInlineUnary(const DebugNode_& node, const TreeStyle_& st, String_& out) {
         const String_& k = node.kind;
         if (k == "log" || k == "exp" || k == "sqrt") {
-            out = String_(k == "log" ? st.logS : k == "exp" ? st.expS : st.sqrtS) + "(" +
-                  TreeInline(node.children[0], st) + ")";
+            out = String_(FunctionSymbol(k, st)) + "(" + TreeInline(node.children[0], st) + ")";
             return true;
         }
         if (k == "uplus") {
             out = TreeParen(node.children[0], st, 6);
             return true;
         }
-        if (k != "neg")
-            return false;
-        //  Parenthesize a nested neg (avoid "−−x") and a pow operand (avoid the
-        //  "−a ^ b" ambiguity between −(a ^ b) and (−a) ^ b)
-        if (node.children[0].kind == "neg")
-            out = String_(st.negate) + "(" + TreeInline(node.children[0], st) + ")";
+        if (k == "neg")
+            out = TreeInlineNeg(node, st);
         else
-            out = String_(st.negate) + TreeParen(node.children[0], st, 8);
+            return false;
         return true;
     }
 
@@ -383,20 +405,23 @@ namespace Dal::Script {
         return true;
     }
 
+    inline String_ TreeInlineIf(const DebugNode_& node, const TreeStyle_& st) {
+        const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
+        String_ rtn = String_("if ") + TreeInline(node.children[0], st) + " then";
+        for (size_t i = 1; i < firstElse; ++i)
+            rtn += " " + TreeInline(node.children[i], st);
+        for (size_t i = firstElse; i < node.children.size(); ++i)
+            rtn += " else " + TreeInline(node.children[i], st);
+        return rtn;
+    }
+
     inline String_ TreeInlineStatement(const DebugNode_& node, const TreeStyle_& st) {
         const String_& k = node.kind;
         if (k == "assign" || k == "pays")
             return TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS) + " " +
                    TreeInline(node.children[1], st);
-        if (k == "if") {
-            const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
-            String_ rtn = String_("if ") + TreeInline(node.children[0], st) + " then";
-            for (size_t i = 1; i < firstElse; ++i)
-                rtn += " " + TreeInline(node.children[i], st);
-            for (size_t i = firstElse; i < node.children.size(); ++i)
-                rtn += " else " + TreeInline(node.children[i], st);
-            return rtn;
-        }
+        if (k == "if")
+            return TreeInlineIf(node, st);
         //  collect
         String_ rtn;
         for (size_t i = 0; i < node.children.size(); ++i) {
@@ -423,17 +448,8 @@ namespace Dal::Script {
         bool connected;
     };
 
-    //  Fills the statement-family header (assign, pays, if); false for other kinds
-    inline bool TreeBranchStatement(const DebugNode_& node, const String_& first, const TreeStyle_& st, size_t width,
-                                    String_& header, Vector_<TreeBranch_>& branches) {
-        const String_& k = node.kind;
-        if (k == "assign" || k == "pays") {
-            header = first + TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS);
-            branches.push_back(TreeBranch_{&node.children[1], String_(), true});
-            return true;
-        }
-        if (k != "if")
-            return false;
+    inline void TreeBranchIf(const DebugNode_& node, const String_& first, const TreeStyle_& st, size_t width,
+                             String_& header, Vector_<TreeBranch_>& branches) {
         const size_t firstElse = node.firstElse < 0 ? node.children.size() : static_cast<size_t>(node.firstElse);
         const String_ condInline = TreeInline(node.children[0], st);
         if (DisplayWidth(first + "if " + condInline + " then") <= width)
@@ -446,6 +462,20 @@ namespace Dal::Script {
             branches.push_back(TreeBranch_{&node.children[i], String_(st.thenS), false});
         for (size_t i = firstElse; i < node.children.size(); ++i)
             branches.push_back(TreeBranch_{&node.children[i], String_(st.elseS), false});
+    }
+
+    //  Fills the statement-family header (assign, pays, if); false for other kinds
+    inline bool TreeBranchStatement(const DebugNode_& node, const String_& first, const TreeStyle_& st, size_t width,
+                                    String_& header, Vector_<TreeBranch_>& branches) {
+        const String_& k = node.kind;
+        if (k == "assign" || k == "pays") {
+            header = first + TreeInline(node.children[0], st) + " " + (k == "assign" ? st.assignS : st.paysS);
+            branches.push_back(TreeBranch_{&node.children[1], String_(), true});
+            return true;
+        }
+        if (k != "if")
+            return false;
+        TreeBranchIf(node, first, st, width, header, branches);
         return true;
     }
 
@@ -456,41 +486,75 @@ namespace Dal::Script {
             return st.negate;
         if (kind == "uplus")
             return "+";
-        if (kind == "log")
-            return st.logS;
-        if (kind == "exp")
-            return st.expS;
-        return st.sqrtS;
+        return FunctionSymbol(kind, st);
     }
 
-    //  Fills the single-operand header (comparisons and unary operators); false for other kinds
-    inline bool TreeBranchValue(const DebugNode_& node, const String_& first, const TreeStyle_& st, String_& header,
-                                Vector_<TreeBranch_>& branches) {
-        const String_& k = node.kind;
-        if (k == "eq0" || k == "gt0" || k == "ge0")
-            header = first + (k == "eq0" ? st.eqS : k == "gt0" ? st.gtS : st.geS) + FuzzySuffix(node, st);
-        else if (k == "not" || k == "neg" || k == "uplus" || k == "log" || k == "exp" || k == "sqrt")
-            header = first + UnarySymbol(k, st);
-        else
-            return false;
+    inline const char* CompareSymbol(const String_& kind, const TreeStyle_& st) {
+        if (kind == "eq0")
+            return st.eqS;
+        if (kind == "gt0")
+            return st.gtS;
+        return st.geS;
+    }
+
+    inline void PushOperand(const DebugNode_& node, Vector_<TreeBranch_>& branches) {
         branches.push_back(TreeBranch_{&node.children[0], String_(), true});
+    }
+
+    inline bool TreeBranchCompare(const DebugNode_& node, const String_& first, const TreeStyle_& st, String_& header,
+                                  Vector_<TreeBranch_>& branches) {
+        if (node.kind != "eq0" && node.kind != "gt0" && node.kind != "ge0")
+            return false;
+        header = first + CompareSymbol(node.kind, st) + FuzzySuffix(node, st);
+        PushOperand(node, branches);
         return true;
     }
 
-    //  Fills the header for everything else: binary operators, max/min, collect
+    inline bool TreeBranchUnaryHeader(const DebugNode_& node, const String_& first, const TreeStyle_& st, String_& header,
+                                      Vector_<TreeBranch_>& branches) {
+        if (node.kind != "not" && node.kind != "neg" && node.kind != "uplus" && node.kind != "log" &&
+            node.kind != "exp" && node.kind != "sqrt")
+            return false;
+        header = first + UnarySymbol(node.kind, st);
+        PushOperand(node, branches);
+        return true;
+    }
+
+    //  Header symbol for everything that branches by operands: binary operators
+    //  and max/min; collect gets no symbol
+    inline String_ OperatorHeader(const String_& kind, const TreeStyle_& st) {
+        if (kind == "max")
+            return String_(st.maxS);
+        if (kind == "min")
+            return String_(st.minS);
+        if (kind == "collect")
+            return String_();
+        if (kind == "pow")
+            return String_(st.power);
+        return String_(BinarySymbol(kind, st));
+    }
+
     inline void TreeBranchOperators(const DebugNode_& node, const String_& first, const TreeStyle_& st, String_& header,
                                     Vector_<TreeBranch_>& branches) {
-        const String_& k = node.kind;
-        if (k == "max" || k == "min")
-            header = first + (k == "max" ? st.maxS : st.minS);
-        else if (k == "collect")
-            header = first;
-        else if (k == "add" || k == "sub" || k == "mul" || k == "div" || k == "pow")
-            header = first + BinarySymbol(k, st);
-        else
-            header = first + k;
+        header = first + OperatorHeader(node.kind, st);
         for (const auto& child : node.children)
             branches.push_back(TreeBranch_{&child, String_(), true});
+    }
+
+    inline void DebugNodeTree(const DebugNode_& node, const String_& first, const String_& cont, const TreeStyle_& st,
+                              size_t width, Vector_<String_>& out);
+
+    inline void EmitBranches(const Vector_<TreeBranch_>& branches, const String_& cont, const TreeStyle_& st,
+                             size_t width, Vector_<String_>& out) {
+        for (size_t i = 0; i < branches.size(); ++i) {
+            const bool last = i + 1 == branches.size();
+            const TreeBranch_& branch = branches[i];
+            const String_ branchFirst =
+                branch.connected ? cont + (last ? st.elbow : st.tee) + branch.marker : cont + branch.marker;
+            const String_ branchCont =
+                branch.connected ? cont + (last ? st.blank : st.pipe) : cont + String_(DisplayWidth(branch.marker), ' ');
+            DebugNodeTree(*branch.node, branchFirst, branchCont, st, width, out);
+        }
     }
 
     //  Human-friendly tree block: inline while it fits the width budget, branches below otherwise.
@@ -507,19 +571,11 @@ namespace Dal::Script {
         String_ header = first;
         Vector_<TreeBranch_> branches;
         if (!TreeBranchStatement(node, first, st, width, header, branches) &&
-            !TreeBranchValue(node, first, st, header, branches))
+            !TreeBranchCompare(node, first, st, header, branches) && !TreeBranchUnaryHeader(node, first, st, header, branches))
             TreeBranchOperators(node, first, st, header, branches);
 
         out.push_back(header);
-        for (size_t i = 0; i < branches.size(); ++i) {
-            const bool last = i + 1 == branches.size();
-            const TreeBranch_& branch = branches[i];
-            const String_ branchFirst =
-                branch.connected ? cont + (last ? st.elbow : st.tee) + branch.marker : cont + branch.marker;
-            const String_ branchCont =
-                branch.connected ? cont + (last ? st.blank : st.pipe) : cont + String_(DisplayWidth(branch.marker), ' ');
-            DebugNodeTree(*branch.node, branchFirst, branchCont, st, width, out);
-        }
+        EmitBranches(branches, cont, st, width, out);
     }
 
     class Debugger_ : public ConstVisitor_<Debugger_> {

--- a/dal-cpp/tests/script/visitor/test_debugger.cpp
+++ b/dal-cpp/tests/script/visitor/test_debugger.cpp
@@ -6,6 +6,7 @@
 #include <dal/platform/platform.hpp>
 #include <dal/script/visitor/all.hpp>
 #include <dal/script/event.hpp>
+#include <dal/storage/globals.hpp>
 
 using namespace Dal;
 using namespace Dal::Script;
@@ -22,6 +23,67 @@ TEST(ScriptTest, TestDebuggerVisit) {
     ASSERT_EQ(visitor.String(), String_("CONST[20.000000]\n"));
 }
 
+TEST(ScriptTest, TestDebuggerVisitNestedExpression) {
+    //  MAX(spot() - STRIKE, 0.0)
+    Expression_ spot = MakeBaseNode<NodeSpot_>();
+    Expression_ strike = MakeBaseNode<NodeConstVar_>("STRIKE", 100.0);
+    Expression_ diff = MakeBaseBinary<NodeSub_>(spot, strike);
+    Expression_ zero = MakeBaseNode<NodeConst_>(0.0);
+    Expression_ maxNode = MakeBaseBinary<NodeMax_>(diff, zero);
+
+    Debugger_ visitor;
+    maxNode->Accept(visitor);
+    ASSERT_EQ(visitor.String(),
+              String_("MAX(\n"
+                      "\tSUBTRACT(\n"
+                      "\t\tSPOT\n"
+                      "\t,\n"
+                      "\t\tCONST_VAR[STRIKE,-1,100.000000]\n"
+                      "\t)\n"
+                      ",\n"
+                      "\tCONST[0.000000]\n"
+                      ")\n"));
+}
+
+TEST(ScriptTest, TestDebuggerVisitIfStatement) {
+    //  IF spot() > BARRIER THEN alive = 0 END
+    Expression_ spot = MakeBaseNode<NodeSpot_>();
+    Expression_ barrier = MakeBaseNode<NodeConstVar_>("BARRIER", 150.0);
+    Expression_ diff = MakeBaseBinary<NodeSub_>(spot, barrier);
+    auto cond = MakeNode<NodeSup_>();
+    cond->arguments_.Resize(1);
+    cond->arguments_[0] = std::move(diff);
+
+    auto assign = MakeNode<NodeAssign_>();
+    assign->arguments_.Resize(2);
+    assign->arguments_[0] = MakeBaseNode<NodeVar_>("alive");
+    assign->arguments_[1] = MakeBaseNode<NodeConst_>(0.0);
+
+    auto ifNode = MakeNode<NodeIf_>();
+    ifNode->arguments_.Resize(2);
+    ifNode->arguments_[0] = std::move(cond);
+    ifNode->arguments_[1] = std::move(assign);
+
+    Debugger_ visitor;
+    ifNode->Accept(visitor);
+    ASSERT_EQ(visitor.String(),
+              String_("IF[FIRSTELSE=-1](\n"
+                      "\tGTZERO[CONT,EPS=0.000000](\n"
+                      "\t\tSUBTRACT(\n"
+                      "\t\t\tSPOT\n"
+                      "\t\t,\n"
+                      "\t\t\tCONST_VAR[BARRIER,-1,150.000000]\n"
+                      "\t\t)\n"
+                      "\t)\n"
+                      ",\n"
+                      "\tASSIGN(\n"
+                      "\t\tVAR[alive,-1,0.000000]\n"
+                      "\t,\n"
+                      "\t\tCONST[0.000000]\n"
+                      "\t)\n"
+                      ")\n"));
+}
+
 TEST(ScriptTest, TestDebuggerVisitWithEmptyEvent) {
     Vector_<Cell_> dates;
     Vector_<String_> events;
@@ -32,4 +94,192 @@ TEST(ScriptTest, TestDebuggerVisitWithEmptyEvent) {
     String_ desc(out.str());
     Vector_<String_> rtn = String::Split(desc, '\n', true);
     ASSERT_EQ(rtn.size(), 0);
+}
+
+namespace {
+    //  MAX(spot() - STRIKE, 0.0)
+    Expression_ MakeMaxStrikeZero() {
+        Expression_ spot = MakeBaseNode<NodeSpot_>();
+        Expression_ strike = MakeBaseNode<NodeConstVar_>("STRIKE", 100.0);
+        Expression_ diff = MakeBaseBinary<NodeSub_>(spot, strike);
+        Expression_ zero = MakeBaseNode<NodeConst_>(0.0);
+        return MakeBaseBinary<NodeMax_>(diff, zero);
+    }
+
+    //  IF spot() > BARRIER:eps THEN alive = 0 END
+    Expression_ MakeKnockoutIf(double eps) {
+        Expression_ spot = MakeBaseNode<NodeSpot_>();
+        Expression_ barrier = MakeBaseNode<NodeConstVar_>("BARRIER", 150.0);
+        Expression_ diff = MakeBaseBinary<NodeSub_>(spot, barrier);
+        auto cond = MakeNode<NodeSup_>();
+        cond->arguments_.Resize(1);
+        cond->arguments_[0] = std::move(diff);
+        cond->eps_ = eps;
+
+        auto assign = MakeNode<NodeAssign_>();
+        assign->arguments_.Resize(2);
+        assign->arguments_[0] = MakeBaseNode<NodeVar_>("alive");
+        assign->arguments_[1] = MakeBaseNode<NodeConst_>(0.0);
+
+        auto ifNode = MakeNode<NodeIf_>();
+        ifNode->arguments_.Resize(2);
+        ifNode->arguments_[0] = std::move(cond);
+        ifNode->arguments_[1] = std::move(assign);
+        return ifNode;
+    }
+} // namespace
+
+TEST(ScriptTest, TestDebuggerJsonNode) {
+    Expression_ maxNode = MakeMaxStrikeZero();
+
+    Debugger_ visitor;
+    maxNode->Accept(visitor);
+    std::ostringstream out;
+    size_t id = 0;
+    DebugNodeJson(visitor.Top(), id, out);
+    ASSERT_EQ(out.str(),
+              "{\"id\":\"n0\",\"kind\":\"max\",\"children\":["
+              "{\"id\":\"n1\",\"kind\":\"sub\",\"children\":["
+              "{\"id\":\"n2\",\"kind\":\"spot\"},"
+              "{\"id\":\"n3\",\"kind\":\"const_var\",\"name\":\"STRIKE\",\"index\":-1,\"value\":100}"
+              "]},"
+              "{\"id\":\"n4\",\"kind\":\"const\",\"value\":0}"
+              "]}");
+}
+
+TEST(ScriptTest, TestDebuggerJsonIfNode) {
+    Expression_ ifNode = MakeKnockoutIf(0.1);
+
+    Debugger_ visitor;
+    ifNode->Accept(visitor);
+    std::ostringstream out;
+    size_t id = 0;
+    DebugNodeJson(visitor.Top(), id, out);
+    ASSERT_EQ(out.str(),
+              "{\"id\":\"n0\",\"kind\":\"if\","
+              "\"condition\":{"
+              "\"id\":\"n1\",\"kind\":\"gt0\",\"mode\":\"continuous\",\"eps\":0.1,\"children\":["
+              "{\"id\":\"n2\",\"kind\":\"sub\",\"children\":["
+              "{\"id\":\"n3\",\"kind\":\"spot\"},"
+              "{\"id\":\"n4\",\"kind\":\"const_var\",\"name\":\"BARRIER\",\"index\":-1,\"value\":150}"
+              "]}"
+              "]},"
+              "\"then\":[{"
+              "\"id\":\"n5\",\"kind\":\"assign\","
+              "\"target\":{\"id\":\"n6\",\"kind\":\"var\",\"name\":\"alive\",\"index\":-1,\"const_value\":0},"
+              "\"value\":{\"id\":\"n7\",\"kind\":\"const\",\"value\":0}"
+              "}],"
+              "\"else\":[]}");
+}
+
+TEST(ScriptTest, TestDebuggerTreeInline) {
+    Expression_ maxNode = MakeMaxStrikeZero();
+    Debugger_ visitor;
+    maxNode->Accept(visitor);
+
+    Vector_<String_> lines;
+    DebugNodeTree(visitor.Top(), "(1) ", "    ", TreeStyle(false), 125, lines);
+    ASSERT_EQ(lines.size(), 1u);
+    ASSERT_EQ(lines[0], String_("(1) max(spot() − STRIKE, 0)"));
+}
+
+TEST(ScriptTest, TestDebuggerTreeBranchesWhenTooWide) {
+    Expression_ maxNode = MakeMaxStrikeZero();
+    Debugger_ visitor;
+    maxNode->Accept(visitor);
+
+    Vector_<String_> lines;
+    DebugNodeTree(visitor.Top(), "(1) ", "    ", TreeStyle(false), 20, lines);
+    ASSERT_EQ(lines.size(), 5u);
+    ASSERT_EQ(lines[0], String_("(1) max"));
+    ASSERT_EQ(lines[1], String_("    ├── −"));
+    ASSERT_EQ(lines[2], String_("    │   ├── spot()"));
+    ASSERT_EQ(lines[3], String_("    │   └── STRIKE"));
+    ASSERT_EQ(lines[4], String_("    └── 0"));
+}
+
+TEST(ScriptTest, TestDebuggerTreeAsciiStyle) {
+    Expression_ maxNode = MakeMaxStrikeZero();
+    Debugger_ visitor;
+    maxNode->Accept(visitor);
+
+    Vector_<String_> lines;
+    DebugNodeTree(visitor.Top(), "(1) ", "    ", TreeStyle(true), 20, lines);
+    ASSERT_EQ(lines.size(), 5u);
+    ASSERT_EQ(lines[0], String_("(1) max"));
+    ASSERT_EQ(lines[1], String_("    |-- -"));
+    ASSERT_EQ(lines[2], String_("    |   |-- spot()"));
+    ASSERT_EQ(lines[3], String_("    |   `-- STRIKE"));
+    ASSERT_EQ(lines[4], String_("    `-- 0"));
+}
+
+TEST(ScriptTest, TestDebuggerTreeIfStatement) {
+    Expression_ ifNode = MakeKnockoutIf(0.1);
+    Debugger_ visitor;
+    ifNode->Accept(visitor);
+
+    Vector_<String_> lines;
+    DebugNodeTree(visitor.Top(), "(1) ", "    ", TreeStyle(false), 125, lines);
+    ASSERT_EQ(lines.size(), 1u);
+    ASSERT_EQ(lines[0], String_("(1) if spot() > BARRIER ⟨ε=0.1⟩ then alive ← 0"));
+}
+
+TEST(ScriptTest, TestDebuggerProductJson) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
+    const Vector_<Cell_> dates = {Cell_("STRIKE"), Cell_(Date_(2023, 9, 25)), Cell_(Date_(2025, 9, 25))};
+    const Vector_<String_> events = {"100.0", "alive = 1", "call pays MAX(spot() - STRIKE, 0.0)"};
+    const ScriptProduct_ product(dates, events);
+
+    std::ostringstream out;
+    product.DebugJson(out);
+    ASSERT_EQ(out.str(),
+              "{\"schema\":\"dal.script-product/1\",\"events\":["
+              "{\"index\":0,\"date\":\"2023-09-25\",\"phase\":\"future\",\"statements\":["
+              "{\"id\":\"n0\",\"kind\":\"assign\","
+              "\"target\":{\"id\":\"n1\",\"kind\":\"var\",\"name\":\"alive\",\"index\":-1,\"const_value\":0},"
+              "\"value\":{\"id\":\"n2\",\"kind\":\"const\",\"value\":1}"
+              "}]},"
+              "{\"index\":1,\"date\":\"2025-09-25\",\"phase\":\"future\",\"statements\":["
+              "{\"id\":\"n3\",\"kind\":\"pays\","
+              "\"target\":{\"id\":\"n4\",\"kind\":\"var\",\"name\":\"call\",\"index\":-1,\"const_value\":0},"
+              "\"value\":{\"id\":\"n5\",\"kind\":\"max\",\"children\":["
+              "{\"id\":\"n6\",\"kind\":\"sub\",\"children\":["
+              "{\"id\":\"n7\",\"kind\":\"spot\"},"
+              "{\"id\":\"n8\",\"kind\":\"const_var\",\"name\":\"STRIKE\",\"index\":-1,\"value\":100}"
+              "]},"
+              "{\"id\":\"n9\",\"kind\":\"const\",\"value\":0}"
+              "]}"
+              "}]}"
+              "]}");
+}
+
+TEST(ScriptTest, TestDebuggerProductTree) {
+    Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
+    const Vector_<Cell_> dates = {Cell_("STRIKE"), Cell_(Date_(2023, 9, 25)), Cell_(Date_(2025, 9, 25))};
+    const Vector_<String_> events = {"100.0", "alive = 1", "call pays MAX(spot() - STRIKE, 0.0)"};
+    const ScriptProduct_ product(dates, events);
+
+    std::ostringstream out;
+    product.DebugTree(out);
+    ASSERT_EQ(out.str(),
+              "📅 1 · 2023-09-25 · future\n"
+              "└── (1) alive ← 1\n"
+              "\n"
+              "📅 2 · 2025-09-25 · future\n"
+              "└── (1) call ⇐ max(spot() − STRIKE, 0)\n"
+              "\n");
+}
+
+TEST(ScriptTest, TestDebuggerEmptyProductJsonAndTree) {
+    Vector_<Cell_> dates;
+    Vector_<String_> events;
+    const ScriptProduct_ product(dates, events);
+
+    std::ostringstream json;
+    product.DebugJson(json);
+    ASSERT_EQ(json.str(), "{\"schema\":\"dal.script-product/1\",\"events\":[]}");
+
+    std::ostringstream tree;
+    product.DebugTree(tree);
+    ASSERT_EQ(tree.str(), "");
 }

--- a/dal-cpp/tests/script/visitor/test_debugger.cpp
+++ b/dal-cpp/tests/script/visitor/test_debugger.cpp
@@ -224,6 +224,38 @@ TEST(ScriptTest, TestDebuggerTreeIfStatement) {
     ASSERT_EQ(lines[0], String_("(1) if spot() > BARRIER ⟨ε=0.1⟩ then alive ← 0"));
 }
 
+TEST(ScriptTest, TestDebuggerTreeNegPowIsParenthesized) {
+    //  -(a ^ b) must not render as the ambiguous "−a ^ b"
+    Expression_ a = MakeBaseNode<NodeVar_>("a");
+    Expression_ b = MakeBaseNode<NodeVar_>("b");
+    Expression_ powNode = MakeBaseBinary<NodePow_>(a, b);
+    auto neg = MakeNode<NodeUMinus_>();
+    neg->arguments_.Resize(1);
+    neg->arguments_[0] = std::move(powNode);
+
+    Debugger_ visitor;
+    neg->Accept(visitor);
+    Vector_<String_> lines;
+    DebugNodeTree(visitor.Top(), "", "", TreeStyle(false), 125, lines);
+    ASSERT_EQ(lines.size(), 1u);
+    ASSERT_EQ(lines[0], String_("−(a ^ b)"));
+}
+
+TEST(ScriptTest, TestDebuggerJsonStringPassesUtf8Through) {
+    //  Multi-byte sequences must pass through as UTF-8, never \u-escaped per byte
+    std::ostringstream utf8;
+    JsonWriteString(String_("naïve"), utf8);
+    ASSERT_EQ(utf8.str(), "\"naïve\"");
+
+    std::ostringstream quoted;
+    JsonWriteString(String_("a\"b\\c"), quoted);
+    ASSERT_EQ(quoted.str(), "\"a\\\"b\\\\c\"");
+
+    std::ostringstream control;
+    JsonWriteString(String_(std::string("a\nb", 3)), control);
+    ASSERT_EQ(control.str(), "\"a\\nb\"");
+}
+
 TEST(ScriptTest, TestDebuggerProductJson) {
     Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
     const Vector_<Cell_> dates = {Cell_("STRIKE"), Cell_(Date_(2023, 9, 25)), Cell_(Date_(2025, 9, 25))};

--- a/dal-public/src/script.hpp
+++ b/dal-public/src/script.hpp
@@ -25,26 +25,26 @@ namespace Dal {
         return rtn;
     }
 
-    namespace Script {
+    namespace Detail {
         //  IndexVariables fills the variable and constant tables (and the payoff
         //  slot) without restructuring the AST, so the dump mirrors the script
         //  as written but with resolved indices
-        FORCE_INLINE ScriptProduct_ ProductForDump(const Handle_<ScriptProductData_>& product) {
+        FORCE_INLINE Script::ScriptProduct_ ProductForDump(const Handle_<ScriptProductData_>& product) {
             auto parsed = product->Product();
             parsed.IndexVariables();
             return parsed;
         }
-    } // namespace Script
+    } // namespace Detail
 
     FORCE_INLINE String_ DebugScriptProductJson(const Handle_<ScriptProductData_>& product) {
         std::ostringstream out;
-        Script::ProductForDump(product).DebugJson(out);
+        Detail::ProductForDump(product).DebugJson(out);
         return String_(out.str());
     }
 
     FORCE_INLINE String_ DebugScriptProductTree(const Handle_<ScriptProductData_>& product, bool ascii = false, int width = 125) {
         std::ostringstream out;
-        Script::ProductForDump(product).DebugTree(out, ascii, width);
+        Detail::ProductForDump(product).DebugTree(out, ascii, width);
         return String_(out.str());
     }
 } // namespace Dal

--- a/dal-public/src/script.hpp
+++ b/dal-public/src/script.hpp
@@ -24,6 +24,29 @@ namespace Dal {
         REQUIRE2(rtn.size() != 0, "empty script product description", ScriptError_);
         return rtn;
     }
+
+    namespace Script {
+        //  IndexVariables fills the variable and constant tables (and the payoff
+        //  slot) without restructuring the AST, so the dump mirrors the script
+        //  as written but with resolved indices
+        FORCE_INLINE ScriptProduct_ ProductForDump(const Handle_<ScriptProductData_>& product) {
+            auto parsed = product->Product();
+            parsed.IndexVariables();
+            return parsed;
+        }
+    } // namespace Script
+
+    FORCE_INLINE String_ DebugScriptProductJson(const Handle_<ScriptProductData_>& product) {
+        std::ostringstream out;
+        Script::ProductForDump(product).DebugJson(out);
+        return String_(out.str());
+    }
+
+    FORCE_INLINE String_ DebugScriptProductTree(const Handle_<ScriptProductData_>& product, bool ascii = false, int width = 125) {
+        std::ostringstream out;
+        Script::ProductForDump(product).DebugTree(out, ascii, width);
+        return String_(out.str());
+    }
 } // namespace Dal
 
 

--- a/dal-public/tests/test_script.cpp
+++ b/dal-public/tests/test_script.cpp
@@ -57,3 +57,66 @@ TEST(ScriptTest, TestDebugRejectsMalformedScript) {
 
     ASSERT_THROW(Dal::DebugScriptProduct(product), Dal::Exception_);
 }
+
+namespace {
+    Dal::Handle_<Dal::ScriptProductData_> MakeCallProduct(const char* name) {
+        const Vector_<Cell_> dates = {Cell_("STRIKE"), Cell_(Date_(2023, 9, 25))};
+        const Vector_<String_> events = {String_("100.0"), String_("call pays MAX(spot() - STRIKE, 0.0)")};
+        return Dal::NewScriptProduct(String_(name), dates, events);
+    }
+} // namespace
+
+TEST(ScriptTest, TestDebugJsonSchemaVariablesAndConstants) {
+    const ScopedEvaluationDate_ evalDate(Date_(2022, 9, 25));
+    const auto product = MakeCallProduct("dal_public_script_json");
+
+    const String_ json = Dal::DebugScriptProductJson(product);
+
+    ASSERT_NE(json.find(String_("\"schema\":\"dal.script-product/1\"")), String_::npos);
+    //  IndexVariables enrichment: resolved indices, variable table, constant table, payoff slot
+    ASSERT_NE(json.find(String_("\"variables\":[{\"index\":0,\"name\":\"call\"}],\"payoff_index\":0")), String_::npos);
+    ASSERT_NE(json.find(String_("\"constants\":[{\"index\":0,\"name\":\"STRIKE\",\"value\":100}]")), String_::npos);
+    ASSERT_NE(json.find(String_("{\"id\":\"n0\",\"kind\":\"pays\",\"target\":{\"id\":\"n1\",\"kind\":\"var\",\"name\":\"call\",\"index\":0")), String_::npos);
+    ASSERT_NE(json.find(String_("\"date\":\"2023-09-25\",\"phase\":\"future\"")), String_::npos);
+}
+
+TEST(ScriptTest, TestDebugJsonIsRepeatable) {
+    const ScopedEvaluationDate_ evalDate(Date_(2022, 9, 25));
+    const auto product = MakeCallProduct("dal_public_script_json_repeat");
+
+    const String_ first = Dal::DebugScriptProductJson(product);
+    const String_ second = Dal::DebugScriptProductJson(product);
+
+    ASSERT_EQ(first, second);
+}
+
+TEST(ScriptTest, TestDebugJsonEmptyProduct) {
+    const ScopedEvaluationDate_ evalDate(Date_(2022, 9, 25));
+    const auto product = Dal::NewScriptProduct(String_("dal_public_script_empty"), {}, {});
+
+    const String_ json = Dal::DebugScriptProductJson(product);
+
+    ASSERT_EQ(json, String_("{\"schema\":\"dal.script-product/1\",\"events\":[]}"));
+}
+
+TEST(ScriptTest, TestDebugTreeShowsVariablesAndEvents) {
+    const ScopedEvaluationDate_ evalDate(Date_(2022, 9, 25));
+    const auto product = MakeCallProduct("dal_public_script_tree");
+
+    const String_ tree = Dal::DebugScriptProductTree(product);
+
+    ASSERT_NE(tree.find(String_("Variables: call*")), String_::npos);
+    ASSERT_NE(tree.find(String_("Constants: STRIKE=100")), String_::npos);
+    ASSERT_NE(tree.find(String_("📅 1 · 2023-09-25 · future")), String_::npos);
+    ASSERT_NE(tree.find(String_("└── (1) call ⇐ max(spot() − STRIKE, 0)")), String_::npos);
+}
+
+TEST(ScriptTest, TestDebugTreeAsciiStyleAndWidth) {
+    const ScopedEvaluationDate_ evalDate(Date_(2022, 9, 25));
+    const auto product = MakeCallProduct("dal_public_script_tree_ascii");
+
+    const String_ tree = Dal::DebugScriptProductTree(product, true, 40);
+
+    ASSERT_NE(tree.find(String_("`-- (1) call <= max(spot() - STRIKE, 0)")), String_::npos);
+    ASSERT_NE(tree.find(String_("# 1 @ 2023-09-25 @ future")), String_::npos);
+}

--- a/dal-python/src/bindings/script.cpp
+++ b/dal-python/src/bindings/script.cpp
@@ -41,4 +41,22 @@ void init_bindings_script(py::module_& m) {
                     std::const_pointer_cast<const ScriptProductData_>(product))
                 ).c_str();
         });
+
+    m.def("Product_DebugJson",
+        [](const std::shared_ptr<ScriptProductData_>& product) -> std::string {
+            return DebugScriptProductJson(
+                Handle_<ScriptProductData_>(
+                    std::const_pointer_cast<const ScriptProductData_>(product))
+                ).c_str();
+        });
+
+    m.def("Product_DebugTree",
+        [](const std::shared_ptr<ScriptProductData_>& product, bool ascii, int width) -> std::string {
+            return DebugScriptProductTree(
+                Handle_<ScriptProductData_>(
+                    std::const_pointer_cast<const ScriptProductData_>(product)),
+                ascii,
+                width).c_str();
+        },
+        py::arg("product"), py::arg("ascii") = false, py::arg("width") = 125);
 }

--- a/dal-python/tests/test_script.py
+++ b/dal-python/tests/test_script.py
@@ -99,7 +99,7 @@ def test_product_debug_contains_payoff_info():
     assert len(debug_str) > 10  # nosec B101 - pytest assertions are intentional
 
 
-def test_product_new_barrier_knockout():
+def test_product_debug_barrier_knockout():
     """Create a barrier knockout product with monitoring schedule."""
     eval_date = dal.Date_(2022, 9, 25)
     maturity = dal.Date_(2025, 9, 25)
@@ -127,3 +127,56 @@ def test_product_new_barrier_knockout():
     assert product is not None  # nosec B101 - pytest assertions are intentional
     debug_str = dal.Product_Debug(product)
     assert len(debug_str) > 0  # nosec B101 - pytest assertions are intentional
+
+
+def _make_european_call():
+    maturity = dal.Date_(2025, 9, 24)
+    dates = [dal.Cell_("STRIKE"), dal.Cell_(maturity)]
+    events = ["100.0", "call pays MAX(spot() - STRIKE, 0.0)"]
+    return dal.Product_New(dates, events)
+
+
+def test_product_debug_json():
+    """Product_DebugJson returns the machine-friendly schema with resolved metadata."""
+    product = _make_european_call()
+
+    debug_json = dal.Product_DebugJson(product)
+    assert debug_json.startswith('{"schema":"dal.script-product/1"')  # nosec B101
+    assert '"payoff_index":0' in debug_json  # nosec B101
+    assert '"variables":[{"index":0,"name":"call"}]' in debug_json  # nosec B101
+    assert '"constants":[{"index":0,"name":"STRIKE","value":100}]' in debug_json  # nosec B101
+    assert '"kind":"pays"' in debug_json  # nosec B101
+    assert '"phase":"future"' in debug_json  # nosec B101
+
+
+def test_product_debug_json_is_repeatable():
+    """Product_DebugJson output is deterministic."""
+    product = _make_european_call()
+
+    assert dal.Product_DebugJson(product) == dal.Product_DebugJson(product)  # nosec B101
+
+
+def test_product_debug_tree():
+    """Product_DebugTree returns a human-friendly unicode tree."""
+    product = _make_european_call()
+
+    tree = dal.Product_DebugTree(product)
+    assert "Variables: call*" in tree  # nosec B101
+    assert "Constants: STRIKE=100" in tree  # nosec B101
+    assert "📅 1 · 2025-09-24 · future" in tree  # nosec B101
+    assert "call ⇐ max(spot() − STRIKE, 0)" in tree  # nosec B101
+
+
+def test_product_debug_tree_ascii_and_width():
+    """Product_DebugTree exposes the ascii style and width parameters."""
+    product = _make_european_call()
+
+    ascii_tree = dal.Product_DebugTree(product, ascii=True, width=40)
+    assert "# 1 @ 2025-09-24 @ future" in ascii_tree  # nosec B101
+    assert "`-- (1) call <= max(spot() - STRIKE, 0)" in ascii_tree  # nosec B101
+
+    narrow = dal.Product_DebugTree(product, ascii=True, width=10)
+    #  Too narrow to inline: the payoff statement keeps its header but branches
+    assert "`-- (1) call <=" in narrow  # nosec B101
+    assert "`-- max" in narrow  # nosec B101
+    assert "`-- 0" in narrow  # nosec B101

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -562,6 +562,48 @@ valuation calls `IndexVariables` and `PreProcess` before evaluation or
 `dal-cpp/dal/script/simulation.hpp`, templated on `double` for value-only runs
 and on `AAD::Number_` for pathwise-adjoint runs.
 
+## Product Debug Outputs
+
+`ScriptProduct_::Debug` writes the legacy dump: the variable table followed by
+each future event's statements as indented s-expressions with labels like
+`MAX(`, `VAR[x,-1,0.000000]`, `IF[FIRSTELSE=-1]`.
+
+Two further dumps render the same AST for other consumers. All three are
+produced from the debug IR that `Debugger_` builds, and the two new ones also
+include past events, tagged with their phase:
+
+- **JSON** — `ScriptProduct_::DebugJson` writes a compact, deterministic
+  document with schema `dal.script-product/1`, meant for machine consumption
+  (the `Product_DebugJson` binding, and web front ends). The document carries
+  the variable and constant tables plus the payoff slot whenever the product
+  has been through `IndexVariables`; every AST node becomes an object with a
+  unique pre-order `id` and a stable snake_case `kind` (`add`, `sub`, `mul`,
+  `div`, `pow`, `log`, `exp`, `sqrt`, `max`, `min`, `neg`, `uplus`, `eq0`,
+  `gt0`, `ge0`, `and`, `or`, `not`, `assign`, `pays`, `if`, `spot`, `const`,
+  `var`, `const_var`, `true`, `false`, `collect`). Structured kinds get
+  structured fields — `condition`/`then`/`else` for `if`, `target`/`value`
+  for `assign` and `pays`, `mode`/`eps` (continuous) or `mode`/`lb`/`rb`
+  (discrete) for comparisons — and everything else uses `children`. Numbers
+  use the shortest decimal form that round-trips; a continuous comparison
+  reports the smoothing width in `eps`, where `-1` means the script did not
+  set one (the default smoothing factor applies).
+- **Tree** — `ScriptProduct_::DebugTree(ost, ascii, width)` writes a
+  human-friendly rendering: statements collapse to inline math while they fit
+  the width budget (`width` caps the line width, default 125), for example
+  `call ⇐ max(spot() − STRIKE, 0)`, with comparisons folded back from
+  `GTZERO(SUB(a, b))` to `a > b` and smoothing shown as `⟨ε=0.1⟩` or
+  `⟨[lb, rb]⟩`. Anything wider expands into box-drawing branches; `if`
+  branches are marked `▶` (then) and `▷` (else). `ascii = true` switches
+  every symbol to a pure-ASCII set for constrained consoles — Unicode output
+  needs a UTF-8 terminal (on Windows, Windows Terminal or `chcp 65001`).
+
+The dal-public wrappers `DebugScriptProductJson` and
+`DebugScriptProductTree` run `IndexVariables` on a private copy before
+dumping, so indices, the variable table, and the payoff slot are resolved
+while the dumped AST still mirrors the script as written. The Python surface
+is `Product_DebugJson(product)` and
+`Product_DebugTree(product, ascii=False, width=125)`.
+
 ## See Also
 
 - [Automatic Adjoint Differentiation](aad.md) — the reverse-mode machinery that


### PR DESCRIPTION
## Summary
- Rework `Debugger_` in `dal-cpp/dal/script/visitor/debugger.hpp` to build a `DebugNode_` IR per statement and render three formats from it: the legacy s-expression text (byte-identical, pinned by new regression tests), plus two new dumps
- Add `ScriptProduct_::DebugJson`: a compact, deterministic JSON document with schema `dal.script-product/1` — variable/constant tables, payoff slot, past and future events with phase tags, and per-node pre-order ids, stable snake_case kinds, and structured fields (`condition/then/else`, `target/value`, `mode/eps` or `mode/lb/rb`)
- Add `ScriptProduct_::DebugTree(ost, ascii, width = 125)`: a human-friendly tree that inlines statements with minimal-precedence math notation (`call ⇐ max(spot() − STRIKE, 0)`, `GTZERO(SUB(a, b))` folded back to `a > b`, smoothing as `⟨ε=0.1⟩` / `⟨[lb, rb]⟩`), expands into box-drawing branches past the width budget, marks if-branches with `▶`/`▷`, and degrades to a pure-ASCII symbol set on request
- Add dal-public wrappers `DebugScriptProductJson` / `DebugScriptProductTree`, which run `IndexVariables` on a private copy so indices and the variable table are resolved while the dumped AST still mirrors the script as written
- Bind `Product_DebugJson(product)` and `Product_DebugTree(product, ascii=False, width=125)` in dal-python
- Fix a display issue surfaced by testing: the parser marks unset comparison smoothing with `eps = -1`; the tree now only annotates when `eps > 0` (the JSON stays faithful and documents the sentinel)
- Document both formats in `docs/methodology/script_engine.md` § Product Debug Outputs and record the new public surface in `CHANGELOG.md`

## Test plan
- [x] `dal_cpp_tests --gtest_filter=ScriptTest.TestDebugger*` — pins legacy text, JSON nodes, tree inline/branch/ascii, product-level dumps, empty product (13 cases)
- [x] `dal_public_tests --gtest_filter=ScriptTest.*` — JSON schema/variables/constants, repeatability, empty product, tree variables/events, ascii + width parameters
- [x] Full CTest on Windows (Release-windows, MSVC/Ninja): 1361/1362 pass; the single failure is `dal_python_pytest`, whose registered interpreter lacks pytest in this local environment (the same tests pass directly, below)
- [x] `pytest dal-python/tests/` with the built `_dal` module: 269 passed, 1 pre-existing skip
- [ ] Linux CI (`build_linux.sh` + ctest) green on this PR