### PR TITLE
docs: reconcile structure and CI descriptions with current state

### DIFF
--- a/.claude/specs/2026-08-14-dal-web-extraction-design.md
+++ b/.claude/specs/2026-08-14-dal-web-extraction-design.md
@@ -1,7 +1,13 @@
 # dal-web Extraction Design
 
+> **Artifact status: implemented history.** The extraction has shipped (merged as
+> PR #290, 2026-08-15): `dal-web/` now lives at
+> [wegamekinglc/dal-web](https://github.com/wegamekinglc/dal-web) and depends on the
+> published `dal-python` PyPI package; the parent-repo removal and CI cleanup merged
+> with it. The design below is retained as historical evidence, not pending work.
+
 Date: 2026-08-14
-Status: approved by user (2026-08-14)
+Status: approved by user (2026-08-14); shipped 2026-08-15 (PR #290)
 Approach: A — three-stage, validate before delete
 
 ## Goal

--- a/.claude/specs/2026-08-14-dal-web-extraction-plan.md
+++ b/.claude/specs/2026-08-14-dal-web-extraction-plan.md
@@ -6,7 +6,11 @@
 > local paths, and commands below describe the execution baseline and are retained
 > as historical evidence, not pending work.
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers (historical):** executing this plan required the
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans sub-skill, and tracked progress with checkbox
+> (`- [ ]`) syntax. Both were execution aids for the shipped work described
+> below, not current instructions.
 
 **Goal:** Move `dal-web/` out of Derivatives-Algorithms-Lib into a standalone `wegamekinglc/dal-web` GitHub repo that depends on PyPI `dal-python>=2026.8.14`, then remove all dal-web content from the parent repo.
 

--- a/.claude/specs/2026-08-14-dal-web-extraction-plan.md
+++ b/.claude/specs/2026-08-14-dal-web-extraction-plan.md
@@ -1,5 +1,11 @@
 # dal-web Extraction Implementation Plan
 
+> **Artifact status: implemented history.** All phases of this plan shipped (merged
+> as PR #290, 2026-08-15); the standalone repository is live at
+> [wegamekinglc/dal-web](https://github.com/wegamekinglc/dal-web). Task checkboxes,
+> local paths, and commands below describe the execution baseline and are retained
+> as historical evidence, not pending work.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Move `dal-web/` out of Derivatives-Algorithms-Lib into a standalone `wegamekinglc/dal-web` GitHub repo that depends on PyPI `dal-python>=2026.8.14`, then remove all dal-web content from the parent repo.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,9 +36,9 @@ Formatting is enforced by `.clang-format` (LLVM base, 4-space indent, 150 column
 
 CMake cache variables (AAD backends, sub-project/test/example/benchmark toggles, sanitizers)
 are listed in [CLAUDE.md](../CLAUDE.md#build-commands) and the
-[installation guide options table](../docs/installation.md#common-cmake-options). CI runs
-the full matrix: native/xad/codipack/adept × gcc-13, gcc-14, gcc-15, clang-18,
-clang-19, clang-20, plus MSVC.
+[installation guide options table](../docs/installation.md#common-cmake-options). Pull requests
+run the full matrix: native/xad/codipack/adept × gcc-13, gcc-14, gcc-15, clang-18,
+clang-19, clang-20, plus MSVC; pushes run a lean gcc-14/clang-20 subset.
 
 ## Architecture
 
@@ -52,8 +52,9 @@ Dependency graph: `dal-cpp ← dal-public ← {dal-python, dal-excel}`. The publ
 | `dal-excel/`  | `.xll` add-in, Windows-only                                                       |
 
 Core modules: `math/` (interp, opt, PDE, RNG, matrix, `aad/`), `script/` (lexer → parser →
-AST → simulation), `model/`, `curve/`, `indice/`, `risk/`, `concurrency/`, `storage/`,
-`auto/` (Machinist-generated).
+AST → simulation), `model/`, `curve/`, `time/`, `protocol/`, `currency/`, `indice/`, `risk/`,
+`concurrency/`, `storage/`, `platform/`, `io/`, `string/`, `utilities/`, `auto/`
+(Machinist-generated).
 
 ## Codegen (Machinist)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Last updated: 2026-08-15
+Last updated: 2026-08-16
 
 Codex-native guidance for this repository. This file is intentionally separate from
 `CLAUDE.md` and `.claude/`; do not edit the Claude originals unless the user explicitly asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Ea
 
 **Core library (`dal-cpp/`)** — built as the `dal_cpp` target (alias `DAL::cpp`):
 - `dal-cpp/dal/math/` — numerical algorithms: interpolation, optimization, PDE solvers, random number generation, matrix ops, root finding, AAD
-- `dal-cpp/dal/script/` — expression scripting engine using visitor pattern (parser → AST nodes → simulation/evaluation), with tree-walk evaluation as the default and a compiled flat-stream evaluator behind the `compiled` flag
+- `dal-cpp/dal/script/` — expression scripting engine using visitor pattern (parser → AST nodes → simulation/evaluation), with tree-walk evaluation as the default, a compiled flat-stream evaluator behind the `compiled` flag, and legacy-text, JSON, and Unicode-tree debug dumps
 - `dal-cpp/dal/model/` — financial models
 - `dal-cpp/dal/curve/` — yield/discount curve handling
 - `dal-cpp/dal/time/` — dates, calendars, schedules, and day-count bases
@@ -163,7 +163,7 @@ Detailed documentation of the quantitative methods implemented in this library:
 - **Log-Discount Curve** — [Log-discount curve](docs/methodology/log_discount_curve.md)
 - **PDE Framework, Grid Construction, and Coordinate Maps** — [PDE framework](docs/methodology/pde.md)
 - **Yield-Curve Jacobian and Inverse-Jacobian Risk** — [Yield-curve Jacobian](docs/methodology/yield_curve_jacobian.md)
-- **Script Engine** — [Script engine](docs/methodology/script_engine.md), including tree-walk, fuzzy AAD, compiled evaluation, parity coverage, and benchmarks
+- **Script Engine** — [Script engine](docs/methodology/script_engine.md), including tree-walk, fuzzy AAD, compiled evaluation, parity coverage, product debug dumps, and benchmarks
 - **Dupire Local Volatility** — [Dupire local volatility](docs/methodology/dupire.md)
 - **Black / Bachelier Vanilla Pricing** — [Black / Bachelier vanilla pricing](docs/methodology/black_scholes.md)
 - **Numerical Quadrature** — [Numerical quadrature](docs/methodology/quadrature.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,13 +103,21 @@ The dependency graph is `dal-cpp ← dal-public ← {dal-python, dal-excel}`. Ea
 - `dal-cpp/dal/script/` — expression scripting engine using visitor pattern (parser → AST nodes → simulation/evaluation), with tree-walk evaluation as the default and a compiled flat-stream evaluator behind the `compiled` flag
 - `dal-cpp/dal/model/` — financial models
 - `dal-cpp/dal/curve/` — yield/discount curve handling
-- `dal-cpp/dal/indice/` — reference rate index management
-- `dal-cpp/dal/risk/` — risk calculations
+- `dal-cpp/dal/time/` — dates, calendars, schedules, and day-count bases
+- `dal-cpp/dal/protocol/` — market and contract conventions (accrual, payment, coupon, option types, collateral)
+- `dal-cpp/dal/currency/` — currency definitions and static data
+- `dal-cpp/dal/indice/` — index interfaces, fixing stores and immutable snapshots, and name-driven parsers
+- `dal-cpp/dal/risk/` — risk report types and aggregation
 - `dal-cpp/dal/concurrency/` — thread pool and concurrent queue
-- `dal-cpp/dal/storage/` — data persistence (files matching `_repository.*` are excluded from the build)
+- `dal-cpp/dal/storage/` — storable objects, archives, and persistence (files matching `_repository.*` are excluded from the build)
+- `dal-cpp/dal/platform/` — compile-time configuration, constants, host and process initialization
+- `dal-cpp/dal/io/` — Excel driver/import helpers
+- `dal-cpp/dal/string/`, `dal-cpp/dal/utilities/` — string type plus algorithms, dictionary, and environment/composite helpers
 - `dal-cpp/dal/auto/` — auto-generated code (Machinist output, glob-included into the library)
+- `dal-cpp/dal/benchmarks/` — shared benchmark harness header (`bench.hpp`)
 - `dal-cpp/tests/` — Google Test files compiled into the `dal_cpp_tests` binary
-- `dal-cpp/examples/` — standalone example programs (AAD, Monte Carlo, finite difference, scripting, concurrency, Sobol, underdetermined optimization)
+- `dal-cpp/test-support/` — test-only helpers shared across suites
+- `dal-cpp/examples/` — standalone example programs (AAD, Monte Carlo vanillas and exotics, finite difference, curve and cross-currency calibration, yield-curve Jacobian, interpolation, scripting, concurrency, Sobol, Excel export, underdetermined optimization)
 - `dal-cpp/benchmarks/` — standalone performance benchmark programs, one executable per target (19 total: matrix, script, tape, jacobian, pde, rng, interp, krylov, banded, cholesky, specialfunctions, black, iv_brent, script_mc, curve_calibration, xccy, ycinstrument, threadpool, stacks); each registers as a CTest test under the `benchmark` label (CI discovers them with `ctest -N -L benchmark`), and `build_linux.sh` never runs them in its ctest pass (`-LE benchmark`); an 8-target subset is gated by the paired regression script. `script_mc_perf` compares tree-walk and compiled script evaluation
 - `dal-cpp/externals/` — git submodules for AAD frameworks, gtest, rapidjson, machinist
 - `dal-cpp/config/` — Machinist input (`dal.ifc`, `dal.mgl`)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ bash ./build_linux.sh --benchmarks
 ./build/Release-linux/dal-cpp/benchmarks/script_mc_perf/script_mc_perf
 ```
 
+### Script Product Debug Dumps
+
+Script products dump three ways: the legacy s-expression listing
+(`DebugScriptProduct` in C++, `Product_Debug` in Python), a versioned JSON AST
+for machine consumers (`DebugScriptProductJson` / `Product_DebugJson`, schema
+`dal.script-product/1`), and a width-aware Unicode tree with an ASCII fallback
+(`DebugScriptProductTree` / `Product_DebugTree`). See
+[Product Debug Outputs](docs/methodology/script_engine.md#product-debug-outputs)
+for the formats.
+
 ### Excel
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ A C++17 quantitative finance library with built-in Automatic Adjoint Differentia
 
 ## CI
 
-Every push and pull request builds and tests this compiler × AAD-backend
-matrix. GitHub publishes one status badge per workflow; open a workflow run
-for per-job results.
+Pull requests build and test the full compiler × AAD-backend matrix below.
+Pushes (master merges and direct branch pushes) run a lean GCC 14 + Clang 20
+subset across all four backends, because the pull request already covered
+every combination. GitHub publishes one status badge per workflow; open a
+workflow run for per-job results.
 
 | Platform                   | Compiler | AADet | XAD | CoDiPack | Adept |
 |----------------------------|----------|-------|-----|----------|-------|
@@ -23,10 +25,11 @@ for per-job results.
 | Ubuntu (`ubuntu-latest`)   | Clang 20 | ✓     | ✓   | ✓        | ✓     |
 | Windows (`windows-latest`) | MSVC     | ✓     | ✓   | —        | ✓     |
 
-- GCC 13/14 legs additionally run gcov coverage; Coveralls tracks GCC 14 + AADet.
+- The GCC 14 + AADet leg additionally runs gcov coverage, tracked by Coveralls.
 - Windows legs additionally build the `dal-python` bindings and the `dal-excel` add-in.
-- Separate Linux jobs cover CoDiPack thread isolation, a warning-clean build,
-  ASan/UBSan/TSan spot tests, Python bindings, and benchmark regression gating.
+- Separate Linux jobs cover CoDiPack thread isolation, Python bindings with
+  generated-source verification, documentation integrity, a warning-clean
+  build, ASan/UBSan/TSan spot tests, and benchmark regression gating.
 
 ## Quick Start
 
@@ -61,14 +64,20 @@ not an ABI-isolated compatibility boundary.
 | `dal-python/` | pybind11 Python bindings                           |
 | `dal-excel/`  | Excel `.xll` add-in (Windows-only)                 |
 
-Core modules in `dal-cpp/dal/`:
+Core domains in `dal-cpp/dal/`:
 
 - **math/** — Interpolation, optimization, PDE solvers, random numbers, matrix ops
 - **math/aad/** — Automatic Adjoint Differentiation (native, XAD, Adept, CoDiPack backends)
 - **curve/** — Yield curve construction, piecewise forward rates, calibration
 - **script/** — Expression scripting engine for exotic payoffs, with tree-walk and compiled evaluation modes
-- **model/** — Financial models (Black-Scholes, etc.)
+- **model/** — Financial models (Black-Scholes, Dupire local volatility, etc.)
+- **time/** — Dates, calendars, schedules, and day-count bases
+- **protocol/**, **currency/**, **indice/** — Market/contract conventions, currency data, and index/fixing management
+- **risk/** — Risk report types and aggregation
+- **storage/** — Storable objects, archives, and repository integration
 - **concurrency/** — Thread pool for parallel Monte Carlo
+- **platform/**, **io/**, **string/**, **utilities/** — Infrastructure: configuration, host init, Excel I/O helpers, strings, dictionaries
+- **auto/** — Machinist-generated enums and serialization (do not hand-edit)
 
 ## Examples
 

--- a/dal-cpp/README.md
+++ b/dal-cpp/README.md
@@ -6,16 +6,16 @@ generation, storage, and concurrency.
 
 ## Layout
 
-| Path          | Contents                                                     |
-|---------------|--------------------------------------------------------------|
+| Path            | Contents                                                     |
+|-----------------|--------------------------------------------------------------|
 | `dal/`          | Core headers and implementations, organized by domain        |
 | `tests/`        | Google Test coverage for core behavior and numerical methods |
 | `test-support/` | Test-only helpers shared across suites                       |
-| `examples/`   | Runnable C++ examples                                        |
-| `benchmarks/` | Opt-in native performance executables                        |
-| `config/`     | Machinist interface and generation configuration             |
-| `cmake/`      | Platform options and installed package configuration         |
-| `externals/`  | Git-submodule dependencies and AAD backends                  |
+| `examples/`     | Runnable C++ examples                                        |
+| `benchmarks/`   | Opt-in native performance executables                        |
+| `config/`       | Machinist interface and generation configuration             |
+| `cmake/`        | Platform options and installed package configuration         |
+| `externals/`    | Git-submodule dependencies and AAD backends                  |
 
 Direct core consumers get the widest API surface and therefore track core source
 changes. Applications that want construction and valuation helpers should also

--- a/dal-cpp/README.md
+++ b/dal-cpp/README.md
@@ -8,8 +8,9 @@ generation, storage, and concurrency.
 
 | Path          | Contents                                                     |
 |---------------|--------------------------------------------------------------|
-| `dal/`        | Core headers and implementations, organized by domain        |
-| `tests/`      | Google Test coverage for core behavior and numerical methods |
+| `dal/`          | Core headers and implementations, organized by domain        |
+| `tests/`        | Google Test coverage for core behavior and numerical methods |
+| `test-support/` | Test-only helpers shared across suites                       |
 | `examples/`   | Runnable C++ examples                                        |
 | `benchmarks/` | Opt-in native performance executables                        |
 | `config/`     | Machinist interface and generation configuration             |

--- a/dal-excel/README.md
+++ b/dal-excel/README.md
@@ -97,6 +97,7 @@ is the exact argument and settings-key reference.
 | `src/`      | Handwritten Excel conversion, repository, and public-function implementations |
 | `auto/`     | Machinist-generated registration wrappers and HTML function help              |
 | `examples/` | Example workbooks                                                             |
+| `tests/`    | Excel-side Google Test coverage                                               |
 
 Machinist generates both core storables and Excel wrappers from the shared
 configuration. After markup changes, regenerate both trees:

--- a/dal-public/README.md
+++ b/dal-public/README.md
@@ -35,6 +35,7 @@ in `DAL_CPP_MSVC_RUNTIME_LIBRARY`; it is a no-op on other toolchains.
 | `random.hpp`                               | Pseudo-random and Sobol matrix fills             |
 | `curveprotocol.hpp`, `curveinstrument.hpp` | Curve conventions and quoted instruments         |
 | `curvedata.hpp`, `curvespec.hpp`           | Curve construction and single/staged calibration |
+| `curvepricing.hpp`                         | Typed rate-cashflow planning, pricing, and node sensitivities |
 | `xccycalibration.hpp`                      | Cross-currency calibration                       |
 | `interp.hpp`                               | Linear interpolation helper                      |
 | `repository.hpp`                           | Host-environment repository operations           |

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -356,7 +356,9 @@ dupire_model = dal.DupireModelData_New(
 ### Products
 
 - `dal.Product_New(dates, events)` — Create a script product from event dates and payoff definitions
-- `dal.Product_Debug(product)` — Print human-readable product structure
+- `dal.Product_Debug(product)` — Print the legacy human-readable product structure
+- `dal.Product_DebugJson(product)` — Versioned JSON dump of the product AST (schema `dal.script-product/1`)
+- `dal.Product_DebugTree(product, ascii=False, width=125)` — Width-aware Unicode (or ASCII) product tree
 
 ### Valuation
 

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -9,6 +9,7 @@ Python bindings for the Derivatives Algorithms Library (DAL) — a high-performa
 - **AAD Greeks** — compute pathwise sensitivities (delta, vega, rho, etc.) in a single simulation
 - **Script engine** — define exotic payoffs using a domain-specific language
 - **Curve calibration** — single-curve, multi-curve, staged XCCY, and joint domestic/foreign/basis calibration with resettable and MTM instruments plus AAD analytic Jacobians
+- **Rate cashflow pricing** — typed planning, batch PV, and AAD node sensitivities for deposit, FRA, future, OIS, IRS, basis-swap, and cross-currency trades
 - **Type-safe wrappers** for `Date_`, `Matrix_`, `Cell_`, and vector types
 
 ## Prerequisites
@@ -418,6 +419,7 @@ Tests are located in `tests/` and cover:
 - AAD Greek computation and validation
 - Random number generator properties
 - Curve construction plus single and staged multi-curve calibration
+- Rate cashflow planning, pricing, and node sensitivities
 - Staged XCCY basis calibration, sensitivity matrices, axes, and availability metadata
 - Resettable/MTM XCCY construction with immutable fixing snapshots
 - Joint domestic/foreign/basis XCCY calibration, including matrix and named-range contracts
@@ -428,7 +430,13 @@ Tests are located in `tests/` and cover:
 dal-python/
 ├── CMakeLists.txt          # Build configuration
 ├── pyproject.toml          # Python package metadata (scikit-build-core)
-├── run_tests.sh            # Standalone binding test helper
+├── build_sdist.sh          # Source distribution helper
+├── build_wheel.sh          # Wheel build helpers (POSIX and PowerShell)
+├── build_wheel.ps1
+├── run_tests.sh            # Standalone binding test helpers (POSIX and PowerShell)
+├── run_tests.ps1
+├── examples/               # Numbered end-to-end Python examples
+├── scripts/                # Release verification and installed-wheel smoke helpers
 ├── src/
 │   ├── bindings/
 │   │   ├── module.cpp        # pybind11 module definition

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,7 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
   - Domain processor (variable range analysis, always-true/false flags)
   - Constant condition processor (dead-branch pruning)
   - Fuzzy evaluator (smooth transitions for pathwise AAD; nested-if merging)
+  - Product debug outputs (legacy text, versioned JSON, Unicode/ASCII tree)
 
 - **[dupire.md](methodology/dupire.md)** — Dupire Local Volatility
   - Discounted spot-call contract and rate-aware Dupire formula

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,17 @@ The main core namespaces live under `dal-cpp/dal/`:
 | `curve/`       | Discount/forward curves, calibration instruments, single- and multi-curve solvers                            |
 | `script/`      | Product preprocessing, parsing, domain analysis, tree-walk/compiled evaluation, Monte Carlo                  |
 | `model/`       | Black-Scholes, Dupire, implied- and local-volatility machinery                                               |
+| `time/`        | Dates, calendars, schedules, and day-count bases                                                             |
+| `protocol/`    | Market and contract conventions: accrual, payment, coupon, option types, collateral                          |
+| `currency/`    | Currency definitions and static data                                                                         |
+| `indice/`      | Index interfaces, fixing stores and immutable snapshots, name-driven parsers                                 |
+| `risk/`        | Risk report types and aggregation                                                                            |
 | `storage/`     | Storables, archives, process-wide dates/fixings, and repository integration                                  |
 | `concurrency/` | Lazy process-wide worker pool and synchronized task queue                                                    |
+| `platform/`    | Compile-time configuration, constants, host and process initialization                                       |
+| `io/`          | Excel driver/import helpers                                                                                  |
+| `string/`, `utilities/` | String type, algorithms, dictionary, and environment/composite helpers                                |
+| `auto/`        | Machinist-generated enums, storables, and readers/writers                                                    |
 
 Methodology belongs in `docs/methodology/`; local source comments document the
 invariants needed to maintain a symbol safely.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,24 +34,24 @@ libraries.
 
 The main core namespaces live under `dal-cpp/dal/`:
 
-| Area           | Contents                                                                                                     |
-|----------------|--------------------------------------------------------------------------------------------------------------|
-| `math/`        | Vectors, matrices, interpolation, root finding, integration, optimization, random generation, PDE primitives |
-| `math/aad/`    | Native and adapter-backed reverse-mode AAD facade                                                            |
-| `curve/`       | Discount/forward curves, calibration instruments, single- and multi-curve solvers                            |
-| `script/`      | Product preprocessing, parsing, domain analysis, tree-walk/compiled evaluation, Monte Carlo                  |
-| `model/`       | Black-Scholes, Dupire, implied- and local-volatility machinery                                               |
-| `time/`        | Dates, calendars, schedules, and day-count bases                                                             |
-| `protocol/`    | Market and contract conventions: accrual, payment, coupon, option types, collateral                          |
-| `currency/`    | Currency definitions and static data                                                                         |
-| `indice/`      | Index interfaces, fixing stores and immutable snapshots, name-driven parsers                                 |
-| `risk/`        | Risk report types and aggregation                                                                            |
-| `storage/`     | Storables, archives, process-wide dates/fixings, and repository integration                                  |
-| `concurrency/` | Lazy process-wide worker pool and synchronized task queue                                                    |
-| `platform/`    | Compile-time configuration, constants, host and process initialization                                       |
-| `io/`          | Excel driver/import helpers                                                                                  |
-| `string/`, `utilities/` | String type, algorithms, dictionary, and environment/composite helpers                                |
-| `auto/`        | Machinist-generated enums, storables, and readers/writers                                                    |
+| Area                    | Contents                                                                                                       |
+|-------------------------|----------------------------------------------------------------------------------------------------------------|
+| `math/`                 | Vectors, matrices, interpolation, root finding, integration, optimization, random generation, PDE primitives   |
+| `math/aad/`             | Native and adapter-backed reverse-mode AAD facade                                                              |
+| `curve/`                | Discount/forward curves, calibration instruments, single- and multi-curve solvers                              |
+| `script/`               | Product preprocessing, parsing, domain analysis, tree-walk/compiled evaluation, Monte Carlo                    |
+| `model/`                | Black-Scholes, Dupire, implied- and local-volatility machinery                                                 |
+| `time/`                 | Dates, calendars, schedules, and day-count bases                                                               |
+| `protocol/`             | Market and contract conventions: accrual, payment, coupon, option types, collateral                            |
+| `currency/`             | Currency definitions and static data                                                                           |
+| `indice/`               | Index interfaces, fixing stores and immutable snapshots, name-driven parsers                                   |
+| `risk/`                 | Risk report types and aggregation                                                                              |
+| `storage/`              | Storables, archives, process-wide dates/fixings, and repository integration                                    |
+| `concurrency/`          | Lazy process-wide worker pool and synchronized task queue                                                      |
+| `platform/`             | Compile-time configuration, constants, host and process initialization                                         |
+| `io/`                   | Excel driver/import helpers                                                                                    |
+| `string/`, `utilities/` | String type, algorithms, dictionary, and environment/composite helpers                                         |
+| `auto/`                 | Machinist-generated enums, storables, and readers/writers                                                      |
 
 Methodology belongs in `docs/methodology/`; local source comments document the
 invariants needed to maintain a symbol safely.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -40,7 +40,7 @@ on other toolchains.
 | Header                                 | Main entry points                                                                                   |
 |----------------------------------------|-----------------------------------------------------------------------------------------------------|
 | `<dal-public/src/global.hpp>`          | `InitGlobalData`, `SetEvaluationDate`, `GetEvaluationDate`                                          |
-| `<dal-public/src/script.hpp>`          | `NewScriptProduct`, `DebugScriptProduct`                                                            |
+| `<dal-public/src/script.hpp>`          | `NewScriptProduct`, `DebugScriptProduct`, `DebugScriptProductJson`, `DebugScriptProductTree`       |
 | `<dal-public/src/models.hpp>`          | `NewBSModelData`, `NewDupireModelData`                                                              |
 | `<dal-public/src/value.hpp>`           | `ValueByMonteCarlo`                                                                                 |
 | `<dal-public/src/random.hpp>`          | Pseudo/Sobol constructors and uniform/normal matrix fills                                           |
@@ -108,6 +108,14 @@ interval, so evaluation-date setters wait until valuation finishes while
 getters remain available through the store lock. Monte Carlo valuations are
 serialized within one process; callers that require independent concurrent
 dates should use isolated processes.
+
+Script products dump three ways: `DebugScriptProduct` returns the legacy
+indented s-expression listing, `DebugScriptProductJson` a compact versioned
+JSON AST (schema `dal.script-product/1`, past events included, variable and
+constant tables resolved), and `DebugScriptProductTree(product, ascii, width)`
+a width-aware Unicode tree with a pure-ASCII fallback. See the
+[script engine methodology](methodology/script_engine.md#product-debug-outputs)
+for the formats and the dump grammar.
 
 ### C++ curve calibration
 
@@ -247,7 +255,7 @@ import dal
 | Workflow                | Python entry points                                                                                                                                                                            |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dates/global state      | `Date_`, `Year`, `Month`, `Day`, `EvaluationDate_Set`, `EvaluationDate_Get`                                                                                                                    |
-| Script products         | `Product_New`, `Product_Debug`                                                                                                                                                                 |
+| Script products         | `Product_New`, `Product_Debug`, `Product_DebugJson`, `Product_DebugTree`                                                                                                                                                        |
 | Models                  | `BSModelData_New`, `DupireModelData_New`                                                                                                                                                       |
 | Valuation               | `MonteCarlo_Value`                                                                                                                                                                             |
 | Random generation       | `PseudoRSG_New`, `SobolRSG_New`, `*_Get_Uniform`, `*_Get_Normal`                                                                                                                               |


### PR DESCRIPTION
## Summary
- Reconcile the documented repository structure with the actual tree: complete the `dal-cpp/dal/` domain lists in README.md, CLAUDE.md, docs/architecture.md, and copilot-instructions.md, add the benchmarks harness header, test-support/, and the full example set
- Correct CI prose: pull requests run the full compiler x AAD-backend matrix, pushes run the lean gcc-14/clang-20 subset, coverage lives on the gcc-14/aadet leg, and the documentation-integrity job is listed separately
- Add curvepricing.hpp to the dal-public surface table, tests/ to the dal-excel layout, and rate-cashflow pricing to the Python component guide
- Record the shipped script-product debug dumps (#293) in the published surface: `DebugScriptProductJson` / `DebugScriptProductTree` in the public-api facade table and prose, `Product_DebugJson` / `Product_DebugTree` in the Python tables, plus the docs index, README.md, CLAUDE.md, and the dal-python API reference
- Mark the merged dal-web extraction design/plan as implemented history

## Test plan
- [x] `python .github/scripts/check_docs.py` — all 46 Markdown files pass (links, tables, forbidden macros, referenced paths)
- [x] `git diff --check` clean; markdown table pipe alignment verified for all four public-api tables
- [x] Mirror pairs `.claude/rules/*` vs `.codex/references/*` remain byte-identical
- [ ] CI green on this PR (documentation-integrity job included in the Linux workflow)