### PR TITLE
Harden AAD node-risk review follow-ups: XCCY token, isolation coverage, perf guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ here as the baseline rather than dated releases:
 
 ## 2026-08
 
+- `curve`: XCCY node-risk failure token corrected for unresolvable markets: when the
+  cross-currency market cannot be resolved (no `xccyMarket_`, or a block the config cannot
+  route), `RateTradeNodeSensitivities` now reports the passive-pricing failure as
+  `TRADE_VALIDATION_FAILED` instead of `TRADE_DOES_NOT_DEPEND_ON_COMPONENT`. Expired XCCY
+  trades are unaffected (they keep the dependency token). The `rate_risk_perf` benchmark
+  gains the contract-8 XCCY case (24 XCCY x 5 consumed components).
+
 - `curve`: batch and portfolio-aggregation node-risk APIs close out the seven-family AAD node
   risk feature. `RateTradeNodeSensitivitiesBatch(trades, market, componentKeys)` sweeps the
   Cartesian product of a trade list and one shared component key list serially and

--- a/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <memory>
 
 #include <dal/benchmarks/bench.hpp>
 #include <dal/curve/curveblock.hpp>

--- a/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
@@ -3,12 +3,19 @@
 //
 // Rate node-risk sweep benchmarks: the long-batch serial sweep (tape memory/latency
 // driver — one passive PV per trade, one preparation per component, one AAD sweep per
-// (trade, component) cell) and the OIS daily-compounding recording shape.
+// (trade, component) cell), the OIS daily-compounding recording shape, and the XCCY
+// active-typed assembly shape (frozen P0 contract 8).
+
+#include <algorithm>
+#include <cstdio>
 
 #include <dal/benchmarks/bench.hpp>
+#include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
 #include <dal/curve/ratecashflowpricing_internal.hpp>
+#include <dal/curve/xccycalibration.hpp>
+#include <dal/curve/xccyinstrument.hpp>
 #include <dal/indice/fixingsnapshot.hpp>
 #include <dal/platform/platform.hpp>
 #include <dal/protocol/rateconvention.hpp>
@@ -33,11 +40,11 @@ namespace {
         return result;
     }
 
