### PR TITLE
DAL-131: add AAD node risk design and implementation plan docs

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -100,10 +100,21 @@ jobs:
 
       # gcc-15 is not in the Ubuntu 24.04 archive; the toolchain test PPA
       # publishes it for noble. add-apt-repository refreshes the apt lists.
+      # The Launchpad lookup and apt refresh are transient-prone (seen on
+      # PR #299: two gcc-15 legs failed in this step within minutes while the
+      # other two succeeded), so retry with backoff before giving up.
       - name: Add gcc-15 toolchain PPA
         if: matrix.compiler == 'gcc-15'
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          for attempt in 1 2 3 4; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then
+              exit 0
+            fi
+            echo "PPA setup failed (attempt $attempt of 4); retrying after backoff"
+            sleep $((attempt * 20))
+          done
+          echo "PPA setup failed after 4 attempts"
+          exit 1
 
       - name: Setup
         run: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,6 +147,11 @@ Reference studies and capability explorations that are not normative methodology
   — Compatibility redirect to the supported yield-curve and AAD methodology.
 - **[replicate-ptirds-single-currency-curve.md](experimental/replicate-ptirds-single-currency-curve.md)**
   — Validated rateslib/PTIRDS single-currency curve replication.
+- **[aad-node-risk-portfolio-aggregation-design.md](experimental/aad-node-risk-portfolio-aggregation-design.md)**
+  — Reviewed design for node-level AAD risk across all rate families with
+  portfolio aggregation.
+- **[aad-node-risk-portfolio-aggregation-plan.md](experimental/aad-node-risk-portfolio-aggregation-plan.md)**
+  — Staged implementation plan (stages 0–5) for the same capability.
 
 ## Documentation Conventions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,10 +148,11 @@ Reference studies and capability explorations that are not normative methodology
 - **[replicate-ptirds-single-currency-curve.md](experimental/replicate-ptirds-single-currency-curve.md)**
   — Validated rateslib/PTIRDS single-currency curve replication.
 - **[aad-node-risk-portfolio-aggregation-design.md](experimental/aad-node-risk-portfolio-aggregation-design.md)**
-  — Reviewed design for node-level AAD risk across all rate families with
-  portfolio aggregation.
+  — Revised design for node-level AAD risk across all rate families, with
+  frozen P0 contracts for tape isolation, batch keys, aggregation, Excel, and
+  XCCY dependency.
 - **[aad-node-risk-portfolio-aggregation-plan.md](experimental/aad-node-risk-portfolio-aggregation-plan.md)**
