### PR TITLE
fix: guard UB and collapse duplicated helpers

### DIFF
--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -32,11 +32,6 @@ namespace Dal {
             AccrualPeriod_ accrual_;
         };
 
-        bool ValidFixingIdentity(const FixingIdentity_& identity) {
-            return !identity.indexName_.empty() && identity.fixingHour_ >= 0 && identity.fixingHour_ < 24 && identity.fixingMinute_ >= 0 &&
-                   identity.fixingMinute_ < 60;
-        }
-
         Date_ FixingDate(const Date_& accrualStart, const RateIndexConvention_& index) {
             if (index.fixingLag_ == 0)
                 return accrualStart;
@@ -46,7 +41,7 @@ namespace Dal {
 
         DateTime_ FixingTime(const Date_& accrualStart, const RateIndexConvention_& index, const FixingIdentity_& identity) {
             REQUIRE(ValidFixingIdentity(identity), "Floating rate pricing requires an explicit valid fixing identity");
-            return DateTime_(FixingDate(accrualStart, index), identity.fixingHour_, identity.fixingMinute_);
+            return FixingDateTime(FixingDate(accrualStart, index), identity);
         }
 
         const DiscountCurve_& Curve(const RatePricingMarket_& market, const String_& key) {
@@ -64,12 +59,8 @@ namespace Dal {
                 values->push_back(value);
         }
 
-        bool SameFixing(const FixingRequest_& lhs, const FixingRequest_& rhs) {
-            return lhs.indexName_ == rhs.indexName_ && lhs.fixingTime_ == rhs.fixingTime_;
-        }
-
         void AddUnique(const FixingRequest_& value, Vector_<FixingRequest_>* values) {
-            if (std::find_if(values->begin(), values->end(), [&](const auto& item) { return SameFixing(item, value); }) == values->end())
+            if (std::find_if(values->begin(), values->end(), [&](const auto& item) { return SameFixingRequest(item, value); }) == values->end())
                 values->push_back(value);
         }
 

--- a/dal-cpp/dal/curve/xccyinstrument.hpp
+++ b/dal-cpp/dal/curve/xccyinstrument.hpp
@@ -10,6 +10,7 @@
 #include <dal/curve/xccynotionalmode.hpp>
 #include <dal/protocol/rateconvention.hpp>
 #include <dal/time/date.hpp>
+#include <dal/time/datetime.hpp>
 
 namespace Dal {
     class CrossCurrencyMarket_;
@@ -34,6 +35,17 @@ namespace Dal {
         int fixingHour_ = -1;
         int fixingMinute_ = -1;
     };
+
+    inline bool ValidFixingIdentity(const FixingIdentity_& identity) {
+        return !identity.indexName_.empty() && identity.fixingHour_ >= 0 && identity.fixingHour_ < 24 && identity.fixingMinute_ >= 0 &&
+               identity.fixingMinute_ < 60;
+    }
+
+    inline DateTime_ FixingDateTime(const Date_& date, const FixingIdentity_& identity) {
+        if (identity.fixingHour_ < 0 || identity.fixingMinute_ < 0)
+            return DateTime_(date);
+        return DateTime_(date, identity.fixingHour_, identity.fixingMinute_);
+    }
 
     struct FxResetConvention_ {
         int fixingLag_ = -1;

--- a/dal-cpp/dal/curve/xccypricing.cpp
+++ b/dal-cpp/dal/curve/xccypricing.cpp
@@ -15,11 +15,6 @@
 
 namespace Dal {
     namespace {
-        bool ValidFixingIdentity(const FixingIdentity_& identity) {
-            return !identity.indexName_.empty() && identity.fixingHour_ >= 0 && identity.fixingHour_ < 24 && identity.fixingMinute_ >= 0 &&
-                   identity.fixingMinute_ < 60;
-        }
-
         void ValidateResetConfig(const CrossCurrencySwapConfig_& config) {
             if (config.notionalMode_ == XccyNotionalMode_::Value_::FIXED)
                 return;
@@ -29,12 +24,6 @@ namespace Dal {
                     "Resettable XCCY plan requires a valid FX fixing time");
             REQUIRE(ValidFixingIdentity(config.domesticRateFixing_) && ValidFixingIdentity(config.foreignRateFixing_),
                     "Resettable XCCY plan requires explicit domestic and foreign rate fixing identities");
-        }
-
-        DateTime_ RateFixingTime(const Date_& date, const FixingIdentity_& identity) {
-            if (identity.fixingHour_ < 0 || identity.fixingMinute_ < 0)
-                return DateTime_(date);
-            return DateTime_(date, identity.fixingHour_, identity.fixingMinute_);
         }
 
         Date_ FxFixingDate(const Date_& effectiveDate, const FxResetConvention_& convention) {
@@ -49,16 +38,12 @@ namespace Dal {
                 return;
             for (auto& period : *periods) {
                 period.rateIndexName_ = identity.indexName_;
-                period.rateFixingTime_ = RateFixingTime(period.schedule_.fixingDate_, identity);
+                period.rateFixingTime_ = FixingDateTime(period.schedule_.fixingDate_, identity);
             }
         }
 
         bool RequestLess(const FixingRequest_& lhs, const FixingRequest_& rhs) {
             return lhs.indexName_ < rhs.indexName_ || (lhs.indexName_ == rhs.indexName_ && lhs.fixingTime_ < rhs.fixingTime_);
-        }
-
-        bool SameRequest(const FixingRequest_& lhs, const FixingRequest_& rhs) {
-            return lhs.indexName_ == rhs.indexName_ && lhs.fixingTime_ == rhs.fixingTime_;
         }
 
         void AddHistoricalRateRequests(const Vector_<XccyCouponPeriod_>& periods,
@@ -197,7 +182,7 @@ namespace Dal {
         }
 
         std::sort(result.begin(), result.end(), RequestLess);
-        result.erase(std::unique(result.begin(), result.end(), SameRequest), result.end());
+        result.erase(std::unique(result.begin(), result.end(), SameFixingRequest), result.end());
         return result;
     }
     template <class T_>

--- a/dal-cpp/dal/curve/ycconst.cpp
+++ b/dal-cpp/dal/curve/ycconst.cpp
@@ -20,8 +20,6 @@ namespace Dal {
     #include <dal/auto/MG_DiscountPWC_v1_Write.inc>
 
     namespace Tape {
-        constexpr double DAYS_PER_YEAR_PWC = 365.0;
-
         template <class T_, class B_>
         DiscountPWC_<T_, B_>::DiscountPWC_(
             const String_& name, const String_& ccy, const Vector_<Date_>& knotDates, const Vector_<T_>& fRightT, const Handle_<B_>& base)
@@ -58,7 +56,7 @@ namespace Dal {
         }
 
         template <class T_, class B_> T_ DiscountPWC_<T_, B_>::operator()(const Date_& from, const Date_& to) const {
-            const T_ logDf = -(IntegralTo(to) - IntegralTo(from)) / DAYS_PER_YEAR_PWC;
+            const T_ logDf = -(IntegralTo(to) - IntegralTo(from)) / DAYS_PER_YEAR;
             return DiscountFromLogDf(logDf, this->base_, from, to);
         }
 

--- a/dal-cpp/dal/curve/ycpwlf.cpp
+++ b/dal-cpp/dal/curve/ycpwlf.cpp
@@ -103,11 +103,11 @@ namespace Dal {
                 // path below stays the AAD-tape recording path.
                 const PiecewiseLinear_ pwl(knotDates_, fLeftT_, fRightT_);
                 const double integral = pwl.IntegralTo(to) - pwl.IntegralTo(from);
-                return DiscountFromLogDf(-integral / DAYS_PER_YEAR_PWLF, this->base_, from, to);
+                return DiscountFromLogDf(-integral / DAYS_PER_YEAR, this->base_, from, to);
             } else {
                 const double fromT = static_cast<double>(from - knotDates_.front());
                 const double toT = static_cast<double>(to - knotDates_.front());
-                const T_ logDf = -(IntegralTo(toT) - IntegralTo(fromT)) / static_cast<double>(DAYS_PER_YEAR_PWLF);
+                const T_ logDf = -(IntegralTo(toT) - IntegralTo(fromT)) / static_cast<double>(DAYS_PER_YEAR);
                 return DiscountFromLogDf(logDf, this->base_, from, to);
             }
         }

--- a/dal-cpp/dal/curve/ycpwlf.hpp
+++ b/dal-cpp/dal/curve/ycpwlf.hpp
@@ -15,7 +15,6 @@
 namespace Dal {
     // See docs/methodology/yield_curve_jacobian.md: "Joint Multi-Curve Analytic Jacobian".
     namespace Tape {
-        constexpr double DAYS_PER_YEAR_PWLF = 365.0;
 
         template <class T_, class B_ = DiscountCurve_<double>>
         class DiscountPWLF_ : public CurveWithBase_<DiscountCurve_<T_>, B_>, public FittableCurve_ {

--- a/dal-cpp/dal/indice/fixingsnapshot.hpp
+++ b/dal-cpp/dal/indice/fixingsnapshot.hpp
@@ -21,6 +21,10 @@ namespace Dal {
         DateTime_ fixingTime_;
     };
 
+    inline bool SameFixingRequest(const FixingRequest_& lhs, const FixingRequest_& rhs) {
+        return lhs.indexName_ == rhs.indexName_ && lhs.fixingTime_ == rhs.fixingTime_;
+    }
+
     class MarketFixingSnapshot_ {
     public:
         using history_t = std::map<DateTime_, double>;

--- a/dal-cpp/dal/math/aad/aad.hpp
+++ b/dal-cpp/dal/math/aad/aad.hpp
@@ -31,6 +31,7 @@ namespace Dal::AAD {
 
     // Contract: one mode per sweep — all nodes on a tape must be recorded under a single multi_ setting between Clear()s.
     FORCE_INLINE auto SetNumResultsForAAD(bool multi = false, size_t numResults = 1) {
+        REQUIRE(numResults > 0 && numResults <= ADJ_SIZE, "SetNumResultsForAAD: numResults out of range");
         Tape_* tape = Tape();
         bool oldMulti = tape->multi_;
         size_t oldNumAdj = tape->numAdj_;

--- a/dal-cpp/dal/math/aad/blocklist.hpp
+++ b/dal-cpp/dal/math/aad/blocklist.hpp
@@ -17,6 +17,7 @@
 #include <iterator>
 #include <list>
 #include <type_traits>
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal::AAD {
 
@@ -105,6 +106,7 @@ namespace Dal::AAD {
         }
 
         template <size_t N_> T_* EmplaceBackMulti() {
+            static_assert(N_ > 0 && N_ <= BLOCK_SIZE_);
             if (std::distance(nextSpace_, lastSpace_) < static_cast<int>(N_))
                 NextBlock();
             auto old_next = nextSpace_;
@@ -113,6 +115,7 @@ namespace Dal::AAD {
         }
 
         T_* EmplaceBackMulti(const size_t& n) {
+            REQUIRE(n > 0 && n <= BLOCK_SIZE_, "EmplaceBackMulti: n out of range");
             if (std::distance(nextSpace_, lastSpace_) < static_cast<int>(n))
                 NextBlock();
             auto old_next = nextSpace_;

--- a/dal-cpp/dal/math/aad/expr.hpp
+++ b/dal-cpp/dal/math/aad/expr.hpp
@@ -472,7 +472,7 @@ namespace Dal::AAD {
             exprNode.pDerivatives_[n_] = adjoint;
         }
 
-        Number_() = default;
+        Number_(): value_(0.0), node_(nullptr) {}
 
         Number_(double val) : value_(val) { node_ = CreateMultiNode<0>(); }
 
@@ -556,7 +556,10 @@ namespace Dal::AAD {
     FORCE_INLINE double Value(const UnaryExpression_<ARG_, OP_>& e) { return e.value_; }
 
     FORCE_INLINE double Value(const Number_& num) { return num.value_; }
-    FORCE_INLINE double& Adjoint(const Number_& num) { return num.node_->Adjoint(); }
+    FORCE_INLINE double& Adjoint(const Number_& num) {
+        REQUIRE(num.node_ != nullptr, "Adjoint: Number_ has no tape node");
+        return num.node_->Adjoint();
+    }
 
     FORCE_INLINE void PutOnTape(Number_& n) { n.node_ = n.CreateMultiNode<0>(); }
 } // namespace Dal::AAD
@@ -738,8 +741,8 @@ namespace Dal::AAD {
 
 #if defined(DAL_USE_ADEPT_AAD) || defined(DAL_USE_XAD_AAD) || defined(DAL_USE_CODIPACK_AAD)
 namespace Dal::AAD {
-    constexpr double INV_SQRT_2PI = 0.3989422804014327;
-    constexpr double SQRT_2 = 1.4142135623730951;
+    constexpr double INV_SQRT_2PI = 1.0 / M_SQRT_2_PI;
+    constexpr double SQRT_2 = M_SQRT_2;
 
     FORCE_INLINE Number_ NPDF(const Number_& z) {
         return INV_SQRT_2PI * exp(-0.5 * z * z);

--- a/dal-cpp/dal/math/analytics/vanilla.cpp
+++ b/dal-cpp/dal/math/analytics/vanilla.cpp
@@ -9,12 +9,14 @@
 namespace Dal::AAD {
 
     double BlackScholesIVol(double spot, double strike, double prem, double mat) {
+        REQUIRE(mat > 0.0, "BlackScholesIVol: maturity must be positive");
         static const OptionType_ type("CALL");
         const auto std_dev = Dal::Distribution::BlackIV(spot, strike, type, prem);
         return std_dev / Dal::sqrt(mat);
     }
 
     double BachelierIVol(double spot, double strike, double prem, double mat) {
+        REQUIRE(mat > 0.0, "BachelierIVol: maturity must be positive");
         static const OptionType_ type("CALL");
         const auto std_dev = Dal::Distribution::BachelierIV(spot, strike, type, prem);
         return std_dev / Dal::sqrt(mat);

--- a/dal-cpp/dal/math/interp/interp.hpp
+++ b/dal-cpp/dal/math/interp/interp.hpp
@@ -20,6 +20,7 @@ namespace Dal {
 
     template <class T_ = double>
     FORCE_INLINE T_ InterpLinearImplX(const Vector_<>& x, const Vector_<T_>& y, const T_& x0) {
+        REQUIRE(!x.empty() && x.size() == y.size(), "InterpLinearImplX: x and y must be non-empty and the same size");
         auto pge = LowerBound(x, Value(x0));
         if (pge == x.end())
             return y.back();

--- a/dal-cpp/dal/math/interp/interp.hpp
+++ b/dal-cpp/dal/math/interp/interp.hpp
@@ -20,7 +20,7 @@ namespace Dal {
 
     template <class T_ = double>
     FORCE_INLINE T_ InterpLinearImplX(const Vector_<>& x, const Vector_<T_>& y, const T_& x0) {
-        REQUIRE(!x.empty() && x.size() == y.size(), "InterpLinearImplX: x and y must be non-empty and the same size");
+        ASSERT(!x.empty() && x.size() == y.size(), "InterpLinearImplX: x and y must be non-empty and the same size");
         auto pge = LowerBound(x, Value(x0));
         if (pge == x.end())
             return y.back();

--- a/dal-cpp/dal/math/interp/interplinear.cpp
+++ b/dal-cpp/dal/math/interp/interplinear.cpp
@@ -37,12 +37,13 @@ namespace Dal {
 
         Interp1Linear_::Interp1Linear_(const String_& name, const Vector_<>& x, const Vector_<>& f)
             : Interp1_(name), x_(x), f_(f) {
-            REQUIRE(x_.size() == f_.size(), "x_ size must be equal to f_ size");
+            REQUIRE(!x_.empty() && x_.size() == f_.size(), "x_ must be non-empty and the same size as f_");
             REQUIRE(IsMonotonic(x_, std::less_equal<>()), "x_ array should be monotonic");
         }
 
         Interp1Linear_::Interp1Linear_(const String_& name, const std::map<double, double>& f)
             : Interp1_(name), x_(Keys(f)), f_(MapValues(f)) {
+            REQUIRE(!x_.empty(), "interpolation map must be non-empty");
             REQUIRE(IsMonotonic(x_, std::less_equal<>()), "x_ array should be monotonic");
         }
 

--- a/dal-cpp/dal/math/matrix/cholesky.cpp
+++ b/dal-cpp/dal/math/matrix/cholesky.cpp
@@ -65,6 +65,10 @@ namespace Dal {
                     lower_ = owned.release();
             }
 
+            Cholesky_(const Cholesky_&) = delete;
+            Cholesky_& operator=(const Cholesky_&) = delete;
+            Cholesky_(Cholesky_&&) = delete;
+            Cholesky_& operator=(Cholesky_&&) = delete;
             ~Cholesky_() override {
                 if (!needKeep_)
                     delete lower_;

--- a/dal-cpp/dal/math/pde/pdeoperators.cpp
+++ b/dal-cpp/dal/math/pde/pdeoperators.cpp
@@ -2,6 +2,7 @@
 // Created by dal-implementer on 2026/7/8.
 //
 
+#include <array>
 #include <memory>
 
 #include <dal/math/pde/pdeoperators.hpp>
@@ -16,35 +17,35 @@ namespace Dal::PDE {
             for (int i = 1; i < static_cast<int>(x.size()); ++i)
                 REQUIRE(x[i - 1] < x[i], "operator builder requires at least 3 strictly increasing locations");
         }
+
+        template <class Coeffs_>
+        std::unique_ptr<Sparse::TriDiagonal_> NewInteriorOperator(const Vector_<>& x, Coeffs_ coeffs) {
+            RequireOperatorLocations(x);
+            const int n = static_cast<int>(x.size());
+            std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
+            for (int i = 1; i < n - 1; ++i) {
+                const double dxl = x[i] - x[i - 1];
+                const double dxu = x[i + 1] - x[i];
+                const double dxm = dxl + dxu;
+                const auto c = coeffs(dxl, dxu, dxm);
+                ret->Set(i, i - 1, c[0]);
+                ret->Set(i, i, c[1]);
+                ret->Set(i, i + 1, c[2]);
+            }
+            return ret;
+        }
+
     } // namespace
 
     std::unique_ptr<Sparse::TriDiagonal_> NewDx(const Vector_<>& x) {
-        RequireOperatorLocations(x);
-        const int n = static_cast<int>(x.size());
-        std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
-        for (int i = 1; i < n - 1; ++i) {
-            const double dxl = x[i] - x[i - 1];
-            const double dxu = x[i + 1] - x[i];
-            const double dxm = dxl + dxu;
-            ret->Set(i, i - 1, -dxu / (dxl * dxm));
-            ret->Set(i, i, (dxu - dxl) / (dxl * dxu));
-            ret->Set(i, i + 1, dxl / (dxu * dxm));
-        }
-        return ret;
+        return NewInteriorOperator(x, [](double dxl, double dxu, double dxm) {
+            return std::array<double, 3>{-dxu / (dxl * dxm), (dxu - dxl) / (dxl * dxu), dxl / (dxu * dxm)};
+        });
     }
 
     std::unique_ptr<Sparse::TriDiagonal_> NewDxx(const Vector_<>& x) {
-        RequireOperatorLocations(x);
-        const int n = static_cast<int>(x.size());
-        std::unique_ptr<Sparse::TriDiagonal_> ret(new Sparse::TriDiagonal_(n));
-        for (int i = 1; i < n - 1; ++i) {
-            const double dxl = x[i] - x[i - 1];
-            const double dxu = x[i + 1] - x[i];
-            const double dxm = dxl + dxu;
-            ret->Set(i, i - 1, 2.0 / (dxl * dxm));
-            ret->Set(i, i, -2.0 / (dxl * dxu));
-            ret->Set(i, i + 1, 2.0 / (dxu * dxm));
-        }
-        return ret;
+        return NewInteriorOperator(x, [](double dxl, double dxu, double dxm) {
+            return std::array<double, 3>{2.0 / (dxl * dxm), -2.0 / (dxl * dxu), 2.0 / (dxu * dxm)};
+        });
     }
 } // namespace Dal::PDE

--- a/dal-cpp/dal/math/specialfunctions.cpp
+++ b/dal-cpp/dal/math/specialfunctions.cpp
@@ -41,7 +41,6 @@ namespace Dal {
 
         REQUIRE(x >= 0.0 && x <= 1.0, "x should be in bound [0, 1]");
 
-        static const double INV_NORM = 2.5066282746310002;
         static const double a1_ = -3.969683028665376e+01;
         static const double a2_ = 2.209460984245205e+02;
         static const double a3_ = -2.759285104469687e+02;
@@ -68,18 +67,14 @@ namespace Dal {
         static const double x_high_ = 1.0 - x_low_;
 
         double z;
+        const auto TailRational = [&](double p) {
+            const double r = std::sqrt(-2.0 * std::log(p));
+            return (((((c1_ * r + c2_) * r + c3_) * r + c4_) * r + c5_) * r + c6_) /
+                   ((((d1_ * r + d2_) * r + d3_) * r + d4_) * r + 1.0);
+        };
+
         if (x < x_low_ || x_high_ < x) {
-            if (x < x_low_) {
-                // Rational approximation for the lower region 0<x<u_low
-                z = std::sqrt(-2.0 * std::log(x));
-                z = (((((c1_ * z + c2_) * z + c3_) * z + c4_) * z + c5_) * z + c6_) /
-                    ((((d1_ * z + d2_) * z + d3_) * z + d4_) * z + 1.0);
-            } else {
-                // Rational approximation for the upper region u_high<x<1
-                z = std::sqrt(-2.0 * std::log(1.0 - x));
-                z = -(((((c1_ * z + c2_) * z + c3_) * z + c4_) * z + c5_) * z + c6_) /
-                    ((((d1_ * z + d2_) * z + d3_) * z + d4_) * z + 1.0);
-            }
+            z = x < x_low_ ? TailRational(x) : -TailRational(1.0 - x);
         } else {
             z = x - 0.5;
             double r = z * z;
@@ -89,7 +84,7 @@ namespace Dal {
 
         if (polish) {
             const double err = NCDF(z, precise) - x;
-            z -= err * INV_NORM * std::exp(std::min(8.0, 0.5 * Square(z)));
+            z -= err * M_SQRT_2_PI * std::exp(std::min(8.0, 0.5 * Square(z)));
         }
         return z;
     }

--- a/dal-cpp/dal/math/specialfunctions.hpp
+++ b/dal-cpp/dal/math/specialfunctions.hpp
@@ -5,9 +5,10 @@
 #pragma once
 
 #include <cmath>
+#include <dal/platform/consts.hpp>
 
 namespace Dal {
-    inline double NPDF(double z) { return z < -10.0 || 10.0 < z ? 0.0 : std::exp(-0.5 * z * z) / 2.506628274631; }
+    inline double NPDF(double z) { return z < -10.0 || 10.0 < z ? 0.0 : std::exp(-0.5 * z * z) / M_SQRT_2_PI; }
     double NCDF(double z, bool precise = true);
     double InverseNCDF(double x, bool precise = true, bool polish = true);
 } // namespace Dal

--- a/dal-cpp/dal/math/vectors.cpp
+++ b/dal-cpp/dal/math/vectors.cpp
@@ -4,8 +4,17 @@
 
 #include <dal/platform/strict.hpp>
 #include <dal/math/vectors.hpp>
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal::Vector {
+    void RequireSameSize(size_t lhs, size_t rhs) {
+        REQUIRE(lhs == rhs, "Vector_ size mismatch");
+    }
+
+    void RequireAtLeastTwoPoints(size_t points) {
+        REQUIRE(points >= 2, "XRange requires at least 2 points");
+    }
+
     Vector_<int> UpTo(int n) {
         Vector_<int> ret_val(static_cast<size_t>(n));
         for (auto i = 0; i != n; ++i)

--- a/dal-cpp/dal/math/vectors.hpp
+++ b/dal-cpp/dal/math/vectors.hpp
@@ -10,6 +10,10 @@
 #include <dal/platform/host.hpp>
 
 namespace Dal {
+    namespace Vector {
+        void RequireSameSize(size_t lhs, size_t rhs);
+        void RequireAtLeastTwoPoints(size_t points);
+    }
     /*
      * PRIVATE INHERITANCE from STL class vector
      * DON'T add any member variable to this class
@@ -48,10 +52,12 @@ namespace Dal {
         }
 
         template <class T_> void operator+=(const Vector_<T_>& other) {
+            Vector::RequireSameSize(size(), other.size());
             std::transform(begin(), end(), other.begin(), begin(), std::plus<E_>());
         }
 
         template <class T_> void operator-=(const Vector_<T_>& other) {
+            Vector::RequireSameSize(size(), other.size());
             std::transform(begin(), end(), other.begin(), begin(), std::minus<E_>());
         }
 
@@ -106,7 +112,6 @@ namespace Dal {
     }
 
     namespace Vector {
-
         template <class E_> Vector_<E_> V1(const E_& val) { return Vector_<E_>(1, val); }
 
         template <class E1_, class C2_> Vector_<E1_> Join(const Vector_<E1_>& c1, const C2_& c2) {
@@ -118,6 +123,7 @@ namespace Dal {
         Vector_<int> UpTo(int n);
 
         template <class E_> Vector_<E_> XRange(E_ start, E_ finish, size_t points) {
+            Vector::RequireAtLeastTwoPoints(points);
             Vector_<E_> x(points);
             E_ dx = (finish - start) / (points - 1);
             for (size_t i = 0; i < points - 1; ++i)
@@ -140,6 +146,7 @@ namespace Dal {
     template <class E_> FORCE_INLINE auto operator*(const E_& left, const Vector_<E_>& right) { return right * left; }
 
     template <class E_> FORCE_INLINE auto operator*(const Vector_<E_>& left, const Vector_<E_>& right) {
+        Vector::RequireSameSize(left.size(), right.size());
         Vector_<E_> ret(left.size());
         std::transform(left.begin(), left.end(), right.begin(), ret.begin(), [](const E_& val1, const E_& val2) { return val1 * val2; });
         return ret;

--- a/dal-cpp/dal/model/dupire.hpp
+++ b/dal-cpp/dal/model/dupire.hpp
@@ -18,8 +18,6 @@
 namespace Dal::AAD {
     // year-fraction (1/730)
     constexpr double HALF_DAY_YF = 0.00136986301369863;
-    // std approximation used by the strike cutoff: atmCall * sqrt(2pi)
-    constexpr double SQRT_2PI = 2.506628274631;
 } // namespace Dal::AAD
 
 /*IF--------------------------------------------------------------------------
@@ -201,7 +199,7 @@ namespace Dal {
             const size_t nSpots = distance(spotsBegin, spotsEnd);
 
             const auto atmCall = static_cast<double>(ivs.Call(ivs.Spot(), maturity));
-            const double std = atmCall * SQRT_2PI;
+            const double std = atmCall * M_SQRT_2_PI;
 
             int il = 0;
             while (il < nSpots && spots[il] < ivs.Spot() - 2.5 * std)

--- a/dal-cpp/dal/platform/consts.hpp
+++ b/dal-cpp/dal/platform/consts.hpp
@@ -12,4 +12,5 @@ namespace Dal {
     constexpr double M_SQRT_2 = 1.4142135623730951;
     constexpr double M_SQRT_2_PI = 2.5066282746310002;
     constexpr double ONE_MINUS_EPS = 0.999999999999;
+    constexpr double DAYS_PER_YEAR = 365.0;
 } // namespace Dal

--- a/dal-cpp/dal/script/event.cpp
+++ b/dal-cpp/dal/script/event.cpp
@@ -88,7 +88,6 @@ namespace Dal::Script {
         }
 
         // TODO: more specific data settings
-        constexpr double DAYS_PER_YEAR = 365.0;
         const auto evaluationDate = Global::Dates_::EvaluationDate();
         for (auto& date : eventDates_) {
             const double ttm = (date - evaluationDate) / DAYS_PER_YEAR;

--- a/dal-cpp/dal/script/node.hpp
+++ b/dal-cpp/dal/script/node.hpp
@@ -118,13 +118,18 @@ namespace Dal::Script {
 
     //	If
     struct NodeIf_ : public Visitable_<ActNode_, NodeIf_, VISITORS> {
-        // -1 means no else branch; consumers test firstElse_ == -1
+        // -1 means no else branch; prefer HasElse() over testing firstElse_ == -1
         int firstElse_ = -1;
         //	For fuzzy eval: indices of variables affected in statements, including nested
         Vector_<size_t> affectedVars_;
         //	Always true/false as per domain processor
         bool alwaysTrue_ = false;
         bool alwaysFalse_ = false;
+
+        [[nodiscard]] bool HasElse() const { return firstElse_ != -1; }
+        [[nodiscard]] size_t LastTrueIndex() const {
+            return HasElse() ? static_cast<size_t>(firstElse_) - 1 : arguments_.size() - 1;
+        }
     };
 
     //	Collection of statements
@@ -154,25 +159,23 @@ namespace Dal::Script {
         return std::unique_ptr<Node_>(new ConcreteNode_(std::forward<Args>(args)...));
     }
 
+    template <class NodeType_> void SetBinaryArgs(NodeType_& top, ExprTree_& lhs, ExprTree_& rhs) {
+        top.arguments_.Resize(2);
+        top.arguments_[0] = std::move(lhs);
+        top.arguments_[1] = std::move(rhs);
+    }
+
     //	Build binary concrete, and set its arguments_ to lhs and rhs
     template <class NodeType_> std::unique_ptr<NodeType_> MakeBinary(ExprTree_& lhs, ExprTree_& rhs) {
         auto top = MakeNode<NodeType_>();
-        top->arguments_.Resize(2);
-        //	Take ownership of lhs and rhs
-        top->arguments_[0] = std::move(lhs);
-        top->arguments_[1] = std::move(rhs);
-        //	Return
+        SetBinaryArgs(*top, lhs, rhs);
         return top;
     }
 
     //  Same but return as pointer on base
     template <class ConcreteNode_> ExprTree_ MakeBaseBinary(ExprTree_& lhs, ExprTree_& rhs) {
         auto top = MakeBaseNode<ConcreteNode_>();
-        top->arguments_.Resize(2);
-        //	Take ownership of lhs and rhs
-        top->arguments_[0] = std::move(lhs);
-        top->arguments_[1] = std::move(rhs);
-        //	Return
+        SetBinaryArgs(*top, lhs, rhs);
         return top;
     }
 } // namespace Dal::Script

--- a/dal-cpp/dal/script/visitor/compiler.hpp
+++ b/dal-cpp/dal/script/visitor/compiler.hpp
@@ -214,52 +214,36 @@ namespace Dal::Script {
             VisitCondition<SupEqual>(node, [](double x) { return x >= 0.0; });
         }
 
-        void Visit(const NodeAnd_& node) {
+        template <NodeType_ Hard, NodeType_ Soft> void VisitBoolBinary(const Node_& node) {
             node.arguments_[0]->Accept(*this);
             node.arguments_[1]->Accept(*this);
-            nodeStream_.emplace_back(fuzzy_ ? FuzzyAnd : And);
+            nodeStream_.emplace_back(fuzzy_ ? Soft : Hard);
         }
 
-        void Visit(const NodeOr_& node) {
-            node.arguments_[0]->Accept(*this);
-            node.arguments_[1]->Accept(*this);
-            nodeStream_.emplace_back(fuzzy_ ? FuzzyOr : Or);
-        }
+        void Visit(const NodeAnd_& node) { VisitBoolBinary<And, FuzzyAnd>(node); }
+        void Visit(const NodeOr_& node) { VisitBoolBinary<Or, FuzzyOr>(node); }
 
         void Visit(const NodeNot_& node) {
             node.arguments_[0]->Accept(*this);
             nodeStream_.emplace_back(fuzzy_ ? FuzzyNot : Not);
         }
 
-        void Visit(const NodeAssign_& node) {
+        template <NodeType_ NT, NodeType_ NTConst> void VisitAssignLike(const Node_& node) {
             const auto* var = Downcast<NodeVar_>(node.arguments_[0]);
             const auto* rhs = Downcast<ExprNode_>(node.arguments_[1]);
-
             if (rhs->isConst_) {
-                nodeStream_.emplace_back(AssignConst);
+                nodeStream_.emplace_back(NTConst);
                 nodeStream_.emplace_back(static_cast<int>(constStream_.size()));
                 constStream_.emplace_back(rhs->constVal_);
             } else {
                 node.arguments_[1]->Accept(*this);
-                nodeStream_.emplace_back(Assign);
+                nodeStream_.emplace_back(NT);
             }
-            nodeStream_.emplace_back(int(var->index_));
+            nodeStream_.emplace_back(static_cast<int>(var->index_));
         }
 
-        void Visit(const NodePays_& node) {
-            const auto* var = Downcast<NodeVar_>(node.arguments_[0]);
-            const auto* rhs = Downcast<ExprNode_>(node.arguments_[1]);
-
-            if (rhs->isConst_) {
-                nodeStream_.emplace_back(PaysConst);
-                nodeStream_.emplace_back(static_cast<int>(constStream_.size()));
-                constStream_.emplace_back(rhs->constVal_);
-            } else {
-                node.arguments_[1]->Accept(*this);
-                nodeStream_.emplace_back(Pays);
-            }
-            nodeStream_.emplace_back(var->index_);
-        }
+        void Visit(const NodeAssign_& node) { VisitAssignLike<Assign, AssignConst>(node); }
+        void Visit(const NodePays_& node) { VisitAssignLike<Pays, PaysConst>(node); }
 
         void Visit(const NodeVar_& node) {
             nodeStream_.emplace_back(Var);
@@ -286,10 +270,10 @@ namespace Dal::Script {
         void Visit(const NodeCollect_& node) { VisitArguments(node); }
 
         void CompileHardIf(const NodeIf_& node, size_t lastTrue, size_t n) {
-            nodeStream_.emplace_back(node.firstElse_ == -1 ? If : IfElse);
+            nodeStream_.emplace_back(node.HasElse() ? IfElse : If);
             const size_t thisSpace = nodeStream_.size() - 1;
             nodeStream_.emplace_back(0);
-            if (node.firstElse_ != -1)
+            if (node.HasElse())
                 nodeStream_.emplace_back(0);
 
             for (size_t i = 1; i <= lastTrue; ++i) {
@@ -297,7 +281,7 @@ namespace Dal::Script {
             }
             nodeStream_[thisSpace + 1] = int(nodeStream_.size());
 
-            if (node.firstElse_ != -1) {
+            if (node.HasElse()) {
                 for (size_t i = node.firstElse_; i < n; ++i) {
                     node.arguments_[i]->Accept(*this);
                 }
@@ -319,7 +303,7 @@ namespace Dal::Script {
                 node.arguments_[i]->Accept(*this);
             nodeStream_[thisSpace + 1] = int(nodeStream_.size());
 
-            if (node.firstElse_ != -1)
+            if (node.HasElse())
                 for (size_t i = node.firstElse_; i < n; ++i)
                     node.arguments_[i]->Accept(*this);
             nodeStream_[thisSpace + 2] = int(nodeStream_.size());
@@ -328,7 +312,7 @@ namespace Dal::Script {
         void Visit(const NodeIf_& node) {
             node.arguments_[0]->Accept(*this);
 
-            const auto lastTrue = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
+            const auto lastTrue = node.LastTrueIndex();
             const auto n = node.arguments_.size();
 
             if (fuzzy_)
@@ -631,6 +615,7 @@ namespace Dal::Script {
                 } else if (t < EPSILON) {
                     i = lastTrue;
                 } else {
+                    REQUIRE(state.nestedIfLvl_ < state.varStore0_.size(), "compiled FuzzyIf nesting exceeds allocated var stores");
                     const size_t lvl = state.nestedIfLvl_++;
                     for (int k = 0; k < nAff; ++k) {
                         const size_t idx = nodeStream[firstAff + k];

--- a/dal-cpp/dal/script/visitor/constcondprocessor.hpp
+++ b/dal-cpp/dal/script/visitor/constcondprocessor.hpp
@@ -57,7 +57,7 @@ namespace Dal::Script {
         // If
         void Visit(NodeIf_& node) {
             if (node.alwaysTrue_) {
-                size_t lastTrueStat = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
+                size_t lastTrueStat = node.LastTrueIndex();
 
                 Vector_<ExprTree_> args = std::move(node.arguments_);
                 *current_ = std::unique_ptr<Node_>(new NodeCollect_);
@@ -67,13 +67,11 @@ namespace Dal::Script {
                 VisitArgsSetCurrent(**current_);
             }
             else if (node.alwaysFalse_) {
-                int firstElseStatement = node.firstElse_;
-
                 Vector_<ExprTree_> args = std::move(node.arguments_);
                 *current_ = std::unique_ptr<Node_>(new NodeCollect_);
 
-                if (firstElseStatement != -1)
-                    for (size_t i = firstElseStatement; i < args.size(); ++i)
+                if (node.HasElse())
+                    for (size_t i = static_cast<size_t>(node.firstElse_); i < args.size(); ++i)
                         (*current_)->arguments_.push_back(std::move(args[i]));
                 VisitArgsSetCurrent(**current_);
             }

--- a/dal-cpp/dal/script/visitor/domainproc.hpp
+++ b/dal-cpp/dal/script/visitor/domainproc.hpp
@@ -87,49 +87,39 @@ namespace Dal::Script {
         }
 
         // Functions
+        void VisitApplyUnary(Node_& node, double (*func)(double), const Interval_& domain) {
+            VisitArguments(node);
+            Domain_ res = domStack_.Top().ApplyFunc<double (*)(double)>(func, domain);
+            domStack_.Pop();
+            domStack_.Push(std::move(res));
+        }
+
         void Visit(NodeLog_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_.Top().ApplyFunc<double (*)(double)>(
-                log, Interval_(Bound_(0.0), Bound_(Bound_::plusInfinity_)));
-            domStack_.Pop();
-            domStack_.Push(std::move(res));
+            VisitApplyUnary(node, log, Interval_(Bound_(0.0), Bound_(Bound_::plusInfinity_)));
         }
-
         void Visit(NodeSqrt_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_.Top().ApplyFunc<double (*)(double)>(sqrt, Interval_(Bound_(0.0), Bound_(Bound_::plusInfinity_)));
-            domStack_.Pop();
-            domStack_.Push(std::move(res));
+            VisitApplyUnary(node, sqrt, Interval_(Bound_(0.0), Bound_(Bound_::plusInfinity_)));
+        }
+        void Visit(NodeExp_& node) {
+            VisitApplyUnary(node, exp, Interval_(Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_)));
         }
 
-        void Visit(NodeExp_& node) {
+        template <class OP_> void VisitExtrema(Node_& node, const OP_& op) {
             VisitArguments(node);
-            Domain_ res = domStack_.Top().ApplyFunc<double (*)(double)>(
-                    exp, Interval_(Bound_(Bound_::minusInfinity_), Bound_(Bound_::plusInfinity_)));
+            Domain_ res = domStack_.Top();
             domStack_.Pop();
+            for (size_t i = 1; i < node.arguments_.size(); ++i) {
+                res = op(res, domStack_.Top());
+                domStack_.Pop();
+            }
             domStack_.Push(std::move(res));
         }
 
         void Visit(NodeMax_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_.Top();
-            domStack_.Pop();
-            for (size_t i = 1; i < node.arguments_.size(); ++i) {
-                res = res.DMax(domStack_.Top());
-                domStack_.Pop();
-            }
-            domStack_.Push(std::move(res));
+            VisitExtrema(node, [](const Domain_& x, const Domain_& y) { return x.DMax(y); });
         }
-
         void Visit(NodeMin_& node) {
-            VisitArguments(node);
-            Domain_ res = domStack_.Top();
-            domStack_.Pop();
-            for (size_t i = 1; i < node.arguments_.size(); ++i) {
-                res = res.DMin(domStack_.Top());
-                domStack_.Pop();
-            }
-            domStack_.Push(std::move(res));
+            VisitExtrema(node, [](const Domain_& x, const Domain_& y) { return x.DMin(y); });
         }
 
         // Conditions
@@ -284,7 +274,7 @@ namespace Dal::Script {
 
         // Instructions
         void Visit(NodeIf_& node) {
-            const size_t lastTrueStat = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
+            const size_t lastTrueStat = node.LastTrueIndex();
 
             node.arguments_[0]->Accept(*this);
 
@@ -299,7 +289,7 @@ namespace Dal::Script {
             } else if (cp == Value_::AlwaysFalse) {
                 node.alwaysTrue_ = false;
                 node.alwaysFalse_ = true;
-                if (node.firstElse_ != -1)
+                if (node.HasElse())
                     for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                         node.arguments_[i]->Accept(*this);
             } else {
@@ -319,7 +309,7 @@ namespace Dal::Script {
                 for (size_t i = 0; i < node.affectedVars_.size(); ++i)
                     varDomains_[node.affectedVars_[i]] = std::move(domStore0[i]);
 
-                if (node.firstElse_ != -1)
+                if (node.HasElse())
                     for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                         node.arguments_[i]->Accept(*this);
 

--- a/dal-cpp/dal/script/visitor/evaluator.hpp
+++ b/dal-cpp/dal/script/visitor/evaluator.hpp
@@ -143,20 +143,20 @@ namespace Dal::Script {
             VisitCondition(node, [](const T_ x) { return x >= 0; });
         }
 
-        FORCE_INLINE void Visit(const NodeAnd_& node) {
+        template <class OP> FORCE_INLINE void VisitBoolBinary(const Node_& node, OP op) {
             VisitNode(*node.arguments_[0]);
             VisitNode(*node.arguments_[1]);
             const bool rhs = bStack_.TopAndPop();
             auto& lhs = bStack_.Top();
-            lhs = lhs && rhs;
+            lhs = op(lhs, rhs);
+        }
+
+        FORCE_INLINE void Visit(const NodeAnd_& node) {
+            VisitBoolBinary(node, [](bool x, bool y) { return x && y; });
         }
 
         FORCE_INLINE void Visit(const NodeOr_& node) {
-            VisitNode(*node.arguments_[0]);
-            VisitNode(*node.arguments_[1]);
-            const bool rhs = bStack_.TopAndPop();
-            auto& lhs = bStack_.Top();
-            lhs = lhs || rhs;
+            VisitBoolBinary(node, [](bool x, bool y) { return x || y; });
         }
 
         FORCE_INLINE void Visit(const NodeNot_& node) {
@@ -171,11 +171,11 @@ namespace Dal::Script {
             const auto isTrue = bStack_.TopAndPop();
 
             if (isTrue) {
-                const auto lastTrue = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
+                const auto lastTrue = node.LastTrueIndex();
                 for (unsigned i = 1; i <= lastTrue; ++i) {
                     VisitNode(*node.arguments_[i]);
                 }
-            } else if (node.firstElse_ != -1) {
+            } else if (node.HasElse()) {
                 const size_t n = node.arguments_.size();
                 for (unsigned i = node.firstElse_; i < n; ++i) {
                     VisitNode(*node.arguments_[i]);

--- a/dal-cpp/dal/script/visitor/fuzzy.hpp
+++ b/dal-cpp/dal/script/visitor/fuzzy.hpp
@@ -82,7 +82,7 @@ namespace Dal::Script {
         }
 
         void EvalFalseBranch(const NodeIf_& node) {
-            if (node.firstElse_ != -1)
+            if (node.HasElse())
                 for (size_t i = node.firstElse_; i < node.arguments_.size(); ++i)
                     VisitNode(*node.arguments_[i]);
         }
@@ -105,6 +105,7 @@ namespace Dal::Script {
         }
 
         void EvalFuzzyBranches(const NodeIf_& node, size_t lastTrueStat, const T& dt) {
+            REQUIRE(nestedIfLvl_ > 0 && nestedIfLvl_ <= varStore0_.size(), "fuzzy If nesting exceeds allocated var stores");
             const size_t lvl = nestedIfLvl_ - 1;
             StoreAffectedVars(node, lvl);
             EvalTrueBranch(node, lastTrueStat);
@@ -114,7 +115,7 @@ namespace Dal::Script {
         }
 
         void Visit(const NodeIf_& node) {
-            const size_t lastTrueStat = node.firstElse_ == -1 ? node.arguments_.size() - 1 : node.firstElse_ - 1;
+            const size_t lastTrueStat = node.LastTrueIndex();
 
             ++nestedIfLvl_;
 

--- a/dal-cpp/dal/script/visitor/ifprocessor.hpp
+++ b/dal-cpp/dal/script/visitor/ifprocessor.hpp
@@ -62,17 +62,13 @@ namespace Dal::Script {
                      inserter(varStack_.Top(), varStack_.Top().end()));
         }
 
-        void Visit(NodeAssign_& node) {
-            //	Visit the lhs var
+        void VisitLhsIfNested(Node_& node) {
             if (nestedIfLvl_)
                 node.arguments_[0]->Accept(*this);
         }
 
-        void Visit(NodePays_& node) {
-            //	Visit the lhs var
-            if (nestedIfLvl_)
-                node.arguments_[0]->Accept(*this);
-        }
+        void Visit(NodeAssign_& node) { VisitLhsIfNested(node); }
+        void Visit(NodePays_& node) { VisitLhsIfNested(node); }
 
         void Visit(NodeVar_& node) {
             //	Insert the var idx

--- a/dal-cpp/tests/math/aad/test_blocklist.cpp
+++ b/dal-cpp/tests/math/aad/test_blocklist.cpp
@@ -3,7 +3,7 @@
 //
 
 #include <gtest/gtest.h>
-
+#include <dal/platform/platform.hpp>
 #include <dal/math/aad/blocklist.hpp>
 
 using namespace Dal::AAD;
@@ -40,4 +40,10 @@ TEST(AADTest, TestBlockListRewindToMark) {
     ASSERT_EQ(blocks.Size(), 8);
     blocks.RewindToMark();
     ASSERT_EQ(blocks.Size(), 5);
+}
+
+TEST(AADTest, TestBlockListEmplaceBackMultiRejectsOversizedN) {
+    BlockList_<double, 10> blocks;
+    ASSERT_THROW(blocks.EmplaceBackMulti(11), Dal::Exception_);
+    ASSERT_THROW(blocks.EmplaceBackMulti(0), Dal::Exception_);
 }

--- a/dal-cpp/tests/math/aad/test_number.cpp
+++ b/dal-cpp/tests/math/aad/test_number.cpp
@@ -658,3 +658,10 @@ TEST(AADTest, TestNumberAbs) {
     PropagateToStart(*Tape());
     ASSERT_NEAR(Adjoint(s1), -1.0, 1e-10);
 }
+
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
+TEST(AADTest, TestDefaultNumberAdjointRequiresTapeNode) {
+    Number_ uninit;
+    ASSERT_THROW(Adjoint(uninit), Dal::Exception_);
+}
+#endif

--- a/dal-cpp/tests/math/aad/test_tape.cpp
+++ b/dal-cpp/tests/math/aad/test_tape.cpp
@@ -186,4 +186,9 @@ TEST(AADTapeTest, TestClearEmptiesAdjointsMultiAfterMultiToNonMultiToggle) {
 
     Clear(*tape);
 }
+
+TEST(AADTapeTest, TestSetNumResultsForAADRejectsOutOfRange) {
+    ASSERT_THROW(Dal::AAD::SetNumResultsForAAD(true, 0), Dal::Exception_);
+    ASSERT_THROW(Dal::AAD::SetNumResultsForAAD(true, Dal::AAD::ADJ_SIZE + 1), Dal::Exception_);
+}
 #endif

--- a/dal-cpp/tests/math/analytics/test_vanilla.cpp
+++ b/dal-cpp/tests/math/analytics/test_vanilla.cpp
@@ -75,3 +75,8 @@ TEST(AnalyticsTest, TestBachelierAAD) {
     ASSERT_NEAR(Adjoint(vol), 0.53578740155317184, 1e-8);
     ASSERT_NEAR(Adjoint(T), 2.9468307085424446, 1e-8);
 }
+
+TEST(AnalyticsTest, TestIVolRejectsNonPositiveMaturity) {
+    ASSERT_THROW(BlackScholesIVol(110.0, 120.0, 8.5, 0.0), Dal::Exception_);
+    ASSERT_THROW(BachelierIVol(110.0, 120.0, 8.0, -1.0), Dal::Exception_);
+}

--- a/dal-cpp/tests/math/interp/test_interp.cpp
+++ b/dal-cpp/tests/math/interp/test_interp.cpp
@@ -24,18 +24,6 @@ TEST(InterpTest, TestInterpLinearImplXWithSmooth) {
     ASSERT_DOUBLE_EQ(calculated, expected);
 }
 
-TEST(InterpTest, TestInterp1Linear) {
-    Vector_<> x = {1., 2., 3., 4., 5.};
-    Vector_<> f = {2.5, 3.5, 1.7, 2.8, 3.6};
-
-    Handle_<Interp1_> interp(NewLinear("interp", x, f));
-
-    ASSERT_DOUBLE_EQ(f[2], (*interp)(x[2]));
-    ASSERT_DOUBLE_EQ(f[0], (*interp)(x[0] - 1.));
-    ASSERT_DOUBLE_EQ(f[4], (*interp)(x[4] + 1.));
-    ASSERT_DOUBLE_EQ((f[2] + f[3]) / 2., (*interp)((x[2] + x[3]) / 2.));
-}
-
 TEST(InterpTest, TestInterp1LinearWithUnorderedX) {
     Vector_<> x = {2., 1., 3., 4., 5.};
     Vector_<> f = {3.5, 2.5, 1.7, 2.8, 3.6};
@@ -79,4 +67,11 @@ TEST(InterpTest, TestInterp1LinearJsonSerialization) {
 
     ASSERT_TRUE(val.get() != nullptr);
     ASSERT_DOUBLE_EQ((*src)(2.5), (*val)(2.5));
+}
+
+TEST(InterpTest, TestNewLinearRejectsEmpty) {
+    Vector_<> x;
+    Vector_<> f;
+    ASSERT_THROW(Handle_<Interp1_> interp(NewLinear("interp", x, f)), Dal::Exception_);
+    ASSERT_THROW(Dal::InterpLinearImplX<>(x, f, 0.0), Dal::Exception_);
 }

--- a/dal-cpp/tests/math/interp/test_interp.cpp
+++ b/dal-cpp/tests/math/interp/test_interp.cpp
@@ -72,6 +72,5 @@ TEST(InterpTest, TestInterp1LinearJsonSerialization) {
 TEST(InterpTest, TestNewLinearRejectsEmpty) {
     Vector_<> x;
     Vector_<> f;
-    ASSERT_THROW(Handle_<Interp1_> interp(NewLinear("interp", x, f)), Dal::Exception_);
-    ASSERT_THROW(Dal::InterpLinearImplX<>(x, f, 0.0), Dal::Exception_);
+    ASSERT_THROW((void)Handle_<Interp1_>(NewLinear("interp", x, f)), Dal::Exception_);
 }

--- a/dal-cpp/tests/math/test_vectors.cpp
+++ b/dal-cpp/tests/math/test_vectors.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <dal/platform/platform.hpp>
 #include <dal/math/vectors.hpp>
+#include <dal/utilities/exceptions.hpp>
 
 using vector_t = Dal::Vector_<>;
 
@@ -218,4 +219,16 @@ TEST(VectorTest, TestVectorMultiply) {
         ASSERT_DOUBLE_EQ(s2[i], 2.0 * s1[i]);
         ASSERT_DOUBLE_EQ(s3[i], 2.0 * s1[i]);
     }
+}
+
+TEST(VectorTest, TestXRangeRequiresAtLeastTwoPoints) {
+    ASSERT_THROW(Dal::Vector::XRange(0.0, 1.0, 0), Dal::Exception_);
+    ASSERT_THROW(Dal::Vector::XRange(0.0, 1.0, 1), Dal::Exception_);
+}
+
+TEST(VectorTest, TestVectorAddSizeMismatch) {
+    vector_t s1 = {1., 2., 3.};
+    vector_t s2 = {1., 2.};
+    ASSERT_THROW(s1 += s2, Dal::Exception_);
+    ASSERT_THROW((void)(s1 * s2), Dal::Exception_);
 }


### PR DESCRIPTION
## Summary - Reject empty interpolators, oversized AAD tape allocations, uninitialized Number_ adjoints, vector size mismatches, non-positive IVol maturity, and over-nested fuzzy If stores before they become undefined behavior. - Delete Cholesky_ copy/move so the owning destructor cannot double-free. - Share fixing-identity helpers, InverseNCDF tails, PDE interior stencils, DAYS_PER_YEAR, and sqrt(2pi) constants, and collapse duplicated script visitor control-flow. - Keep InterpLinearImplX empty-input checking debug-only so the linear interp query hot path does not regress in Release.  ## Test plan - [x] Windows Release dal_cpp_tests focused filters: VectorTest, InterpTest, AnalyticsTest, AADTest blocklist/number, AADTapeTest, SpecialFunctionsTest, PdeOperatorsTest, RateCashflowPricingTest, XccyPricingTest, XccyMarketTest, ScriptCompiledParityTest - [ ] CI Linux and Windows test jobs - [ ] CI Linux Benchmarks gate (interp_perf Linear interp was +18% on the first head; follow-up moves the per-query REQUIRE to debug ASSERT) - [x] Codacy: 0 new issues - [x] Copilot: unused named Handle_ in TestNewLinearRejectsEmpty 