-    Handle_<DiscountCurve_> KnottedCurve(const String_& name, const Date_& horizon, double flatForward) {
+    Handle_<DiscountCurve_> KnottedCurve(const String_& name, const Date_& horizon, double flatForward, const String_& ccy = "USD") {
         static const Vector_<Date_> knots{Date_(2026, 7, 15), Date_(2027, 1, 15), Date_(2028, 1, 15), Date_(2029, 1, 15),
                                           Date_(2030, 1, 15), Date_(2031, 1, 15), Date_(2032, 1, 15), Date_(2033, 1, 15)};
         (void)horizon;
-        return Handle_<DiscountCurve_>(NewDiscountPWC(name, "USD", PiecewiseConstant_(knots, Vector_<>(knots.size(), flatForward))));
+        return Handle_<DiscountCurve_>(NewDiscountPWC(name, ccy, PiecewiseConstant_(knots, Vector_<>(knots.size(), flatForward))));
     }
 
     RatePricingMarket_ Market(const Date_& today, const Date_& horizon) {
@@ -72,6 +79,71 @@ namespace {
 
     RateTradeDefinition_ OisTrade(const Date_& today, const Date_& start, const Date_& maturity) {
         return {"ois", RateInstrumentType_(RateInstrumentType_::Value_::OIS), today, start, maturity, Ccy_("USD"), OisTradeTerms_{FixedFloatTerms()}};
+    }
+
+    RateIndexConvention_ XccyIndex() {
+        RateIndexConvention_ result = QuarterlyIndex();
+        result.useProjectionCurve_ = true;
+        result.forecastTenor_ = PeriodLength_("3M");
+        return result;
+    }
+
+    XccyTradeTerms_ XccyTerms(bool receiveNonSpread) {
+        XccyTradeTerms_ result;
+        result.positionCount_ = 1.0;
+        result.contractSpread_ = 0.001;
+        result.spreadOnForeignLeg_ = true;
+        result.receiveNonSpreadPaySpread_ = receiveNonSpread;
+        result.config_.pair_ = CurrencyPair_(Ccy_("USD"), Ccy_("EUR"));
+        result.config_.domesticNotional_ = 1'000'000.0;
+        result.config_.foreignNotional_ = 900'000.0;
+        result.config_.convention_.domesticLeg_ = AnnualLeg();
+        result.config_.convention_.foreignLeg_ = AnnualLeg();
+        result.config_.convention_.domesticIndex_ = XccyIndex();
+        result.config_.convention_.foreignIndex_ = XccyIndex();
+        result.config_.convention_.spreadOnForeignLeg_ = true;
+        result.config_.domesticRateFixing_ = {"USD-INDEX", 11, 0};
+        result.config_.foreignRateFixing_ = {"EUR-INDEX", 11, 0};
+        return result;
+    }
+
+    // Pointer-identity contract: the block slots and the curveComponents_ entries share the same
+    // Handles, so every consumed curve is addressable under its key.
+    RatePricingMarket_ XccyMarket(const Date_& today, const Date_& horizon) {
+        const auto domesticOis = KnottedCurve("domOis", horizon, 0.03);
+        const auto domesticFwd = KnottedCurve("domFwd3M", horizon, 0.032);
+        const auto foreignOis = KnottedCurve("forOis", horizon, 0.02, "EUR");
+        const auto foreignFwd = KnottedCurve("forFwd3M", horizon, 0.022, "EUR");
+        const auto basis = KnottedCurve("basis", horizon, 0.001);
+        const auto domesticBlock = Handle_<CurveBlock_>(new CurveBlock_("domestic",
+                                                                        "USD",
+                                                                        {{CollateralType_(CollateralType_::Value_::OIS), domesticOis}},
+                                                                        {{PeriodLength_("3M"), domesticFwd}},
+                                                                        DayBasis::Act365F()));
+        const auto foreignBlock = Handle_<CurveBlock_>(new CurveBlock_("foreign",
+                                                                       "EUR",
+                                                                       {{CollateralType_(CollateralType_::Value_::OIS), foreignOis}},
+                                                                       {{PeriodLength_("3M"), foreignFwd}},
+                                                                       DayBasis::Act365F()));
+        const auto fixings = Handle_<MarketFixingSnapshot_>(new MarketFixingSnapshot_());
+        auto native = std::make_shared<CrossCurrencyMarket_>(domesticBlock, foreignBlock, 1.2, DateTime_(today, 10, 30), Ccy_("USD"), fixings);
+        native->SetBasisCurve(basis);
+
+        RatePricingMarket_ result;
+        result.valuationTime_ = DateTime_(today, 10, 30);
+        result.resultCurrency_ = Ccy_("USD");
+        result.xccyMarket_ = native;
+        result.fixings_ = fixings;
+        result.curveComponents_["domOis"] = domesticOis;
+        result.curveComponents_["domFwd3M"] = domesticFwd;
+        result.curveComponents_["forOis"] = foreignOis;
+        result.curveComponents_["forFwd3M"] = foreignFwd;
+        result.curveComponents_["basis"] = basis;
+        return result;
+    }
+
+    RateTradeDefinition_ XccyTrade(const Date_& today, const Date_& start, const Date_& maturity, bool receiveNonSpread) {
+        return {"xccy", RateInstrumentType_(RateInstrumentType_::Value_::XCCY), today, start, maturity, Ccy_("USD"), XccyTerms(receiveNonSpread)};
     }
 } // namespace
 
@@ -144,5 +216,29 @@ int main() {
         std::fprintf(stderr, "OIS daily sweep native tape nodes: %d (eligible=%d)\n", tapeNodes, static_cast<int>(sensitivity.eligible_));
     }
 #endif
+
+    {
+        // The XCCY shape of frozen P0 contract 8: every consumed curve is rebuilt active-typed on
+        // each (trade, component) sweep and only the addressed component is registered, so the
+        // per-sweep tape is bounded by periods x knots touched. 24 trades x 5 consumed components
+        // = 120 serial sweeps; this is the regression-gate guard for that bound.
+        const Date_ xccyMaturity(2031, 4, 15);
+        const auto xccyMarket = XccyMarket(today, xccyMaturity);
+        const Vector_<String_> xccyKeys{"domOis", "domFwd3M", "forOis", "forFwd3M", "basis"};
+        Vector_<RateTradeDefinition_> xccyTrades;
+        xccyTrades.reserve(24);
+        for (int index = 0; index < 24; ++index)
+            xccyTrades.push_back(XccyTrade(today, start, xccyMaturity, index % 2 == 0));
+        const auto probe = RateTradeNodeSensitivitiesBatch(xccyTrades, xccyMarket, xccyKeys);
+        const int eligible = static_cast<int>(std::count_if(probe.begin(), probe.end(), [](const auto& cell) { return cell.result_.eligible_; }));
+        std::fprintf(stderr, "XCCY batch eligible cells: %d/%d\n", eligible, static_cast<int>(probe.size()));
+        double sink = 0.0;
+        const auto result = Bench::Run("Rate XCCY batch serial (24 XCCY x 5 components)", [&]() {
+            const auto cells = RateTradeNodeSensitivitiesBatch(xccyTrades, xccyMarket, xccyKeys);
+            sink += cells.front().result_.pv_ + cells.back().result_.pv_;
+        });
+        Bench::Print(result);
+        Bench::DoNotOptimize(&sink);
+    }
     return 0;
 }

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -861,6 +861,16 @@ namespace Dal {
             RateTradeNodeSensitivityResult_ SweepXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, const String_& componentKey) {
                 using namespace RateCashflowPricingInternal;
                 const XccyNodeSensitivityHoist_& hoist = HoistXccy(trade, terms);
+                if (!hoist.consumed_.resolved_) {
+                    // Unresolvable market structure (no XCCY market, or a block the config cannot
+                    // route): no key is addressable, but the honest token is the failure passive
+                    // pricing produces -- not "trade does not depend on component". An expired
+                    // trade prices to zero without touching the XCCY market, so it keeps the
+                    // dependency token.
+                    if (!PassiveOk(trade))
+                        return NodeSensitivityFailure("TRADE_VALIDATION_FAILED");
+                    return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+                }
                 if (std::find(hoist.dependencyKeys_.begin(), hoist.dependencyKeys_.end(), componentKey) == hoist.dependencyKeys_.end())
                     return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
                 REQUIRE(market_.xccyMarket_, "XCCY node sensitivity requires an immutable cross-currency market");

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -93,7 +93,7 @@ namespace Dal::RateCashflowPricingInternal {
             TapeGuard_ guard(AAD::Tape());
             NodeSensitivityCandidate_ candidate = std::forward<Runner_>(runner)();
 #if DAL_RATE_RISK_NATIVE_AAD
-            if (int* sink = g_nodeSensitivityTapeSizeSink.load())
+            if (int* sink = g_nodeSensitivityTapeSizeSink.load(std::memory_order_relaxed))
                 *sink = AAD::Tape()->nodes_.Size();
 #endif
             return FinalizeNodeSensitivityCandidate(std::move(candidate), expectedParameterCount);

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cmath>
 #include <exception>
 #include <utility>
@@ -28,13 +29,16 @@ namespace Dal::RateCashflowPricingInternal {
     // native tape's live node count here (measured after propagation, before the TapeGuard_ rewind).
     // An unregistered-constant AAD::Number_ passive curve still yields correct values and gradient
     // width, so only this direct count distinguishes it from a truly passive double curve.
-    inline int* g_nodeSensitivityTapeSizeSink = nullptr;
+    // Atomic because library code reads it on every sweep; P0 is serial, but callers may sweep
+    // concurrently on separate threads.
+    inline std::atomic<int*> g_nodeSensitivityTapeSizeSink{nullptr};
 #endif
 
     // Test instrumentation for the sweep engine shared by the single-trade and batch entry points:
-    // the hoisted per-trade passive prices and per-curve preparations actually performed.
-    inline int g_nodeSensitivityPassivePriceCount = 0;
-    inline int g_nodeSensitivityPreparationCount = 0;
+    // the hoisted per-trade passive prices and per-curve preparations actually performed. Atomic
+    // for the same concurrent-caller reason.
+    inline std::atomic<int> g_nodeSensitivityPassivePriceCount{0};
+    inline std::atomic<int> g_nodeSensitivityPreparationCount{0};
 
     using NodeSensitivityCurve_ = std::variant<std::monostate,
                                                const Tape::DiscountPWC_<double>*,
@@ -89,8 +93,8 @@ namespace Dal::RateCashflowPricingInternal {
             TapeGuard_ guard(AAD::Tape());
             NodeSensitivityCandidate_ candidate = std::forward<Runner_>(runner)();
 #if DAL_RATE_RISK_NATIVE_AAD
-            if (g_nodeSensitivityTapeSizeSink)
-                *g_nodeSensitivityTapeSizeSink = AAD::Tape()->nodes_.Size();
+            if (int* sink = g_nodeSensitivityTapeSizeSink.load())
+                *sink = AAD::Tape()->nodes_.Size();
 #endif
             return FinalizeNodeSensitivityCandidate(std::move(candidate), expectedParameterCount);
         } catch (const std::exception&) {

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -3239,3 +3239,99 @@ TEST(RateCashflowPricingTest, TestXccyNodeAADUnresolvableMarketFailsAsValidation
     AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(expired, noXccyMarket, XCCY_DOM_OIS), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
 }
 
+TEST(RateCashflowPricingTest, TestIrsNodeAADBaseCurveIsolationOnLayeredCurves) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const Dal::Vector_<> overlayParameters{0.005, 0.01, 0.015};
+    const auto base = FlatCurve(maturity, 0.02);
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("overlay", "USD", Dal::PiecewiseConstant_(knots, parameters), base));
+    };
+    const auto trade = Trade(Dal::RateInstrumentType_("IRS"), today, start, maturity, AsFamilyTerms(Dal::RateInstrumentType_("IRS"), FixedFloatTerms()));
+
+    for (const char* componentKey : {"forecast", "discount"}) {
+        const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& layered) {
+            return Dal::String_(componentKey) == "forecast" ? ComponentMarket(today, layered, FlatCurve(maturity, 0.03))
+                                                            : ComponentMarket(today, FlatCurve(maturity, 0.035), layered);
+        };
+        const auto market = assembleMarket(buildCurve(overlayParameters));
+        const auto aad = Dal::RateTradeNodeSensitivities(trade, market, componentKey);
+        const auto passive = Dal::PriceRateTrade(trade, market);
+
+        ASSERT_TRUE(passive.succeeded_);
+        ASSERT_TRUE(aad.eligible_);
+        ASSERT_EQ(static_cast<int>(aad.gradient_.size()), 3);
+        // The overlay is the active layer: bitwise identical PV, nonzero gradient on every overlay
+        // node, while the double base stays passive and out of the tape.
+        ASSERT_DOUBLE_EQ(aad.pv_, passive.pv_);
+        for (const double column : aad.gradient_)
+            ASSERT_NE(column, 0.0);
+
+        constexpr double bump = 1.0e-6;
+        for (int column = 0; column < 3; ++column) {
+            auto plusParameters = overlayParameters;
+            auto minusParameters = overlayParameters;
+            plusParameters[column] += bump;
+            minusParameters[column] -= bump;
+            const auto plus = Dal::PriceRateTrade(trade, assembleMarket(buildCurve(plusParameters)));
+            const auto minus = Dal::PriceRateTrade(trade, assembleMarket(buildCurve(minusParameters)));
+            ASSERT_TRUE(plus.succeeded_);
+            ASSERT_TRUE(minus.succeeded_);
+            const double finiteDifference = (plus.pv_ - minus.pv_) / (2.0 * bump);
+            const double tolerance = 1.0e-6 + 1.0e-7 * std::max(std::abs(aad.gradient_[column]), std::abs(finiteDifference));
+            ASSERT_NEAR(aad.gradient_[column], finiteDifference, tolerance) << componentKey << " overlay column " << column;
+        }
+    }
+}
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADBaseCurveIsolationOnLayeredCurve) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto horizon = Dal::Date_(2031, 1, 15);
+    const Dal::Vector_<Dal::Date_> knots{Dal::Date_(2026, 7, 15), Dal::Date_(2027, 1, 15), Dal::Date_(2028, 1, 15)};
+    const Dal::Vector_<> overlayParameters{0.005, 0.01, 0.015};
+    const auto base = FlatCurve(horizon, 0.025, "USD");
+    const auto buildCurve = [&](const Dal::Vector_<>& parameters) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("overlay", "USD", Dal::PiecewiseConstant_(knots, parameters), base));
+    };
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+    const auto assembleMarket = [&](const Dal::Handle_<Dal::DiscountCurve_>& layered) {
+        auto spec = FlatXccySpec(horizon);
+        spec.domesticFwd3M_ = layered;
+        return BuildXccyMarket(today, spec);
+    };
+    const auto market = assembleMarket(buildCurve(overlayParameters));
+    const auto aad = Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_FWD_3M);
+    const auto passive = Dal::PriceRateTrade(trade, market);
+
+    ASSERT_TRUE(passive.succeeded_);
+    ASSERT_TRUE(aad.eligible_);
+    ASSERT_EQ(static_cast<int>(aad.gradient_.size()), 3);
+    ASSERT_DOUBLE_EQ(aad.pv_, passive.pv_);
+    for (const double column : aad.gradient_)
+        ASSERT_NE(column, 0.0);
+
+    constexpr double bump = 1.0e-6;
+    for (int column = 0; column < 3; ++column) {
+        auto plusParameters = overlayParameters;
+        auto minusParameters = overlayParameters;
+        plusParameters[column] += bump;
+        minusParameters[column] -= bump;
+        const auto plus = Dal::PriceRateTrade(trade, assembleMarket(buildCurve(plusParameters)));
+        const auto minus = Dal::PriceRateTrade(trade, assembleMarket(buildCurve(minusParameters)));
+        ASSERT_TRUE(plus.succeeded_);
+        ASSERT_TRUE(minus.succeeded_);
+        const double finiteDifference = (plus.pv_ - minus.pv_) / (2.0 * bump);
+        const double tolerance = 1.0e-6 + 1.0e-7 * std::max(std::abs(aad.gradient_[column]), std::abs(finiteDifference));
+        ASSERT_NEAR(aad.gradient_[column], finiteDifference, tolerance) << "xccy overlay column " << column;
+    }
+
+    // The other consumed components keep their own live gradients against the same layered market.
+    const auto domOis = Dal::RateTradeNodeSensitivities(trade, market, XCCY_DOM_OIS);
+    ASSERT_TRUE(domOis.eligible_);
+    ASSERT_DOUBLE_EQ(domOis.pv_, passive.pv_);
+    ASSERT_GT(std::abs(domOis.gradient_[0]), 1.0e-8);
+}

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -967,11 +967,13 @@ TEST(RateCashflowPricingTest, TestRegistryTracksAadEnabledFamiliesAndLockedOnesS
               (Dal::Vector_<Dal::String_>{"forecast", "reference", "discount"}));
     for (const auto& key : {"forecast", "reference", "discount"})
         ASSERT_TRUE(Dal::RateTradeNodeSensitivities(basisTrade, market, key).eligible_);