-  — Staged implementation plan (stages 0–5) for the same capability.
+  — Staged implementation plan (stages 0–5) matching those frozen P0 contracts.
 
 ## Documentation Conventions
 

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
@@ -1,0 +1,200 @@
+# Full Product-Family AAD Node Risk and Portfolio Aggregation — Design
+
+> Status: reviewed design, not yet implemented. The plan passed an L-level review
+> (AAD/numerics and public-contract focus) with no blockers against baseline
+> `origin/master@ec89eb72`. The staged execution steps, test strategy, and
+> acceptance criteria live in the companion
+> [implementation plan](aad-node-risk-portfolio-aggregation-plan.md).
+
+## Goals and Scope
+
+- **Goal.** Widen the success domain of `RateTradeNodeSensitivities(trade, market, componentKey)`
+  from Deposit to all seven rate families (Deposit, FRA, Future, OIS, IRS, Basis,
+  XCCY); add batch node-sensitivities and portfolio-aggregation APIs; and carry the
+  capability through the dal-public, Python, and Excel surfaces.
+- **Widening the success domain is the feature itself.** Trades that today return
+  `TRADE_FAMILY_NOT_AAD_ENABLED` because they are not Deposits become eligible. The
+  token stays in the closed set — its meaning narrows to "the family does not have
+  AAD enabled, or the terms do not match the family" — so it remains available for
+  future families shipped without AAD.
+- **Compatibility promises.** The single-trade API signature, the closed set of six
+  failure tokens and their priority order, the canonical failure shape, and the
+  passive batch `PriceRateTrades` behavior are all unchanged. Existing Deposit tests
+  — including the case where mismatched terms return `TRADE_FAMILY_NOT_AAD_ENABLED` —
+  stay green without touching their assertions. The family gate generalizes to a
+  registry lookup of whether (family, terms) has AAD enabled, so the existing
+  terms-mismatch cases continue to hit the family gate by construction.
+- **Non-goals.** No new product families (cap/floor/swaption are P2); no vega or
+  volatility axis; no parallel batch execution in P0 (serial, deterministic order —
+  see risk 3); no AAD axis on the FX spot (the hook already exists:
+  `XccyMarketView_::fxSpot_` is already `T_`, a later small step can activate it);
+  no new JSON/serialization contracts (P1); the `Report_` storage format and the
+  `RateInstrumentType_` closed set are untouched; no ABI-isolation layer rework.
+
+## Current-Code Facts
+
+These facts, verified against `origin/master@ec89eb72`, determine the shape of the
+design:
+
+- The single-trade entry `RateTradeNodeSensitivities(trade, market, componentKey)`
+  in `dal-cpp/dal/curve/ratecashflowpricing.cpp` hardcodes Deposit. The six-gate
+  pipeline, the closed set of six failure tokens, and their priority order are
+  fixed in `dal-cpp/dal/curve/ratecashflowpricing_internal.hpp` and documented in
+  `docs/public-api.md`. The failure shape is `eligible_=false / pv_=0 / empty
+  gradient_ / non-empty reason_`.
+- The Deposit AAD pricing formula is **hand-copied** inside the stage lambda and
+  exists in parallel with the passive `Price` Deposit branch. This is the direct
+  motivation for "kernel templatization first": without removing the fork, every new
+  family would hand-copy its formula again and maintain numerical consistency
+  independently.
+- The curve layer is already fully templated:
+  `BuildCurveParameterLayout` / `DescribeCurveFreeParameters` (a date + component
+  descriptor per parameter) / `RegisterCurveParameters` /
+  `BuildDiscountCurveUnique<T_,B_>`, including an existing mixed-base
+  instantiation `<AAD::Number_, DiscountCurve_<double>>` in
+  `dal-cpp/dal/curve/curveparameterization.cpp`. The XCCY kernel
+  (`PriceXccyContract<T_>`, `XccyMarketView_<T_>`) is already instantiated for
+  both double and AAD. The ready-made template for assembling multi-curve active
+  blocks is `BuildTypedCurveBlock<T_>` (with base layering,
+  `dal-cpp/dal/curve/jointcalibration_internal.hpp`), and the complete stage
+  pattern — `Residuals<T_>` + `TapeGuard_` + `RegisterCurveParameters` +
+  `NewRecording` + `HarvestCurveJacobian` — is in
+  `dal-cpp/dal/curve/xccyjointcalibration.cpp`.
+- Not yet templated: the linear-family pricing kernels themselves —
+  `PriceFixedFloat`, `PriceBasis`, the Deposit/FRA/Future branches of `Price`, and
+  the `Discount`/`ForwardRate`/`ResolveRate` helpers (all double-only).
+- The AAD tape is `thread_local` on all four backends
+  (`dal-cpp/dal/math/aad/expr.hpp`); `TapeGuard_` rewinds on scope exit (block
+  reuse rather than reallocation); per-backend adjoint-cleanup differences already
+  have the `PrepareAdjoints`/`ClearIndependentAdjoints` paradigm in
+  `dal-cpp/dal/curve/aadjacobian.cpp`.
+- Python bindings are already keyword-only with GIL release
+  (`dal-python/src/bindings/curve.cpp`); the calibration side has the
+  `_CurveCalibrationGilBarrier_EnableForTesting` artificial-barrier test paradigm
+  that can be mirrored. Excel currently has **no** rate-pricing surface at
+  all (`dal-excel/src/` has no corresponding file), so it is a net-new binding.
+- `BuildRateCashflowPlan` currently leaves `dependencyComponentKeys_` empty for
+  XCCY, and `RatePricingMarket_::resultCurrency_` is passed through without
+  conversion (each family's PV is denominated in the trade's own currency).
+- Existing test assets generalize directly: `AssertRawNodeGradientMatchesCentralBumps`
+  in `dal-cpp/tests/curve/test_ratecashflowpricing.cpp` (central-difference
+  comparison across the four curve representations, borrow/lend sign antisymmetry,
+  structurally zero columns), the token-priority matrix, the finalizer/tape-rewind
+  unit tests, and the Python contract tests locking keyword-only and read-only
+  results.
+
+## Incremental Public API Design
+
+- **Single trade (unchanged, success domain only widened).**
+  `RateTradeNodeSensitivities(trade, market, componentKey)`; each call produces a
+  gradient for one component, and multiple components are handled by repeated calls
+  or composed through the batch entry point.
+- **Batch (new, C++ core layer).**
+  `RateTradeNodeSensitivitiesBatch(trades, market, componentKeys)` returns, per
+  (trade, component), exactly the same `RateTradeNodeSensitivityResult_` shape as
+  the single-trade call; failures are isolated per entry (a failed entry carries
+  its token, nothing is thrown, other entries are unaffected), aligning with the
+  per-trade isolation semantics of `PriceRateTrades`. P0 executes serially with a
+  deterministic result order.
+- **Portfolio aggregation (new).** Sum the successful entries along the
+  (component, currency, node/parameter) axes and return the aggregate plus axis
+  labels. The axis labels (parameter dates, component types) **must** be derived
+  from `DescribeCurveFreeParameters`, and the parameter count and order **must**
+  take `BuildCurveParameterLayout().parameterCount_` as the single source of
+  truth — no hand-written parameter ordering or counting is acceptable (the
+  existing `FinalizeNodeSensitivityCandidate` already consistency-checks against
+  that count; keep doing so). The gradient keeps its meaning of "native curve
+  parameter perturbation" (the same convention as the existing Deposit path and
+  the central-difference tests); quote-space conversion is deliberately not done —
+  that is the job of the calibration Jacobian, an existing capability.
+- **Multi-currency treatment.** Aggregation groups by trade currency; the
+  pass-through-no-conversion status of `resultCurrency_` is preserved, and
+  cross-currency totals are explicitly labeled "unconverted, grouped by currency".
+  Optional conversion at the valuation time is a later increment (it depends on an
+  FX-input contract, which this feature deliberately does not introduce
+  implicitly).
+- **Python.** The new batch/aggregation functions stay keyword-only with
+  read-only results and release the GIL for the whole native execution (one
+  release per batch, marshalling afterwards); existing bindings are untouched.
+- **Excel.** A new `dal-excel/src/__curvepricing.cpp` surface plus the Machinist
+  `public` marker (regenerate the stubs and commit them), results emitted as a
+  spill table (rows = trade/component, columns = nodes), naming following the
+  existing `public`-function conventions; no internal object structure leaks.
+- **Documentation.** The sentence "Native node AAD currently admits deposit trades
+  only" in `docs/public-api.md` is updated in the same PR as each family lands (the
+  docs must never disagree with the success domain), and the CHANGELOG records the
+  behavior change.
+
+### Frozen decision points
+
+The L-level review verified all three decision points against the code; none
+carries production-level risk:
+
+1. **XCCY addressing by pointer identity.** The curves an XCCY trade depends on
+   live in the domestic/foreign `CurveBlock_` of `CrossCurrencyMarket_` (keyed by
+   `CollateralType_`/`PeriodLength_`) and in the basis curve — a different
+   namespace from the `String_` keys of `curveComponents_`. The contract: require
+   the addressed curve object to be *also* registered under a stable key in
+   `market.curveComponents_`, and locate its slot in the XCCY market block by
+   **pointer identity**. The review confirmed this is well-defined and safe: the
+   `CurveBlock_` discount/forward maps and `market.curveComponents_` both hold
+   `Handle_<DiscountCurve_>` (shared ownership, in
+   `dal-cpp/dal/curve/curveblock.hpp` and
+   `dal-cpp/dal/curve/ratecashflowpricing.hpp`), and `BasisCurve()` also takes
+   the raw pointer from a Handle, so cross-namespace pointer comparison is
+   well-defined with no false positives — strictly better than matching by Name.
+   In the same step, the XCCY branch of `BuildRateCashflowPlan` is extended to
+   emit these dependency keys (currently empty), which makes the
+   `TRADE_DOES_NOT_DEPEND_ON_COMPONENT` gate effective for XCCY. A curve that
+   cannot be classified inside a block falls through to
+   `CURVE_REPRESENTATION_NOT_AAD_ENABLED`.
+2. **Batch result shape: reuse the single-trade structure.** Consistent with the
+   precedent of `PriceRateTrades` reusing `RatePricingTradeResult_`; the new
+   function is a purely incremental surface with no compatibility risk, and per
+   (trade, component) entries make failure isolation align naturally with
+   single-trade semantics.
+3. **Aggregation currency treatment: group without converting.** The same
+   componentKey within a single market always points to the same curve object
+   (map semantics), the parameter axis is aligned through
+   `BuildCurveParameterLayout`, and gradient additivity holds within a currency
+   group. One caveat from the review — the grouping key must derive from each
+   family's *actual* PV pricing currency — is pinned in the implementation plan
+   (review follow-up 2).
+
+## Key Risks and Countermeasures
+
+1. **Tape/adjoint lifetime differences across the four backends** (native vs
+   xad/adept/codipack differ in registration order and adjoint-cleanup semantics):
+   reuse the existing `RegisterCurveParameters` → `NewRecording` order and the
+   per-backend cleanup paradigm inside `HarvestCurveJacobian`; invent nothing new.
+   Between sweeps, depend on `TapeGuard_` rewinds rather than manual resets
+   (the rewind pattern is documented in `dal-cpp/dal/curve/tapeguard.hpp`).
+   Verification belongs to the CI full compiler × AAD-backend matrix (full matrix
+   on PRs).
+2. **Tape memory on long batches.** Every (trade, component) sweep rewinds on
+   scope exit (block reuse; the `tapeguard.hpp` comment documents the pattern);
+   the `rate_risk_perf` benchmark joins the regression-script subset to guard
+   against memory and latency drift.
+3. **GIL/thread boundary.** One `gil_scoped_release` for the whole native batch,
+   with no Python callbacks inside; results are marshalled under the GIL; the
+   calibration-side barrier-test paradigm proves the release actually happens.
+   The tape is `thread_local`, so any future parallelism designed as "one task
+   owns a complete sweep" is naturally safe. P0 stays serial; parallelism is an
+   explicit later increment gated by TSan (`DAL_ENABLE_SANITIZERS=thread`) and the
+   `dal-cpp/tests/math/aad/test_concurrent_aad.cpp` pattern.
+4. **XCCY addressing and the empty-dependency-key status quo.** The most
+   error-prone link (the prior weekly report flagged it too). The countermeasure
+   is the frozen pointer-identity contract (decision point 1) plus planner key
+   emission plus negative cases for wrong keys, unregistered keys, and
+   unclassifiable in-block curves — all landing on existing tokens.
+5. **Tape size of OIS daily compounding.** Long-period OIS daily observation
+   counts amplify the number of tape nodes; the benchmark covers that shape, and
+   if it exceeds thresholds, interval collapsing is evaluated later (only under a
+   numerical-equivalence proof) — not pre-built in P0.
+6. **Passive-path regressions from templatization.** Stage 0 is a pure refactor
+   and the "active == passive PV" invariant runs through all later tests, so any
+   templatization mistake surfaces on that invariant.
+7. **Downstream visibility of the widened success domain.** External consumers
+   that use `TRADE_FAMILY_NOT_AAD_ENABLED` to detect non-Deposit trades will see
+   the behavior flip; each stage calls it out in the CHANGELOG, and
+   `docs/public-api.md` is updated in the same PR.

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
@@ -1,7 +1,11 @@
 # Full Product-Family AAD Node Risk and Portfolio Aggregation — Design
 
-> Status: revised design, not yet implemented. Identifiers match the local tree.
-> P0 contracts that the implementation review found still open are frozen below.
+> Status: revised design (rev. 2), not yet implemented. Identifiers match the
+> local tree. P0 contracts that the implementation review found still open are
+> frozen below; rev. 2 additionally freezes the heterogeneous curve-view
+> mechanism (contract 1), the per-component aggregation shape (contract 4),
+> and the XCCY active-typed assembly (contract 8), and tightens
+> active == passive PV to bitwise equality.
 > Staged execution, tests, and acceptance criteria live in the companion
 > [implementation plan](aad-node-risk-portfolio-aggregation-plan.md).
 
@@ -26,8 +30,10 @@
 - **Non-goals.** No new product families (cap/floor/swaption are P2); no vega or
   volatility axis; no parallel batch execution in P0 (serial, deterministic order —
   see risk 3); no AAD axis on the FX spot (the hook already exists:
-  `XccyMarketView_::fxSpot_` is already `T_`, a later small step can activate it);
-  no new JSON/serialization contracts (P1); the `Report_` storage format and the
+  `XccyMarketView_::fxSpot_` is already `T_`, a later small step can activate
+  it) — P0 XCCY node risk therefore ships rate axes only, with no FX delta,
+  and consumers must not read it as complete XCCY risk; no new
+  JSON/serialization contracts (P1); the `Report_` storage format and the
   `RateInstrumentType_` closed set are untouched; no ABI-isolation layer rework.
 
 ## Frozen P0 contracts
