### PR TITLE
DAL-162: user-facing AAD node-risk examples (docs only)

### DIFF
--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -606,6 +606,73 @@ installed in the active environment, run it from the repository root:
 python dal-python/examples/007.xccy_joint_calibration.py
 ```
 
+## Rate Cashflow Pricing and Node Risk
+
+Typed rate trades price and produce AAD node sensitivities against a
+component-keyed market. Every pricing and sensitivity function is keyword-only,
+returns read-only results, and releases the GIL around native work. A complete
+deposit example, mirroring the fixtures in `tests/test_curve_pricing.py`:
+
+```python
+import dal
+
+today, maturity = dal.Date_(2026, 1, 15), dal.Date_(2027, 1, 15)
+
+# 1) Curve and market: curves are registered by component key; trade terms
+#    address them through their *_component_key fields.
+curve = dal.DiscountPWC_New("usd", "USD", [maturity], [0.04])
+market = dal.RatePricingMarket_(
+    valuation_time=dal.DateTime_(today, 10, 30),
+    result_currency="USD",
+    curve_components={"discount": curve, "forecast": curve},
+    fixings=dal.MarketFixingSnapshot_New({}),
+)
+
+# 2) Index convention, terms, and trade
+index = dal.RateIndexConvention_New(
+    dal.PeriodLength_New("3M"), dal.DayBasis_New("ACT_365F"), dal.CollateralType_OIS())
+terms = dal.DepositTradeTerms_(
+    notional=100.0, contract_rate=0.05, lend=True,
+    index=index, discount_component_key="discount")
+trade = dal.RateTradeDefinition_(
+    instrument_id="deposit-1", instrument_type=dal.RateInstrumentType.DEPOSIT,
+    trade_date=today, start_date=today, maturity_date=maturity,
+    currency="USD", terms=terms)
+
+# 3) Single-trade sensitivity (a deposit depends only on the discount component,
+#    so a "forecast" request returns reason="TRADE_DOES_NOT_DEPEND_ON_COMPONENT")
+r = dal.RateTradeNodeSensitivities(trade=trade, market=market, component_key="discount")
+assert r.eligible and len(r.gradient) == 1 and r.reason == ""
+
+# 4) Batch: component_keys must be a list — a tuple raises TypeError before any
+#    native work starts. Deterministic trade-major then key order.
+cells = dal.RateTradeNodeSensitivitiesBatch(
+    trades=[trade], market=market, component_keys=["discount", "forecast"])
+for c in cells:
+    print(c.instrument_id, c.component_key, c.result.eligible, c.result.reason)
+
+# 5) Portfolio aggregation
+agg = dal.AggregateRatePortfolioNodeRisk(
+    trades=[trade], market=market, component_keys=["discount"])
+print(agg.policy)                    # UnconvertedByActualPvCcy
+comp = agg.components[0]             # .component_key / .node_count / .node_dates /
+                                     # .node_components / .values
+print(dict(agg.pv_by_actual_pv_ccy)) # {'USD': ...}
+print(agg.meta[0].reason, agg.meta[0].actual_pv_ccy)
+```
+
+Failures never raise. A trade that fails passive pricing — for example
+`notional=float("nan")` — keeps `PriceRateTrades` field-level detail in
+`result[0].error`, while every sensitivity call returns the canonical read-only
+four-field result: `eligible=False`, `pv=0.0`, `gradient=[]`, and a stable
+`reason` token (`"TRADE_VALIDATION_FAILED"` here). In a batch, failed entries
+are isolated per (trade, component) cell; the remaining entries are unaffected.
+
+All seven families — deposit, FRA, future, OIS, IRS, basis swap, and XCCY —
+share this call pattern and differ only in their terms class. The per-family
+terms fields, the addressable components, and the C++ and Excel equivalents are
+in the [public API guide](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/blob/master/docs/public-api.md#c-rate-cashflow-pricing).
+
 ## Troubleshooting
 
 ### "Cannot find DAL::public" during build

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -610,20 +610,21 @@ and trade with their constructors, assemble the market, then spill the results.
 A minimal deposit sequence:
 
 ```text
-A1: =PERIODLENGTH.NEW("3M")
-B1: =DAYBASIS.NEW("ACT_365F")
-C1: =RATEINDEXCONVENTION.NEW(A1, B1, COLLATERALTYPE.OIS())
+C1: =RATEINDEXCONVENTION.NEW("3M", "ACT_365F", "OIS")
 D1: =RATETRADEHEADER.NEW("deposit-1", DATE(2026,1,15), DATE(2026,1,15), DATE(2027,1,15), "USD")
 E1: =RATEDEPOSITTRADE.NEW(D1, 100, 0.05, TRUE, C1, "discount")