-    // XCCY is open in the registry; that market carries no cross-currency market, so no component
-    // can be addressed and the dependency gate — not the family gate — answers.
+    // XCCY is open in the registry; that market carries no cross-currency market, so passive
+    // pricing fails and the validation gate — not the family gate — answers (an expired XCCY
+    // trade would keep the dependency token).
     AssertCanonicalFailure(
-        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("XCCY"), today, today, maturity, Dal::XccyTradeTerms_{}), market, "forecast"),
-        "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+        Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms())), market,
+                                        "forecast"),
+        "TRADE_VALIDATION_FAILED");
 
     AssertCanonicalFailure(
         Dal::RateTradeNodeSensitivities(Trade(Dal::RateInstrumentType_("FUTURE"), today, start, maturity, Dal::RateTradeTerms_(FraTerms())), market,
@@ -3216,3 +3218,24 @@ TEST(RateCashflowPricingTest, TestAggregatePortfolioNodeRiskCountsDuplicateKeysO
         ASSERT_DOUBLE_EQ((*duplicated.components_[0].values_)[duplicatedAddress], (*single.components_[0].values_)[singleAddress]);
     }
 }
+
+TEST(RateCashflowPricingTest, TestXccyNodeAADUnresolvableMarketFailsAsValidation) {
+    const Dal::Date_ today(2026, 1, 15);
+    const Dal::Date_ start(2026, 10, 15);
+    const Dal::Date_ maturity(2029, 1, 15);
+    const auto trade = Trade(Dal::RateInstrumentType_("XCCY"), today, start, maturity, Dal::RateTradeTerms_(XccyTerms()));
+
+    // No XCCY market at all: nothing is addressable, and the honest token is the passive
+    // validation failure -- not "trade does not depend on component".
+    auto noXccyMarket = FlatXccyMarket(today);
+    noXccyMarket.xccyMarket_.reset();
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, noXccyMarket, XCCY_DOM_OIS), "TRADE_VALIDATION_FAILED");
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(trade, noXccyMarket, "unknown"), "TRADE_VALIDATION_FAILED");
+
+    // An expired trade has no market dependency: passive pricing returns zero before touching the
+    // XCCY market, so the request stays on the dependency token even without a resolvable market.
+    const auto expired =
+        Trade(Dal::RateInstrumentType_("XCCY"), today, today.AddDays(-400), today.AddDays(-5), Dal::RateTradeTerms_(XccyTerms()));
+    AssertCanonicalFailure(Dal::RateTradeNodeSensitivities(expired, noXccyMarket, XCCY_DOM_OIS), "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+}
+

--- a/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
+++ b/docs/experimental/aad-node-risk-portfolio-aggregation-design.md
@@ -123,8 +123,13 @@ design:
   in `dal-cpp/dal/curve/ratecashflowpricing.cpp` hardcodes Deposit. The six-gate
   pipeline, the closed set of six failure tokens, and their priority order are
   fixed in `dal-cpp/dal/curve/ratecashflowpricing_internal.hpp` and documented in
-  `docs/public-api.md`. The failure shape is `eligible_=false / pv_=0 / empty
-  gradient_ / non-empty reason_`.
+  `docs/public-api.md`. (Post-implementation note: the gate pipeline now lives in
+  the `NodeSensitivitySweeper_` sweep engine in `ratecashflowpricing.cpp`;
+  `ratecashflowpricing_internal.hpp` keeps the family registry, the finalizer,
+  and the stage runner. For the single-currency families the availability and
+  representation gates walk every dependency key in dependency order, and the
+  first failing key decides the token.) The failure shape is `eligible_=false /
+  pv_=0 / empty gradient_ / non-empty reason_`.
 - The Deposit AAD pricing formula is **hand-copied** inside the stage lambda and
   exists in parallel with the passive `Price` Deposit branch. This is the direct
   motivation for "kernel templatization first": without removing the fork, every new

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -266,7 +266,12 @@ the token: `CURVE_REPRESENTATION_NOT_AAD_ENABLED` when it is the addressed
 component, `AAD_EVALUATION_FAILED` for any other consumed curve (that token stays
 a failure of the addressed representation). This walk runs before passive trade
 validation, so a consumed non-target curve that cannot be classified reports
-`AAD_EVALUATION_FAILED` even when passive pricing would also fail.
+`AAD_EVALUATION_FAILED` even when passive pricing would also fail. When the XCCY
+market itself cannot be resolved — no `xccyMarket_`, or a block the config cannot
+route — no component key is addressable and the request reports the passive
+pricing failure as `TRADE_VALIDATION_FAILED` instead of
+`TRADE_DOES_NOT_DEPEND_ON_COMPONENT` (an expired trade prices to zero without
+touching the XCCY market and keeps the dependency token).
 
 `RateTradeNodeSensitivitiesBatch(trades, market, componentKeys)` applies one
 shared component key list to every trade (Cartesian product), serially and in a

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -251,7 +251,11 @@ availability (`CURVE_COMPONENT_UNAVAILABLE`), curve representation
 (`TRADE_VALIDATION_FAILED`), then AAD evaluation (`AAD_EVALUATION_FAILED`).
 `TRADE_VALIDATION_FAILED` is the stable token for a supported trade that
 fails passive pricing validation; field-level detail remains available through
-`PriceRateTrade.error_`.
+`PriceRateTrade.error_`. For the single-currency families the availability and
+representation gates walk every component the trade depends on, in dependency
+order, and the first failing key decides the token — a passive (non-target)
+dependency that is unavailable or not AAD-representable fails the cell even
+when the addressed component itself is healthy.
 
 Every node-sensitivity failure uses the canonical four-field result:
 `eligible_ == false`, `pv_ == 0.0`, an empty `gradient_`, and a non-empty stable


### PR DESCRIPTION
## Summary

Review follow-ups for the seven-family AAD node-risk and portfolio-aggregation feature (design/plan: `docs/experimental/aad-node-risk-portfolio-aggregation-design.md` / `-plan.md`). No functional defects were found in the staged implementation; this PR closes the gaps the review identified between the frozen P0 contracts and the landed guards:

- **XCCY failure-token correction**: an XCCY node-sensitivity request against an unresolvable market (no `xccyMarket_`, or a block the config cannot route) previously reported `TRADE_DOES_NOT_DEPEND_ON_COMPONENT` for every key, masking the market-structure error. It now reports the passive-pricing failure as `TRADE_VALIDATION_FAILED`. The six-token closed set and its priority are unchanged; expired XCCY trades keep the dependency token (they price to zero without touching the market). Recorded in CHANGELOG and `docs/public-api.md`.
- **Layered-base isolation coverage**: the acceptance criteria ask every family with a layered curve to carry a base-curve isolation case, but only FRA had one. Added IRS (forecast and discount overlays) and XCCY (consumed forward overlay) cases asserting the active-overlay gradient against central bumps, bitwise `active == passive` PV, with the double base staying passive.
- **`rate_risk_perf` XCCY case**: frozen P0 contract 8 states the XCCY tape bound "is guarded by the `rate_risk_perf` XCCY case", which did not exist. Added a 24-trade × 5-component XCCY batch (`Rate XCCY batch serial (24 XCCY x 5 components)`, ~1.2 ms locally, 120/120 cells eligible) plus a one-time eligibility probe on stderr so the regression gate cannot silently time all-failure sweeps. The binary is already in the paired regression-gate subset.
- **Atomic test instrumentation**: the tape-size sink and hoisting counters in `ratecashflowpricing_internal.hpp` are written inside library code paths; made them `std::atomic` so concurrent caller threads cannot race on them (benign values, but formally UB before).
- **Docs alignment**: `docs/public-api.md` now states that for single-currency families the availability/representation gates walk every dependency key in dependency order (first failing key decides the token), and the design doc notes the gate pipeline's post-implementation location (`NodeSensitivitySweeper_` in `ratecashflowpricing.cpp`).

## Test plan

- [x] New tests red-then-green: `TestXccyNodeAADUnresolvableMarketFailsAsValidation` failed before the token fix, passes after; layered-base cases pin the existing isolation mechanism
- [x] Full `dal_cpp_tests` (Windows Release, native AAD): 1336/1336 passed, including 86 `RateCashflowPricingTest` cases
- [x] `dal_public_tests` 100/100, `dal_excel_tests` 24/24 passed
- [x] `rate_risk_perf` rebuilt with `DAL_CPP_BUILD_BENCHMARKS=ON` and run: all four cases produce output, XCCY probe reports 120/120 eligible
- [x] `python .github/scripts/check_docs.py` passes (48 files)
- [ ] Python binding tests not run locally (extension not built in this environment) — covered by CI; no binding code changed
- [ ] XAD/Adept/CoDiPack backend legs — covered by the PR full matrix; the atomic instrumentation change is backend-agnostic and the tape-size sink remains native-only