@@ -35,14 +41,25 @@
 These are closed for the first implementation series. Reopening any of them
 requires a new design revision, not a silent choice inside a stage-5 issue.
 
-1. **Non-target curves are truly passive `double` curves.** The active component
-   is built as `AAD::Number_` and registered through `RegisterCurveParameters`.
-   Every other curve the kernel reads is a `DiscountCurve_<double>` (or the
-   existing mixed-base `<AAD::Number_, DiscountCurve_<double>>` handle when the
-   active curve has a double base). Unregistered constant `AAD::Number_` curves
-   are not an acceptable "passive" stand-in: they still record OIS daily
-   compounding on the tape. Isolation tests must show the non-target gradient is
-   identically zero and that tape size does not scale with passive-node count.
+1. **Non-target curves are truly passive `double` curves, reached through a
+   heterogeneous curve reference.** The active component is built as
+   `AAD::Number_` and registered through `RegisterCurveParameters`. The
+   single-currency kernels do not read `market.curveComponents_` (a
+   double-only map) directly: each component key is resolved once per call
+   into an internal `CurveRef_<T_>` sum type holding exactly one of
+   `const DiscountCurve_<T_>*` (the target component) or
+   `const DiscountCurve_<double>*` (every other component), so mixed
+   active/passive arithmetic type-checks without registering passive
+   parameters. The passive path is `T_ = double` with every reference
+   passive, keeping `Price<double>` a thin wrapper over the same code. The
+   active curve's own base keeps the existing mixed-base
+   `<AAD::Number_, DiscountCurve_<double>>` handle. Unregistered constant
+   `AAD::Number_` curves are not an acceptable "passive" stand-in for the
+   single-currency families: they still record OIS daily compounding on the
+   tape. Isolation tests must show the non-target gradient is identically
+   zero and that tape size does not scale with passive-node count. XCCY
+   follows contract 8 instead — its view types cannot express this
+   mechanism.
 2. **Batch `componentKeys` is one shared list.**
    `RateTradeNodeSensitivitiesBatch(trades, market, componentKeys)` applies the
    same key list to every trade (Cartesian product, deterministic trade-major
@@ -56,9 +73,13 @@ requires a new design revision, not a silent choice inside a stage-5 issue.
    `market.resultCurrency_` and must never be used as a grouping key. The
    aggregate result carries an explicit policy label `UnconvertedByActualPvCcy`.
    FX conversion is a later increment and needs an explicit FX-input contract.
-4. **`Report_` is the numeric tensor, not the whole result.** Successful node
-   values live in a `Report_` whose axes come from
-   `DescribeCurveFreeParameters` / `BuildCurveParameterLayout`. Failures,
+4. **`Report_` is the numeric tensor, not the whole result — one dense tensor
+   per component.** `Report_` is dense with fixed strides, and node counts
+   differ across components (PWC N vs PWLF 2N), so the aggregation result is
+   one `Report_` per component over a single node axis whose labels come from
+   `DescribeCurveFreeParameters` / `BuildCurveParameterLayout` of the
+   market's curve for that component; no padding convention is introduced.
+   PV totals are grouped by actual PV currency under contract 3. Failures,
    currencies, and the aggregation policy live in a parallel meta table.
 5. **Excel emits a long-form spill.** Columns are
    `trade, component, reason, pv, node, value` (plus currency on aggregate
@@ -75,6 +96,23 @@ requires a new design revision, not a silent choice inside a stage-5 issue.
    is a negative case (must not be eligible-with-all-zeros). An in-block curve
    that cannot be classified is not `CURVE_REPRESENTATION_NOT_AAD_ENABLED`; that
    token remains a representation failure.
+8. **XCCY builds every consumed curve active-typed; only the target component
+   is registered.** `XccyMarketView_<T_>` and `JointCurveBlock_<T_>` are
+   uniformly typed in `T_` — a block cannot hold `double` curves — so
+   contract 1's heterogeneous reference does not extend to XCCY. The XCCY
+   stage follows the proven `Residuals<T_>` assembly instead: every curve the
+   trade actually consumes is built as `AAD::Number_`
+   (`BuildTypedCurveBlock<AAD::Number_>` for the domestic/foreign blocks,
+   `BuildDiscountCurveUniqueT<AAD::Number_>` for the basis), and only the
+   target component's parameters go through `RegisterCurveParameters`;
+   `fxSpot_` is an unregistered constant scalar, as in calibration. This is
+   acceptable specifically for XCCY because the kernel resolves one fixing
+   per coupon period (no daily loop): tape size is bounded by periods ×
+   knots touched and is guarded by the `rate_risk_perf` XCCY case, while the
+   OIS daily-compounding amplification that contract 1 excludes does not
+   occur. Isolation is still enforced — non-target gradients are identically
+   zero — but the tape assertion is a size bound, not passive-node-count
+   independence.
 
 ## Current-Code Facts
 
@@ -95,11 +133,14 @@ design:
 - The curve layer is already fully templated:
   `BuildCurveParameterLayout` / `DescribeCurveFreeParameters` (a date + component
   descriptor per parameter) / `RegisterCurveParameters` /
-  `BuildDiscountCurveUnique<T_,B_>`, including an existing mixed-base
+  `BuildDiscountCurveUniqueT<T_,B_>`, including an existing mixed-base
   instantiation `<AAD::Number_, DiscountCurve_<double>>` in
   `dal-cpp/dal/curve/curveparameterization.cpp`. The XCCY kernel
   (`PriceXccyContract<T_>`, `XccyMarketView_<T_>`) is already instantiated for
-  both double and AAD. The ready-made template for assembling multi-curve active
+  both double and AAD. `XccyMarketView_<T_>` and `JointCurveBlock_<T_>` are
+  uniformly typed in `T_` (a block cannot mix `double` and `AAD::Number_`
+  curves), so the XCCY node stage cannot reuse contract 1's heterogeneous
+  reference and follows frozen P0 contract 8. The ready-made template for assembling multi-curve active
   blocks is `BuildTypedCurveBlock<T_>` (with base layering,
   `dal-cpp/dal/curve/jointcalibration_internal.hpp`), and the complete stage
   pattern — `Residuals<T_>` + `TapeGuard_` + `RegisterCurveParameters` +
@@ -146,7 +187,8 @@ design:
   deterministic result order.
 - **Portfolio aggregation (new).** Sum the successful entries along the
   (component, currency, node/parameter) axes and return the aggregate plus axis
-  labels. The axis labels (parameter dates, component types) **must** be derived
+  labels: one dense `Report_` per component over its node axis, plus PV totals
+  per actual PV currency (frozen P0 contracts 3 and 4). The axis labels (parameter dates, component types) **must** be derived
   from `DescribeCurveFreeParameters`, and the parameter count and order **must**
   take `BuildCurveParameterLayout().parameterCount_` as the single source of
   truth — no hand-written parameter ordering or counting is acceptable (the

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
@@ -1,9 +1,8 @@
 # Full Product-Family AAD Node Risk and Portfolio Aggregation — Design
 
-> Status: reviewed design, not yet implemented. The plan passed an L-level review
-> (AAD/numerics and public-contract focus) with no blockers against baseline
-> `origin/master@ec89eb72`. The staged execution steps, test strategy, and
-> acceptance criteria live in the companion
+> Status: revised design, not yet implemented. Identifiers match the local tree.
+> P0 contracts that the implementation review found still open are frozen below.
+> Staged execution, tests, and acceptance criteria live in the companion
 > [implementation plan](aad-node-risk-portfolio-aggregation-plan.md).
 
 ## Goals and Scope
@@ -30,6 +29,52 @@
   `XccyMarketView_::fxSpot_` is already `T_`, a later small step can activate it);
   no new JSON/serialization contracts (P1); the `Report_` storage format and the
   `RateInstrumentType_` closed set are untouched; no ABI-isolation layer rework.
+
+## Frozen P0 contracts
+
+These are closed for the first implementation series. Reopening any of them
+requires a new design revision, not a silent choice inside a stage-5 issue.
+
+1. **Non-target curves are truly passive `double` curves.** The active component
+   is built as `AAD::Number_` and registered through `RegisterCurveParameters`.
+   Every other curve the kernel reads is a `DiscountCurve_<double>` (or the
+   existing mixed-base `<AAD::Number_, DiscountCurve_<double>>` handle when the
+   active curve has a double base). Unregistered constant `AAD::Number_` curves
+   are not an acceptable "passive" stand-in: they still record OIS daily
+   compounding on the tape. Isolation tests must show the non-target gradient is
+   identically zero and that tape size does not scale with passive-node count.
+2. **Batch `componentKeys` is one shared list.**
+   `RateTradeNodeSensitivitiesBatch(trades, market, componentKeys)` applies the
+   same key list to every trade (Cartesian product, deterministic trade-major
+   then key order). A trade that does not depend on a listed key returns the
+   existing `TRADE_DOES_NOT_DEPEND_ON_COMPONENT` cell. Per-trade key lists are
+   out of scope for P0.
+3. **Aggregation is unconverted, grouped by actual PV currency.** The grouping
+   key is each family's actual PV denomination: non-XCCY in the trade currency,
+   XCCY in the domestic currency produced by covered-interest parity inside
+   `PriceXccyContract`. `RatePricingTradeResult_.currency_` is
+   `market.resultCurrency_` and must never be used as a grouping key. The
+   aggregate result carries an explicit policy label `UnconvertedByActualPvCcy`.
+   FX conversion is a later increment and needs an explicit FX-input contract.
+4. **`Report_` is the numeric tensor, not the whole result.** Successful node
+   values live in a `Report_` whose axes come from
+   `DescribeCurveFreeParameters` / `BuildCurveParameterLayout`. Failures,
+   currencies, and the aggregation policy live in a parallel meta table.
+5. **Excel emits a long-form spill.** Columns are
+   `trade, component, reason, pv, node, value` (plus currency on aggregate
+   rows). Mixed components have different node counts and dates, so a single
+   "columns = nodes" grid is not a P0 contract. The surface is
+   `dal-excel/src/__curvepricing.cpp` plus Machinist-generated stubs.
+6. **P0 is serial on one tape.** `RateTradeNodeSensitivitiesBatch` must not
+   dispatch onto the existing thread pool. The tape is `thread_local`.
+7. **XCCY "depends on" means curves actually consumed.** A market-aware
+   `BuildRateCashflowPlan` overload (existing `(trade, valuationTime)` signature
+   unchanged) emits keys for the collateral/tenor-selected curves, not for every
+   in-block member. Pointer identity is valid only when the XCCY block and
+   `market.curveComponents_` share the same `Handle_`. An unused in-block member
+   is a negative case (must not be eligible-with-all-zeros). An in-block curve
+   that cannot be classified is not `CURVE_REPRESENTATION_NOT_AAD_ENABLED`; that
+   token remains a representation failure.
 
 ## Current-Code Facts
 
@@ -74,8 +119,11 @@ design:
   that can be mirrored. Excel currently has **no** rate-pricing surface at
   all (`dal-excel/src/` has no corresponding file), so it is a net-new binding.
 - `BuildRateCashflowPlan` currently leaves `dependencyComponentKeys_` empty for
-  XCCY, and `RatePricingMarket_::resultCurrency_` is passed through without
-  conversion (each family's PV is denominated in the trade's own currency).
+  XCCY, and `RatePricingTradeResult_.currency_` copies
+  `RatePricingMarket_::resultCurrency_` without conversion. Non-XCCY PV is
+  denominated in the trade currency; XCCY PV is already in the domestic
+  currency via covered-interest parity inside `PriceXccyContract`. Aggregation
+  must use that actual PV currency, not the passthrough field.
 - Existing test assets generalize directly: `AssertRawNodeGradientMatchesCentralBumps`
   in `dal-cpp/tests/curve/test_ratecashflowpricing.cpp` (central-difference
   comparison across the four curve representations, borrow/lend sign antisymmetry,
@@ -107,19 +155,19 @@ design:
   parameter perturbation" (the same convention as the existing Deposit path and
   the central-difference tests); quote-space conversion is deliberately not done —
   that is the job of the calibration Jacobian, an existing capability.
-- **Multi-currency treatment.** Aggregation groups by trade currency; the
-  pass-through-no-conversion status of `resultCurrency_` is preserved, and
-  cross-currency totals are explicitly labeled "unconverted, grouped by currency".
-  Optional conversion at the valuation time is a later increment (it depends on an
+- **Multi-currency treatment.** Frozen P0 contract 3: group without converting,
+  using each family's actual PV currency and the `UnconvertedByActualPvCcy`
+  label. Do not group on `RatePricingTradeResult_.currency_`. Optional
+  conversion at the valuation time is a later increment (it depends on an
   FX-input contract, which this feature deliberately does not introduce
   implicitly).
 - **Python.** The new batch/aggregation functions stay keyword-only with
   read-only results and release the GIL for the whole native execution (one
   release per batch, marshalling afterwards); existing bindings are untouched.
-- **Excel.** A new `dal-excel/src/__curvepricing.cpp` surface plus the Machinist
-  `public` marker (regenerate the stubs and commit them), results emitted as a
-  spill table (rows = trade/component, columns = nodes), naming following the
-  existing `public`-function conventions; no internal object structure leaks.
+- **Excel.** Frozen P0 contract 5: `dal-excel/src/__curvepricing.cpp` plus
+  Machinist-generated stubs; long-form spill
+  (`trade, component, reason, pv, node, value`). No internal object structure
+  leaks.
 - **Documentation.** The sentence "Native node AAD currently admits deposit trades
   only" in `docs/public-api.md` is updated in the same PR as each family lands (the
   docs must never disagree with the success domain), and the CHANGELOG records the
@@ -146,20 +194,14 @@ carries production-level risk:
    In the same step, the XCCY branch of `BuildRateCashflowPlan` is extended to
    emit these dependency keys (currently empty), which makes the
    `TRADE_DOES_NOT_DEPEND_ON_COMPONENT` gate effective for XCCY. A curve that
-   cannot be classified inside a block falls through to
-   `CURVE_REPRESENTATION_NOT_AAD_ENABLED`.
-2. **Batch result shape: reuse the single-trade structure.** Consistent with the
-   precedent of `PriceRateTrades` reusing `RatePricingTradeResult_`; the new
-   function is a purely incremental surface with no compatibility risk, and per
-   (trade, component) entries make failure isolation align naturally with
-   single-trade semantics.
-3. **Aggregation currency treatment: group without converting.** The same
-   componentKey within a single market always points to the same curve object
-   (map semantics), the parameter axis is aligned through
-   `BuildCurveParameterLayout`, and gradient additivity holds within a currency
-   group. One caveat from the review — the grouping key must derive from each
-   family's *actual* PV pricing currency — is pinned in the implementation plan
-   (review follow-up 2).
+   cannot be classified inside a block is not
+   `CURVE_REPRESENTATION_NOT_AAD_ENABLED`; that token remains a representation
+   failure (frozen P0 contract 7).
+2. **Batch result shape: reuse the single-trade structure**, with one shared
+   `componentKeys` list (frozen P0 contract 2).
+3. **Aggregation currency treatment: group without converting**, using actual PV
+   currency and the `UnconvertedByActualPvCcy` label (frozen P0 contract 3).
+   `RatePricingTradeResult_.currency_` must never be the grouping key.
 
 ## Key Risks and Countermeasures
 

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-plan.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-plan.md
@@ -1,43 +1,25 @@
 # Full Product-Family AAD Node Risk and Portfolio Aggregation — Implementation Plan
 
-> Status: reviewed implementation plan, not yet started. The underlying design
-> passed an L-level review with no blockers against baseline
-> `origin/master@ec89eb72`; the review's three non-blocking follow-ups are
-> incorporated below. Design rationale, current-code facts, the incremental API,
-> and the frozen decision points live in the companion
+> Status: revised implementation plan, not yet started. P0 contracts from the
+> implementation review are frozen below and in the companion
 > [design](aad-node-risk-portfolio-aggregation-design.md).
 
-## Review follow-ups (non-blocking, pinned here)
+## Frozen P0 follow-ups
 
-The L-level review raised three suggestions that must be resolved when the
-corresponding implementation issue is created. They narrow or clarify the plan
-below without reopening the design:
+These are no longer open questions. They match the Frozen P0 contracts in the
+design; implementation issues must not reopen them.
 
-1. **XCCY dependency-key derivation must be pinned (stage 4).** The current
-   signature `BuildRateCashflowPlan(trade, valuationTime)` cannot see the market,
-   and `XccyTradeTerms_` carries no component keys — the "XCCY emits non-empty
-   dependency keys" requirement can only be met by a market-aware overload
-   (incremental; the existing public signature is unchanged) or an equivalent
-   mechanism. The review also pins the meaning of "depends on": the curves the
-   trade's config **actually consumes** (selected by collateral/tenor), not block
-   membership — otherwise an in-block but unused curve would yield the ambiguous
-   eligible-with-all-zero-gradient result. A negative test case covers exactly
-   that unused-member shape.
-2. **Aggregation grouping key must derive from each family's actual PV pricing
-   currency (stage 5).** XCCY PV is denominated in the domestic currency via
-   covered interest parity inside the kernel (`PriceXccyContract` returns the
-   combined domestic−foreign value); non-XCCY families are denominated in the
-   trade's own currency. `RatePricingTradeResult_.currency_` is only a
-   `market.resultCurrency_` passthrough (constant within a batch) and
-   **must never** be used as the grouping key —
-   grouping on it would silently sum across currencies. The implementation issue
-   fixes the XCCY treatment explicitly: either the pair key forms its own group,
-   or it is explicitly folded into domestic with an annotation.
-3. **The `componentKeys` parameter semantics of the batch API need one pinned
-   sentence (stage 5).** Either one key list applied to every trade (a cross
-   product of unified keys × trades) or per-trade key lists. The new surface
-   carries no compatibility risk either way, but the aggregation axis definition
-   depends on the choice.
+1. **XCCY dependency keys (stage 4).** Add a market-aware
+   `BuildRateCashflowPlan` overload (existing `(trade, valuationTime)` signature
+   unchanged). "Depends on" means curves the config actually consumes (collateral
+   / tenor), not block membership. Unused in-block members are a negative case.
+   Unclassifiable in-block curves are not `CURVE_REPRESENTATION_NOT_AAD_ENABLED`.
+2. **Aggregation grouping (stage 5).** Group by each family's actual PV currency
+   (XCCY domestic via CIP). Never group on `RatePricingTradeResult_.currency_`.
+   Label the policy `UnconvertedByActualPvCcy`. Do not convert FX in P0.
+3. **Batch `componentKeys` (stage 5).** One shared key list applied to every
+   trade (Cartesian product, trade-major then key order). Missing dependency
+   returns `TRADE_DOES_NOT_DEPEND_ON_COMPONENT`.
 
 ## Stages 0–5
 
@@ -76,12 +58,13 @@ unmerged earlier state.
 - **Scope.** Generalize `PrepareNodeSensitivityCurve` into "prepare
   definition + passive parameters separately for **every** component the trade
   depends on": the target component's parameters are registered as independent
-  variables via `RegisterCurveParameters`, and the remaining dependent curves are
-  built as constant (unregistered) `AAD::Number_` of type `<AAD::Number_>` and fed
-  to the templated kernel together — gradients are naturally nonzero only for the
-  target component. Where base layering is needed, reuse the existing
-  `<AAD::Number_, DiscountCurve_<double>>` mixed instantiation (base stays
-  passive). Keep the current stage skeleton: `TapeGuard_` → register parameters →
+  variables via `RegisterCurveParameters`. Every other curve the kernel reads is
+  a `DiscountCurve_<double>` (or the existing mixed-base
+  `<AAD::Number_, DiscountCurve_<double>>` handle when the active curve has a
+  double base). Unregistered constant `AAD::Number_` curves are not an acceptable
+  passive stand-in. Isolation tests must show non-target gradients identically
+  zero and tape size independent of passive-node count. Keep the current stage
+  skeleton: `TapeGuard_` → register parameters →
   `NewRecording` (order as today) → price → seed → `PropagateToStart` → the
   `FinalizeNodeSensitivityCandidate` consistency check. Onboard FRA (forecast +
   discount, including the settleAtStart division path) and Future (forecast
@@ -106,8 +89,9 @@ unmerged earlier state.
 
 - **Scope.** Three-component dependency (spread forecast, reference forecast,
   discount); verify that when any one forecast is active the other curves'
-  gradients are strictly zero (the structural zeros of constant `Number_`), and
-  cover both legs having different fixing identities.
+  gradients are strictly zero (passive curves are `DiscountCurve_<double>`, not
+  unregistered `AAD::Number_`), and cover both legs having different fixing
+  identities.
 - **Gate.** The Basis test family is green.
 - **Rollback boundary.** Registry-only closure of Basis, as in stage 2.
 
@@ -117,14 +101,15 @@ unmerged earlier state.
   locate in-block slots by pointer identity, and walk classification +
   preparation for each of the domestic/foreign blocks and the basis curve;
   assemble `XccyMarketView_<AAD::Number_>` on the `Residuals<T_>` pattern
-  (non-target blocks built from constant `Number_`, fxSpot constant); give
-  `PriceXccy` the `result` accounting parameter so it matches the other families
-  (a missing fixing goes through `TRADE_VALIDATION_FAILED` — no new token).
-  `BuildRateCashflowPlan` emits the XCCY dependency keys per review follow-up 1
-  (market-aware overload or equivalent; "depends on" = actually consumed curves).
-  Test coverage: multi-currency pairs, collateral currencies, wrong/unregistered
-  keys, in-block unclassifiable representations, before/after maturity, missing
-  fixings in both currencies, and the unused-block-member negative case.
+  (non-target blocks stay `double` / mixed-base; fxSpot remains a constant
+  `double` in P0); give `PriceXccy` the `result` accounting parameter so it
+  matches the other families (a missing fixing goes through
+  `TRADE_VALIDATION_FAILED` — no new token). `BuildRateCashflowPlan` emits the
+  XCCY dependency keys per frozen P0 follow-up 1 (market-aware overload;
+  "depends on" = actually consumed curves). Test coverage: multi-currency pairs,
+  collateral currencies, wrong/unregistered keys, in-block unclassifiable
+  representations, before/after maturity, missing fixings in both currencies,
+  and the unused-block-member negative case.
 - **Gate.** The XCCY test family is green, including all negative cases; the
   planner emits non-empty dependency keys for XCCY.
 - **Rollback boundary.** Reverting closes XCCY in the registry and removes its
@@ -132,15 +117,15 @@ unmerged earlier state.
 
 ### Stage 5 — batch/aggregation + bindings + performance
 
-- **Scope.** `RateTradeNodeSensitivitiesBatch` and the aggregation (a `Report_`
-  export helper reusing the existing storable containers — no new storage
-  format); the `componentKeys` semantics and the currency grouping rule are
-  pinned per review follow-ups 3 and 2 before the issue is created. dal-public
+- **Scope.** `RateTradeNodeSensitivitiesBatch` and aggregation as a `Report_`
+  numeric tensor plus a parallel meta table (failures, currencies,
+  `UnconvertedByActualPvCcy`). `componentKeys` is one shared list (frozen P0
+  contract 2). P0 is serial: do not dispatch onto the thread pool. dal-public
   passthrough; Python batch binding (keyword-only, read-only, one GIL release
-  for the whole batch, mirroring `_CurveCalibrationGilBarrier` for the
-  release-proof test); the Excel spill surface + Machinist regeneration; a new
-  `rate_risk_perf` benchmark (naming follows the existing `*_perf` convention)
-  wired into the regression-gate script subset; docs/CHANGELOG close-out.
+  for the whole batch, mirroring `_CurveCalibrationGilBarrier_EnableForTesting`);
+  Excel long-form spill + Machinist regeneration; a new `rate_risk_perf`
+  benchmark wired into the regression-gate script subset; docs/CHANGELOG
+  close-out.
 - **Gate.** The full acceptance criteria below.
 - **Rollback boundary.** Reverting removes the new APIs and surfaces; the
   single-trade success domain from stages 0–4 is unaffected.
@@ -169,7 +154,14 @@ Core tests carry the load; public/Python/Excel contract tests close it out.
 - **XCCY specifics.** Multi-currency pairs, collateral currencies, wrong keys,
   unregistered keys, in-block unclassifiable representations, before/after
   maturity, missing fixings in both currencies, and the unused-block-member
-  negative case from review follow-up 1.
+  negative case from frozen P0 follow-up 1.
+- **Base curve.** For each family that prices against a layered curve, the
+  active overlay yields a nonzero gradient while the double base stays
+  identically zero (reuse the mixed-base
+  `<AAD::Number_, DiscountCurve_<double>>` instantiation).
+- **Expiry.** Every family, not only XCCY, has a before/after-maturity case:
+  expired cashflows contribute zero PV and a structurally zero gradient; live
+  cashflows remain comparable to central differences.
 - **Batch partial failure.** Mixed lists of eligible and per-token-failing
   trades; per-entry isolation with successful entries numerically identical to
   single-trade calls; empty lists; duplicate keys.
@@ -178,8 +170,10 @@ Core tests carry the load; public/Python/Excel contract tests close it out.
   Deposit priority cases are kept verbatim as compatibility guards.
 - **Surface contracts.** dal-public passthrough is a compile-time contract;
   Python keyword-only + read-only + signature snapshots (reusing the
-  `__doc__` first-line assertions) + GIL-release proof; the Excel spill column
-  contract (columns = nodes, order = layout order).
+  `__doc__` first-line assertions) + GIL-release proof; the Excel long-form
+  spill contract (`trade, component, reason, pv, node, value`, plus currency
+  on aggregate rows). Node order within a component still follows
+  `BuildCurveParameterLayout`.
 - **Registry.** The consistency assertion between the family-enabled set and
   `RateInstrumentTypeListAll()` is updated as stages land.
 
@@ -206,13 +200,17 @@ Gates belong to GitHub CI; this section only marks where they attach.
   terms-mismatch still returns `TRADE_FAMILY_NOT_AAD_ENABLED`; the six-token
   closed set and its priority are unchanged, and the existing Deposit assertions
   are unmodified.
-- XCCY: in-block/basis addressing, wrong keys, multi-currency, and the three
-  fixing states pass; `BuildRateCashflowPlan` emits non-empty dependency keys
-  for XCCY.
+- XCCY: in-block/basis addressing, wrong keys, multi-currency, unused in-block
+  members, and the three fixing states pass; `BuildRateCashflowPlan` emits
+  non-empty dependency keys for XCCY.
+- Every family has a before/after-maturity case and, where a layered curve
+  applies, a base-curve isolation case.
 - Batch: partial-failure isolation + numerical identity with single-trade calls
-  + deterministic order; aggregation axis labels correspond one-to-one with
+  + deterministic serial order; aggregation groups by actual PV currency under
+  `UnconvertedByActualPvCcy`; axis labels correspond one-to-one with
   `DescribeCurveFreeParameters`, and the parameter count matches
-  `BuildCurveParameterLayout`.
+  `BuildCurveParameterLayout`. Failures and currency/policy live in the
+  parallel meta table, not inside `Report_`.
 - The Python/Excel surface contract tests pass; `rate_risk_perf` is wired into
   the gate and within its baseline.
 - Before and after stage 0 merges, `dal_cpp_tests`/`dal_public_tests`/pytest are

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-plan.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-plan.md
@@ -1,0 +1,219 @@
+# Full Product-Family AAD Node Risk and Portfolio Aggregation — Implementation Plan
+
+> Status: reviewed implementation plan, not yet started. The underlying design
+> passed an L-level review with no blockers against baseline
+> `origin/master@ec89eb72`; the review's three non-blocking follow-ups are
+> incorporated below. Design rationale, current-code facts, the incremental API,
+> and the frozen decision points live in the companion
+> [design](aad-node-risk-portfolio-aggregation-design.md).
+
+## Review follow-ups (non-blocking, pinned here)
+
+The L-level review raised three suggestions that must be resolved when the
+corresponding implementation issue is created. They narrow or clarify the plan
+below without reopening the design:
+
+1. **XCCY dependency-key derivation must be pinned (stage 4).** The current
+   signature `BuildRateCashflowPlan(trade, valuationTime)` cannot see the market,
+   and `XccyTradeTerms_` carries no component keys — the "XCCY emits non-empty
+   dependency keys" requirement can only be met by a market-aware overload
+   (incremental; the existing public signature is unchanged) or an equivalent
+   mechanism. The review also pins the meaning of "depends on": the curves the
+   trade's config **actually consumes** (selected by collateral/tenor), not block
+   membership — otherwise an in-block but unused curve would yield the ambiguous
+   eligible-with-all-zero-gradient result. A negative test case covers exactly
+   that unused-member shape.
+2. **Aggregation grouping key must derive from each family's actual PV pricing
+   currency (stage 5).** XCCY PV is denominated in the domestic currency via
+   covered interest parity inside the kernel (`PriceXccyContract` returns the
+   combined domestic−foreign value); non-XCCY families are denominated in the
+   trade's own currency. `RatePricingTradeResult_.currency_` is only a
+   `market.resultCurrency_` passthrough (constant within a batch) and
+   **must never** be used as the grouping key —
+   grouping on it would silently sum across currencies. The implementation issue
+   fixes the XCCY treatment explicitly: either the pair key forms its own group,
+   or it is explicitly folded into domestic with an annotation.
+3. **The `componentKeys` parameter semantics of the batch API need one pinned
+   sentence (stage 5).** Either one key list applied to every trade (a cross
+   product of unified keys × trades) or per-trade key lists. The new surface
+   carries no compatibility risk either way, but the aggregation axis definition
+   depends on the choice.
+
+## Stages 0–5
+
+Each stage is one independently mergeable, independently revertable PR. A stage's
+rollback boundary is what reverting that PR restores; later stages never assume
+unmerged earlier state.
+
+| Stage | Scope                            | Gate                             | Rollback                       |
+|-------|----------------------------------|----------------------------------|--------------------------------|
+| 0     | Kernel templatization            | Existing tests green, unmodified | Passive pricing unchanged      |
+| 1     | Multi-component AAD + FRA/Future | FRA/Future tests green           | Success domain back to Deposit |
+| 2     | OIS/IRS                          | OIS/IRS tests green              | Success domain back to stage 1 |
+| 3     | Basis                            | Basis tests green                | Success domain back to stage 2 |
+| 4     | XCCY                             | XCCY tests green                 | Success domain back to stage 3 |
+| 5     | Batch + bindings + perf          | Full acceptance criteria         | New APIs/surfaces removed      |
+
+### Stage 0 — kernel templatization (pure refactor, no behavior change)
+
+- **Scope.** Templatize `Discount`/`ForwardRate`/`ResolveRate`/`PriceFixedFloat`/
+  `PriceBasis` and the Deposit/FRA/Future branches of `Price` to `T_`;
+  `Price(trade, market, result)` collapses into a thin wrapper over
+  `Price<double>`; add explicit double/`AAD::Number_` instantiations. Fixing reads
+  and exception paths (the THROW inside `ResolveRate` plus the
+  `missingHistoricalFixings_` accounting) keep identical logic inside the template.
+  Switch the Deposit AAD stage to the templated kernel and delete the hand-written
+  formula in the lambda — from then on "active PV == passive PV" is guaranteed by
+  the same code, not maintained by comparison.
+- **Gate.** All existing tests (core/public/Python) stay green without assertion
+  changes; no public semantic change to any header or symbol.
+- **Rollback boundary.** Reverting restores the pre-templatization kernels;
+  passive pricing is bit-identical before and after, so the revert is invisible
+  to every consumer.
+
+### Stage 1 — generalized multi-component AAD stage + FRA/Future
+
+- **Scope.** Generalize `PrepareNodeSensitivityCurve` into "prepare
+  definition + passive parameters separately for **every** component the trade
+  depends on": the target component's parameters are registered as independent
+  variables via `RegisterCurveParameters`, and the remaining dependent curves are
+  built as constant (unregistered) `AAD::Number_` of type `<AAD::Number_>` and fed
+  to the templated kernel together — gradients are naturally nonzero only for the
+  target component. Where base layering is needed, reuse the existing
+  `<AAD::Number_, DiscountCurve_<double>>` mixed instantiation (base stays
+  passive). Keep the current stage skeleton: `TapeGuard_` → register parameters →
+  `NewRecording` (order as today) → price → seed → `PropagateToStart` → the
+  `FinalizeNodeSensitivityCandidate` consistency check. Onboard FRA (forecast +
+  discount, including the settleAtStart division path) and Future (forecast
+  only); open those two families in the family-eligibility registry.
+- **Gate.** The FRA/Future tests of the test strategy below are green; OIS/IRS/
+  Basis/XCCY still return `TRADE_FAMILY_NOT_AAD_ENABLED` (registry not yet open).
+- **Rollback boundary.** Reverting closes FRA/Future in the registry and removes
+  the generalized stage; Deposit behavior (already shipped since stage 0 only
+  changed its internals) is untouched.
+
+### Stage 2 — OIS/IRS
+
+- **Scope.** `PriceFixedFloat` was already templated in stage 0; this stage opens
+  the registry and focuses the tests: the tape path of the OIS daily-compounding
+  loop, fixed/float both legs, and the forecast≠discount two-component setting
+  (a gradient per component, compared against central differences).
+- **Gate.** The OIS/IRS test families are green.
+- **Rollback boundary.** Reverting closes OIS/IRS in the registry only; no
+  shared code is removed, so FRA/Future remain eligible.
+
+### Stage 3 — Basis
+
+- **Scope.** Three-component dependency (spread forecast, reference forecast,
+  discount); verify that when any one forecast is active the other curves'
+  gradients are strictly zero (the structural zeros of constant `Number_`), and
+  cover both legs having different fixing identities.
+- **Gate.** The Basis test family is green.
+- **Rollback boundary.** Registry-only closure of Basis, as in stage 2.
+
+### Stage 4 — XCCY
+
+- **Scope.** Follow the frozen componentKey contract (design, decision point 1):
+  locate in-block slots by pointer identity, and walk classification +
+  preparation for each of the domestic/foreign blocks and the basis curve;
+  assemble `XccyMarketView_<AAD::Number_>` on the `Residuals<T_>` pattern
+  (non-target blocks built from constant `Number_`, fxSpot constant); give
+  `PriceXccy` the `result` accounting parameter so it matches the other families
+  (a missing fixing goes through `TRADE_VALIDATION_FAILED` — no new token).
+  `BuildRateCashflowPlan` emits the XCCY dependency keys per review follow-up 1
+  (market-aware overload or equivalent; "depends on" = actually consumed curves).
+  Test coverage: multi-currency pairs, collateral currencies, wrong/unregistered
+  keys, in-block unclassifiable representations, before/after maturity, missing
+  fixings in both currencies, and the unused-block-member negative case.
+- **Gate.** The XCCY test family is green, including all negative cases; the
+  planner emits non-empty dependency keys for XCCY.
+- **Rollback boundary.** Reverting closes XCCY in the registry and removes its
+  planner key emission; stages 0–3 families are unaffected.
+
+### Stage 5 — batch/aggregation + bindings + performance
+
+- **Scope.** `RateTradeNodeSensitivitiesBatch` and the aggregation (a `Report_`
+  export helper reusing the existing storable containers — no new storage
+  format); the `componentKeys` semantics and the currency grouping rule are
+  pinned per review follow-ups 3 and 2 before the issue is created. dal-public
+  passthrough; Python batch binding (keyword-only, read-only, one GIL release
+  for the whole batch, mirroring `_CurveCalibrationGilBarrier` for the
+  release-proof test); the Excel spill surface + Machinist regeneration; a new
+  `rate_risk_perf` benchmark (naming follows the existing `*_perf` convention)
+  wired into the regression-gate script subset; docs/CHANGELOG close-out.
+- **Gate.** The full acceptance criteria below.
+- **Rollback boundary.** Reverting removes the new APIs and surfaces; the
+  single-trade success domain from stages 0–4 is unaffected.
+
+## Per-Family Testing Strategy
+
+Core tests carry the load; public/Python/Excel contract tests close it out.
+
+- **AAD vs central differences.** Generalize
+  `AssertRawNodeGradientMatchesCentralBumps` from Deposit to per-family trade
+  builders; for each family × each of the four available curve representations
+  (PWC/PWLF/LogDF/ZeroRate), compare every native parameter column (tolerances
+  keep the existing mixed absolute + relative form).
+- **Active == passive PV.** For each family and component, assert `aad.pv_`
+  equals `PriceRateTrade().pv_` (the existing Deposit case uses 1e-12); when the
+  borrow/pay direction flips, PV and gradient flip sign together (reusing the
+  borrow-antisymmetry case pattern).
+- **Three fixing states.** Future fixing (projection path, nonzero gradient);
+  past and supplied (that period's gradient is structurally zero, asserted
+  explicitly); past and missing (passive pricing fails →
+  `TRADE_VALIDATION_FAILED`, with the `missingHistoricalFixings_` accounting
+  inspectable).
+- **Multi-component.** Call separately for each dependent component; non-target
+  component columns are all zero; forecast≠discount, the Basis three-component
+  case, and XCCY dual-block + basis each covered.
+- **XCCY specifics.** Multi-currency pairs, collateral currencies, wrong keys,
+  unregistered keys, in-block unclassifiable representations, before/after
+  maturity, missing fixings in both currencies, and the unused-block-member
+  negative case from review follow-up 1.
+- **Batch partial failure.** Mixed lists of eligible and per-token-failing
+  trades; per-entry isolation with successful entries numerically identical to
+  single-trade calls; empty lists; duplicate keys.
+- **Token priority matrix extension.** Each newly opened family adds a priority
+  case such as "wrong component key precedes missing component"; the existing
+  Deposit priority cases are kept verbatim as compatibility guards.
+- **Surface contracts.** dal-public passthrough is a compile-time contract;
+  Python keyword-only + read-only + signature snapshots (reusing the
+  `__doc__` first-line assertions) + GIL-release proof; the Excel spill column
+  contract (columns = nodes, order = layout order).
+- **Registry.** The consistency assertion between the family-enabled set and
+  `RateInstrumentTypeListAll()` is updated as stages land.
+
+## CI Verification Points
+
+Gates belong to GitHub CI; this section only marks where they attach.
+
+- The PR-tier full compiler × AAD-backend matrix must include all new tests
+  (backend differences are the biggest numerical risk of this feature — risk 1 in
+  the design); the push-tier reduced matrix stays as is.
+- Coverage of the new code paths joins the centralized coverage job.
+- `rate_risk_perf` joins the `.github/scripts/check_benchmark_regressions.py`
+  gate subset (long-batch tape memory/latency and the OIS daily-compounding
+  shape included).
+- `docs/public-api.md` changes pass the `check_docs.py` lint.
+- If parallel batching lands as a later increment: the TSan matrix entry.
+
+## Acceptance Criteria
+
+- All seven families × (each applicable curve representation) have passing
+  AAD-vs-central-difference cases; each family has a passing active == passive
+  case.
+- Gradients for any non-target dependent component are strictly zero;
+  terms-mismatch still returns `TRADE_FAMILY_NOT_AAD_ENABLED`; the six-token
+  closed set and its priority are unchanged, and the existing Deposit assertions
+  are unmodified.
+- XCCY: in-block/basis addressing, wrong keys, multi-currency, and the three
+  fixing states pass; `BuildRateCashflowPlan` emits non-empty dependency keys
+  for XCCY.
+- Batch: partial-failure isolation + numerical identity with single-trade calls
+  + deterministic order; aggregation axis labels correspond one-to-one with
+  `DescribeCurveFreeParameters`, and the parameter count matches
+  `BuildCurveParameterLayout`.
+- The Python/Excel surface contract tests pass; `rate_risk_perf` is wired into
+  the gate and within its baseline.
+- Before and after stage 0 merges, `dal_cpp_tests`/`dal_public_tests`/pytest are
+  all green with no assertion modifications.

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-plan.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-plan.md
@@ -1,8 +1,11 @@
 # Full Product-Family AAD Node Risk and Portfolio Aggregation — Implementation Plan
 
-> Status: revised implementation plan, not yet started. P0 contracts from the
-> implementation review are frozen below and in the companion
-> [design](aad-node-risk-portfolio-aggregation-design.md).
+> Status: revised implementation plan (rev. 2), not yet started. P0 contracts
+> from the implementation review are frozen below and in the companion
+> [design](aad-node-risk-portfolio-aggregation-design.md); rev. 2 freezes the
+> heterogeneous curve view and the aggregation shape (follow-ups 4–5), the
+> stage-0 `Value()` unwrap points, batch hoisting, and bitwise
+> active == passive.
 
 ## Frozen P0 follow-ups
 
@@ -20,6 +23,19 @@ design; implementation issues must not reopen them.
 3. **Batch `componentKeys` (stage 5).** One shared key list applied to every
    trade (Cartesian product, trade-major then key order). Missing dependency
    returns `TRADE_DOES_NOT_DEPEND_ON_COMPONENT`.
+4. **Heterogeneous curve view (stages 0–1).** Single-currency kernels reach
+   curves through an internal `CurveRef_<T_>` sum type (active
+   `const DiscountCurve_<T_>*` for the target key, passive
+   `const DiscountCurve_<double>*` otherwise), resolved once per curve per
+   call; the `Price<double>` wrapper builds every reference passive. XCCY
+   does not use this mechanism — its uniformly typed view follows design
+   frozen P0 contract 8 (all consumed curves active-typed, only the target
+   registered).
+5. **Aggregation shape (stage 5).** One dense `Report_` per component over
+   its node axis; PV totals grouped by actual PV currency under
+   `UnconvertedByActualPvCcy`; failures/currency/policy in the parallel meta
+   table (design, frozen P0 contracts 3 and 4). No ragged-tensor or padding
+   convention.
 
 ## Stages 0–5
 
@@ -41,9 +57,18 @@ unmerged earlier state.
 - **Scope.** Templatize `Discount`/`ForwardRate`/`ResolveRate`/`PriceFixedFloat`/
   `PriceBasis` and the Deposit/FRA/Future branches of `Price` to `T_`;
   `Price(trade, market, result)` collapses into a thin wrapper over
-  `Price<double>`; add explicit double/`AAD::Number_` instantiations. Fixing reads
+  `Price<double>` (every `CurveRef_` passive); add explicit
+  double/`AAD::Number_` instantiations. Fixing reads
   and exception paths (the THROW inside `ResolveRate` plus the
-  `missingHistoricalFixings_` accounting) keep identical logic inside the template.
+  `missingHistoricalFixings_` accounting) keep identical logic inside the
+  template. Every `REQUIRE` on a `T_`-typed intermediate unwraps through
+  `Dal::AAD::Value` — never `static_cast<double>`, which only compiles on the
+  native and CoDiPack backends (the `jointrate.hpp` paradigm): the
+  `ForwardRate` accrual/discount-factor check, the FRA start-settled
+  denominator check, and the discount-positivity check (already centralized
+  in the templated `Tape::DiscountFromValuation`). Fixing values stay
+  `double` end to end, so their checks are untouched; primal-side checks
+  record nothing on the tape.
   Switch the Deposit AAD stage to the templated kernel and delete the hand-written
   formula in the lambda — from then on "active PV == passive PV" is guaranteed by
   the same code, not maintained by comparison.