-F1: =DISCOUNTPWLF.NEW("flat", "USD", DATE(2027,1,15), 0.04)
+F1: =DISCOUNTPWLF.NEW("flat-discount", "USD", DATE(2027,1,15), 0.04)
+F2: =DISCOUNTPWLF.NEW("flat-forecast", "USD", DATE(2027,1,15), 0.04)
 
-' component keys and curve handles are parallel arrays; the six optional
-' trailing market arguments (fixings, XCCY blocks, fxSpot, collateral
-' currency, basis curve) stay empty for a single-currency market
-G1: =RATEPRICINGMARKET.NEW(NOW(), "USD", {"discount","forecast"}, {F1,F1}, , , , , , )
+' the index convention's first three arguments are plain strings, not handles;
+' the component-key array and the curve-handle range must be equal-length
+' parallel arrays; the six optional trailing market arguments (fixings, XCCY
+' blocks, fxSpot, collateral currency, basis curve) stay empty for a
+' single-currency market
+G1: =RATEPRICINGMARKET.NEW(NOW(), "USD", {"discount","forecast"}, F1:F2, , , , , , )
 
-H1: =RATETRADENODESENSITIVITIESBATCH.SPILL({E1}, {"discount","forecast"}, G1)
-I1: =RATEPORTFOLIONODERISK.SPILL({E1}, {"discount"}, G1)
+H1: =RATETRADENODESENSITIVITIESBATCH.SPILL(E1, {"discount","forecast"}, G1)
+I1: =RATEPORTFOLIONODERISK.SPILL(E1, {"discount"}, G1)
 ```
 
 Both spill functions take `(trades, componentKeys, market)` and return long-form

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -296,6 +296,98 @@ fails carries no tensor; its failures live only in the meta table, and no paddin
 convention is introduced. `RateNodeSensitivityAxisLabels(market, componentKey)`
 exposes the same `<date>:<component>` node labels standalone.
 
+The wiring is name-based: terms address curves through their `*ComponentKey_`
+fields, those keys must resolve in `RatePricingMarket_::curveComponents_`, and
+the requested `componentKey` selects which curve's parameters are registered as
+AAD inputs. This deposit example is illustrative — it mirrors the fixtures in
+`dal-cpp/tests/curve/test_ratecashflowpricing.cpp`:
+
+```cpp
+#include <dal-public/src/curvedata.hpp>
+#include <dal-public/src/curvepricing.hpp>
+#include <iostream>
+
+namespace {
+    Dal::RateIndexConvention_ QuarterlyIndex() {
+        Dal::RateIndexConvention_ result;
+        result.forecastTenor_ = Dal::PeriodLength_("3M");
+        result.dayBasis_ = Dal::DayBasis_("ACT_365F");
+        result.collateral_ = Dal::CollateralType_("OIS");
+        return result;
+    }
+}
+
+int main() {
+    const Dal::Date_ today(2026, 1, 15), maturity(2027, 1, 15);
+
+    // Curve components are registered by name in the market.
+    Dal::RatePricingMarket_ market;
+    market.valuationTime_ = Dal::DateTime_(today, 10, 30);
+    market.resultCurrency_ = Dal::Ccy_("USD");
+    market.curveComponents_["discount"] = Dal::DiscountPWCNew("flat", "USD", {maturity}, {0.04});
+    market.curveComponents_["forecast"] = Dal::DiscountPWCNew("flat", "USD", {maturity}, {0.04});
+    market.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_());
+
+    Dal::DepositTradeTerms_ terms;
+    terms.notional_ = 100.0;
+    terms.contractRate_ = 0.05;
+    terms.lend_ = true;
+    terms.index_ = QuarterlyIndex();
+    terms.discountComponentKey_ = "discount";
+    const Dal::RateTradeDefinition_ trade{"deposit-1", Dal::RateInstrumentType_("DEPOSIT"),
+                                          today, today, maturity, Dal::Ccy_("USD"), terms};
+    const Dal::Vector_<Dal::RateTradeDefinition_> trades{trade};
+    const Dal::Vector_<Dal::String_> keys{"discount", "forecast"};
+
+    // Single trade: a deposit only depends on the discount component, so a
+    // "forecast" request returns TRADE_DOES_NOT_DEPEND_ON_COMPONENT.
+    const auto single = Dal::RateTradeNodeSensitivities(trade, market, "discount");
+    std::cout << "eligible=" << single.eligible_ << " pv=" << single.pv_
+              << " |grad|=" << single.gradient_.size() << " reason='" << single.reason_ << "'\n";
+
+    // Batch: shared key list, Cartesian product, trade-major then key order.
+    const auto cells = Dal::RateTradeNodeSensitivitiesBatch(trades, market, keys);
+    for (const auto& c : cells)
+        std::cout << c.instrumentId_ << " x " << c.componentKey_
+                  << " -> eligible=" << c.result_.eligible_
+                  << " reason='" << c.result_.reason_ << "'\n";
+
+    // Portfolio aggregation: dense tensor per component, PV by actual PV currency, meta table.
+    const auto agg = Dal::AggregateRatePortfolioNodeRisk(trades, market, keys);
+    std::cout << "policy=" << agg.policy_ << "\n";
+    for (const auto& comp : agg.components_)
+        std::cout << "component " << comp.componentKey_
+                  << " nodes=" << comp.values_->Size("node") << "\n";
+    for (const auto& [ccy, pv] : agg.pvByActualPvCcy_)
+        std::cout << "PV[" << ccy << "] = " << pv << "\n";
+
+    // Node labels, one per tensor row, "<date>:<component>".
+    const auto labels = Dal::RateNodeSensitivityAxisLabels(market, "discount");
+    return 0;
+}
+```
+
+`RateTradeNodeSensitivityResult_` is `{ eligible_, pv_, gradient_, reason_ }`;
+`RateTradeNodeSensitivityCell_` adds the `instrumentId_` / `componentKey_`
+addressing fields; `RatePortfolioNodeRiskMetaEntry_` rows carry
+`{ instrumentId_, componentKey_, eligible_, reason_, actualPvCcy_, pv_ }`.
+The other families differ only in their terms struct — Python names the same
+fields in snake_case:
+
+| Family  | Terms type                                                        | Fields beyond notional and the index convention                                                                            | Addressable components                              |
+|---------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| FRA     | `FraTradeTerms_`                                                  | `contractRate_`, `receiveFloating_`, `settleAtStart_`, `fixingIdentity_`                                                   | forecast or discount                                |
+| Future  | `FutureTradeTerms_`                                               | `contractCount_`, `long_`, `referencePrice_`, `contractValuePerPricePoint_`, `convexityAdjustment_`, `fixingIdentity_`     | forecast                                            |
+| OIS/IRS | `FixedFloatTradeTerms_` (via `OisTradeTerms_` / `IrsTradeTerms_`) | `contractRate_`, `payFixed_`, `fixedLeg_`, `floatLeg_`, `fixingIdentity_`                                                  | forecast or discount                                |
+| Basis   | `BasisTradeTerms_`                                                | `contractSpread_`, `receiveReferencePaySpread_`, `spreadFixingIdentity_`, `referenceFixingIdentity_`, both leg conventions | spread forecast, reference forecast, or discount    |
+| XCCY    | `XccyTradeTerms_`                                                 | `positionCount_`, `contractSpread_`, `spreadOnForeignLeg_`, `receiveNonSpreadPaySpread_`                                   | any consumed curve registered under a component key |
+
+Fixing treatment is common to all families: future fixings project (nonzero
+gradient), past fixings must be supplied in the snapshot (that period's gradient
+is structurally zero), and a past-but-missing fixing fails passive validation —
+`PriceRateTrades(...)[i].missingHistoricalFixings_` names the gap while the
+sensitivity returns the `TRADE_VALIDATION_FAILED` token.
+
 ## Python
 
 Import the installed package with:
@@ -422,10 +514,21 @@ bump requires division by the spec's `tolerance_`, as described in the
 ### Python rate cashflow pricing
 
 Python exports the seven-family enum, all family-specific terms classes,
-`RateTradeDefinition_`, `RatePricingMarket_`, `PriceRateTrades`, and
-`RateTradeNodeSensitivities`. The pricing and sensitivity functions use
-keyword-only arguments and release the GIL around native work. A complete
-deposit example is in `dal-python/tests/test_curve_pricing.py`.
+`RateTradeDefinition_`, `RatePricingMarket_`, `PriceRateTrades`,
+`RateTradeNodeSensitivities`, `RateTradeNodeSensitivitiesBatch`, and
+`AggregateRatePortfolioNodeRisk`. The pricing and sensitivity functions use
+keyword-only arguments and release the GIL around native work.
+`component_keys` must be a Python `list` — a tuple is rejected with `TypeError`
+before any native work starts. The minimal single-trade call:
+
+```python
+r = dal.RateTradeNodeSensitivities(trade=trade, market=market, component_key="discount")
+# r.eligible, r.pv, list(r.gradient), r.reason
+```
+
+Results are read-only projections of the C++ shapes. A complete runnable
+deposit example covering the batch and aggregation calls is in the
+[dal-python README](../dal-python/README.md#rate-cashflow-pricing-and-node-risk).
 
 `Storable_` exposes read-only `name` and `type` properties, and the native
 `YieldCurve_` / `CurveBlock_` / `Bag_` hierarchy is bound for archive
@@ -499,6 +602,40 @@ handles.
 `modelRates`, `residuals`, `jacobian`, `effJacobianInverse`,
 `parameterRanges`, or `residualRanges`. Joint settings can request both matrix
 computations independently.
+
+### Rate risk
+
+The rate-risk family is handle-based: build the index convention, trade header,
+and trade with their constructors, assemble the market, then spill the results.
+A minimal deposit sequence:
+
+```text
+A1: =PERIODLENGTH.NEW("3M")
+B1: =DAYBASIS.NEW("ACT_365F")
+C1: =RATEINDEXCONVENTION.NEW(A1, B1, COLLATERALTYPE.OIS())
+D1: =RATETRADEHEADER.NEW("deposit-1", DATE(2026,1,15), DATE(2026,1,15), DATE(2027,1,15), "USD")
+E1: =RATEDEPOSITTRADE.NEW(D1, 100, 0.05, TRUE, C1, "discount")
+F1: =DISCOUNTPWLF.NEW("flat", "USD", DATE(2027,1,15), 0.04)
+
+' component keys and curve handles are parallel arrays; the six optional
+' trailing market arguments (fixings, XCCY blocks, fxSpot, collateral
+' currency, basis curve) stay empty for a single-currency market
+G1: =RATEPRICINGMARKET.NEW(NOW(), "USD", {"discount","forecast"}, {F1,F1}, , , , , , )
+
+H1: =RATETRADENODESENSITIVITIESBATCH.SPILL({E1}, {"discount","forecast"}, G1)
+I1: =RATEPORTFOLIONODERISK.SPILL({E1}, {"discount"}, G1)
+```
+
+Both spill functions take `(trades, componentKeys, market)` and return long-form
+spills rather than node-gridded columns, since components can carry different
+node counts. `RATETRADENODESENSITIVITIESBATCH.SPILL` emits the six columns
+`trade, component, reason, pv, node, value` — one row per node of each eligible
+(trade, component) entry plus a reason row per failed entry.
+`RATEPORTFOLIONODERISK.SPILL` emits the same columns plus a trailing
+`currency`, with one aggregate row per actual PV currency. Only trades with
+past fixing dates need a fixing-snapshot handle, and XCCY additionally needs
+the domestic/foreign blocks and the basis curve.
+
 Generated function help under `dal-excel/auto/*.htm` is the argument-level
 catalog used by Excel registration.
 


### PR DESCRIPTION
Closes DAL-162

## Summary
- Add the user-facing runnable examples for AAD node risk (single trade, batch, portfolio aggregation) that previously existed only in test files
- `docs/public-api.md`:
  - C++ rate cashflow pricing section gains a complete deposit example (annotated illustrative — it mirrors the fixtures in `dal-cpp/tests/curve/test_ratecashflowpricing.cpp`) plus a per-family terms quick-reference table and the fixing-treatment rules
  - Excel section gains a "Rate risk" subsection with the handle-plus-spill worksheet sequence
  - Python section now names `RateTradeNodeSensitivitiesBatch` and `AggregateRatePortfolioNodeRisk` in the prose enumeration, states the list-only `component_keys` contract, and links the README example instead of pointing at a test file
- `dal-python/README.md`: new "Rate Cashflow Pricing and Node Risk" section with a complete runnable deposit example covering all three calls, the canonical failure shape, and a pointer to the per-family reference
- Placement follows existing repo structure: cross-language entry-point examples live in the public API guide, Python package examples in its README; no new `docs/examples/` directory is introduced

## Verification
- [x] Every field name, parameter order, and call signature checked against master (`642fa0ff`): `dal-cpp/dal/curve/ratecashflowpricing.hpp` structs, `dal-public/src/curvedata.hpp` facade, `dal-python` pybind11 bindings (`py::list` for `component_keys`), and the Machinist Excel stub registrations (`RATEPRICINGMARKET.NEW` 10-argument order, spill argument order and 6/7-column layout)
- [x] Three corrections applied to the supplied material during re-verification: `forecastTenor_` (not `tenor_`), facade `DiscountPWCNew`, and `Report_::Size("node")` instead of the nonexistent `rows(1)`
- [x] `python3 .github/scripts/check_docs.py` passes (48 files)
- [x] All new/edited relative links and anchors resolve; the Python example parses as valid Python

Docs-only change: no product code, tests, or generated stubs touched, so no build/test matrix applies.
