### PR TITLE
DAL-154: AAD node risk Stage 1 — multi-component AAD stage + FRA/Future (GitHub #302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ here as the baseline rather than dated releases:
 
 ## 2026-08
 
+- `curve`: `RateTradeNodeSensitivities` success domain widened from Deposit-only to FRA and
+  Future trades (per requested dependency: FRA forecast/discount, Future forecast), via a
+  multi-component AAD stage that registers only the target component's parameters and holds
+  every other dependency as a passive `double` curve. OIS/IRS/Basis/XCCY remain gated by
+  `TRADE_FAMILY_NOT_AAD_ENABLED`; the six-token failure set and its priority are unchanged.
+
 - `script`: Added two script-product debug dumps alongside the legacy
   s-expression one: `DebugScriptProductJson` / `Product_DebugJson` emit a
   versioned JSON AST (schema `dal.script-product/1`) for machine consumers

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -169,16 +169,50 @@ namespace Dal {
         }
 
         // #lizard forgives -- explicit instrument-family validation is the public contract boundary.
+        bool TermsMatchFamily(const RateTradeDefinition_& trade) {
+            return (trade.instrumentType_ == RateInstrumentType_::Value_::DEPOSIT && std::holds_alternative<DepositTradeTerms_>(trade.terms_)) ||
+                   (trade.instrumentType_ == RateInstrumentType_::Value_::FRA && std::holds_alternative<FraTradeTerms_>(trade.terms_)) ||
+                   (trade.instrumentType_ == RateInstrumentType_::Value_::FUTURE && std::holds_alternative<FutureTradeTerms_>(trade.terms_)) ||
+                   (trade.instrumentType_ == RateInstrumentType_::Value_::OIS && std::holds_alternative<OisTradeTerms_>(trade.terms_)) ||
+                   (trade.instrumentType_ == RateInstrumentType_::Value_::IRS && std::holds_alternative<IrsTradeTerms_>(trade.terms_)) ||
+                   (trade.instrumentType_ == RateInstrumentType_::Value_::BASIS_SWAP && std::holds_alternative<BasisTradeTerms_>(trade.terms_)) ||
+                   (trade.instrumentType_ == RateInstrumentType_::Value_::XCCY && std::holds_alternative<XccyTradeTerms_>(trade.terms_));
+        }
+
         void ValidateTermMatch(const RateTradeDefinition_& trade) {
-            const bool matches =
-                (trade.instrumentType_ == RateInstrumentType_::Value_::DEPOSIT && std::holds_alternative<DepositTradeTerms_>(trade.terms_)) ||
-                (trade.instrumentType_ == RateInstrumentType_::Value_::FRA && std::holds_alternative<FraTradeTerms_>(trade.terms_)) ||
-                (trade.instrumentType_ == RateInstrumentType_::Value_::FUTURE && std::holds_alternative<FutureTradeTerms_>(trade.terms_)) ||
-                (trade.instrumentType_ == RateInstrumentType_::Value_::OIS && std::holds_alternative<OisTradeTerms_>(trade.terms_)) ||
-                (trade.instrumentType_ == RateInstrumentType_::Value_::IRS && std::holds_alternative<IrsTradeTerms_>(trade.terms_)) ||
-                (trade.instrumentType_ == RateInstrumentType_::Value_::BASIS_SWAP && std::holds_alternative<BasisTradeTerms_>(trade.terms_)) ||
-                (trade.instrumentType_ == RateInstrumentType_::Value_::XCCY && std::holds_alternative<XccyTradeTerms_>(trade.terms_));
-            REQUIRE(matches, "Rate instrument type does not match its immutable terms alternative");
+            REQUIRE(TermsMatchFamily(trade), "Rate instrument type does not match its immutable terms alternative");
+        }
+
+        bool IsFamilyAadEnabled(const RateTradeDefinition_& trade) {
+            const auto enabled = RateCashflowPricingInternal::AadEnabledRateFamilies();
+            return std::find(enabled.begin(), enabled.end(), trade.instrumentType_) != enabled.end() && TermsMatchFamily(trade);
+        }
+
+        // Curve components the trade's pricing actually reads, in deterministic terms order; the
+        // AAD stage prepares every one of them and registers only the requested target.
+        Vector_<String_> AadDependencyKeys(const RateTradeDefinition_& trade) {
+            Vector_<String_> result;
+            std::visit(
+                [&](const auto& terms) {
+                    using terms_t = std::decay_t<decltype(terms)>;
+                    if constexpr (std::is_same_v<terms_t, DepositTradeTerms_>) {
+                        AddUnique(terms.discountComponentKey_, &result);
+                    } else if constexpr (std::is_same_v<terms_t, FraTradeTerms_>) {
+                        AddUnique(terms.forecastComponentKey_, &result);
+                        AddUnique(terms.discountComponentKey_, &result);
+                    } else if constexpr (std::is_same_v<terms_t, FutureTradeTerms_>) {
+                        AddUnique(terms.forecastComponentKey_, &result);
+                    } else if constexpr (std::is_same_v<terms_t, OisTradeTerms_> || std::is_same_v<terms_t, IrsTradeTerms_>) {
+                        AddUnique(terms.value_.forecastComponentKey_, &result);
+                        AddUnique(terms.value_.discountComponentKey_, &result);
+                    } else if constexpr (std::is_same_v<terms_t, BasisTradeTerms_>) {
+                        AddUnique(terms.spreadForecastComponentKey_, &result);
+                        AddUnique(terms.referenceForecastComponentKey_, &result);
+                        AddUnique(terms.discountComponentKey_, &result);
+                    }
+                },
+                trade.terms_);
+            return result;
         }
 
         template <class T_>
@@ -531,34 +565,42 @@ namespace Dal {
     RateTradeNodeSensitivityResult_
     RateTradeNodeSensitivities(const RateTradeDefinition_& trade, const RatePricingMarket_& market, const String_& componentKey) {
         using namespace RateCashflowPricingInternal;
-        const auto* terms = std::get_if<DepositTradeTerms_>(&trade.terms_);
-        if (!terms || trade.instrumentType_ != RateInstrumentType_::Value_::DEPOSIT)
+        if (!IsFamilyAadEnabled(trade))
             return NodeSensitivityFailure("TRADE_FAMILY_NOT_AAD_ENABLED");
-        if (terms->discountComponentKey_ != componentKey)
+        const Vector_<String_> dependencyKeys = AadDependencyKeys(trade);
+        if (std::find(dependencyKeys.begin(), dependencyKeys.end(), componentKey) == dependencyKeys.end())
             return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
-        const auto found = market.curveComponents_.find(componentKey);
-        if (found == market.curveComponents_.end() || !found->second)
-            return NodeSensitivityFailure("CURVE_COMPONENT_UNAVAILABLE");
-        const auto classifiedCurve = ClassifyNodeSensitivityCurve(*found->second);
-        if (std::holds_alternative<std::monostate>(classifiedCurve))
-            return NodeSensitivityFailure("CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+
+        // Availability and representation are gated for every component the trade depends on:
+        // the stage prepares each one separately and registers only the target's parameters.
+        std::map<String_, NodeSensitivityCurve_> classifiedCurves;
+        for (const auto& key : dependencyKeys) {
+            const auto found = market.curveComponents_.find(key);
+            if (found == market.curveComponents_.end() || !found->second)
+                return NodeSensitivityFailure("CURVE_COMPONENT_UNAVAILABLE");
+            classifiedCurves[key] = ClassifyNodeSensitivityCurve(*found->second);
+            if (std::holds_alternative<std::monostate>(classifiedCurves[key]))
+                return NodeSensitivityFailure("CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+        }
 
         const auto passive = PriceRateTrade(trade, market);
         if (!passive.succeeded_ || !std::isfinite(passive.pv_))
             return NodeSensitivityFailure("TRADE_VALIDATION_FAILED");
 
-        NodeSensitivityPreparation_ preparation;
+        std::map<String_, NodeSensitivityPreparation_> preparations;
         try {
-            preparation = PrepareNodeSensitivityCurve(classifiedCurve, market.valuationTime_.Date());
+            for (const auto& [key, classifiedCurve] : classifiedCurves)
+                preparations.emplace(key, PrepareNodeSensitivityCurve(classifiedCurve, market.valuationTime_.Date()));
         } catch (const std::exception&) {
             return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
         }
 
-        return RunNodeSensitivityAADStage(preparation.expectedParameterCount_, [&]() {
-            Vector_<AAD::Number_> parameters = RegisterCurveParameters(preparation.passiveParameters_);
+        const auto target = preparations.find(componentKey);
+        return RunNodeSensitivityAADStage(target->second.expectedParameterCount_, [&]() {
+            Vector_<AAD::Number_> parameters = RegisterCurveParameters(target->second.passiveParameters_);
             AAD::NewRecording(*AAD::Tape());
-            const auto activeCurve = BuildDiscountCurveUniqueT<AAD::Number_>(preparation.definition_, parameters, preparation.passiveBase_);
-            // Deposit pricing resolves no fixings; the passive gate above already did the fixing accounting.
+            const auto activeCurve = BuildDiscountCurveUniqueT<AAD::Number_>(target->second.definition_, parameters, target->second.passiveBase_);
+            // Fixing failures were already gated by the passive price above; this diagnostics result is stage scratch.
             RatePricingTradeResult_ activeDiagnostics;
             const RateMarketView_<AAD::Number_> view{&market, &componentKey, activeCurve.get()};
             AAD::Number_ pv = Price(trade, view, &activeDiagnostics);

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -40,6 +40,14 @@ namespace Dal::RateCashflowPricingInternal {
         Vector_<> gradient_;
     };
 
+    // AAD family-eligibility registry: the rate families whose node-sensitivity stage is
+    // open. A family enters this set only once its multi-component AAD stage is onboarded;
+    // the per-trade gate additionally requires the terms alternative to match the family,
+    // so terms-mismatch trades keep hitting the family gate by construction.
+    inline Vector_<RateInstrumentType_> AadEnabledRateFamilies() {
+        return {RateInstrumentType_::Value_::DEPOSIT, RateInstrumentType_::Value_::FRA, RateInstrumentType_::Value_::FUTURE};
+    }
+
     inline RateTradeNodeSensitivityResult_ NodeSensitivityFailure(const String_& reason) {
         RateTradeNodeSensitivityResult_ result;
         result.reason_ = reason;

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -193,14 +193,10 @@ namespace {
 
     // Family-generic form of the Deposit battery above: the assembled market places the built
     // curve under the target component key and holds every other dependency on a fixed curve,
-    // so central bumps perturb the target component only.
+    // so central bumps perturb the target component only. Dates follow the Deposit battery;
+    // the early window falls entirely before the first knot so later columns are structural zeros.
     template <class BuildCurve_, class AssembleMarket_>
     void AssertFamilyNodeGradientMatchesCentralBumps(const Dal::RateInstrumentType_& family,
-                                                     const Dal::Date_& today,
-                                                     const Dal::Date_& start,
-                                                     const Dal::Date_& maturity,
-                                                     const Dal::Date_& earlyStart,
-                                                     const Dal::Date_& earlyMaturity,
                                                      const Dal::RateTradeTerms_& terms,
                                                      const Dal::RateTradeTerms_& oppositeTerms,
                                                      const Dal::String_& componentKey,
@@ -212,6 +208,11 @@ namespace {
                                                      double absoluteTolerance,
                                                      double relativeTolerance,
                                                      const Dal::Vector_<int>& structuralZeroColumns) {
+        const Dal::Date_ today(2026, 1, 15);
+        const Dal::Date_ start(2026, 10, 15);
+        const Dal::Date_ maturity(2029, 1, 15);
+        const Dal::Date_ earlyStart(2026, 2, 15);
+        const Dal::Date_ earlyMaturity(2026, 4, 15);
         const auto trade = Trade(family, today, start, maturity, terms);
         const auto market = assembleMarket(buildCurve(parameters));
         const auto aad = Dal::RateTradeNodeSensitivities(trade, market, componentKey);
@@ -755,9 +756,8 @@ TEST(RateCashflowPricingTest, TestFraNodeAADForecastPwcRawColumnsMatchCentralBum
     };
     auto opposite = FraTerms();
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
-                                                assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
                                                 PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
 }
 
@@ -783,10 +783,10 @@ TEST(RateCashflowPricingTest, TestFraNodeAADForecastPwlfRawColumnsMatchCentralBu
     };
     auto opposite = FraTerms();
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
-                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, PWLF_NATIVE_PARAMETER_BUMP,
-                                                PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6,
+                                                PWLF_NATIVE_PARAMETER_BUMP, PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
+                                                PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
 }
 
 TEST(RateCashflowPricingTest, TestFraNodeAADForecastLogDiscountRawColumnsMatchCentralBumps) {
@@ -808,9 +808,8 @@ TEST(RateCashflowPricingTest, TestFraNodeAADForecastLogDiscountRawColumnsMatchCe
     };
     auto opposite = FraTerms();
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
-                                                assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
                                                 LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
 }
 
@@ -831,9 +830,8 @@ TEST(RateCashflowPricingTest, TestFraNodeAADForecastZeroRateRawColumnsMatchCentr
     };
     auto opposite = FraTerms();
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
-                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
                                                 ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
 }
 
@@ -854,9 +852,8 @@ TEST(RateCashflowPricingTest, TestFraNodeAADDiscountPwcRawColumnsMatchCentralBum
     auto terms = FraTerms(false);
     auto opposite = terms;
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
-                                                assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite),
+                                                "discount", assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
                                                 PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
 }
 
@@ -883,10 +880,10 @@ TEST(RateCashflowPricingTest, TestFraNodeAADDiscountPwlfRawColumnsMatchCentralBu
     auto terms = FraTerms(false);
     auto opposite = terms;
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
-                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, PWLF_NATIVE_PARAMETER_BUMP,
-                                                PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite),
+                                                "discount", assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6,
+                                                PWLF_NATIVE_PARAMETER_BUMP, PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
+                                                PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
 }
 
 TEST(RateCashflowPricingTest, TestFraNodeAADDiscountLogDiscountRawColumnsMatchCentralBumps) {
@@ -909,9 +906,8 @@ TEST(RateCashflowPricingTest, TestFraNodeAADDiscountLogDiscountRawColumnsMatchCe
     auto terms = FraTerms(false);
     auto opposite = terms;
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
-                                                assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite),
+                                                "discount", assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
                                                 LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
 }
 
@@ -933,9 +929,8 @@ TEST(RateCashflowPricingTest, TestFraNodeAADDiscountZeroRateRawColumnsMatchCentr
     auto terms = FraTerms(false);
     auto opposite = terms;
     opposite.receiveFloating_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
-                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite),
+                                                "discount", assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
                                                 ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
 }
 
@@ -955,10 +950,10 @@ TEST(RateCashflowPricingTest, TestFutureNodeAADForecastPwcRawColumnsMatchCentral
     };
     auto opposite = FutureTerms();
     opposite.long_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
-                                                "forecast", assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
-                                                PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), Dal::RateTradeTerms_(FutureTerms()),
+                                                Dal::RateTradeTerms_(opposite), "forecast", assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3,
+                                                PWC_NATIVE_PARAMETER_BUMP, PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE,
+                                                {1, 2});
 }
 
 TEST(RateCashflowPricingTest, TestFutureNodeAADForecastPwlfRawColumnsMatchCentralBumps) {
@@ -983,11 +978,10 @@ TEST(RateCashflowPricingTest, TestFutureNodeAADForecastPwlfRawColumnsMatchCentra
     };
     auto opposite = FutureTerms();
     opposite.long_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
-                                                "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6,
-                                                PWLF_NATIVE_PARAMETER_BUMP, PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
-                                                PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), Dal::RateTradeTerms_(FutureTerms()),
+                                                Dal::RateTradeTerms_(opposite), "forecast", assembleMarket, buildCurve,
+                                                {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, PWLF_NATIVE_PARAMETER_BUMP,
+                                                PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
 }
 
 TEST(RateCashflowPricingTest, TestFutureNodeAADForecastLogDiscountRawColumnsMatchCentralBumps) {
@@ -1009,10 +1003,10 @@ TEST(RateCashflowPricingTest, TestFutureNodeAADForecastLogDiscountRawColumnsMatc
     };
     auto opposite = FutureTerms();
     opposite.long_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
-                                                "forecast", assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
-                                                LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), Dal::RateTradeTerms_(FutureTerms()),
+                                                Dal::RateTradeTerms_(opposite), "forecast", assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3,
+                                                LOG_DISCOUNT_NATIVE_PARAMETER_BUMP, LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
+                                                LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
 }
 
 TEST(RateCashflowPricingTest, TestFutureNodeAADForecastZeroRateRawColumnsMatchCentralBumps) {
@@ -1032,10 +1026,10 @@ TEST(RateCashflowPricingTest, TestFutureNodeAADForecastZeroRateRawColumnsMatchCe
     };
     auto opposite = FutureTerms();
     opposite.long_ = false;
-    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
-                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
-                                                "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
-                                                ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), Dal::RateTradeTerms_(FutureTerms()),
+                                                Dal::RateTradeTerms_(opposite), "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3,
+                                                ZERO_RATE_NATIVE_PARAMETER_BUMP, ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
+                                                ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
 }
 
 TEST(RateCashflowPricingTest, TestFraAndFutureNodeAADActivePvEqualsPassiveBitwiseBothSettlementModes) {

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -72,6 +72,44 @@ namespace {
         return result;
     }
 
+    Dal::FraTradeTerms_ FraTerms(bool settleAtStart = true) {
+        Dal::FraTradeTerms_ result;
+        result.notional_ = 2'000'000.0;
+        result.contractRate_ = 0.03;
+        result.receiveFloating_ = true;
+        result.settleAtStart_ = settleAtStart;
+        result.index_ = QuarterlyIndex();
+        result.fixingIdentity_ = {"USD-LIBOR-3M", 11, 0};
+        result.forecastComponentKey_ = "forecast";
+        result.discountComponentKey_ = "discount";
+        return result;
+    }
+
+    Dal::FutureTradeTerms_ FutureTerms() {
+        Dal::FutureTradeTerms_ result;
+        result.contractCount_ = 12.0;
+        result.long_ = true;
+        result.referencePrice_ = 95.0;
+        result.contractValuePerPricePoint_ = 25.0;
+        result.convexityAdjustment_ = 0.0005;
+        result.index_ = QuarterlyIndex();
+        result.fixingIdentity_ = {"USD-LIBOR-3M", 11, 0};
+        result.forecastComponentKey_ = "forecast";
+        return result;
+    }
+
+    Dal::RatePricingMarket_
+    ComponentMarket(const Dal::Date_& today, const Dal::Handle_<Dal::DiscountCurve_>& forecast, const Dal::Handle_<Dal::DiscountCurve_>& discount) {
+        Dal::RatePricingMarket_ result;
+        result.valuationTime_ = Dal::DateTime_(today, 10, 30);
+        result.resultCurrency_ = Dal::Ccy_("USD");
+        result.curveComponents_["discount"] = discount;
+        result.curveComponents_["forecast"] = forecast;
+        result.curveComponents_["reference"] = discount;
+        result.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_());
+        return result;
+    }
+
     class UnsupportedDiscountCurve_ : public Dal::DiscountCurve_ {
     public:
         UnsupportedDiscountCurve_() : DiscountCurve_("unsupported", "USD") {}
@@ -147,6 +185,66 @@ namespace {
 
         const auto shortTrade = Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, start, terms);
         const auto structural = Dal::RateTradeNodeSensitivities(shortTrade, market, "discount");
+        ASSERT_TRUE(structural.eligible_);
+        ASSERT_EQ(static_cast<int>(structural.gradient_.size()), expectedParameterCount);
+        for (const int column : structuralZeroColumns)
+            ASSERT_NEAR(structural.gradient_[column], 0.0, 1.0e-12) << "structural-zero raw column " << column;
+    }
+
+    // Family-generic form of the Deposit battery above: the assembled market places the built
+    // curve under the target component key and holds every other dependency on a fixed curve,
+    // so central bumps perturb the target component only.
+    template <class BuildCurve_, class AssembleMarket_>
+    void AssertFamilyNodeGradientMatchesCentralBumps(const Dal::RateInstrumentType_& family,
+                                                     const Dal::Date_& today,
+                                                     const Dal::Date_& start,
+                                                     const Dal::Date_& maturity,
+                                                     const Dal::Date_& earlyStart,
+                                                     const Dal::Date_& earlyMaturity,
+                                                     const Dal::RateTradeTerms_& terms,
+                                                     const Dal::RateTradeTerms_& oppositeTerms,
+                                                     const Dal::String_& componentKey,
+                                                     const AssembleMarket_& assembleMarket,
+                                                     const BuildCurve_& buildCurve,
+                                                     const Dal::Vector_<>& parameters,
+                                                     int expectedParameterCount,
+                                                     double bump,
+                                                     double absoluteTolerance,
+                                                     double relativeTolerance,
+                                                     const Dal::Vector_<int>& structuralZeroColumns) {
+        const auto trade = Trade(family, today, start, maturity, terms);
+        const auto market = assembleMarket(buildCurve(parameters));
+        const auto aad = Dal::RateTradeNodeSensitivities(trade, market, componentKey);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+
+        ASSERT_TRUE(aad.eligible_);
+        ASSERT_EQ(static_cast<int>(aad.gradient_.size()), expectedParameterCount);
+        ASSERT_TRUE(passive.succeeded_);
+        ASSERT_DOUBLE_EQ(aad.pv_, passive.pv_);
+        for (int column = 0; column < expectedParameterCount; ++column) {
+            auto plusParameters = parameters;
+            auto minusParameters = parameters;
+            plusParameters[column] += bump;
+            minusParameters[column] -= bump;
+            const auto plus = Dal::PriceRateTrade(trade, assembleMarket(buildCurve(plusParameters)));
+            const auto minus = Dal::PriceRateTrade(trade, assembleMarket(buildCurve(minusParameters)));
+            ASSERT_TRUE(plus.succeeded_);
+            ASSERT_TRUE(minus.succeeded_);
+            const double finiteDifference = (plus.pv_ - minus.pv_) / (2.0 * bump);
+            const double tolerance = absoluteTolerance + relativeTolerance * std::max(std::abs(aad.gradient_[column]), std::abs(finiteDifference));
+            ASSERT_NEAR(aad.gradient_[column], finiteDifference, tolerance) << "raw native-parameter column " << column;
+        }
+
+        const auto opposite = Trade(family, today, start, maturity, oppositeTerms);
+        const auto flipped = Dal::RateTradeNodeSensitivities(opposite, market, componentKey);
+        ASSERT_TRUE(flipped.eligible_);
+        ASSERT_DOUBLE_EQ(flipped.pv_, -aad.pv_);
+        ASSERT_EQ(flipped.gradient_.size(), aad.gradient_.size());
+        for (int column = 0; column < expectedParameterCount; ++column)
+            ASSERT_DOUBLE_EQ(flipped.gradient_[column], -aad.gradient_[column]);
+
+        const auto early = Trade(family, today, earlyStart, earlyMaturity, terms);
+        const auto structural = Dal::RateTradeNodeSensitivities(early, market, componentKey);
         ASSERT_TRUE(structural.eligible_);
         ASSERT_EQ(static_cast<int>(structural.gradient_.size()), expectedParameterCount);
         for (const int column : structuralZeroColumns)
@@ -528,6 +626,646 @@ TEST(RateCashflowPricingTest, TestDepositNodeAADRewindsPerTradeAndIsThreadLocal)
     const auto rightControl = evaluate(0.06);
     ASSERT_EQ(rightResult.pv_, rightControl.pv_);
     ASSERT_EQ(rightResult.gradient_, rightControl.gradient_);
+}
+
+TEST(RateCashflowPricingTest, TestRegistryTracksAadEnabledFamiliesAndLockedOnesStayGated) {
+    const auto enabled = Dal::RateCashflowPricingInternal::AadEnabledRateFamilies();
+    const auto families = Dal::RateInstrumentTypeListAll();
+    ASSERT_EQ(enabled.size(), 3);
+    for (const auto& family : enabled)
+        ASSERT_NE(std::find(families.begin(), families.end(), family), families.end());
+
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto market = Market(today, FlatCurve(maturity));
+
+    auto flipFraSide = [](Dal::FraTradeTerms_ terms) {
+        terms.receiveFloating_ = !terms.receiveFloating_;
+        return terms;
+    };
+    auto flipFutureSide = [](Dal::FutureTradeTerms_ terms) {
+        terms.long_ = !terms.long_;
+        return terms;
+    };
+    const auto fraOpposite = Dal::RateTradeTerms_(flipFraSide(FraTerms()));
+    const auto futureOpposite = Dal::RateTradeTerms_(flipFutureSide(FutureTerms()));
+    ASSERT_TRUE(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("DEPOSIT"), today, today, maturity, DepositTerms()), market, "discount")
+            .eligible_);
+    ASSERT_TRUE(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, FraTerms()), market, "forecast").eligible_);
+    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, FutureTerms()), market, "forecast")
+                    .eligible_);
+    ASSERT_TRUE(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, fraOpposite), market, "forecast").eligible_);
+    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, futureOpposite), market, "forecast")
+                    .eligible_);
+
+    Dal::FixedFloatTradeTerms_ fixedFloat;
+    fixedFloat.notional_ = 1'000'000.0;
+    fixedFloat.fixedLeg_ = AnnualLeg();
+    fixedFloat.floatLeg_ = AnnualLeg();
+    fixedFloat.floatIndex_ = QuarterlyIndex();
+    fixedFloat.fixingIdentity_ = {"USD-SOFR", 11, 0};
+    fixedFloat.forecastComponentKey_ = "forecast";
+    fixedFloat.discountComponentKey_ = "discount";
+    Dal::BasisTradeTerms_ basis;
+    basis.spreadLeg_ = AnnualLeg();
+    basis.referenceLeg_ = AnnualLeg();
+    basis.spreadIndex_ = QuarterlyIndex();
+    basis.referenceIndex_ = QuarterlyIndex();
+    basis.spreadFixingIdentity_ = {"USD-LIBOR-3M", 11, 0};
+    basis.referenceFixingIdentity_ = {"USD-SOFR", 11, 0};
+    basis.spreadForecastComponentKey_ = "forecast";
+    basis.referenceForecastComponentKey_ = "reference";
+    basis.discountComponentKey_ = "discount";
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(
+                               Trade(Dal::RateInstrumentType_("OIS"), today, today, maturity, Dal::OisTradeTerms_{fixedFloat}), market, "forecast"),
+                           "TRADE_FAMILY_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(
+                               Trade(Dal::RateInstrumentType_("IRS"), today, today, maturity, Dal::IrsTradeTerms_{fixedFloat}), market, "forecast"),
+                           "TRADE_FAMILY_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("BASIS_SWAP"), today, today, maturity, basis), market, "forecast"),
+        "TRADE_FAMILY_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("XCCY"), today, today, maturity, Dal::XccyTradeTerms_{}), market, "forecast"),
+        "TRADE_FAMILY_NOT_AAD_ENABLED");
+
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::RateTradeTerms_(FraTerms())), market,
+                                        "forecast"),
+        "TRADE_FAMILY_NOT_AAD_ENABLED");
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::RateTradeTerms_(DepositTerms())), market,
+                                        "forecast"),
+        "TRADE_FAMILY_NOT_AAD_ENABLED");
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADReasonPrecedenceForCombinedFailures) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto forecast = FlatCurve(maturity, 0.04);
+    const auto discount = FlatCurve(maturity, 0.03);
+    const auto supported = ComponentMarket(today, forecast, discount);
+    auto invalidTerms = FraTerms();
+    invalidTerms.notional_ = std::numeric_limits<double>::quiet_NaN();
+    const auto invalidTrade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, invalidTerms);
+    const auto validTrade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, FraTerms());
+
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, supported, "reference"), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, supported, "reference"), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+    AssertCanonicalFailure(
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, FutureTerms()), supported, "discount"),
+        "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+
+    auto missingDiscount = supported;
+    missingDiscount.curveComponents_.erase("discount");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, missingDiscount, "forecast"), "CURVE_COMPONENT_UNAVAILABLE");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, missingDiscount, "forecast"), "CURVE_COMPONENT_UNAVAILABLE");
+    auto nullDiscount = supported;
+    nullDiscount.curveComponents_["discount"] = Dal::Handle_<Dal::DiscountCurve_>();
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, nullDiscount, "forecast"), "CURVE_COMPONENT_UNAVAILABLE");
+
+    auto unsupportedPassive = supported;
+    unsupportedPassive.curveComponents_["discount"] = Dal::Handle_<Dal::DiscountCurve_>(std::make_shared<const UnsupportedDiscountCurve_>());
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, unsupportedPassive, "forecast"), "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+    auto unsupportedTarget = supported;
+    unsupportedTarget.curveComponents_["forecast"] = Dal::Handle_<Dal::DiscountCurve_>(std::make_shared<const UnsupportedDiscountCurve_>());
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(validTrade, unsupportedTarget, "forecast"), "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, supported, "forecast"), "TRADE_VALIDATION_FAILED");
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADForecastPwcRawColumnsMatchCentralBumps) {
+    constexpr double PWC_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(knots, parameters)));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FraTerms();
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
+                                                assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
+                                                PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADForecastPwlfRawColumnsMatchCentralBumps) {
+    constexpr double PWLF_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> left(3);
+        Dal::Vector_<> right(3);
+        for (int node = 0; node < 3; ++node) {
+            left[node] = parameters[2 * node];
+            right[node] = parameters[2 * node + 1];
+        }
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWLF("pwlf", "USD", Dal::PiecewiseLinear_(knots, left, right)));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FraTerms();
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
+                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, PWLF_NATIVE_PARAMETER_BUMP,
+                                                PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADForecastLogDiscountRawColumnsMatchCentralBumps) {
+    constexpr double LOG_DISCOUNT_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> stored{0.0};
+        stored.Append(parameters);
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountLogDF("logdf", "USD", Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]},
+                                                                       stored, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FraTerms();
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
+                                                assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
+                                                LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADForecastZeroRateRawColumnsMatchCentralBumps) {
+    constexpr double ZERO_RATE_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(
+            Dal::NewDiscountZeroRate("zero", "USD", today, knots, parameters, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FraTerms();
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FraTerms()), Dal::RateTradeTerms_(opposite), "forecast",
+                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
+                                                ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADDiscountPwcRawColumnsMatchCentralBumps) {
+    constexpr double PWC_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(knots, parameters)));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, FlatCurve(maturity, 0.04), curve);
+    };
+    auto terms = FraTerms(false);
+    auto opposite = terms;
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
+                                                assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
+                                                PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADDiscountPwlfRawColumnsMatchCentralBumps) {
+    constexpr double PWLF_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> left(3);
+        Dal::Vector_<> right(3);
+        for (int node = 0; node < 3; ++node) {
+            left[node] = parameters[2 * node];
+            right[node] = parameters[2 * node + 1];
+        }
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWLF("pwlf", "USD", Dal::PiecewiseLinear_(knots, left, right)));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, FlatCurve(maturity, 0.04), curve);
+    };
+    auto terms = FraTerms(false);
+    auto opposite = terms;
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
+                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, PWLF_NATIVE_PARAMETER_BUMP,
+                                                PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADDiscountLogDiscountRawColumnsMatchCentralBumps) {
+    constexpr double LOG_DISCOUNT_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> stored{0.0};
+        stored.Append(parameters);
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountLogDF("logdf", "USD", Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]},
+                                                                       stored, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, FlatCurve(maturity, 0.04), curve);
+    };
+    auto terms = FraTerms(false);
+    auto opposite = terms;
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
+                                                assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
+                                                LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADDiscountZeroRateRawColumnsMatchCentralBumps) {
+    constexpr double ZERO_RATE_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(
+            Dal::NewDiscountZeroRate("zero", "USD", today, knots, parameters, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, FlatCurve(maturity, 0.04), curve);
+    };
+    auto terms = FraTerms(false);
+    auto opposite = terms;
+    opposite.receiveFloating_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FRA"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(terms), Dal::RateTradeTerms_(opposite), "discount",
+                                                assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
+                                                ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestFutureNodeAADForecastPwcRawColumnsMatchCentralBumps) {
+    constexpr double PWC_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWC_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(knots, parameters)));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FutureTerms();
+    opposite.long_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {0.01, -0.005, 0.03}, 3, PWC_NATIVE_PARAMETER_BUMP,
+                                                PWC_RAW_GRADIENT_ABSOLUTE_TOLERANCE, PWC_RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
+}
+
+TEST(RateCashflowPricingTest, TestFutureNodeAADForecastPwlfRawColumnsMatchCentralBumps) {
+    constexpr double PWLF_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> left(3);
+        Dal::Vector_<> right(3);
+        for (int node = 0; node < 3; ++node) {
+            left[node] = parameters[2 * node];
+            right[node] = parameters[2 * node + 1];
+        }
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWLF("pwlf", "USD", Dal::PiecewiseLinear_(knots, left, right)));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FutureTerms();
+    opposite.long_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6,
+                                                PWLF_NATIVE_PARAMETER_BUMP, PWLF_RAW_GRADIENT_ABSOLUTE_TOLERANCE,
+                                                PWLF_RAW_GRADIENT_RELATIVE_TOLERANCE, {2, 3, 4, 5});
+}
+
+TEST(RateCashflowPricingTest, TestFutureNodeAADForecastLogDiscountRawColumnsMatchCentralBumps) {
+    constexpr double LOG_DISCOUNT_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        Dal::Vector_<> stored{0.0};
+        stored.Append(parameters);
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountLogDF("logdf", "USD", Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]},
+                                                                       stored, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FutureTerms();
+    opposite.long_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {-0.005, 0.0, -0.06}, 3, LOG_DISCOUNT_NATIVE_PARAMETER_BUMP,
+                                                LOG_DISCOUNT_RAW_GRADIENT_ABSOLUTE_TOLERANCE, LOG_DISCOUNT_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestFutureNodeAADForecastZeroRateRawColumnsMatchCentralBumps) {
+    constexpr double ZERO_RATE_NATIVE_PARAMETER_BUMP = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
+    constexpr double ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-8;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(
+            Dal::NewDiscountZeroRate("zero", "USD", today, knots, parameters, Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
+    };
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+        return ComponentMarket(today, curve, FlatCurve(maturity, 0.03));
+    };
+    auto opposite = FutureTerms();
+    opposite.long_ = false;
+    AssertFamilyNodeGradientMatchesCentralBumps(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::Date_(2026, 2, 15),
+                                                Dal::Date_(2026, 4, 15), Dal::RateTradeTerms_(FutureTerms()), Dal::RateTradeTerms_(opposite),
+                                                "forecast", assembleMarket, buildCurve, {0.01, 0.0, -0.005}, 3, ZERO_RATE_NATIVE_PARAMETER_BUMP,
+                                                ZERO_RATE_RAW_GRADIENT_ABSOLUTE_TOLERANCE, ZERO_RATE_RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
+}
+
+TEST(RateCashflowPricingTest, TestFraAndFutureNodeAADActivePvEqualsPassiveBitwiseBothSettlementModes) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 4, 15);
+    const Dal::Date_ maturity(2026, 7, 15);
+    const auto market = ComponentMarket(today, FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+
+    for (const bool settleAtStart : {true, false}) {
+        for (const bool receiveFloating : {true, false}) {
+            auto terms = FraTerms(settleAtStart);
+            terms.receiveFloating_ = receiveFloating;
+            const auto trade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, terms);
+            const auto passive = Dal::PriceRateTrade(trade, market);
+            ASSERT_TRUE(passive.succeeded_);
+            const auto forecastSensitivity = Dal::RateTradeNodeSensitivities(trade, market, "forecast");
+            const auto discountSensitivity = Dal::RateTradeNodeSensitivities(trade, market, "discount");
+            ASSERT_TRUE(forecastSensitivity.eligible_);
+            ASSERT_TRUE(discountSensitivity.eligible_);
+            ASSERT_DOUBLE_EQ(forecastSensitivity.pv_, passive.pv_);
+            ASSERT_DOUBLE_EQ(discountSensitivity.pv_, passive.pv_);
+        }
+    }
+
+    for (const bool isLong : {true, false}) {
+        auto terms = FutureTerms();
+        terms.long_ = isLong;
+        const auto trade = Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, terms);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_TRUE(passive.succeeded_);
+        const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, "forecast");
+        ASSERT_TRUE(sensitivity.eligible_);
+        ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_);
+    }
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADFixingStatesFutureSuppliedAndMissing) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 4, 15);
+    const Dal::Date_ maturity(2026, 7, 15);
+    auto terms = FraTerms(false);
+    const auto trade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, terms);
+
+    {
+        const auto market = ComponentMarket(today, FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+        const auto projected = Dal::RateTradeNodeSensitivities(trade, market, "forecast");
+        ASSERT_TRUE(projected.eligible_);
+        ASSERT_NE(projected.gradient_[0], 0.0);
+        const auto discounted = Dal::RateTradeNodeSensitivities(trade, market, "discount");
+        ASSERT_TRUE(discounted.eligible_);
+        ASSERT_NE(discounted.gradient_[0], 0.0);
+    }
+
+    Dal::MarketFixingSnapshot_::values_t history;
+    history["USD-LIBOR-3M"][Dal::DateTime_(start, 11, 0)] = 0.0415;
+    auto supplied = ComponentMarket(Dal::Date_(start.AddDays(1)), FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+    supplied.valuationTime_ = Dal::DateTime_(start.AddDays(1), 10, 30);
+    supplied.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_(history));
+    {
+        const auto passive = Dal::PriceRateTrade(trade, supplied);
+        ASSERT_TRUE(passive.succeeded_);
+        ASSERT_EQ(passive.requiredHistoricalFixings_.size(), 1);
+        ASSERT_TRUE(passive.missingHistoricalFixings_.empty());
+
+        const auto forecastSensitivity = Dal::RateTradeNodeSensitivities(trade, supplied, "forecast");
+        ASSERT_TRUE(forecastSensitivity.eligible_);
+        ASSERT_EQ(forecastSensitivity.gradient_.size(), 1);
+        ASSERT_DOUBLE_EQ(forecastSensitivity.pv_, passive.pv_);
+        for (const double column : forecastSensitivity.gradient_)
+            ASSERT_DOUBLE_EQ(column, 0.0);
+
+        const auto discountSensitivity = Dal::RateTradeNodeSensitivities(trade, supplied, "discount");
+        ASSERT_TRUE(discountSensitivity.eligible_);
+        ASSERT_DOUBLE_EQ(discountSensitivity.pv_, passive.pv_);
+        ASSERT_NE(discountSensitivity.gradient_[0], 0.0);
+    }
+
+    auto missing = ComponentMarket(Dal::Date_(start.AddDays(1)), FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+    missing.valuationTime_ = Dal::DateTime_(start.AddDays(1), 10, 30);
+    {
+        const auto passive = Dal::PriceRateTrade(trade, missing);
+        ASSERT_FALSE(passive.succeeded_);
+        ASSERT_EQ(passive.missingHistoricalFixings_.size(), 1);
+        Dal::RateTradeNodeSensitivityResult_ sensitivity;
+        ASSERT_NO_THROW(sensitivity = Dal::RateTradeNodeSensitivities(trade, missing, "forecast"));
+        AssertCanonicalFailure(sensitivity, "TRADE_VALIDATION_FAILED");
+    }
+}
+
+TEST(RateCashflowPricingTest, TestFutureNodeAADFixingStatesFutureSuppliedAndMissing) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 4, 15);
+    const Dal::Date_ maturity(2026, 7, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, FutureTerms());
+
+    {
+        const auto market = ComponentMarket(today, FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+        const auto projected = Dal::RateTradeNodeSensitivities(trade, market, "forecast");
+        ASSERT_TRUE(projected.eligible_);
+        ASSERT_NE(projected.gradient_[0], 0.0);
+    }
+
+    Dal::MarketFixingSnapshot_::values_t history;
+    history["USD-LIBOR-3M"][Dal::DateTime_(start, 11, 0)] = 0.0415;
+    auto supplied = ComponentMarket(Dal::Date_(start.AddDays(1)), FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+    supplied.valuationTime_ = Dal::DateTime_(start.AddDays(1), 10, 30);
+    supplied.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_(history));
+    {
+        const auto passive = Dal::PriceRateTrade(trade, supplied);
+        ASSERT_TRUE(passive.succeeded_);
+        const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, supplied, "forecast");
+        ASSERT_TRUE(sensitivity.eligible_);
+        ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_);
+        for (const double column : sensitivity.gradient_)
+            ASSERT_DOUBLE_EQ(column, 0.0);
+    }
+
+    auto missing = ComponentMarket(Dal::Date_(start.AddDays(1)), FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03));
+    missing.valuationTime_ = Dal::DateTime_(start.AddDays(1), 10, 30);
+    {
+        const auto passive = Dal::PriceRateTrade(trade, missing);
+        ASSERT_FALSE(passive.succeeded_);
+        ASSERT_EQ(passive.missingHistoricalFixings_.size(), 1);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, missing, "forecast"), "TRADE_VALIDATION_FAILED");
+    }
+}
+
+TEST(RateCashflowPricingTest, TestFraAndFutureNodeAADBeforeAndAfterMaturityExpiry) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 4, 15);
+    const Dal::Date_ maturity(2026, 7, 15);
+    auto expired = ComponentMarket(Dal::Date_(maturity.AddDays(1)), FlatCurve(maturity.AddDays(30), 0.04), FlatCurve(maturity.AddDays(30), 0.03));
+    expired.valuationTime_ = Dal::DateTime_(maturity.AddDays(1), 10, 30);
+
+    for (const bool settleAtStart : {true, false}) {
+        const auto trade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, FraTerms(settleAtStart));
+        const auto live =
+            Dal::RateTradeNodeSensitivities(trade, ComponentMarket(today, FlatCurve(maturity, 0.04), FlatCurve(maturity, 0.03)), "forecast");
+        ASSERT_TRUE(live.eligible_);
+        ASSERT_NE(live.pv_, 0.0);
+        ASSERT_NE(live.gradient_[0], 0.0);
+
+        const auto settled = Dal::RateTradeNodeSensitivities(trade, expired, "forecast");
+        ASSERT_TRUE(settled.eligible_);
+        ASSERT_DOUBLE_EQ(settled.pv_, 0.0);
+        for (const double column : settled.gradient_)
+            ASSERT_DOUBLE_EQ(column, 0.0);
+        const auto settledDiscount = Dal::RateTradeNodeSensitivities(trade, expired, "discount");
+        ASSERT_TRUE(settledDiscount.eligible_);
+        ASSERT_DOUBLE_EQ(settledDiscount.pv_, 0.0);
+        for (const double column : settledDiscount.gradient_)
+            ASSERT_DOUBLE_EQ(column, 0.0);
+    }
+
+    const auto futureTrade = Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, FutureTerms());
+    const auto futureSettled = Dal::RateTradeNodeSensitivities(futureTrade, expired, "forecast");
+    ASSERT_TRUE(futureSettled.eligible_);
+    ASSERT_DOUBLE_EQ(futureSettled.pv_, 0.0);
+    for (const double column : futureSettled.gradient_)
+        ASSERT_DOUBLE_EQ(column, 0.0);
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADIsolationFromPassiveNodeCount) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, FraTerms(false));
+    const Dal::Vector_<Dal::Date_> forecastKnots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const auto forecast =
+        Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(forecastKnots, {0.01, -0.005, 0.03})));
+
+    const auto small = Dal::RateTradeNodeSensitivities(trade, ComponentMarket(today, forecast, FlatCurve(maturity, 0.03)), "forecast");
+    Dal::Vector_<Dal::Date_> denseKnots;
+    for (Dal::Date_ knot = Dal::Date_(2026, 2, 15); knot <= Dal::Date_(2029, 12, 15); knot = knot.AddDays(30))
+        denseKnots.push_back(knot);
+    const Dal::Vector_<> denseForward(denseKnots.size(), 0.03);
+    const auto denseDiscount =
+        Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("dense", "USD", Dal::PiecewiseConstant_(denseKnots, denseForward)));
+    const auto large = Dal::RateTradeNodeSensitivities(trade, ComponentMarket(today, forecast, denseDiscount), "forecast");
+
+    ASSERT_TRUE(small.eligible_);
+    ASSERT_TRUE(large.eligible_);
+    ASSERT_EQ(small.gradient_.size(), 3);
+    ASSERT_EQ(large.gradient_.size(), 3);
+    ASSERT_NEAR(large.pv_, small.pv_, 1.0e-10 * std::max(1.0, std::abs(small.pv_)));
+    for (int column = 0; column < 3; ++column)
+        ASSERT_NEAR(large.gradient_[column], small.gradient_[column], 1.0e-10 * std::max(1.0, std::abs(small.gradient_[column])))
+            << "column " << column;
+
+    const auto discountSensitivity = Dal::RateTradeNodeSensitivities(trade, ComponentMarket(today, forecast, denseDiscount), "discount");
+    ASSERT_TRUE(discountSensitivity.eligible_);
+    ASSERT_EQ(static_cast<int>(discountSensitivity.gradient_.size()), static_cast<int>(denseKnots.size()));
+}
+
+TEST(RateCashflowPricingTest, TestFraNodeAADBaseCurveIsolationOnLayeredForecast) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const Dal::Vector_<> overlayParameters{0.005, 0.01, 0.015};
+    const auto base = FlatCurve(maturity, 0.02);
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("overlay", "USD", Dal::PiecewiseConstant_(knots, parameters), base));
+    };
+    const auto trade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, FraTerms(false));
+    const auto market = ComponentMarket(today, buildCurve(overlayParameters), FlatCurve(maturity, 0.03));
+    const auto aad = Dal::RateTradeNodeSensitivities(trade, market, "forecast");
+    const auto passive = Dal::PriceRateTrade(trade, market);
+
+    ASSERT_TRUE(passive.succeeded_);
+    ASSERT_TRUE(aad.eligible_);
+    ASSERT_EQ(static_cast<int>(aad.gradient_.size()), 3);
+    ASSERT_DOUBLE_EQ(aad.pv_, passive.pv_);
+    for (const double column : aad.gradient_)
+        ASSERT_NE(column, 0.0);
+
+    constexpr double bump = 1.0e-6;
+    for (int column = 0; column < 3; ++column) {
+        auto plusParameters = overlayParameters;
+        auto minusParameters = overlayParameters;
+        plusParameters[column] += bump;
+        minusParameters[column] -= bump;
+        const auto plus = Dal::PriceRateTrade(trade, ComponentMarket(today, buildCurve(plusParameters), FlatCurve(maturity, 0.03)));
+        const auto minus = Dal::PriceRateTrade(trade, ComponentMarket(today, buildCurve(minusParameters), FlatCurve(maturity, 0.03)));
+        ASSERT_TRUE(plus.succeeded_);
+        ASSERT_TRUE(minus.succeeded_);
+        const double finiteDifference = (plus.pv_ - minus.pv_) / (2.0 * bump);
+        const double tolerance = 1.0e-6 + 1.0e-8 * std::max(std::abs(aad.gradient_[column]), std::abs(finiteDifference));
+        ASSERT_NEAR(aad.gradient_[column], finiteDifference, tolerance) << "overlay column " << column;
+    }
 }
 
 TEST(RateCashflowPricingTest, TestFraAndFutureFormulas) {

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -226,13 +226,15 @@ The supported family enum is closed to `DEPOSIT`, `FRA`, `FUTURE`, `OIS`,
 required historical rate/FX fixing keys before valuation. Batch pricing retains
 a success/failure result per trade.
 
-Native node AAD currently admits deposit trades only. The first failing gate
+Native node AAD currently admits deposit, FRA, and futures trades; for FRA the
+requested component may be either dependency (forecast or discount), for futures
+the forecast dependency. The first failing gate
 selects the reason in this order: family (`TRADE_FAMILY_NOT_AAD_ENABLED`),
 requested dependency (`TRADE_DOES_NOT_DEPEND_ON_COMPONENT`), component
 availability (`CURVE_COMPONENT_UNAVAILABLE`), curve representation
 (`CURVE_REPRESENTATION_NOT_AAD_ENABLED`), passive trade validation
 (`TRADE_VALIDATION_FAILED`), then AAD evaluation (`AAD_EVALUATION_FAILED`).
-`TRADE_VALIDATION_FAILED` is the stable token for a supported deposit that
+`TRADE_VALIDATION_FAILED` is the stable token for a supported trade that
 fails passive pricing validation; field-level detail remains available through
 `PriceRateTrade.error_`.
 


### PR DESCRIPTION
Closes DAL-154
Closes #302

## Summary

Stage 1 of the AAD node-risk plan (docs/experimental/aad-node-risk-portfolio-aggregation-plan.md § Stage 1), building on the Stage 0 templatized kernels (PR #307):

- **Multi-component AAD stage.** `RateTradeNodeSensitivities` no longer hardcodes Deposit: it enumerates the curve components the trade's terms actually read, classifies and prepares **every** dependency (definition + passive parameters + base), and registers only the requested target's parameters via `RegisterCurveParameters`. The `CurveRef_<T_>` view from Stage 0 (target key → freshly built active curve, every other key → the market's existing `DiscountCurve_<double>`, resolved once per curve per call) is the frozen-follow-up-4 mechanism; no unregistered constant `AAD::Number_` stand-ins. Stage skeleton unchanged: `TapeGuard_` → register parameters → `NewRecording` → price → seed → `PropagateToStart` → `FinalizeNodeSensitivityCandidate`.
- **Family-eligibility registry.** New `AadEnabledRateFamilies()` in `ratecashflowpricing_internal.hpp` opens Deposit, FRA, and Future (terms must also match the family, so terms-mismatch keeps hitting the family gate). OIS/IRS/Basis/XCCY still return `TRADE_FAMILY_NOT_AAD_ENABLED`. Dependency enumeration for the not-yet-opened single-currency families is in place behind the gate so Stage 2/3 are registry-only.
- **Gates.** Availability (`CURVE_COMPONENT_UNAVAILABLE`) and representation (`CURVE_REPRESENTATION_NOT_AAD_ENABLED`) now apply to every dependency component (in deterministic dependency order), still before passive validation; six-token set and priority unchanged; no new tokens; existing Deposit assertions untouched (test-file diff is pure additions).
- **FRA** onboards forecast + discount (settleAtStart division path exercised); **Future** onboards forecast only.
- Docs: `docs/public-api.md` success-domain sentence updated in the same PR (docs never disagree with the success domain); CHANGELOG entry added.

## Test evidence (focused; full matrix/coverage/perf belong to CI)

- `cmake --build build/Release-linux --target dal_cpp_tests -j32` — clean, no warnings
- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='RateCashflowPricingTest.*'` — **38/38 passed** (18 pre-existing + 20 new; all four representations × {FRA forecast, FRA discount, Future forecast} central-bump batteries, bitwise active == passive `ASSERT_DOUBLE_EQ`, exact side antisymmetry, three fixing states incl. past-missing → `TRADE_VALIDATION_FAILED`, before/after-maturity expiry, layered-base isolation, passive-node-count isolation, registry closure for OIS/IRS/Basis/XCCY, token-priority extension)
- `./build/Release-linux/dal-cpp/dal_cpp_tests` (full binary) — **1288/1288 passed**
- `./build/Release-linux/dal-public/dal_public_tests` — **99/99 passed**
- `cd dal-python && bash run_tests.sh` — **270/270 passed** (binding surface unchanged)
- `clang-format --dry-run --Werror` on all three touched C++ files — clean
- `python3 .github/scripts/check_docs.py` — passed (48 files)

## Notes for review

- The literal "tape size" measurement is not observable through the public API (`TapeGuard_` rewinds on exit and the native block list exposes no allocated-block count), so tape isolation is enforced via (a) the type system — `CurveRef_<AAD::Number_>::passive_` is a `const DiscountCurve_<double>*`, which cannot record — plus (b) API-visible assertions: gradient width stays at the target's parameter count while the passive curve grows 3 → 46 knots, and gradient/PV values are unchanged (1e-10) across that growth.
- Availability/representation gates now cover non-target dependencies too (a FRA whose discount curve is missing/unclassifiable fails with `CURVE_COMPONENT_UNAVAILABLE`/`CURVE_REPRESENTATION_NOT_AAD_ENABLED` rather than `TRADE_VALIDATION_FAILED`). This follows the stage instruction to prepare every dependency component; pinned by `TestFraNodeAADReasonPrecedenceForCombinedFailures`.
- The two Stage-0 reviewer follow-ups in these files (duplicated `DiscountFromValuation` spelling in `Discount()`, dangling "design contract 1" comment pointer) are deliberately left untouched to keep this diff inside the stage scope.

## CI snapshot (one shot, non-blocking)

Taken right after push; recorded below. No polling — remaining checks are CI's to own.
