### PR TITLE
DAL-157: AAD node risk Stage 4 — XCCY + dependency keys (GitHub #305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ here as the baseline rather than dated releases:
 
 ## 2026-08
 
+- `curve`: `RateTradeNodeSensitivities` success domain widened to XCCY trades (any consumed curve
+  registered under a component key — the collateral/tenor-selected domestic/foreign discount and
+  forecast curves plus the basis curve), completing the seven-family P0 success domain. XCCY
+  addressing locates block slots by pointer identity against `curveComponents_`; the active stage
+  rebuilds every consumed curve as `AAD::Number_` and registers only the addressed component's
+  parameters (the FX spot stays a constant, so XCCY node risk ships rate axes only). A market-aware
+  `BuildRateCashflowPlan(trade, market)` overload emits the XCCY dependency keys, and `PriceXccy`
+  now carries the fixing accounting so a missing fixing returns `TRADE_VALIDATION_FAILED`. The
+  six-token failure set and its priority are unchanged.
+
 - `curve`: `RateTradeNodeSensitivities` success domain widened to basis swap trades (any of the three
   dependencies: spread forecast, reference forecast, or discount), on top of Deposit/FRA/Future/OIS/IRS;
   the generalized multi-component stage prices them unchanged, holding the two non-target dependencies

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -303,7 +303,31 @@ namespace Dal {
             return result;
         }
 
-        double PriceXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, const RatePricingMarket_& market) {
+        const MarketFixingSnapshot_& XccyFixings(const RatePricingMarket_& market, const CrossCurrencyMarket_& nativeMarket) {
+            static const MarketFixingSnapshot_ empty;
+            const Handle_<MarketFixingSnapshot_>& fixings = market.fixings_ ? market.fixings_ : nativeMarket.Fixings();
+            return fixings ? *fixings : empty;
+        }
+
+        // Same accounting contract as ResolveRate: every strictly-past observation the plan needs is
+        // recorded as required, and the first missing one fails validation on the stable token.
+        void AccountXccyHistoricalFixings(const XccyCashflowPlan_& plan,
+                                          const DateTime_& valuationTime,
+                                          const MarketFixingSnapshot_& fixings,
+                                          RatePricingTradeResult_* result) {
+            for (const auto& request : RequiredHistoricalFixings(plan, valuationTime)) {
+                AddUnique(request, &result->requiredHistoricalFixings_);
+                if (!fixings.Find(request.indexName_, request.fixingTime_)) {
+                    AddUnique(request, &result->missingHistoricalFixings_);
+                    THROW("Missing historical fixing " + request.indexName_);
+                }
+            }
+        }
+
+        double PriceXccy(const RateTradeDefinition_& trade,
+                         const XccyTradeTerms_& terms,
+                         const RatePricingMarket_& market,
+                         RatePricingTradeResult_* result) {
             REQUIRE(std::isfinite(terms.positionCount_) && terms.positionCount_ > 0.0, "XCCY position count must be positive and finite");
             if (trade.maturityDate_ < market.valuationTime_.Date())
                 return 0.0;
@@ -324,11 +348,11 @@ namespace Dal {
             view.domestic_ = &domestic;
             view.foreign_ = &foreign;
             view.basis_ = nativeMarket.BasisCurve();
-            const Handle_<MarketFixingSnapshot_> fixings = market.fixings_ ? market.fixings_ : nativeMarket.Fixings();
-            const MarketFixingSnapshot_ empty;
             const auto plan = BuildXccyCashflowPlan(trade.startDate_, trade.maturityDate_, terms.config_);
-            return terms.positionCount_ * PriceXccyContract(plan, view, fixings ? *fixings : empty, terms.contractSpread_, terms.spreadOnForeignLeg_,
-                                                            terms.receiveNonSpreadPaySpread_);
+            const MarketFixingSnapshot_& fixings = XccyFixings(market, nativeMarket);
+            AccountXccyHistoricalFixings(plan, market.valuationTime_, fixings, result);
+            return terms.positionCount_ *
+                   PriceXccyContract(plan, view, fixings, terms.contractSpread_, terms.spreadOnForeignLeg_, terms.receiveNonSpreadPaySpread_);
         }
 
         // #lizard forgives -- family-specific pricing branches preserve the audited formula mapping.
@@ -396,7 +420,7 @@ namespace Dal {
             if (const auto* terms = std::get_if<BasisTradeTerms_>(&trade.terms_))
                 return PriceBasis(trade, *terms, view, result);
             if (const auto* terms = std::get_if<XccyTradeTerms_>(&trade.terms_))
-                return T_(PriceXccy(trade, *terms, market));
+                return T_(PriceXccy(trade, *terms, market, result));
             THROW("Rate trade terms alternative is unsupported");
         }
 
@@ -485,6 +509,158 @@ namespace Dal {
             result.expectedParameterCount_ = BuildCurveParameterLayout(result.definition_).parameterCount_;
             return result;
         }
+
+        void AddUniqueCurve(const DiscountCurve_* curve, Vector_<const DiscountCurve_*>* curves) {
+            if (curve && std::find(curves->begin(), curves->end(), curve) == curves->end())
+                curves->push_back(curve);
+        }
+
+        // XCCY addressing (design decision point 1): the curves a trade consumes are the
+        // collateral/tenor-selected slots of the domestic/foreign blocks plus the basis curve —
+        // never mere block membership. Slots are located by routing the same JointCurveBlock_
+        // logic the pricing kernel uses.
+        Vector_<const DiscountCurve_*> ConsumedXccyCurves(const XccyTradeTerms_& terms, const CrossCurrencyMarket_& nativeMarket) {
+            const auto domestic = JointBlock(nativeMarket.DomesticBlock());
+            const auto foreign = JointBlock(nativeMarket.ForeignBlock());
+            const auto& convention = terms.config_.convention_;
+            Vector_<const DiscountCurve_*> result;
+            AddUniqueCurve(&domestic.Discount(convention.domesticIndex_.collateral_), &result);
+            AddUniqueCurve(&Tape::ForecastCurve(domestic, convention.domesticIndex_), &result);
+            AddUniqueCurve(&foreign.Discount(convention.foreignIndex_.collateral_), &result);
+            AddUniqueCurve(&Tape::ForecastCurve(foreign, convention.foreignIndex_), &result);
+            AddUniqueCurve(nativeMarket.BasisCurve(), &result);
+            return result;
+        }
+
+        // An addressed curve must also be registered under a stable key in curveComponents_; the
+        // shared-ownership Handles make pointer comparison well-defined with no false positives.
+        // Without an XCCY market — or against a block the config cannot route — no key can be
+        // established, so the dependency gate reports every request as not consumed.
+        Vector_<String_> XccyDependencyKeys(const XccyTradeTerms_& terms, const RatePricingMarket_& market) {
+            Vector_<String_> result;
+            if (!market.xccyMarket_)
+                return result;
+            Vector_<const DiscountCurve_*> consumed;
+            try {
+                consumed = ConsumedXccyCurves(terms, *market.xccyMarket_);
+            } catch (const std::exception&) {
+                return result;
+            }
+            for (const auto* curve : consumed)
+                for (const auto& [key, handle] : market.curveComponents_)
+                    if (handle && handle.get() == curve)
+                        AddUnique(key, &result);
+            return result;
+        }
+
+        Vector_<AAD::Number_> ConstantActiveParameters(const Vector_<>& parameters) {
+            Vector_<AAD::Number_> result(parameters.size());
+            for (int i = 0; i < static_cast<int>(parameters.size()); ++i)
+                result[i] = AAD::Number_(parameters[i]);
+            return result;
+        }
+
+        // #lizard forgives -- the XCCY stage mirrors the audited six-gate pipeline of the single-currency path.
+        RateTradeNodeSensitivityResult_ RateTradeNodeSensitivitiesXccy(const RateTradeDefinition_& trade,
+                                                                       const XccyTradeTerms_& terms,
+                                                                       const RatePricingMarket_& market,
+                                                                       const String_& componentKey) {
+            using namespace RateCashflowPricingInternal;
+            const Vector_<String_> dependencyKeys = XccyDependencyKeys(terms, market);
+            if (std::find(dependencyKeys.begin(), dependencyKeys.end(), componentKey) == dependencyKeys.end())
+                return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+            REQUIRE(market.xccyMarket_, "XCCY node sensitivity requires an immutable cross-currency market");
+            const auto& nativeMarket = *market.xccyMarket_;
+            const DiscountCurve_* targetCurve = market.curveComponents_.at(componentKey).get();
+
+            // Classification walk over the consumed curves only — unused in-block members are never
+            // classified. The addressed component keeps the representation token; any other
+            // consumed curve that cannot be classified is an assembly failure instead (frozen P0
+            // contract 7: that token stays a representation failure).
+            std::map<const DiscountCurve_*, NodeSensitivityCurve_> classified;
+            for (const auto* curve : ConsumedXccyCurves(terms, nativeMarket)) {
+                classified[curve] = ClassifyNodeSensitivityCurve(*curve);
+                if (!std::holds_alternative<std::monostate>(classified[curve]))
+                    continue;
+                return NodeSensitivityFailure(curve == targetCurve ? "CURVE_REPRESENTATION_NOT_AAD_ENABLED" : "AAD_EVALUATION_FAILED");
+            }
+
+            const auto passive = PriceRateTrade(trade, market);
+            if (!passive.succeeded_ || !std::isfinite(passive.pv_))
+                return NodeSensitivityFailure("TRADE_VALIDATION_FAILED");
+
+            std::map<const DiscountCurve_*, NodeSensitivityPreparation_> prepared;
+            int expectedParameterCount = 0;
+            try {
+                for (const auto& [curve, classification] : classified) {
+                    prepared[curve] = PrepareNodeSensitivityCurve(classification, market.valuationTime_.Date());
+                    if (curve == targetCurve)
+                        expectedParameterCount = prepared[curve].expectedParameterCount_;
+                }
+            } catch (const std::exception&) {
+                return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+            }
+
+            const auto plan = BuildXccyCashflowPlan(trade.startDate_, trade.maturityDate_, terms.config_);
+            const bool expired = trade.maturityDate_ < market.valuationTime_.Date();
+            // Active-typed assembly (frozen P0 contract 8): the uniformly typed XCCY view cannot
+            // hold double curves, so every consumed curve is rebuilt as AAD::Number_ — only the
+            // addressed component's parameters are registered, the others stay constant-typed, and
+            // fxSpot_ is an unregistered constant scalar (P0 ships rate axes only, no FX delta).
+            return RunNodeSensitivityAADStage(expectedParameterCount, [&]() {
+                const Vector_<AAD::Number_> targetParameters = RegisterCurveParameters(prepared.at(targetCurve).passiveParameters_);
+                AAD::NewRecording(*AAD::Tape());
+                NodeSensitivityCandidate_ candidate;
+                if (expired) {
+                    candidate.pv_ = 0.0;
+                    candidate.gradient_ = Vector_<>(targetParameters.size(), 0.0);
+                    return candidate;
+                }
+                std::map<const DiscountCurve_*, std::shared_ptr<Tape::DiscountCurve_<AAD::Number_>>> active;
+                for (const auto& [curve, preparation] : prepared)
+                    active.emplace(curve, BuildDiscountCurveUniqueT<AAD::Number_>(
+                                              preparation.definition_,
+                                              curve == targetCurve ? targetParameters : ConstantActiveParameters(preparation.passiveParameters_),
+                                              preparation.passiveBase_));
+
+                const auto fillTypedBlock = [&](const CurveBlock_& source, Tape::JointCurveBlock_<AAD::Number_>* typed) {
+                    for (const auto& [collateral, handle] : source.DiscountCurves()) {
+                        const auto found = active.find(handle.get());
+                        if (found != active.end())
+                            typed->discountCurves[collateral] = found->second.get();
+                    }
+                    for (const auto& [tenor, handle] : source.ForwardCurves()) {
+                        const auto found = active.find(handle.get());
+                        if (found != active.end())
+                            typed->forwardCurves[tenor] = found->second.get();
+                    }
+                };
+                Tape::JointCurveBlock_<AAD::Number_> domesticBlock, foreignBlock;
+                fillTypedBlock(nativeMarket.DomesticBlock(), &domesticBlock);
+                fillTypedBlock(nativeMarket.ForeignBlock(), &foreignBlock);
+
+                XccyMarketView_<AAD::Number_> view;
+                view.valuationTime_ = market.valuationTime_;
+                view.pair_ = terms.config_.pair_;
+                view.collateralCurrency_ = nativeMarket.CollateralCurrency();
+                view.fxSpot_ = AAD::Number_(nativeMarket.FxSpot());
+                view.domestic_ = &domesticBlock;
+                view.foreign_ = &foreignBlock;
+                if (const DiscountCurve_* basisCurve = nativeMarket.BasisCurve())
+                    view.basis_ = active.at(basisCurve).get();
+
+                const MarketFixingSnapshot_& fixings = XccyFixings(market, nativeMarket);
+                AAD::Number_ pv = terms.positionCount_ * PriceXccyContract(plan, view, fixings, terms.contractSpread_, terms.spreadOnForeignLeg_,
+                                                                           terms.receiveNonSpreadPaySpread_);
+                AAD::Adjoint(pv) = 1.0;
+                AAD::PropagateToStart(*AAD::Tape());
+                candidate.pv_ = AAD::Value(pv);
+                candidate.gradient_ = Vector_<>(targetParameters.size());
+                for (int i = 0; i < static_cast<int>(targetParameters.size()); ++i)
+                    candidate.gradient_[i] = AAD::AdjointValue(targetParameters[i]);
+                return candidate;
+            });
+        }
     } // namespace
 
     // #lizard forgives -- one plan builder keeps family-specific cashflow admission atomic.
@@ -527,13 +703,21 @@ namespace Dal {
         return result;
     }
 
+    RateCashflowPlan_ BuildRateCashflowPlan(const RateTradeDefinition_& trade, const RatePricingMarket_& market) {
+        RateCashflowPlan_ result = BuildRateCashflowPlan(trade, market.valuationTime_);
+        if (const auto* terms = std::get_if<XccyTradeTerms_>(&trade.terms_))
+            for (const auto& key : XccyDependencyKeys(*terms, market))
+                AddUnique(key, &result.dependencyComponentKeys_);
+        return result;
+    }
+
     RatePricingTradeResult_ PriceRateTrade(const RateTradeDefinition_& trade, const RatePricingMarket_& market) {
         RatePricingTradeResult_ result;
         result.instrumentId_ = trade.instrumentId_;
         result.instrumentType_ = trade.instrumentType_;
         result.currency_ = market.resultCurrency_;
         try {
-            const auto plan = BuildRateCashflowPlan(trade, market.valuationTime_);
+            const auto plan = BuildRateCashflowPlan(trade, market);
             result.requiredHistoricalFixings_ = plan.requiredHistoricalFixings_;
             result.dependencyComponentKeys_ = plan.dependencyComponentKeys_;
             result.pv_ = Price(trade, market, &result);
@@ -559,6 +743,8 @@ namespace Dal {
         using namespace RateCashflowPricingInternal;
         if (!IsFamilyAadEnabled(trade))
             return NodeSensitivityFailure("TRADE_FAMILY_NOT_AAD_ENABLED");
+        if (const auto* xccyTerms = std::get_if<XccyTradeTerms_>(&trade.terms_))
+            return RateTradeNodeSensitivitiesXccy(trade, *xccyTerms, market, componentKey);
         const Vector_<String_> dependencyKeys = AadDependencyKeys(trade);
         if (std::find(dependencyKeys.begin(), dependencyKeys.end(), componentKey) == dependencyKeys.end())
             return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");

--- a/dal-cpp/dal/curve/ratecashflowpricing.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.hpp
@@ -151,6 +151,10 @@ namespace Dal {
     };
 
     RateCashflowPlan_ BuildRateCashflowPlan(const RateTradeDefinition_& trade, const DateTime_& valuationTime);
+    // Market-aware plan: identical to the (trade, valuationTime) form for single-currency families;
+    // for XCCY it additionally emits the dependency keys of the curves the trade actually consumes,
+    // addressed by pointer identity against curveComponents_ (frozen P0 follow-up 1).
+    RateCashflowPlan_ BuildRateCashflowPlan(const RateTradeDefinition_& trade, const RatePricingMarket_& market);
     RatePricingTradeResult_ PriceRateTrade(const RateTradeDefinition_& trade, const RatePricingMarket_& market);
     Vector_<RatePricingTradeResult_> PriceRateTrades(const Vector_<RateTradeDefinition_>& trades, const RatePricingMarket_& market);
     RateTradeNodeSensitivityResult_

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -46,7 +46,8 @@ namespace Dal::RateCashflowPricingInternal {
     // so terms-mismatch trades keep hitting the family gate by construction.
     inline Vector_<RateInstrumentType_> AadEnabledRateFamilies() {
         return {RateInstrumentType_::Value_::DEPOSIT, RateInstrumentType_::Value_::FRA, RateInstrumentType_::Value_::FUTURE,
-                RateInstrumentType_::Value_::OIS,     RateInstrumentType_::Value_::IRS, RateInstrumentType_::Value_::BASIS_SWAP};
+                RateInstrumentType_::Value_::OIS,     RateInstrumentType_::Value_::IRS, RateInstrumentType_::Value_::BASIS_SWAP,
+                RateInstrumentType_::Value_::XCCY};
     }
 
     inline RateTradeNodeSensitivityResult_ NodeSensitivityFailure(const String_& reason) {

--- a/dal-cpp/dal/curve/xccypricing.cpp
+++ b/dal-cpp/dal/curve/xccypricing.cpp
@@ -125,7 +125,11 @@ namespace Dal {
             const T_ domesticDf = DiscountFromValuation(domesticDiscount, market.valuationTime_, fixingTime.Date());
             const T_ foreignDf = DiscountFromValuation(foreignDiscount, market.valuationTime_, fixingTime.Date());
             const T_ basisDf = market.basis_ ? DiscountFromValuation(*market.basis_, market.valuationTime_, fixingTime.Date()) : T_(1.0);
-            return market.fxSpot_ * foreignDf / (domesticDf * basisDf);
+            // Spelled as an explicit reciprocal: Adept evaluates an active-denominator division's
+            // primal as lhs*(1/rhs), so the plain quotient would round differently from the double
+            // path and break bitwise active == passive PV (1/basisDf with a unit numerator is
+            // correctly rounded on every backend).
+            return market.fxSpot_ * foreignDf * (T_(1.0) / (domesticDf * basisDf));
         }
 
         template <class T_> void ValidateMarketView(const XccyCashflowPlan_& plan, const XccyMarketView_<T_>& market) {
@@ -251,7 +255,9 @@ namespace Dal {
         T_ ForeignConversionFactor(const Tape::DiscountCurve_<T_>& foreignDiscount, const XccyMarketView_<T_>& market, const Date_& paymentDate) {
             const T_ foreignDf = DiscountFromValuation(foreignDiscount, market.valuationTime_, paymentDate);
             const T_ basisDf = market.basis_ ? DiscountFromValuation(*market.basis_, market.valuationTime_, paymentDate) : T_(1.0);
-            return market.fxSpot_ * foreignDf / basisDf;
+            // Explicit reciprocal, same reasoning as ActiveFxForward: the plain quotient would
+            // round differently from the double path on Adept and break bitwise active == passive.
+            return market.fxSpot_ * foreignDf * (T_(1.0) / basisDf);
         }
 
         template <class T_> struct XccyCouponValues_ {

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -18,10 +18,12 @@
 #include <dal/curve/piecewiselinear.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
 #include <dal/curve/ratecashflowpricing_internal.hpp>
+#include <dal/curve/xccypricing.hpp>
 #include <dal/curve/ycconst.hpp>
 #include <dal/curve/ycimp.hpp>
 #include <dal/curve/yclogdf.hpp>
 #include <dal/curve/yczerorate.hpp>
+#include <dal/math/aad/aad.hpp>
 
 namespace {
     Dal::RateIndexConvention_ QuarterlyIndex() {
@@ -132,6 +134,8 @@ namespace {
 
     // Shared wrapper of the fixed-float terms into the family's terms alternative.
     Dal::RateTradeTerms_ AsFamilyTerms(const Dal::RateInstrumentType_& family, const Dal::FixedFloatTradeTerms_& value) {
+        REQUIRE(family == Dal::RateInstrumentType_("OIS") || family == Dal::RateInstrumentType_("IRS"),
+                "AsFamilyTerms wraps fixed-float terms for OIS/IRS only");
         return family == Dal::RateInstrumentType_("OIS") ? Dal::RateTradeTerms_(Dal::OisTradeTerms_{value})
                                                          : Dal::RateTradeTerms_(Dal::IrsTradeTerms_{value});
     }
@@ -164,7 +168,7 @@ namespace {
 
     class UnsupportedDiscountCurve_ : public Dal::DiscountCurve_ {
     public:
-        UnsupportedDiscountCurve_() : DiscountCurve_("unsupported", "USD") {}
+        explicit UnsupportedDiscountCurve_(const Dal::String_& ccy = "USD") : DiscountCurve_("unsupported", ccy) {}
 
         double operator()(const Dal::Date_&, const Dal::Date_&) const override { return 1.0; }
         void Poll(Dal::Vector_<const Dal::YCComponent_*>* all) const override { all->push_back(this); }
@@ -309,12 +313,14 @@ namespace {
     // the target component key and holds every other dependency on a distinct flat curve, so
     // central bumps perturb the target component only. The relative tolerance sits one order above
     // the single-period families: multi-period discounting and compounding add curvature that
-    // scales the central-difference truncation.
+    // scales the central-difference truncation. curveCcy names the currency of the built curve's
+    // slot (XCCY foreign/basis slots are not USD).
     template <class MakeTerms_, class AssembleMarket_>
     void AssertFamilyNodeBatteries(const Dal::RateInstrumentType_& family,
                                    const MakeTerms_& makeTerms,
                                    const Dal::String_& componentKey,
-                                   const AssembleMarket_& assembleMarket) {
+                                   const AssembleMarket_& assembleMarket,
+                                   const Dal::String_& curveCcy = "USD") {
         constexpr double NATIVE_PARAMETER_BUMP = 1.0e-6;
         constexpr double RAW_GRADIENT_ABSOLUTE_TOLERANCE = 1.0e-6;
         constexpr double RAW_GRADIENT_RELATIVE_TOLERANCE = 1.0e-7;
@@ -324,7 +330,7 @@ namespace {
         AssertFamilyNodeGradientMatchesCentralBumps(
             family, makeTerms(true), makeTerms(false), componentKey, assembleMarket,
             [&](const Dal::Vector_<>& parameters) {
-                return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_(knots, parameters)));
+                return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("pwc", curveCcy, Dal::PiecewiseConstant_(knots, parameters)));
             },
             {0.01, -0.005, 0.03}, 3, NATIVE_PARAMETER_BUMP, RAW_GRADIENT_ABSOLUTE_TOLERANCE, RAW_GRADIENT_RELATIVE_TOLERANCE, {1, 2});
         AssertFamilyNodeGradientMatchesCentralBumps(
@@ -336,7 +342,7 @@ namespace {
                     left[node] = parameters[2 * node];
                     right[node] = parameters[2 * node + 1];
                 }
-                return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWLF("pwlf", "USD", Dal::PiecewiseLinear_(knots, left, right)));
+                return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWLF("pwlf", curveCcy, Dal::PiecewiseLinear_(knots, left, right)));
             },
             {0.01, 0.0, -0.005, 0.02, 0.03, -0.01}, 6, NATIVE_PARAMETER_BUMP, RAW_GRADIENT_ABSOLUTE_TOLERANCE, RAW_GRADIENT_RELATIVE_TOLERANCE,
             {2, 3, 4, 5});
@@ -345,7 +351,7 @@ namespace {
                                                         Dal::Vector_<> stored{0.0};
                                                         stored.Append(parameters);
                                                         return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountLogDF(
-                                                            "logdf", "USD", Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]}, stored,
+                                                            "logdf", curveCcy, Dal::Vector_<Dal::Date_>{today, knots[0], knots[1], knots[2]}, stored,
                                                             Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
                                                     },
                                                     {-0.005, 0.0, -0.06}, 3, NATIVE_PARAMETER_BUMP, RAW_GRADIENT_ABSOLUTE_TOLERANCE,
@@ -353,8 +359,8 @@ namespace {
         AssertFamilyNodeGradientMatchesCentralBumps(
             family, makeTerms(true), makeTerms(false), componentKey, assembleMarket,
             [&](const Dal::Vector_<>& parameters) {
-                return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountZeroRate("zero", "USD", today, knots, parameters, Dal::DayBasis_("ACT_365F"),
-                                                                                  Dal::LogDfScheme_::Value_::LOG_LINEAR));
+                return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountZeroRate("zero", curveCcy, today, knots, parameters,
+                                                                                  Dal::DayBasis_("ACT_365F"), Dal::LogDfScheme_::Value_::LOG_LINEAR));
             },
             {0.01, 0.0, -0.005}, 3, NATIVE_PARAMETER_BUMP, RAW_GRADIENT_ABSOLUTE_TOLERANCE, RAW_GRADIENT_RELATIVE_TOLERANCE, {2});
     }
@@ -387,6 +393,146 @@ namespace {
         AssertFamilyNodeBatteries(
             Dal::RateInstrumentType_("BASIS_SWAP"), [](bool receiveReference) { return Dal::RateTradeTerms_(BasisTerms(receiveReference)); },
             componentKey, assembleMarket);
+    }
+
+    constexpr const char* XCCY_DOM_OIS = "domOis";
+    constexpr const char* XCCY_DOM_FWD_3M = "domFwd3M";
+    constexpr const char* XCCY_DOM_FWD_6M = "domFwd6M";
+    constexpr const char* XCCY_FOR_OIS = "forOis";
+    constexpr const char* XCCY_FOR_FWD_3M = "forFwd3M";
+    constexpr const char* XCCY_BASIS = "basis";
+
+    Dal::RateIndexConvention_ XccyIndex(bool projection) {
+        auto result = QuarterlyIndex();
+        if (projection) {
+            result.useProjectionCurve_ = true;
+            result.forecastTenor_ = Dal::PeriodLength_("3M");
+        }
+        return result;
+    }
+
+    Dal::XccyTradeTerms_ XccyTerms(const Dal::Ccy_& domestic,
+                                   const Dal::Ccy_& foreign,
+                                   bool receiveNonSpread,
+                                   bool projection,
+                                   const Dal::CollateralType_& domesticCollateral = Dal::CollateralType_(Dal::CollateralType_::Value_::OIS)) {
+        Dal::XccyTradeTerms_ result;
+        result.positionCount_ = 1.0;
+        result.contractSpread_ = 0.001;
+        result.spreadOnForeignLeg_ = true;
+        result.receiveNonSpreadPaySpread_ = receiveNonSpread;
+        result.config_.pair_ = Dal::CurrencyPair_(domestic, foreign);
+        result.config_.domesticNotional_ = 1'000'000.0;
+        result.config_.foreignNotional_ = 900'000.0;
+        result.config_.convention_.domesticLeg_ = AnnualLeg();
+        result.config_.convention_.foreignLeg_ = AnnualLeg();
+        result.config_.convention_.domesticIndex_ = XccyIndex(projection);
+        result.config_.convention_.domesticIndex_.collateral_ = domesticCollateral;
+        result.config_.convention_.foreignIndex_ = XccyIndex(projection);
+        result.config_.convention_.spreadOnForeignLeg_ = true;
+        result.config_.domesticRateFixing_ = {Dal::String_(domestic.String()) + "-INDEX", 11, 0};
+        result.config_.foreignRateFixing_ = {Dal::String_(foreign.String()) + "-INDEX", 11, 0};
+        return result;
+    }
+
+    Dal::XccyTradeTerms_ XccyTerms(bool receiveNonSpread = true, bool projection = true) {
+        return XccyTerms(Dal::Ccy_("USD"), Dal::Ccy_("EUR"), receiveNonSpread, projection);
+    }
+
+    // Curve inventory of a test XCCY market. Null handles leave the slot out of the block and the
+    // key out of curveComponents_, so negative cases can shape addressing precisely.
+    struct XccyMarketSpec_ {
+        Dal::Handle_<Dal::DiscountCurve_> domesticOis_, domesticGc_, domesticFwd3M_, domesticFwd6M_;
+        Dal::Handle_<Dal::DiscountCurve_> foreignOis_, foreignFwd3M_;
+        Dal::Handle_<Dal::DiscountCurve_> basis_;
+        double fxSpot_ = 1.2;
+        Dal::Ccy_ domestic_ = Dal::Ccy_("USD");
+        Dal::Ccy_ foreign_ = Dal::Ccy_("EUR");
+        Dal::Handle_<Dal::MarketFixingSnapshot_> fixings_;
+    };
+
+    XccyMarketSpec_ FlatXccySpec(const Dal::Date_& horizon) {
+        XccyMarketSpec_ spec;
+        spec.domesticOis_ = FlatCurve(horizon, 0.03, "USD");
+        spec.domesticFwd3M_ = FlatCurve(horizon, 0.032, "USD");
+        spec.foreignOis_ = FlatCurve(horizon, 0.02, "EUR");
+        spec.foreignFwd3M_ = FlatCurve(horizon, 0.022, "EUR");
+        spec.basis_ = FlatCurve(horizon, 0.001, "USD");
+        return spec;
+    }
+
+    // Pointer-identity contract: the block slots and the curveComponents_ entries share the same
+    // Handles, so every consumed curve is addressable under a stable key.
+    Dal::RatePricingMarket_ BuildXccyMarket(const Dal::Date_& today, const XccyMarketSpec_& spec) {
+        std::map<Dal::CollateralType_, Dal::Handle_<Dal::DiscountCurve_>> domesticDiscounts;
+        domesticDiscounts[Dal::CollateralType_(Dal::CollateralType_::Value_::OIS)] = spec.domesticOis_;
+        if (spec.domesticGc_)
+            domesticDiscounts[Dal::CollateralType_(Dal::CollateralType_::Value_::GC)] = spec.domesticGc_;
+        std::map<Dal::PeriodLength_, Dal::Handle_<Dal::DiscountCurve_>> domesticForwards;
+        if (spec.domesticFwd3M_)
+            domesticForwards[Dal::PeriodLength_("3M")] = spec.domesticFwd3M_;
+        if (spec.domesticFwd6M_)
+            domesticForwards[Dal::PeriodLength_("6M")] = spec.domesticFwd6M_;
+        std::map<Dal::CollateralType_, Dal::Handle_<Dal::DiscountCurve_>> foreignDiscounts;
+        foreignDiscounts[Dal::CollateralType_(Dal::CollateralType_::Value_::OIS)] = spec.foreignOis_;
+        std::map<Dal::PeriodLength_, Dal::Handle_<Dal::DiscountCurve_>> foreignForwards;
+        if (spec.foreignFwd3M_)
+            foreignForwards[Dal::PeriodLength_("3M")] = spec.foreignFwd3M_;
+
+        const auto domesticBlock = Dal::Handle_<Dal::CurveBlock_>(
+            new Dal::CurveBlock_("domestic", spec.domestic_.String(), domesticDiscounts, domesticForwards, Dal::DayBasis_("ACT_365F")));
+        const auto foreignBlock = Dal::Handle_<Dal::CurveBlock_>(
+            new Dal::CurveBlock_("foreign", spec.foreign_.String(), foreignDiscounts, foreignForwards, Dal::DayBasis_("ACT_365F")));
+        const auto fixings = spec.fixings_ ? spec.fixings_ : Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_());
+        const auto native = std::make_shared<Dal::CrossCurrencyMarket_>(domesticBlock, foreignBlock, spec.fxSpot_, Dal::DateTime_(today, 10, 30),
+                                                                        spec.domestic_, fixings);
+        if (spec.basis_)
+            native->SetBasisCurve(spec.basis_);
+
+        Dal::RatePricingMarket_ result;
+        result.valuationTime_ = Dal::DateTime_(today, 10, 30);
+        result.resultCurrency_ = spec.domestic_;
+        result.xccyMarket_ = native;
+        result.fixings_ = fixings;
+        const auto registerIf = [&](const char* key, const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+            if (curve)
+                result.curveComponents_[key] = curve;
+        };
+        registerIf(XCCY_DOM_OIS, spec.domesticOis_);
+        registerIf("domGc", spec.domesticGc_);
+        registerIf(XCCY_DOM_FWD_3M, spec.domesticFwd3M_);
+        registerIf(XCCY_DOM_FWD_6M, spec.domesticFwd6M_);
+        registerIf(XCCY_FOR_OIS, spec.foreignOis_);
+        registerIf(XCCY_FOR_FWD_3M, spec.foreignFwd3M_);
+        registerIf(XCCY_BASIS, spec.basis_);
+        return result;
+    }
+
+    Dal::RatePricingMarket_ FlatXccyMarket(const Dal::Date_& today) { return BuildXccyMarket(today, FlatXccySpec(Dal::Date_(2031, 1, 15))); }
+
+    // XCCY battery: the built curve lands in the addressed block slot (registered under its key)
+    // while every other consumed curve stays on a distinct flat curve, so central bumps perturb the
+    // addressed component only. Foreign slots are EUR curves; the basis stays domestic (USD).
+    void AssertXccyNodeBatteries(const Dal::String_& componentKey) {
+        const Dal::Date_ today(2026, 1, 15);
+        const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& curve) {
+            auto spec = FlatXccySpec(Dal::Date_(2031, 1, 15));
+            if (componentKey == XCCY_DOM_OIS)
+                spec.domesticOis_ = curve;
+            else if (componentKey == XCCY_DOM_FWD_3M)
+                spec.domesticFwd3M_ = curve;
+            else if (componentKey == XCCY_FOR_OIS)
+                spec.foreignOis_ = curve;
+            else if (componentKey == XCCY_FOR_FWD_3M)
+                spec.foreignFwd3M_ = curve;
+            else
+                spec.basis_ = curve;
+            return BuildXccyMarket(today, spec);
+        };
+        const Dal::String_ curveCcy = componentKey == XCCY_FOR_OIS || componentKey == XCCY_FOR_FWD_3M ? Dal::String_("EUR") : Dal::String_("USD");
+        AssertFamilyNodeBatteries(
+            Dal::RateInstrumentType_("XCCY"), [](bool receiveNonSpread) { return Dal::RateTradeTerms_(XccyTerms(receiveNonSpread)); }, componentKey,
+            assembleMarket, curveCcy);
     }
 } // namespace
 
@@ -769,7 +915,7 @@ TEST(RateCashflowPricingTest, TestDepositNodeAADRewindsPerTradeAndIsThreadLocal)
 TEST(RateCashflowPricingTest, TestRegistryTracksAadEnabledFamiliesAndLockedOnesStayGated) {
     const auto enabled = Dal::RateCashflowPricingInternal::AadEnabledRateFamilies();
     const auto families = Dal::RateInstrumentTypeListAll();
-    ASSERT_EQ(enabled.size(), 6);
+    ASSERT_EQ(enabled.size(), 7);
     for (const auto& family : enabled)
         ASSERT_NE(std::find(families.begin(), families.end(), family), families.end());
 
@@ -821,9 +967,11 @@ TEST(RateCashflowPricingTest, TestRegistryTracksAadEnabledFamiliesAndLockedOnesS
               (Dal::Vector_<Dal::String_>{"forecast", "reference", "discount"}));
     for (const auto& key : {"forecast", "reference", "discount"})
         ASSERT_TRUE(Dal::RateTradeNodeSensitivities(basisTrade, market, key).eligible_);
+    // XCCY is open in the registry; that market carries no cross-currency market, so no component
+    // can be addressed and the dependency gate — not the family gate — answers.
     AssertCanonicalFailure(
         Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("XCCY"), today, today, maturity, Dal::XccyTradeTerms_{}), market, "forecast"),
-        "TRADE_FAMILY_NOT_AAD_ENABLED");
+        "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
 
     AssertCanonicalFailure(
         Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::RateTradeTerms_(FraTerms())), market,
@@ -1819,6 +1967,447 @@ TEST(RateCashflowPricingTest, TestBasisNodeAADReasonPrecedenceForCombinedFailure
 
     AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(invalidTrade, supported, "forecast"), "TRADE_VALIDATION_FAILED");
 }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADDomOisRawColumnsMatchCentralBumpsAllRepresentations) { AssertXccyNodeBatteries(XCCY_DOM_OIS); }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADDomFwd3MRawColumnsMatchCentralBumpsAllRepresentations) { AssertXccyNodeBatteries(XCCY_DOM_FWD_3M); }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADForOisRawColumnsMatchCentralBumpsAllRepresentations) { AssertXccyNodeBatteries(XCCY_FOR_OIS); }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADForFwd3MRawColumnsMatchCentralBumpsAllRepresentations) { AssertXccyNodeBatteries(XCCY_FOR_FWD_3M); }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADBasisRawColumnsMatchCentralBumpsAllRepresentations) { AssertXccyNodeBatteries(XCCY_BASIS); }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADPlannerEmitsConsumedDependencyKeys) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+    const auto market = FlatXccyMarket(today);