@@ -58,7 +83,11 @@ unmerged earlier state.
 - **Scope.** Generalize `PrepareNodeSensitivityCurve` into "prepare
   definition + passive parameters separately for **every** component the trade
   depends on": the target component's parameters are registered as independent
-  variables via `RegisterCurveParameters`. Every other curve the kernel reads is
+  variables via `RegisterCurveParameters`. The stage assembles the
+  `CurveRef_<AAD::Number_>` view of frozen follow-up 4 — the target key
+  resolves to the freshly built active curve, every other key to the existing
+  `DiscountCurve_<double>` — and the templated kernels consume that view.
+  Every other curve the kernel reads is
   a `DiscountCurve_<double>` (or the existing mixed-base
   `<AAD::Number_, DiscountCurve_<double>>` handle when the active curve has a
   double base). Unregistered constant `AAD::Number_` curves are not an acceptable
@@ -100,9 +129,12 @@ unmerged earlier state.
 - **Scope.** Follow the frozen componentKey contract (design, decision point 1):
   locate in-block slots by pointer identity, and walk classification +
   preparation for each of the domestic/foreign blocks and the basis curve;
-  assemble `XccyMarketView_<AAD::Number_>` on the `Residuals<T_>` pattern
-  (non-target blocks stay `double` / mixed-base; fxSpot remains a constant
-  `double` in P0); give `PriceXccy` the `result` accounting parameter so it
+  assemble `XccyMarketView_<AAD::Number_>` on the `Residuals<T_>` pattern per
+  frozen P0 contract 8 — every consumed curve is built active-typed
+  (`BuildTypedCurveBlock<AAD::Number_>` blocks,
+  `BuildDiscountCurveUniqueT<AAD::Number_>` basis), only the target
+  component's parameters are registered, and `fxSpot_` stays an unregistered
+  constant scalar; give `PriceXccy` the `result` accounting parameter so it
   matches the other families (a missing fixing goes through
   `TRADE_VALIDATION_FAILED` — no new token). `BuildRateCashflowPlan` emits the
   XCCY dependency keys per frozen P0 follow-up 1 (market-aware overload;
@@ -117,9 +149,13 @@ unmerged earlier state.
 
 ### Stage 5 — batch/aggregation + bindings + performance
 
-- **Scope.** `RateTradeNodeSensitivitiesBatch` and aggregation as a `Report_`
-  numeric tensor plus a parallel meta table (failures, currencies,
-  `UnconvertedByActualPvCcy`). `componentKeys` is one shared list (frozen P0
+- **Scope.** `RateTradeNodeSensitivitiesBatch` and aggregation as one dense
+  `Report_` per component plus a parallel meta table (failures, currencies,
+  `UnconvertedByActualPvCcy`). The batch hoists each trade's passive pricing
+  (the `TRADE_VALIDATION_FAILED` gate) and each component's
+  classification/preparation out of the (trade, component) inner loop — the
+  Cartesian product costs one passive PV per trade and one preparation per
+  component, not T×K of each. `componentKeys` is one shared list (frozen P0
   contract 2). P0 is serial: do not dispatch onto the thread pool. dal-public
   passthrough; Python batch binding (keyword-only, read-only, one GIL release
   for the whole batch, mirroring `_CurveCalibrationGilBarrier_EnableForTesting`);
@@ -140,7 +176,9 @@ Core tests carry the load; public/Python/Excel contract tests close it out.
   (PWC/PWLF/LogDF/ZeroRate), compare every native parameter column (tolerances
   keep the existing mixed absolute + relative form).
 - **Active == passive PV.** For each family and component, assert `aad.pv_`
-  equals `PriceRateTrade().pv_` (the existing Deposit case uses 1e-12); when the
+  is bitwise equal to `PriceRateTrade().pv_` (`ASSERT_DOUBLE_EQ`) — after
+  stage 0 both paths run the same templated code in the same operation order,
+  so equality is exact, not 1e-12; when the
   borrow/pay direction flips, PV and gradient flip sign together (reusing the
   borrow-antisymmetry case pattern).
 - **Three fixing states.** Future fixing (projection path, nonzero gradient);
@@ -150,7 +188,10 @@ Core tests carry the load; public/Python/Excel contract tests close it out.
   inspectable).
 - **Multi-component.** Call separately for each dependent component; non-target
   component columns are all zero; forecast≠discount, the Basis three-component
-  case, and XCCY dual-block + basis each covered.
+  case, and XCCY dual-block + basis each covered. Tape isolation: for
+  single-currency families, tape size does not scale with passive-node count;
+  for XCCY, assert the contract-8 size bound (periods × knots touched)
+  instead.
 - **XCCY specifics.** Multi-currency pairs, collateral currencies, wrong keys,
   unregistered keys, in-block unclassifiable representations, before/after
   maturity, missing fixings in both currencies, and the unused-block-member
@@ -173,7 +214,8 @@ Core tests carry the load; public/Python/Excel contract tests close it out.
   `__doc__` first-line assertions) + GIL-release proof; the Excel long-form
   spill contract (`trade, component, reason, pv, node, value`, plus currency
   on aggregate rows). Node order within a component still follows
