### PR TITLE
DAL-163: fix two doc nits from #313 review (RATEPRICINGMARKET trailing-args wording, XCCY config_ row)

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -380,7 +380,7 @@ fields in snake_case:
 | Future  | `FutureTradeTerms_`                                               | `contractCount_`, `long_`, `referencePrice_`, `contractValuePerPricePoint_`, `convexityAdjustment_`, `fixingIdentity_`     | forecast                                            |
 | OIS/IRS | `FixedFloatTradeTerms_` (via `OisTradeTerms_` / `IrsTradeTerms_`) | `contractRate_`, `payFixed_`, `fixedLeg_`, `floatLeg_`, `fixingIdentity_`                                                  | forecast or discount                                |
 | Basis   | `BasisTradeTerms_`                                                | `contractSpread_`, `receiveReferencePaySpread_`, `spreadFixingIdentity_`, `referenceFixingIdentity_`, both leg conventions | spread forecast, reference forecast, or discount    |
-| XCCY    | `XccyTradeTerms_`                                                 | `positionCount_`, `contractSpread_`, `spreadOnForeignLeg_`, `receiveNonSpreadPaySpread_`                                   | any consumed curve registered under a component key |
+| XCCY    | `XccyTradeTerms_`                                                 | `positionCount_`, `contractSpread_`, `spreadOnForeignLeg_`, `receiveNonSpreadPaySpread_`, `config_`                        | any consumed curve registered under a component key |
 
 Fixing treatment is common to all families: future fixings project (nonzero
 gradient), past fixings must be supplied in the snapshot (that period's gradient
@@ -618,9 +618,10 @@ F2: =DISCOUNTPWLF.NEW("flat-forecast", "USD", DATE(2027,1,15), 0.04)
 
 ' the index convention's first three arguments are plain strings, not handles;
 ' the component-key array and the curve-handle range must be equal-length
-' parallel arrays; the six optional trailing market arguments (fixings, XCCY
-' blocks, fxSpot, collateral currency, basis curve) stay empty for a
-' single-currency market
+' parallel arrays; the six trailing market arguments (fixings, domestic block,
+' foreign block, fxSpot, collateral currency, basis curve) stay empty for a
+' single-currency market, while an XCCY market requires both blocks, a positive
+' fxSpot, and a collateral currency
 G1: =RATEPRICINGMARKET.NEW(NOW(), "USD", {"discount","forecast"}, F1:F2, , , , , , )
 
 H1: =RATETRADENODESENSITIVITIESBATCH.SPILL(E1, {"discount","forecast"}, G1)


### PR DESCRIPTION
Closes DAL-163

## Summary
- Two bounded doc corrections in `docs/public-api.md` from the #313 review:
- **RATEPRICINGMARKET.NEW Excel comment**: the old text called all six trailing
  market arguments "optional" and collapsed the two XCCY curve-block parameters
  into "XCCY blocks". The comment now names the six trailing arguments
  (fixings, domestic block, foreign block, fxSpot, collateral currency, basis
  curve), notes they stay empty for a single-currency market, and states that an
  XCCY market requires both blocks, a positive fxSpot, and a collateral
  currency — matching the ten-argument stub
  (`dal-excel/auto/MG_RatePricingMarket_New_public.inc`) and the REQUIREs in
  `AddXccyMarket` (`dal-excel/src/__curvepricing.cpp`). The parallel-arrays
  REQUIRE at `__curvepricing.cpp:347` was re-verified unchanged.
- **Terms quick-reference table**: added the missing `config_` field to the
  `XccyTradeTerms_` row (`dal-cpp/dal/curve/ratecashflowpricing.hpp`), matching
  the field-name granularity of the other rows.
- Note: the issue text called the basis curve a hard XCCY requirement, but the
  code treats it as optional once the XCCY market exists (pricing falls back to
  a unit discount factor when no basis curve is set, `xccypricing.cpp`), so the
  requirement clause lists only the three enforced REQUIREs.

## Test plan
- [x] `python3 .github/scripts/check_docs.py` passes (48 Markdown files)
- [x] Docs-only change: no code, test, or stub files touched