+
+    // Market-aware overload: "depends on" = the collateral/tenor-selected curves actually consumed
+    // (domestic discount + forecast, foreign discount + forecast, basis), in deterministic walk order.
+    const auto plan = Dal::BuildRateCashflowPlan(trade, market);
+    ASSERT_EQ(plan.dependencyComponentKeys_,
+              (Dal::Vector_<Dal::String_>({XCCY_DOM_OIS, XCCY_DOM_FWD_3M, XCCY_FOR_OIS, XCCY_FOR_FWD_3M, XCCY_BASIS})));
+
+    // The (trade, valuationTime) signature and its XCCY behaviour stay unchanged: no keys without a market.
+    ASSERT_TRUE(Dal::BuildRateCashflowPlan(trade, market.valuationTime_).dependencyComponentKeys_.empty());
+    const auto priced = Dal::PriceRateTrade(trade, market);
+    ASSERT_TRUE(priced.succeeded_);
+    ASSERT_EQ(priced.dependencyComponentKeys_, plan.dependencyComponentKeys_);
+
+    // Without projection the forecast routes to the discount slot: the walk dedupes by pointer, so
+    // each block contributes exactly one curve.
+    const auto noProjection = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms(true, false)));
+    ASSERT_EQ(Dal::BuildRateCashflowPlan(noProjection, market).dependencyComponentKeys_,
+              (Dal::Vector_<Dal::String_>({XCCY_DOM_OIS, XCCY_FOR_OIS, XCCY_BASIS})));
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADAllConsumedComponentsEligibleWithLiveGradients) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+    const auto market = FlatXccyMarket(today);
+    const auto passive = Dal::PriceRateTrade(trade, market);
+    ASSERT_TRUE(passive.succeeded_);
+
+    for (const auto& key : {XCCY_DOM_OIS, XCCY_DOM_FWD_3M, XCCY_FOR_OIS, XCCY_FOR_FWD_3M, XCCY_BASIS}) {
+        const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, key);
+        ASSERT_TRUE(sensitivity.eligible_) << key;
+        ASSERT_EQ(static_cast<int>(sensitivity.gradient_.size()), 1) << key;
+        ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_) << key;
+        // Magnitude floor, not just non-zero: a live column must carry real sensitivity.
+        ASSERT_GT(std::abs(sensitivity.gradient_[0]), 1.0e-8) << key;
+    }
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADMultiCurrencyPairs) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+
+    {
+        auto spec = FlatXccySpec(Dal::Date_(2031, 1, 15));
+        spec.domestic_ = Dal::Ccy_("EUR");
+        spec.foreign_ = Dal::Ccy_("JPY");
+        spec.fxSpot_ = 160.0;
+        spec.domesticOis_ = FlatCurve(Dal::Date_(2031, 1, 15), 0.025, "EUR");
+        spec.domesticFwd3M_ = FlatCurve(Dal::Date_(2031, 1, 15), 0.027, "EUR");
+        spec.foreignOis_ = FlatCurve(Dal::Date_(2031, 1, 15), 0.005, "JPY");
+        spec.foreignFwd3M_ = FlatCurve(Dal::Date_(2031, 1, 15), 0.007, "JPY");
+        spec.basis_ = FlatCurve(Dal::Date_(2031, 1, 15), 0.0008, "EUR");
+        const auto market = BuildXccyMarket(today, spec);
+        const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity,
+                                 Dal::RateTradeTerms_(XccyTerms(Dal::Ccy_("EUR"), Dal::Ccy_("JPY"), true, true)));
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_TRUE(passive.succeeded_);
+        ASSERT_NE(passive.pv_, 0.0);
+        for (const auto& key : {XCCY_DOM_OIS, XCCY_DOM_FWD_3M, XCCY_FOR_OIS, XCCY_FOR_FWD_3M, XCCY_BASIS}) {
+            const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, key);
+            ASSERT_TRUE(sensitivity.eligible_) << key;
+            ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_) << key;
+            ASSERT_GT(std::abs(sensitivity.gradient_[0]), 1.0e-8) << key;
+        }
+    }
+
+    {
+        // USD/EUR with the reverse notional direction: PV and gradient flip sign together.
+        const auto market = FlatXccyMarket(today);
+        const auto receive = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms(true)));
+        const auto pay = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms(false)));
+        const auto receiveSensitivity = Dal::RateTradeNodeSensitivities(receive, market, XCCY_DOM_OIS);
+        const auto paySensitivity = Dal::RateTradeNodeSensitivities(pay, market, XCCY_DOM_OIS);
+        ASSERT_TRUE(receiveSensitivity.eligible_);
+        ASSERT_TRUE(paySensitivity.eligible_);
+        ASSERT_DOUBLE_EQ(paySensitivity.pv_, -receiveSensitivity.pv_);
+        ASSERT_DOUBLE_EQ(paySensitivity.gradient_[0], -receiveSensitivity.gradient_[0]);
+    }
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADCollateralRoutingSelectsConsumedDiscount) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto horizon = Dal::Date_(2031, 1, 15);
+    auto spec = FlatXccySpec(horizon);
+    spec.domesticGc_ = FlatCurve(horizon, 0.035, "USD");
+    const auto market = BuildXccyMarket(today, spec);
+    const auto trade = Trade(
+        Dal::RateInstrumentType_("XCCY"), today, start, maturity,
+        Dal::RateTradeTerms_(XccyTerms(Dal::Ccy_("USD"), Dal::Ccy_("EUR"), true, true, Dal::CollateralType_(Dal::CollateralType_::Value_::GC))));
+
+    // The GC-collateral index selects the GC discount curve; the OIS discount curve stays in the
+    // block but unconsumed, so it is not a dependency (unused-block-member semantics).
+    ASSERT_EQ(Dal::BuildRateCashflowPlan(trade, market).dependencyComponentKeys_,
+              (Dal::Vector_<Dal::String_>({"domGc", XCCY_DOM_FWD_3M, XCCY_FOR_OIS, XCCY_FOR_FWD_3M, XCCY_BASIS})));
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+
+    const auto passive = Dal::PriceRateTrade(trade, market);
+    ASSERT_TRUE(passive.succeeded_);
+    const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, "domGc");
+    ASSERT_TRUE(sensitivity.eligible_);
+    ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_);
+    ASSERT_GT(std::abs(sensitivity.gradient_[0]), 1.0e-8);
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADAddressingNegativeCases) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto horizon = Dal::Date_(2031, 1, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+    const auto supported = FlatXccyMarket(today);
+
+    // Wrong key: never consumed, whatever the registry holds.
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, supported, "unknown"), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+
+    {
+        // Unused in-block member: a registered 6M forward the trade never reads must be a canonical
+        // failure, never eligible-with-all-zeros.
+        auto spec = FlatXccySpec(horizon);
+        spec.domesticFwd6M_ = FlatCurve(horizon, 0.04, "USD");
+        const auto market = BuildXccyMarket(today, spec);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_FWD_6M), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS).eligible_);
+        ASSERT_GT(std::abs(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS).gradient_[0]), 1.0e-8);
+    }
+
+    {
+        // Unregistered key: the consumed foreign forecast is dropped from the registry; the key no
+        // longer addresses anything, and the remaining targets still sweep unchanged.
+        auto unregistered = supported;
+        unregistered.curveComponents_.erase(XCCY_FOR_FWD_3M);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, unregistered, XCCY_FOR_FWD_3M), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+        const auto reference = Dal::RateTradeNodeSensitivities(trade, supported, XCCY_DOM_OIS);
+        const auto unaffected = Dal::RateTradeNodeSensitivities(trade, unregistered, XCCY_DOM_OIS);
+        ASSERT_TRUE(unaffected.eligible_);
+        ASSERT_DOUBLE_EQ(unaffected.pv_, reference.pv_);
+        ASSERT_EQ(unaffected.gradient_, reference.gradient_);
+    }
+
+    {
+        // In-block unclassifiable representation, unused member: never classified, no effect.
+        auto spec = FlatXccySpec(horizon);
+        spec.domesticFwd6M_ = Dal::Handle_<Dal::DiscountCurve_>(std::make_shared<const UnsupportedDiscountCurve_>());
+        const auto market = BuildXccyMarket(today, spec);
+        const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS);
+        ASSERT_TRUE(sensitivity.eligible_);
+        ASSERT_GT(std::abs(sensitivity.gradient_[0]), 1.0e-8);
+    }
+
+    {
+        // In-block unclassifiable representation, addressed target: the representation token.
+        auto spec = FlatXccySpec(horizon);
+        spec.domesticOis_ = Dal::Handle_<Dal::DiscountCurve_>(std::make_shared<const UnsupportedDiscountCurve_>());
+        const auto market = BuildXccyMarket(today, spec);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS), "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+    }
+
+    {
+        // In-block unclassifiable representation, consumed non-target: passive pricing succeeds on
+        // its constant DFs, but the active assembly cannot rebuild it — an evaluation failure, not
+        // the representation token (that token stays a failure of the addressed component).
+        auto spec = FlatXccySpec(horizon);
+        spec.foreignOis_ = Dal::Handle_<Dal::DiscountCurve_>(std::make_shared<const UnsupportedDiscountCurve_>("EUR"));
+        const auto market = BuildXccyMarket(today, spec);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_TRUE(passive.succeeded_);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS), "AAD_EVALUATION_FAILED");
+    }
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADBeforeAndAfterMaturityExpiry) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 2, 15);
+    const Dal::Date_ maturity(2026, 4, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+    const auto horizon = Dal::Date_(2031, 1, 15);
+
+    auto expired = FlatXccySpec(horizon);
+    const auto expiredMarket = BuildXccyMarket(maturity.AddDays(1), expired);
+    const auto liveMarket = BuildXccyMarket(today, FlatXccySpec(horizon));
+
+    for (const auto& key : {XCCY_DOM_OIS, XCCY_DOM_FWD_3M, XCCY_FOR_OIS, XCCY_FOR_FWD_3M, XCCY_BASIS}) {
+        const auto live = Dal::RateTradeNodeSensitivities(trade, liveMarket, key);
+        ASSERT_TRUE(live.eligible_) << key;
+        ASSERT_NE(live.pv_, 0.0) << key;
+        ASSERT_GT(std::abs(live.gradient_[0]), 1.0e-8) << key;
+
+        const auto settled = Dal::RateTradeNodeSensitivities(trade, expiredMarket, key);
+        ASSERT_TRUE(settled.eligible_) << key;
+        ASSERT_DOUBLE_EQ(settled.pv_, 0.0) << key;
+        for (const double column : settled.gradient_)
+            ASSERT_DOUBLE_EQ(column, 0.0) << key;
+    }
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADFixingStatesProjectedSuppliedAndMissing) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 2, 15);
+    const Dal::Date_ maturity(2026, 4, 15);
+    const auto horizon = Dal::Date_(2031, 1, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+    const auto terms = XccyTerms();
+    const Dal::String_ domesticIndex = terms.config_.domesticRateFixing_.indexName_;
+    const Dal::String_ foreignIndex = terms.config_.foreignRateFixing_.indexName_;
+    // Fixing keys come from the plan itself: the schedule business-day adjustment moves the accrual
+    // start, so hand-built DateTime_ keys would silently miss.
+    const auto plan = Dal::BuildXccyCashflowPlan(start, maturity, terms.config_);
+    const Dal::DateTime_ domesticFixingTime = plan.domesticPeriods_.front().rateFixingTime_;
+    const Dal::DateTime_ foreignFixingTime = plan.foreignPeriods_.front().rateFixingTime_;
+    const Dal::Date_ valuationDate = std::max(domesticFixingTime.Date(), foreignFixingTime.Date()).AddDays(1);
+
+    {
+        // Both legs projected before either fixing.
+        const auto market = BuildXccyMarket(today, FlatXccySpec(horizon));
+        for (const auto& key : {XCCY_DOM_FWD_3M, XCCY_FOR_FWD_3M, XCCY_DOM_OIS, XCCY_BASIS}) {
+            const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, key);
+            ASSERT_TRUE(sensitivity.eligible_) << key;
+            ASSERT_GT(std::abs(sensitivity.gradient_[0]), 1.0e-8) << key;
+        }
+    }
+
+    const auto withFixings = [&](const Dal::MarketFixingSnapshot_::values_t& values) {
+        auto spec = FlatXccySpec(horizon);
+        spec.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_(values));
+        return BuildXccyMarket(valuationDate, spec);
+    };
+    Dal::MarketFixingSnapshot_::values_t domesticOnly;
+    domesticOnly[domesticIndex][domesticFixingTime] = 0.031;
+    Dal::MarketFixingSnapshot_::values_t foreignOnly;
+    foreignOnly[foreignIndex][foreignFixingTime] = 0.021;
+    Dal::MarketFixingSnapshot_::values_t both = domesticOnly;
+    both[foreignIndex][foreignFixingTime] = 0.021;
+
+    {
+        // Missing fixing in the foreign currency: passive pricing records both requests, fails on
+        // exactly the foreign one, and the node stage answers with the validation token.
+        const auto market = withFixings(domesticOnly);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_FALSE(passive.succeeded_);
+        ASSERT_EQ(passive.requiredHistoricalFixings_.size(), 2);
+        ASSERT_EQ(passive.missingHistoricalFixings_.size(), 1);
+        ASSERT_EQ(passive.missingHistoricalFixings_[0].indexName_, foreignIndex);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS), "TRADE_VALIDATION_FAILED");
+    }
+    {
+        // Mirror: missing fixing in the domestic currency.
+        const auto market = withFixings(foreignOnly);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_FALSE(passive.succeeded_);
+        ASSERT_EQ(passive.missingHistoricalFixings_.size(), 1);
+        ASSERT_EQ(passive.missingHistoricalFixings_[0].indexName_, domesticIndex);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_FOR_OIS), "TRADE_VALIDATION_FAILED");
+    }
+    {
+        // Both fixings missing: accounting is fail-fast on the first missing request (name order),
+        // so exactly one entry is recorded before the validation throw.
+        const auto market = withFixings({});
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_FALSE(passive.succeeded_);
+        ASSERT_EQ(passive.requiredHistoricalFixings_.size(), 2);
+        ASSERT_EQ(passive.missingHistoricalFixings_.size(), 1);
+        AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS), "TRADE_VALIDATION_FAILED");
+    }
+    {
+        // Both supplied: the whole float legs are constants, so both forecast gradients are
+        // structurally zero while discounting and the basis stay live.
+        const auto market = withFixings(both);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_TRUE(passive.succeeded_);
+        ASSERT_EQ(passive.requiredHistoricalFixings_.size(), 2);
+        ASSERT_TRUE(passive.missingHistoricalFixings_.empty());
+        for (const auto& key : {XCCY_DOM_FWD_3M, XCCY_FOR_FWD_3M}) {
+            const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, key);
+            ASSERT_TRUE(sensitivity.eligible_) << key;
+            ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_) << key;
+            for (const double column : sensitivity.gradient_)
+                ASSERT_DOUBLE_EQ(column, 0.0) << key;
+        }
+        for (const auto& key : {XCCY_DOM_OIS, XCCY_FOR_OIS, XCCY_BASIS}) {
+            const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, key);
+            ASSERT_TRUE(sensitivity.eligible_) << key;
+            ASSERT_GT(std::abs(sensitivity.gradient_[0]), 1.0e-8) << key;
+        }
+    }
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADTriPartiteIsolation) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    // The last knot sits inside the accrual span so every column is live.
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15), Dal::Date_(2028, 10, 15)};
+    const auto shaped = [&](double forward, const Dal::String_& ccy) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("shaped", ccy, Dal::PiecewiseConstant_(knots, {forward, forward, forward})));
+    };
+    const auto noCurve = Dal::Handle_<Dal::DiscountCurve_>();
+    const auto assemble = [&](const Dal::Handle_<Dal::DiscountCurve_>& denseForeignOis, const Dal::Handle_<Dal::DiscountCurve_>& denseDomesticFwd) {
+        auto spec = FlatXccySpec(Dal::Date_(2031, 1, 15));
+        spec.domesticOis_ = shaped(0.03, "USD");
+        spec.domesticFwd3M_ = denseDomesticFwd ? denseDomesticFwd : shaped(0.032, "USD");
+        spec.foreignOis_ = denseForeignOis ? denseForeignOis : shaped(0.02, "EUR");
+        spec.foreignFwd3M_ = shaped(0.022, "EUR");
+        spec.basis_ = shaped(0.001, "USD");
+        return BuildXccyMarket(today, spec);
+    };
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+
+    {
+        // Each of the five consumed components reports exactly its own three columns — all live.
+        const auto market = assemble(noCurve, noCurve);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+        ASSERT_TRUE(passive.succeeded_);
+        for (const auto& key : {XCCY_DOM_OIS, XCCY_DOM_FWD_3M, XCCY_FOR_OIS, XCCY_FOR_FWD_3M, XCCY_BASIS}) {
+            const auto sensitivity = Dal::RateTradeNodeSensitivities(trade, market, key);
+            ASSERT_TRUE(sensitivity.eligible_) << key;
+            ASSERT_EQ(static_cast<int>(sensitivity.gradient_.size()), 3) << key;
+            ASSERT_DOUBLE_EQ(sensitivity.pv_, passive.pv_) << key;
+            for (int column = 0; column < 3; ++column)
+                ASSERT_GT(std::abs(sensitivity.gradient_[column]), 1.0e-8) << key << " column " << column;
+        }
+    }
+
+    // Dense non-target curves with the same flat forwards: the constant-typed rebuilds contribute
+    // their values only, so the target's PV and gradient do not scale with the passive node count.
+    Dal::Vector_<Dal::Date_> denseKnots;
+    for (Dal::Date_ knot = Dal::Date_(2026, 2, 15); knot <= Dal::Date_(2029, 12, 15); knot = knot.AddDays(30))
+        denseKnots.push_back(knot);
+    const auto dense = [&](double forward, const Dal::String_& ccy) {
+        return Dal::Handle_<Dal::DiscountCurve_>(
+            Dal::NewDiscountPWC("dense", ccy, Dal::PiecewiseConstant_(denseKnots, Dal::Vector_<>(denseKnots.size(), forward))));
+    };
+    const auto assertDenseNonTargetLeavesTargetUntouched = [&](const Dal::String_& key, const auto& flat, const auto& withDense) {
+        const auto small = Dal::RateTradeNodeSensitivities(trade, flat, key);
+        const auto large = Dal::RateTradeNodeSensitivities(trade, withDense, key);
+        ASSERT_TRUE(small.eligible_);
+        ASSERT_TRUE(large.eligible_);
+        ASSERT_EQ(small.gradient_.size(), large.gradient_.size());
+        ASSERT_NEAR(large.pv_, small.pv_, 1.0e-10 * std::max(1.0, std::abs(small.pv_)));
+        for (int column = 0; column < static_cast<int>(small.gradient_.size()); ++column)
+            ASSERT_NEAR(large.gradient_[column], small.gradient_[column], 1.0e-10 * std::max(1.0, std::abs(small.gradient_[column])))
+                << "column " << column;
+    };
+    assertDenseNonTargetLeavesTargetUntouched(XCCY_DOM_OIS, assemble(noCurve, noCurve), assemble(dense(0.02, "EUR"), noCurve));
+    assertDenseNonTargetLeavesTargetUntouched(XCCY_FOR_OIS, assemble(noCurve, noCurve), assemble(noCurve, dense(0.032, "USD")));
+}
+
+#if !defined(DAL_USE_XAD_AAD) && !defined(DAL_USE_CODIPACK_AAD) && !defined(DAL_USE_ADEPT_AAD)
+TEST(RateCashflowPricingTest, TestXccyNodeAADTapeSizeBoundedByPeriodsTimesKnots) {
+    // Frozen P0 contract 8 size bound: the kernel resolves one fixing per coupon period, so the
+    // recording scales with periods (and a per-knot curve-construction constant), never with the
+    // calendar-day count a daily-compounding loop would add. Measured on the native tape.
+    using Dal::AAD::Number_;
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 7, 15), Dal::Date_(2028, 7, 15), Dal::Date_(2029, 7, 15)};
+
+    const auto flatForward = [&](const Dal::String_& ccy, double forward) {
+        const auto definition =
+            Dal::MakeCurveDefinition("flat", ccy, Dal::CurveParameterization_(Dal::CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD),
+                                     Dal::LogDfScheme_::Value_::LOG_LINEAR, knots, today, Dal::DayBasis_("ACT_365F"));
+        Dal::Vector_<Number_> parameters(knots.size());
+        for (int i = 0; i < static_cast<int>(knots.size()); ++i)
+            parameters[i] = Number_(forward);
+        return Dal::BuildDiscountCurveUniqueT<Number_>(definition, parameters);
+    };
+
+    Dal::RateLegConvention_ quarterlyLeg;
+    quarterlyLeg.paymentFrequency_ = Dal::PeriodLength_("3M");
+    quarterlyLeg.dayBasis_ = Dal::DayBasis_("ACT_365F");
+    const auto configWithLeg = [&](const Dal::RateLegConvention_& leg) {
+        auto config = XccyTerms(true, true).config_;
+        config.convention_.domesticLeg_ = leg;
+        config.convention_.foreignLeg_ = leg;
+        return config;
+    };
+
+    // Mirrors the stage order: recording starts, then every consumed curve is rebuilt (per-knot
+    // constant) and the contract priced.
+    const auto measure = [&](const Dal::Date_& start, const Dal::Date_& maturity, const Dal::RateLegConvention_& leg) {
+        auto* tape = Dal::AAD::Tape();
+        Dal::AAD::Rewind(*tape);
+        Dal::AAD::NewRecording(*tape);
+        auto domesticOis = flatForward("USD", 0.03);
+        auto domesticFwd = flatForward("USD", 0.032);
+        auto foreignOis = flatForward("EUR", 0.02);
+        auto foreignFwd = flatForward("EUR", 0.022);
+        auto basis = flatForward("USD", 0.001);
+        Dal::Tape::JointCurveBlock_<Number_> domestic, foreign;
+        domestic.discountCurves[Dal::CollateralType_(Dal::CollateralType_::Value_::OIS)] = domesticOis.get();
+        domestic.forwardCurves[Dal::PeriodLength_("3M")] = domesticFwd.get();
+        foreign.discountCurves[Dal::CollateralType_(Dal::CollateralType_::Value_::OIS)] = foreignOis.get();
+        foreign.forwardCurves[Dal::PeriodLength_("3M")] = foreignFwd.get();
+        Dal::XccyMarketView_<Number_> view;
+        view.valuationTime_ = Dal::DateTime_(today, 10, 30);
+        view.pair_ = Dal::CurrencyPair_(Dal::Ccy_("USD"), Dal::Ccy_("EUR"));
+        view.collateralCurrency_ = Dal::Ccy_("USD");
+        view.fxSpot_ = Number_(1.2);
+        view.domestic_ = &domestic;
+        view.foreign_ = &foreign;
+        view.basis_ = basis.get();
+        const Dal::MarketFixingSnapshot_ empty;
+        const Number_ pv = Dal::PriceXccyContract(Dal::BuildXccyCashflowPlan(start, maturity, configWithLeg(leg)), view, empty, 0.001, true, true);
+        (void)Dal::AAD::Value(pv);
+        const int size = tape->nodes_.Size();
+        Dal::AAD::Rewind(*tape);
+        return size;
+    };
+
+    // Eight quarterly periods vs sixteen: linear in periods up to the fixed curve-construction cost.
+    const int sizeQuarterly = measure(Dal::Date_(2026, 4, 15), Dal::Date_(2028, 4, 15), quarterlyLeg);
+    const int sizeQuarterlyDoubled = measure(Dal::Date_(2026, 4, 15), Dal::Date_(2030, 4, 15), quarterlyLeg);
+    ASSERT_GT(sizeQuarterly, 0);
+    ASSERT_NEAR(sizeQuarterlyDoubled, 2 * sizeQuarterly, 0.25 * sizeQuarterly);
+
+    // Eight annual periods vs eight quarterly periods: the same period count over a four-times
+    // longer calendar span records a comparable amount — no per-day amplification.
+    const int sizeAnnual = measure(Dal::Date_(2026, 4, 15), Dal::Date_(2034, 4, 15), AnnualLeg());
+    ASSERT_GT(sizeAnnual, 0);
+    ASSERT_LE(sizeAnnual, 1.5 * sizeQuarterly);
+}
+#endif
 
 TEST(RateCashflowPricingTest, TestFraAndFutureNodeAADActivePvEqualsPassiveBitwiseBothSettlementModes) {
     const Dal::Date_ today(2026, 1, 15);

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -215,6 +215,7 @@ exposes the core `RateTradeDefinition_`, family-specific terms,
 
 ```cpp
 Dal::BuildRateCashflowPlan(trade, market.valuationTime_);
+Dal::BuildRateCashflowPlan(trade, market);
 Dal::PriceRateTrade(trade, market);
 Dal::PriceRateTrades(trades, market);
 Dal::RateTradeNodeSensitivities(trade, market, componentKey);
@@ -224,13 +225,21 @@ Dal::CurvePricingFamilyRegistry();
 The supported family enum is closed to `DEPOSIT`, `FRA`, `FUTURE`, `OIS`,
 `IRS`, `BASIS_SWAP`, and `XCCY`. Planning determines curve dependencies and
 required historical rate/FX fixing keys before valuation. Batch pricing retains
-a success/failure result per trade.
+a success/failure result per trade. Both plan overloads agree for the
+single-currency families; the market-aware form additionally emits the XCCY
+dependency keys of the curves the trade actually consumes (the
+collateral/tenor-selected domestic and foreign discount and forecast curves
+plus the basis curve), each addressed by pointer identity against
+`RatePricingMarket_::curveComponents_`.
 
-Native node AAD currently admits deposit, FRA, futures, OIS, IRS, and basis
-swap trades; for FRA, OIS, and IRS the requested component may be either
+Native node AAD currently admits deposit, FRA, futures, OIS, IRS, basis swap,
+and XCCY trades; for FRA, OIS, and IRS the requested component may be either
 dependency (forecast or discount), for futures the forecast dependency, for
-deposits the discount dependency, and for basis swaps any of the three
-dependencies (spread forecast, reference forecast, or discount). The first
+deposits the discount dependency, for basis swaps any of the three
+dependencies (spread forecast, reference forecast, or discount), and for XCCY
+any consumed curve registered under a component key. XCCY node risk ships
+rate axes only — the FX spot is a constant, not an AAD input — so consumers
+must not read it as complete XCCY risk. The first
 failing gate
 selects the reason in this order: family (`TRADE_FAMILY_NOT_AAD_ENABLED`),
 requested dependency (`TRADE_DOES_NOT_DEPEND_ON_COMPONENT`), component


### PR DESCRIPTION
Closes DAL-157
Closes #305

## Summary

- **XCCY opens in the AAD node-sensitivity registry** (`RateTradeNodeSensitivities`), completing the seven-family P0 success domain. The addressed component must be a curve the trade actually consumes — the collateral/tenor-selected domestic/foreign discount and forecast curves plus the basis curve — located in the `CrossCurrencyMarket_` blocks **by pointer identity** against `RatePricingMarket_::curveComponents_` (frozen design decision point 1).
- **Active-typed assembly per frozen P0 contract 8** (`Residuals<T_>` paradigm): the uniformly typed `XccyMarketView_<AAD::Number_>` is assembled with every consumed curve rebuilt as `AAD::Number_`; only the target component's parameters go through `RegisterCurveParameters`, the others stay constant-typed, and `fxSpot_` is an unregistered constant scalar — P0 ships rate axes only, no FX delta.
- **Dependency keys per frozen P0 follow-up 1**: a market-aware `BuildRateCashflowPlan(trade, market)` overload (existing `(trade, valuationTime)` signature unchanged) emits the XCCY dependency keys; `PriceRateTrade` now carries them in its result. "Depends on" means curves actually consumed, never block membership.
- **`PriceXccy` fixing accounting**: a missing historical fixing now flows through `requiredHistoricalFixings_` / `missingHistoricalFixings_` and fails validation on `TRADE_VALIDATION_FAILED` — no new token; the six-token set and priority are unchanged.
- Token semantics on the XCCY path: an unclassifiable curve keeps the representation token only when it is the **addressed** component; a consumed non-target curve that cannot be classified is `AAD_EVALUATION_FAILED` (assembly failure); an unused in-block member is never classified and has no effect.

## Test evidence

Exact commands and results (Release-linux, native AAD backend, GCC):

- `cmake --preset=Release-linux -S . -B build/Release-linux && cmake --build build/Release-linux -j32` — full workspace builds clean (library, both test binaries, all examples).
- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='RateCashflowPricingTest.*'` — **73/73 passed** (58 existing + 15 new XCCY tests).
- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='<17 curve/XCCY suites>*'` (Calibration, CurveBlock, CurveParameterization, JointCalibration, JointAnalyticJacobian, XccyMarket/Pricing/JointCalibration/JointJacobian/BasisJacobian, YCInstrument, ZeroRate, PTIRDSCurve, RateCashflowPricing) — **276/276 passed**.
- `./build/Release-linux/dal-cpp/dal_cpp_tests` (full core suite) — **1323/1323 passed**.
- `./build/Release-linux/dal-public/dal_public_tests` — **99/99 passed**.
- `clang-format --dry-run` clean on all touched files; `python3 .github/scripts/check_docs.py` passed (48 files).

New coverage: five-component central-difference batteries across all four curve representations (PWC/PWLF/LogDF/ZeroRate) for each of domOis/domFwd3M/forOis/forFwd3M/basis with bitwise active==passive PV and side-flip antisymmetry; multi-currency pairs (USD/EUR, EUR/JPY); GC-collateral routing; wrong keys, unregistered keys, unused-block-member (canonical failure, never eligible-with-all-zeros), in-block unclassifiable representations (unused / target / consumed non-target); before/after maturity; missing fixings in both currencies with accounting checks; tri-partite isolation with dense non-target invariance; and the contract-8 tape-size bound (linear in periods — 292→540 nodes for 8→16 periods — and calendar-span invariant, 8 annual periods cost 1.02× the 8 quarterly ones; native-backend guard per the test_tape.cpp precedent).

## Notes

- Consumers must not read P0 XCCY node risk as complete XCCY risk (no FX axis); documented in `docs/public-api.md` and CHANGELOG.
- Full compiler × AAD-backend matrix, coverage, and performance gates belong to CI on this PR.
