### PR TITLE
fix: remove duplicate final barrier check

### DIFF
--- a/dal-cpp/examples/script_tree/script_tree.cpp
+++ b/dal-cpp/examples/script_tree/script_tree.cpp
@@ -57,7 +57,7 @@ int main() {
 
     // final payoff
     eventDates.emplace_back(Date_(2023, 9, 25));
-    events.emplace_back("IF spot() > BARRIER:0.1 THEN alive = 0 END uoc pays alive * MAX(spot() - STRIKE, 0.0)");
+    events.emplace_back("uoc pays alive * MAX(spot() - STRIKE, 0.0)");
 
     ScriptProduct_ product(eventDates, events);
     //  Resolve the variable/constant tables and the payoff slot, so the dump


### PR DESCRIPTION
## Summary
- remove the duplicate barrier check from the final payoff script
- rely on the monitoring schedule, which already includes the expiry date

## Test plan
- [x] `cmake --build build/Release-windows --target script_tree --config Release`
- [x] Run `build/Release-windows/dal-cpp/examples/script_tree/script_tree.exe`
- [x] Full suite not run; this change only simplifies a script literal in the example