-  `BuildCurveParameterLayout`.
+  `BuildCurveParameterLayout`. The aggregation result carries one dense
+  `Report_` per component — no padded shared node axis.
 - **Registry.** The consistency assertion between the family-enabled set and
   `RateInstrumentTypeListAll()` is updated as stages land.
 
@@ -194,8 +236,8 @@ Gates belong to GitHub CI; this section only marks where they attach.
 ## Acceptance Criteria
 
 - All seven families × (each applicable curve representation) have passing
-  AAD-vs-central-difference cases; each family has a passing active == passive
-  case.
+  AAD-vs-central-difference cases; each family has a passing bitwise
+  active == passive case.
 - Gradients for any non-target dependent component are strictly zero;
   terms-mismatch still returns `TRADE_FAMILY_NOT_AAD_ENABLED`; the six-token
   closed set and its priority are unchanged, and the existing Deposit assertions
@@ -206,8 +248,11 @@ Gates belong to GitHub CI; this section only marks where they attach.
 - Every family has a before/after-maturity case and, where a layered curve
   applies, a base-curve isolation case.
 - Batch: partial-failure isolation + numerical identity with single-trade calls
-  + deterministic serial order; aggregation groups by actual PV currency under
-  `UnconvertedByActualPvCcy`; axis labels correspond one-to-one with
+  + deterministic serial order; passive pricing and per-component preparation
+  are hoisted (one passive PV per trade, one preparation per component, not
+  T×K); aggregation groups by actual PV currency under
+  `UnconvertedByActualPvCcy`; each component's node values form a dense
+  `Report_` whose axis labels correspond one-to-one with
   `DescribeCurveFreeParameters`, and the parameter count matches
   `BuildCurveParameterLayout`. Failures and currency/policy live in the
   parallel meta table, not inside `Report_`.


### PR DESCRIPTION
## Summary
- Add the DAL-131 design and staged plan for widening node-level AAD risk from Deposit to all seven rate families, plus batch and portfolio-aggregation APIs.
- Freeze the P0 contracts the implementation review left open: truly passive `double` sibling curves (not unregistered `AAD::Number_`), one shared `componentKeys` list, aggregation by actual PV currency under `UnconvertedByActualPvCcy`, `Report_` as numeric tensor plus a parallel meta table, Excel long-form spill, serial execution on the `thread_local` tape, and XCCY dependency as actually consumed curves.
- Index both docs under the Experimental section of `docs/README.md`.

Docs-only change: no code touched, no CHANGELOG entry (nothing has shipped yet).

## Test plan
- [x] Docs-only edit; identifiers match the local tree (`RateTradeNodeSensitivities`, `TRADE_FAMILY_NOT_AAD_ENABLED`, `TRADE_VALIDATION_FAILED`, `dal-excel`, Machinist).
- [ ] CI `check_docs.py` on this PR.