### PR TITLE
feat: add script product tree visualization examples

### DIFF
--- a/dal-cpp/examples/CMakeLists.txt
+++ b/dal-cpp/examples/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(european_fd)
 add_subdirectory(snowball)
 add_subdirectory(sobol)
 add_subdirectory(script)
+add_subdirectory(script_tree)
 add_subdirectory(underdetermined)
 add_subdirectory(uoc)
 add_subdirectory(vanilla)
@@ -68,6 +69,7 @@ set(DAL_EXAMPLE_TARGETS
     snowball
     sobol
     script
+    script_tree
     underdetermined
     uoc
     vanilla

--- a/dal-cpp/examples/script_tree/CMakeLists.txt
+++ b/dal-cpp/examples/script_tree/CMakeLists.txt
@@ -1,0 +1,22 @@
+file(GLOB_RECURSE SCRIPT_TREE_FILES CONFIGURE_DEPENDS "*.hpp" "*.cpp")
+add_executable(script_tree ${SCRIPT_TREE_FILES})
+
+target_link_libraries(script_tree dal_library)
+
+if(DAL_USE_XAD_AAD)
+    target_link_libraries(script_tree XAD::xad)
+elseif(DAL_USE_CODIPACK_AAD)
+    target_link_libraries(script_tree CoDiPack)
+elseif(DAL_USE_ADEPT_AAD)
+    target_link_libraries(script_tree adept)
+endif ()
+
+if(MSVC)
+else()
+    target_link_libraries(script_tree pthread)
+endif()
+
+install(TARGETS script_tree
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+        )

--- a/dal-cpp/examples/script_tree/script_tree.cpp
+++ b/dal-cpp/examples/script_tree/script_tree.cpp
@@ -1,0 +1,81 @@
+//
+// Created by wegam on 2026/8/17.
+//
+//  Visualizes a script product with the width-aware Unicode tree dump
+//  (ScriptProduct_::DebugTree) -- the human-friendly companion of the legacy
+//  s-expression dump (examples/script) and the JSON dump (DebugJson).
+//
+//  Unicode output needs a UTF-8 terminal; on Windows use Windows Terminal or
+//  `chcp 65001`. The ASCII style (ascii = true) is the constrained-console
+//  fallback.
+
+#include <iostream>
+
+//  DAL headers first: <windows.h> macros (VOID, ...) clash with DAL enums
+#include <dal/platform/platform.hpp>
+#include <dal/script/event.hpp>
+#include <dal/storage/globals.hpp>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+using namespace std;
+using namespace Dal;
+using namespace Dal::Script;
+
+
+int main() {
+#ifdef _WIN32
+    //  Render the box-drawing glyphs on the Windows console as well
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
+    Dal::RegisterAll_::Init();
+
+    Global::Dates_::SetEvaluationDate(Date_(2022, 9, 25));
+
+    Vector_<Cell_> eventDates;
+    Vector_<String_> events;
+
+    // macro definition for `BARRIER` and `STRIKE` constants
+    eventDates.emplace_back("BARRIER");
+    events.emplace_back("150.00");
+    eventDates.emplace_back("STRIKE");
+    events.emplace_back("120.00");
+
+    // initialization
+    eventDates.emplace_back(Date_(2022, 9, 25));
+    events.emplace_back("alive = 1");
+
+    // monitor periods -- quarterly over one year keeps the demo output compact
+    eventDates.emplace_back(
+            "START: 2022-09-25\n"
+            "END: 2023-09-25\n"
+            "FREQ: 3M");
+    events.emplace_back("IF spot() > BARRIER:0.1 THEN alive = 0 END");
+
+    // final payoff
+    eventDates.emplace_back(Date_(2023, 9, 25));
+    events.emplace_back("IF spot() > BARRIER:0.1 THEN alive = 0 END uoc pays alive * MAX(spot() - STRIKE, 0.0)");
+
+    ScriptProduct_ product(eventDates, events);
+    //  Resolve the variable/constant tables and the payoff slot, so the dump
+    //  header shows `Variables:`/`Constants:` -- mirroring what the dal-public
+    //  wrapper DebugScriptProductTree does on its private copy
+    product.IndexVariables();
+
+    //  Unicode style: statements inline while they fit the width budget
+    cout << "=== Unicode tree (width = 125) ===" << endl;
+    product.DebugTree(cout, false, 125);
+
+    //  Narrow the budget: oversized statements expand into box-drawing branches
+    cout << "\n=== Unicode tree (width = 40) ===" << endl;
+    product.DebugTree(cout, false, 40);
+
+    //  ASCII fallback for constrained consoles
+    cout << "\n=== ASCII tree (width = 40) ===" << endl;
+    product.DebugTree(cout, true, 40);
+
+    return 0;
+}

--- a/dal-python/examples/008.script_tree.py
+++ b/dal-python/examples/008.script_tree.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Visualize a script product with the width-aware Unicode tree dump.
+
+``Product_DebugTree`` renders the parsed product as a human-friendly tree:
+statements collapse to inline math while they fit the width budget
+(``width``, default 125) and expand into box-drawing branches otherwise;
+``if`` branches are marked with ``▶`` (then) / ``▷`` (else) and fuzzy
+comparisons show their smoothing as ``⟨ε=0.1⟩``. ``ascii=True`` switches to
+a pure-ASCII fallback for constrained consoles.
+
+Unicode output needs a UTF-8 terminal (on Windows, Windows Terminal or
+``chcp 65001``). Machine consumers should use ``Product_DebugJson`` instead.
+"""
+
+import sys
+
+from dal import *
+
+if sys.platform == "win32":
+    #  Render the box-drawing glyphs on a UTF-8 capable Windows console
+    sys.stdout.reconfigure(encoding="utf-8")
+
+event_dates = [
+    # macro definition for `BARRIER` and `STRIKE` constants
+    "BARRIER",
+    "STRIKE",
+    # initialization
+    Date_(2022, 9, 25),
+    # monitor periods -- quarterly over one year keeps the demo output compact
+    "START: 2022-09-25\nEND: 2023-09-25\nFREQ: 3M",
+    # final payoff
+    Date_(2023, 9, 25),
+]
+events = [
+    "150.00",
+    "120.00",
+    "alive = 1",
+    "IF spot() > BARRIER:0.1 THEN alive = 0 END",
+    "IF spot() > BARRIER:0.1 THEN alive = 0 END uoc pays alive * MAX(spot() - STRIKE, 0.0)",
+]
+
+EvaluationDate_Set(Date_(2022, 9, 25))
+product = Product_New(event_dates, events)
+
+print("=== Unicode tree (width = 125) ===")
+print(Product_DebugTree(product))
+
+print("=== Unicode tree (width = 40) ===")
+print(Product_DebugTree(product, width=40))
+
+print("=== ASCII tree (width = 40) ===")
+print(Product_DebugTree(product, ascii=True, width=40))

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -611,3 +611,6 @@ is `Product_DebugJson(product)` and
 - [`dal-cpp/examples/script/`](../../dal-cpp/examples/script/) — runnable example
   of the full pipeline: events table parsing, preprocessing, domain analysis,
   condition folding, and evaluation.
+- [`dal-cpp/examples/script_tree/`](../../dal-cpp/examples/script_tree/) and
+  [`dal-python/examples/008.script_tree.py`](../../dal-python/examples/008.script_tree.py)
+  — runnable demos of the Unicode/ASCII tree dump at several width budgets.


### PR DESCRIPTION
## Summary
- Add `dal-cpp/examples/script_tree`: renders a UOC script product with `ScriptProduct_::DebugTree` in Unicode at the default width (125) and a narrow width (40) — showing inline statements expanding into box-drawing `├──`/`└──` branches with `▶` then-markers — plus the pure-ASCII fallback for constrained consoles. The example resolves the variable/constant tables via `IndexVariables()` (mirroring the dal-public `DebugScriptProductTree` wrapper), sets the Windows console to UTF-8, and keeps `<windows.h>` after the DAL headers (its `VOID` macro breaks `MG_StackInfoType_enum.hpp`).
- Add `dal-python/examples/008.script_tree.py` mirroring the C++ demo through `Product_DebugTree(product, ascii=..., width=...)`, with UTF-8 stdout reconfiguration on Windows.
- Register the new `script_tree` target in `dal-cpp/examples/CMakeLists.txt` (`add_subdirectory` + `DAL_EXAMPLE_TARGETS`) and link both demos from `docs/methodology/script_engine.md` § See Also.

## Test plan
- [x] Run `script_tree` executable on Windows (MSVC/Release-windows) and Linux (WSL gcc-15/Release-linux); Unicode, narrow-width, and ASCII outputs verified identical across platforms
- [x] Run `008.script_tree.py` against the built `_dal` module; output identical to the C++ demo
- [x] Full `ctest --test-dir build/Release-linux --output-on-failure -LE benchmark`: 1363/1363 passed, 0 failed
- [x] `python3 .github/scripts/check_docs.py` documentation integrity check passed (46 files)
- [x] `clang-format` review: new file follows the same conventions as the sibling `examples/script` (remaining dry-run notes are version drift affecting all committed examples equally)