### PR TITLE
ci: speed up pull request validation

### DIFF
--- a/.github/scripts/classify_ci_changes.py
+++ b/.github/scripts/classify_ci_changes.py
@@ -1,0 +1,82 @@
+"""Classify a Git diff for the lightweight documentation CI path."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess  # nosec B404 -- fixed, repository-owned git command only
+import sys
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCUMENTATION_SUFFIXES = frozenset({".md", ".mdx", ".rst"})
+DOCUMENTATION_ROOT_FILES = frozenset({"LICENSE", "NOTICE"})
+
+
+def _is_documentation(path_text: str) -> bool:
+    path = PurePosixPath(path_text)
+    if path.is_absolute() or ".." in path.parts:
+        return False
+    return (
+        path.parts[:1] == ("docs",)
+        or path.suffix.lower() in DOCUMENTATION_SUFFIXES
+        or path.as_posix() in DOCUMENTATION_ROOT_FILES
+    )
+
+
+def docs_only(paths: Sequence[str]) -> bool:
+    """Return whether every changed path is documentation-only."""
+    return bool(paths) and all(_is_documentation(path) for path in paths)
+
+
+def changed_paths(base: str, head: str) -> tuple[str, ...]:
+    """Return NUL-safe changed paths between two repository revisions."""
+    if base and set(base) == {"0"}:
+        return ()
+    completed = subprocess.run(  # nosec B603  # nosemgrep
+        (
+            "git",
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            base,
+            head,
+            "--",
+        ),
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return tuple(
+        path.decode("utf-8", errors="surrogateescape")
+        for path in completed.stdout.split(b"\0")
+        if path
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--github-output", type=Path, required=True)
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> None:
+    options = _parser().parse_args(arguments)
+    try:
+        classification = docs_only(changed_paths(options.base, options.head))
+    except subprocess.CalledProcessError as error:
+        print(
+            f"git diff failed with exit code {error.returncode}; running full CI",
+            file=sys.stderr,
+        )
+        classification = False
+    with options.github_output.open("a", encoding="utf-8") as output:
+        output.write(f"docs_only={str(classification).lower()}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_classify_ci_changes.py
+++ b/.github/scripts/tests/test_classify_ci_changes.py
@@ -1,0 +1,217 @@
+"""Tests for the CI change classifier and workflow fast-path contract."""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "classify_ci_changes.py"
+SPEC = importlib.util.spec_from_file_location("classify_ci_changes", SCRIPT)
+CLASSIFIER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CLASSIFIER)
+
+
+class ClassifyCiChangesTest(unittest.TestCase):
+    def test_markdown_and_document_assets_are_docs_only(self):
+        self.assertTrue(
+            CLASSIFIER.docs_only(
+                (
+                    "README.md",
+                    "CHANGELOG.md",
+                    "docs/introduction.md",
+                    "docs/images/runtime.svg",
+                    "examples/README.md",
+                    "LICENSE",
+                    "NOTICE",
+                )
+            )
+        )
+
+    def test_source_or_configuration_change_requires_full_ci(self):
+        for paths in (
+            ("docs/introduction.md", "dal-cpp/dal/math/matrix/matrix.cpp"),
+            (".github/workflows/cmake-linux.yml",),
+            ("CMakeLists.txt",),
+            (".codex/agents/dal-tester.toml",),
+        ):
+            with self.subTest(paths=paths):
+                self.assertFalse(CLASSIFIER.docs_only(paths))
+
+    def test_empty_or_noncanonical_change_set_requires_full_ci(self):
+        for paths in ((), ("../README.md",), ("docs/../CMakeLists.txt",)):
+            with self.subTest(paths=paths):
+                self.assertFalse(CLASSIFIER.docs_only(paths))
+
+    @mock.patch.object(CLASSIFIER.subprocess, "run")
+    def test_changed_paths_uses_nul_safe_fail_closed_git_diff(self, run):
+        run.return_value = mock.Mock(stdout=b"src/lib.cpp\0docs/lib.md\0")
+
+        self.assertEqual(
+            CLASSIFIER.changed_paths("base", "head"),
+            ("src/lib.cpp", "docs/lib.md"),
+        )
+        run.assert_called_once_with(
+            (
+                "git",
+                "diff",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                "base",
+                "head",
+                "--",
+            ),
+            cwd=CLASSIFIER.ROOT,
+            check=True,
+            capture_output=True,
+        )
+
+    @mock.patch.object(CLASSIFIER.subprocess, "run")
+    def test_zero_push_base_requires_full_ci(self, run):
+        self.assertEqual(CLASSIFIER.changed_paths("0" * 40, "head"), ())
+        run.assert_not_called()
+
+    @mock.patch.object(CLASSIFIER, "changed_paths")
+    def test_main_appends_lowercase_github_output(self, changed_paths):
+        changed_paths.return_value = ("docs/introduction.md",)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "github-output"
+
+            CLASSIFIER.main(
+                (
+                    "--base",
+                    "base",
+                    "--head",
+                    "head",
+                    "--github-output",
+                    str(output),
+                )
+            )
+
+            self.assertEqual(output.read_text(encoding="utf-8"), "docs_only=true\n")
+
+    @mock.patch.object(CLASSIFIER, "changed_paths")
+    def test_diff_failure_falls_back_to_full_ci(self, changed_paths):
+        changed_paths.side_effect = CLASSIFIER.subprocess.CalledProcessError(
+            128, ("git", "diff")
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "github-output"
+
+            CLASSIFIER.main(
+                (
+                    "--base",
+                    "missing-base",
+                    "--head",
+                    "head",
+                    "--github-output",
+                    str(output),
+                )
+            )
+
+            self.assertEqual(output.read_text(encoding="utf-8"), "docs_only=false\n")
+
+
+class CiWorkflowFastPathTest(unittest.TestCase):
+    ROOT = Path(__file__).resolve().parents[3]
+
+    @staticmethod
+    def job(workflow, job_id):
+        marker = f"  {job_id}:\n"
+        start = workflow.index(marker) + len(marker)
+        remainder = workflow[start:]
+        next_job = remainder.find("\n  ")
+        while next_job >= 0:
+            candidate = remainder[next_job + 3 :].split("\n", 1)[0]
+            if candidate.endswith(":") and " " not in candidate:
+                return remainder[:next_job]
+            next_job = remainder.find("\n  ", next_job + 3)
+        return remainder
+
+    def workflow(self, name):
+        return (self.ROOT / ".github" / "workflows" / name).read_text(
+            encoding="utf-8"
+        )
+
+    def test_workflows_classify_with_full_history(self):
+        for name in ("cmake-linux.yml", "cmake-windows.yml"):
+            with self.subTest(name=name):
+                workflow = self.workflow(name)
+                self.assertIn(
+                    "on:\n  pull_request:\n  push:\n    branches:\n      - master\n",
+                    workflow,
+                )
+                changes = self.job(workflow, "changes")
+                self.assertIn("name: Classify changes", changes)
+                self.assertIn("fetch-depth: 0", changes)
+                self.assertIn("classify_ci_changes.py", changes)
+                self.assertIn(
+                    "docs_only: ${{ steps.classify.outputs.docs_only }}", changes
+                )
+
+    def test_release_workflow_excludes_component_documentation(self):
+        workflow = self.workflow("dal-python-release.yml")
+        positive_paths = ("dal-python/**", "dal-cpp/**", "dal-public/**")
+        for positive in positive_paths:
+            with self.subTest(positive=positive):
+                self.assertIn(f"      - {positive}\n", workflow)
+                positive_offset = workflow.index(f"      - {positive}\n")
+                for suffix in ("md", "mdx", "rst"):
+                    negative = f"      - '!{positive}/*.{suffix}'\n"
+                    self.assertIn(negative, workflow)
+                    self.assertGreater(workflow.index(negative), positive_offset)
+
+    def test_linux_fast_path_preserves_docs_and_stable_gate(self):
+        workflow = self.workflow("cmake-linux.yml")
+        heavy_jobs = (
+            "define-matrix",
+            "build",
+            "codipack-thread-isolation",
+            "build-extended",
+            "warning-clean",
+            "sanitizers",
+            "benchmark",
+        )
+        for job_id in heavy_jobs:
+            with self.subTest(job_id=job_id):
+                job = self.job(workflow, job_id)
+                self.assertIn("changes", job)
+                self.assertIn("needs.changes.outputs.docs_only != 'true'", job)
+
+        documentation = self.job(workflow, "documentation")
+        self.assertIn("needs: changes", documentation)
+        self.assertNotIn("needs.changes.outputs.docs_only", documentation)
+
+        gate = self.job(workflow, "linux-gate")
+        self.assertIn("name: Linux CI gate", gate)
+        self.assertIn("if: always()", gate)
+        self.assertIn('test "$CHANGES_RESULT" = success', gate)
+        self.assertIn('test "$DOCS_RESULT" = success', gate)
+        self.assertIn('if [ "$DOCS_ONLY" = true ]; then', gate)
+        for job_id in heavy_jobs:
+            with self.subTest(gate_dependency=job_id):
+                self.assertIn(f"needs.{job_id}.result", gate)
+
+    def test_windows_fast_path_preserves_stable_gate(self):
+        workflow = self.workflow("cmake-windows.yml")
+        heavy_jobs = ("build", "build-script", "benchmark")
+        for job_id in heavy_jobs:
+            with self.subTest(job_id=job_id):
+                job = self.job(workflow, job_id)
+                self.assertIn("needs: changes", job)
+                self.assertIn("needs.changes.outputs.docs_only != 'true'", job)
+
+        gate = self.job(workflow, "windows-gate")
+        self.assertIn("name: Windows CI gate", gate)
+        self.assertIn("if: always()", gate)
+        self.assertIn('test "$CHANGES_RESULT" = success', gate)
+        self.assertIn('if [ "$DOCS_ONLY" = true ]; then', gate)
+        for job_id in heavy_jobs:
+            with self.subTest(gate_dependency=job_id):
+                self.assertIn(f"needs.{job_id}.result", gate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,5 +1,9 @@
 name: CMake Linux CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 # Per-ref grouping: a new push cancels stale runs of the same ref only --
 # distinct PRs (refs/pull/N/merge) never cancel each other.
@@ -8,9 +12,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python3 .github/scripts/classify_ci_changes.py
+          --base "$BASE_SHA" --head "$HEAD_SHA"
+          --github-output "$GITHUB_OUTPUT"
+
   # The matrix is generated rather than declared inline for two reasons:
   #
-  # 1. Push events (master merges, direct branch pushes) run a lean subset --
+  # 1. Push events (master merges or direct master pushes) run a lean subset --
   #    gcc-14 and clang-20 across all four AAD backends (8 legs) -- because
   #    pull requests already ran the full 6 x 4 matrix before merge. Pull
   #    requests still get every compiler x backend combination.
@@ -19,6 +43,8 @@ jobs:
   #    tested; the dropped legs only repeated gcov-instrumented builds whose
   #    lcov output nobody read.
   define-matrix:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
@@ -70,7 +96,10 @@ jobs:
     # Explicit name keeps the historical "build (<compiler>, <backend>)"
     # check names stable for branch protection and log searching.
     name: build (${{ matrix.compiler }}, ${{ matrix.aad-backend }})
-    needs: define-matrix
+    needs:
+      - changes
+      - define-matrix
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -191,6 +220,8 @@ jobs:
 
   codipack-thread-isolation:
     name: CoDiPack thread isolation
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     env:
       CC: gcc-14
@@ -234,6 +265,8 @@ jobs:
   # lean — the Python bindings are backend-agnostic, so testing them
   # against one representative configuration is sufficient.
   build-extended:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     env:
       CMAKE_C_COMPILER_LAUNCHER: ccache
@@ -285,6 +318,7 @@ jobs:
 
   documentation:
     name: Documentation integrity
+    needs: changes
     runs-on: ubuntu-latest
 
     steps:
@@ -296,6 +330,8 @@ jobs:
 
   warning-clean:
     name: Warning-clean GCC build
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     env:
       CMAKE_C_COMPILER_LAUNCHER: ccache
@@ -345,6 +381,8 @@ jobs:
 
   sanitizers:
     name: ${{ matrix.label }}
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     env:
       CMAKE_C_COMPILER_LAUNCHER: ccache
@@ -431,6 +469,8 @@ jobs:
   # interleaves repeated runs so host noise affects both sides comparably.
   benchmark:
     name: Benchmarks
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     # No ccache here: this job builds with -march=native, and cached objects
     # restored on a different runner CPU generation crash with SIGILL.
@@ -558,3 +598,47 @@ jobs:
             --samples 10 \
             --confirmation-rounds 2 \
             --threshold-percent 4
+
+  linux-gate:
+    name: Linux CI gate
+    if: always()
+    needs:
+      - changes
+      - documentation
+      - define-matrix
+      - build
+      - codipack-thread-isolation
+      - build-extended
+      - warning-clean
+      - sanitizers
+      - benchmark
+    runs-on: ubuntu-latest
+    env:
+      DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+      CHANGES_RESULT: ${{ needs.changes.result }}
+      DOCS_RESULT: ${{ needs.documentation.result }}
+      MATRIX_RESULT: ${{ needs.define-matrix.result }}
+      BUILD_RESULT: ${{ needs.build.result }}
+      CODIPACK_RESULT: ${{ needs.codipack-thread-isolation.result }}
+      EXTENDED_RESULT: ${{ needs.build-extended.result }}
+      WARNING_RESULT: ${{ needs.warning-clean.result }}
+      SANITIZER_RESULT: ${{ needs.sanitizers.result }}
+      BENCHMARK_RESULT: ${{ needs.benchmark.result }}
+    steps:
+      - name: Require the selected CI path to pass
+        run: |
+          test "$CHANGES_RESULT" = success
+          test "$DOCS_RESULT" = success
+          if [ "$DOCS_ONLY" = true ]; then
+            exit 0
+          fi
+          for result in \
+            "$MATRIX_RESULT" \
+            "$BUILD_RESULT" \
+            "$CODIPACK_RESULT" \
+            "$EXTENDED_RESULT" \
+            "$WARNING_RESULT" \
+            "$SANITIZER_RESULT" \
+            "$BENCHMARK_RESULT"; do
+            test "$result" = success
+          done

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,5 +1,9 @@
 name: CMake Windows CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 # Per-ref grouping: a new push cancels stale runs of the same ref only --
 # distinct PRs (refs/pull/N/merge) never cancel each other.
@@ -8,7 +12,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python3 .github/scripts/classify_ci_changes.py
+          --base "$BASE_SHA" --head "$HEAD_SHA"
+          --github-output "$GITHUB_OUTPUT"
+
   build:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     env:
       CMAKE_C_COMPILER_LAUNCHER: ccache
@@ -189,6 +215,8 @@ jobs:
   # remains the proven direct-cmake path for compilation and tests.
   build-script:
     name: build_windows.bat (configure-only)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
 
     steps:
@@ -205,6 +233,8 @@ jobs:
   # Results appear in the CI logs and job summary; timings are not a pass/fail gate.
   benchmark:
     name: Benchmarks
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     # No ccache here: this job builds with -march=native, and cached objects
     # restored on a different runner CPU generation crash with SIGILL.
@@ -320,3 +350,29 @@ jobs:
           done
 
           exit "$benchmark_failure"
+
+  windows-gate:
+    name: Windows CI gate
+    if: always()
+    needs:
+      - changes
+      - build
+      - build-script
+      - benchmark
+    runs-on: ubuntu-latest
+    env:
+      DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+      CHANGES_RESULT: ${{ needs.changes.result }}
+      BUILD_RESULT: ${{ needs.build.result }}
+      BUILD_SCRIPT_RESULT: ${{ needs.build-script.result }}
+      BENCHMARK_RESULT: ${{ needs.benchmark.result }}
+    steps:
+      - name: Require the selected CI path to pass
+        run: |
+          test "$CHANGES_RESULT" = success
+          if [ "$DOCS_ONLY" = true ]; then
+            exit 0
+          fi
+          test "$BUILD_RESULT" = success
+          test "$BUILD_SCRIPT_RESULT" = success
+          test "$BENCHMARK_RESULT" = success

--- a/.github/workflows/dal-python-release.yml
+++ b/.github/workflows/dal-python-release.yml
@@ -12,10 +12,19 @@ on:
       - .github/scripts/tests/test_python_syntax.py
       - .github/workflows/dal-python-release.yml
       - dal-python/**
+      - '!dal-python/**/*.md'
+      - '!dal-python/**/*.mdx'
+      - '!dal-python/**/*.rst'
       - CMakeLists.txt
       - CMakePresets.json
       - dal-cpp/**
+      - '!dal-cpp/**/*.md'
+      - '!dal-cpp/**/*.mdx'
+      - '!dal-cpp/**/*.rst'
       - dal-public/**
+      - '!dal-public/**/*.md'
+      - '!dal-public/**/*.mdx'
+      - '!dal-public/**/*.rst'
   push:
     tags:
       - dal-python-v*

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ A C++17 quantitative finance library with built-in Automatic Adjoint Differentia
 
 ## CI
 
-Pull requests build and test the full compiler × AAD-backend matrix below.
-Pushes (master merges and direct branch pushes) run a lean GCC 14 + Clang 20
-subset across all four backends, because the pull request already covered
-every combination. GitHub publishes one status badge per workflow; open a
-workflow run for per-job results.
+Pull requests with source, configuration, or build changes build and test the
+full compiler × AAD-backend matrix below. Documentation-only changes run the
+documentation integrity check and stable Linux/Windows gates without starting
+the compile, sanitizer, or benchmark jobs. Pushes to `master` (merges and direct
+master pushes) run a lean GCC 14 + Clang 20 subset across all four backends,
+because the pull request already covered every combination. GitHub publishes
+one status badge per workflow; open a workflow run for per-job results.
 
 | Platform                   | Compiler | AADet | XAD | CoDiPack | Adept |
 |----------------------------|----------|-------|-----|----------|-------|

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -162,11 +162,12 @@ The repository release workflow builds and tests this wheel matrix:
 
 Every release artifact is a CPython-specific native wheel. Python/ABI tags run
 from `cp39-cp39` through `cp313-cp313`; DAL does not publish `abi3` or universal
-wheels. Pull requests build the floor and ceiling (`cp39` and `cp313`) on both
-platforms, for four wheels. Manual and release-tag runs build all five supported
-interpreters on both platforms, for ten wheels. Every wheel runs the complete
-installed-wheel Python suite, and the two `cp39` wheels also run a fresh,
-source-independent installed-wheel smoke test.
+wheels. Path-matched pull requests build the floor and ceiling (`cp39` and
+`cp313`) on both platforms, for four wheels; documentation-only component
+changes remain on the lightweight documentation CI path. Manual and release-tag
+runs build all five supported interpreters on both platforms, for ten wheels.
+Every wheel runs the complete installed-wheel Python suite, and the two `cp39`
+wheels also run a fresh, source-independent installed-wheel smoke test.
 
 Linux filenames always include `manylinux_2_28_x86_64` and may also contain
 unique compatible PEP 600 x86-64 components for glibc baselines no newer than


### PR DESCRIPTION
## Summary
- add a fail-closed documentation-only classifier and stable Linux/Windows aggregate gates
- skip expensive compile, sanitizer, benchmark, and wheel jobs for documentation-only changes
- run feature-branch validation only through pull requests while retaining post-merge `master` checks
- document the current CI paths and lock them down with workflow contract tests

## Test plan
- [x] `python3 -m unittest discover -s .github/scripts/tests -v` (121 passed, 6 Windows-only skipped)
- [x] `python3 .github/scripts/check_docs.py` (48 Markdown files)
- [x] `actionlint v1.7.12` on all three changed workflows
- [x] historical documentation/source commits classify as `docs_only=true` / `false`
- [x] no C++ build locally because production C++ sources are unchanged; the remote full workflow validates the exact PR head
