### PR TITLE
feat: add single-curve quote risk aggregation

### DIFF
--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -297,6 +297,7 @@ namespace Dal {
             bool calibrateDiscountCurve_;
             DayBasis_ liborBasis_;
             CurveJacobianMode_ jacobianMode_;
+            double bumpSize_;
             AnalyticEligibility_ analyticEligibility_ = AnalyticEligibility_::Value_::UNKNOWN;
 
         public:
@@ -314,12 +315,13 @@ namespace Dal {
                                        bool calibrateDiscountCurve,
                                        const DayBasis_& liborBasis,
                                        LogDfScheme_ logDfScheme,
-                                       CurveJacobianMode_ jacobianMode)
+                                       CurveJacobianMode_ jacobianMode,
+                                       CurveSolveMode_ solveMode)
                 : ccy_(ccy), curveName_(curveName), anchor_(anchor),
                   definition_(MakeCurveDefinition(curveName, ccy, parameterization, logDfScheme, knotDates, anchor, liborBasis)),
                   instruments_(instruments), discountCurves_(discountCurves), forwardCurves_(forwardCurves), baseCurve_(baseCurve),
                   targetCollateral_(targetCollateral), targetTenor_(targetTenor), calibrateDiscountCurve_(calibrateDiscountCurve),
-                  liborBasis_(liborBasis), jacobianMode_(jacobianMode) {
+                  liborBasis_(liborBasis), jacobianMode_(jacobianMode), bumpSize_(solveMode == CurveSolveMode_::Value_::EXACT ? 1.0e-6 : 1.0e-4) {
                 Handle_<YieldCurve_> fundingYC;
                 if (!discountCurves_.empty())
                     fundingYC.reset(new CurveBlock_(curveName_, ccy_, discountCurves_, forwardCurves_, liborBasis_));
@@ -334,7 +336,8 @@ namespace Dal {
                         EligibleForAnalyticJacobian() ? AnalyticEligibility_::Value_::ELIGIBLE : AnalyticEligibility_::Value_::INELIGIBLE;
             }
 
-            [[nodiscard]] double BumpSize() const override { return 1.0e-6; }
+            // Exact quote-risk diagnostics need the oracle bump; approximate solves retain their historical linearization.
+            [[nodiscard]] double BumpSize() const override { return bumpSize_; }
 
             [[nodiscard]] Vector_<> F(const Vector_<>& x) const override {
                 Handle_<DiscountCurve_> dc(BuildDiscountCurveUniqueT<double>(definition_, x, baseCurve_).release());
@@ -669,7 +672,7 @@ namespace Dal {
 
         YieldCurveCalibrationFunc_ func(spec.ccy_, spec.curveName_, spec.today_, spec.parameterization_, instruments, knotDates, spec.discountCurves_,
                                         spec.forwardCurves_, spec.baseCurve_, spec.targetCollateral_, spec.targetTenor_, spec.calibrateDiscountCurve_,
-                                        spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_);
+                                        spec.liborBasis_, spec.logDfScheme_, options.jacobianMode_, spec.solveMode_);
 
         // Forward Jacobian requested only for ANALYTIC + EXACT + eligible; nullptr otherwise so the solver leaves the output empty.
         const bool wantFwdJacobian = options.computeForwardJacobian_ && options.jacobianMode_ == CurveJacobianMode_::Value_::ANALYTIC &&

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -199,10 +199,10 @@ namespace Dal {
             result->counts_.instrumentCandidates_ = static_cast<int>(instruments.size()) * MAX_RELEVANT_DATES_PER_INSTRUMENT;
             for (int i = 0; i < static_cast<int>(instruments.size()); ++i) {
                 const auto span = instruments[i]->TimeSpan();
-                VisitKnotCandidate(result, traversalIndex, today, span.first,
-                                   InstrumentOrigin(CurveKnotOriginKind_::Value_::INSTRUMENT_START, i), true);
-                VisitKnotCandidate(result, traversalIndex, today, span.second,
-                                   InstrumentOrigin(CurveKnotOriginKind_::Value_::INSTRUMENT_END, i), true);
+                VisitKnotCandidate(result, traversalIndex, today, span.first, InstrumentOrigin(CurveKnotOriginKind_::Value_::INSTRUMENT_START, i),
+                                   true);
+                VisitKnotCandidate(result, traversalIndex, today, span.second, InstrumentOrigin(CurveKnotOriginKind_::Value_::INSTRUMENT_END, i),
+                                   true);
             }
         }
 
@@ -225,8 +225,7 @@ namespace Dal {
             if (parameterization != CurveParameterization_::Value_::LOG_DISCOUNT)
                 return;
             REQUIRE(resolvedDates.front() == today &&
-                        std::any_of(result.resolvedDeclaredNodes_.front().origins_.begin(),
-                                    result.resolvedDeclaredNodes_.front().origins_.end(),
+                        std::any_of(result.resolvedDeclaredNodes_.front().origins_.begin(), result.resolvedDeclaredNodes_.front().origins_.end(),
                                     [](const CurveKnotOrigin_& origin) { return origin.kind_ == CurveKnotOriginKind_::Value_::INPUT; }),
                     "LOG_DISCOUNT knot planning requires an input anchor at today");
         }
@@ -334,6 +333,8 @@ namespace Dal {
                     analyticEligibility_ =
                         EligibleForAnalyticJacobian() ? AnalyticEligibility_::Value_::ELIGIBLE : AnalyticEligibility_::Value_::INELIGIBLE;
             }
+
+            [[nodiscard]] double BumpSize() const override { return 1.0e-6; }
 
             [[nodiscard]] Vector_<> F(const Vector_<>& x) const override {
                 Handle_<DiscountCurve_> dc(BuildDiscountCurveUniqueT<double>(definition_, x, baseCurve_).release());

--- a/dal-cpp/dal/curve/quoteriskaggregation.hpp
+++ b/dal-cpp/dal/curve/quoteriskaggregation.hpp
@@ -1,0 +1,56 @@
+//
+// Created by dal-implementer on 2026/9/1.
+//
+
+#pragma once
+
+#include <map>
+
+#include <dal/curve/quoteriskprovenance.hpp>
+#include <dal/curve/ratecashflowpricing.hpp>
+
+namespace Dal {
+    struct RateQuoteRiskBucket_ {
+        String_ calibrationId_;
+        String_ axisFingerprint_;
+        String_ quoteKey_;
+        String_ quoteName_;
+        String_ residualBlock_;
+        int quoteOrdinal_ = 0;
+        Ccy_ actualPvCcy_;
+        double dPvDDecimalQuote_ = 0.0;
+        double dv01_ = 0.0;
+    };
+
+    struct RatePortfolioQuoteRiskMetaEntry_ {
+        String_ instrumentId_;
+        String_ calibrationId_;
+        bool eligible_ = false;
+        bool structuralZero_ = false;
+        String_ reason_;
+        String_ failingComponentKey_;
+        String_ originalNodeRiskReason_;
+        Ccy_ actualPvCcy_;
+        double pv_ = 0.0;
+    };
+
+    struct RateQuoteRiskProvenanceFailure_ {
+        String_ calibrationId_;
+        String_ reason_;
+        String_ componentKey_;
+        String_ expectedStateFingerprint_;
+        String_ actualStateFingerprint_;
+    };
+
+    struct RatePortfolioQuoteRisk_ {
+        String_ policy_ = "UnconvertedByActualPvCcy";
+        Vector_<RateQuoteRiskBucket_> buckets_;
+        std::map<String_, double> pvByActualPvCcy_;
+        Vector_<RatePortfolioQuoteRiskMetaEntry_> meta_;
+        Vector_<RateQuoteRiskProvenanceFailure_> provenanceFailures_;
+    };
+
+    RatePortfolioQuoteRisk_ AggregateRatePortfolioQuoteRisk(const Vector_<RateTradeDefinition_>& trades,
+                                                            const RatePricingMarket_& market,
+                                                            const Vector_<RateQuoteRiskProvenance_>& provenances);
+} // namespace Dal

--- a/dal-cpp/dal/curve/quoteriskprovenance.cpp
+++ b/dal-cpp/dal/curve/quoteriskprovenance.cpp
@@ -23,6 +23,7 @@
 #include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveparameterization.hpp>
 #include <dal/curve/quoteriskprovenance.hpp>
+#include <dal/curve/quoteriskprovenance_internal.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
 #include <dal/curve/ycconst.hpp>
 #include <dal/curve/yclogdf.hpp>
@@ -1208,7 +1209,9 @@ namespace Dal {
             const auto* typed = dynamic_cast<const Tape::DiscountZeroRate_<double>*>(&curve);
             REQUIRE(typed, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
             REQUIRE(typed->AnchorDate() == definition.anchorDate_, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
-            REQUIRE(typed->NodeDates() == definition.nodeDates_, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
+            REQUIRE(!definition.nodeDates_.empty() && definition.nodeDates_.front() == definition.anchorDate_, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
+            const Vector_<Date_> futureNodes(definition.nodeDates_.begin() + 1, definition.nodeDates_.end());
+            REQUIRE(typed->NodeDates() == futureNodes, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
             REQUIRE(typed->Scheme() == definition.logDfScheme_, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
             REQUIRE(typed->DayCount() == definition.dayCount_, "QUOTE_RISK_SPEC_RESULT_MISMATCH");
             ValidateExpectedBase(*typed, expectedBase);
@@ -1915,6 +1918,13 @@ namespace Dal {
     const String_& RateQuoteRiskStateFingerprintScheme() {
         static const String_ result("dal.quote-risk-state/1+jcs+sha256");
         return result;
+    }
+
+    RateQuoteRiskComponentState_ CurrentRateQuoteRiskComponentState(const String_& componentKey, const RatePricingMarket_& market) {
+        const auto found = market.curveComponents_.find(componentKey);
+        if (found == market.curveComponents_.end() || !found->second)
+            return {componentKey, String_()};
+        return ComponentState(componentKey, *found->second, market);
     }
 
     RateQuoteRiskProvenance_ BuildSingleCurveQuoteRiskProvenance(const CurveCalibrationSpec_& spec,

--- a/dal-cpp/dal/curve/quoteriskprovenance_internal.hpp
+++ b/dal-cpp/dal/curve/quoteriskprovenance_internal.hpp
@@ -1,0 +1,13 @@
+//
+// Created by dal-implementer on 2026/9/1.
+//
+
+#pragma once
+
+#include <dal/curve/quoteriskprovenance.hpp>
+
+namespace Dal {
+    struct RatePricingMarket_;
+
+    RateQuoteRiskComponentState_ CurrentRateQuoteRiskComponentState(const String_& componentKey, const RatePricingMarket_& market);
+} // namespace Dal

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -1199,16 +1199,22 @@ namespace Dal {
             return prepared;
         }
 
+        Vector_<>& EnsureQuoteRiskGradient(int provenanceIndex,
+                                           const String_& currency,
+                                           int parameterCount,
+                                           std::map<std::pair<int, String_>, Vector_<>>* sums) {
+            auto [found, inserted] = sums->try_emplace({provenanceIndex, currency});
+            if (inserted)
+                found->second = Vector_<>(parameterCount, 0.0);
+            REQUIRE(static_cast<int>(found->second.size()) == parameterCount, "QUOTE_RISK_GRADIENT_WIDTH_MISMATCH");
+            return found->second;
+        }
+
         void AddQuoteRiskGradient(int provenanceIndex,
                                   const String_& currency,
                                   const Vector_<>& gradient,
                                   std::map<std::pair<int, String_>, Vector_<>>* sums) {
-            Vector_<>& sum = (*sums)[{provenanceIndex, currency}];
-            if (sum.empty()) {
-                sum.Resize(gradient.size());
-                std::fill(sum.begin(), sum.end(), 0.0);
-            }
-            REQUIRE(sum.size() == gradient.size(), "QUOTE_RISK_GRADIENT_WIDTH_MISMATCH");
+            Vector_<>& sum = EnsureQuoteRiskGradient(provenanceIndex, currency, static_cast<int>(gradient.size()), sums);
             for (int i = 0; i < static_cast<int>(gradient.size()); ++i) {
                 REQUIRE(std::isfinite(gradient[i]), "QUOTE_RISK_NON_FINITE_GRADIENT");
                 sum[i] += gradient[i];
@@ -1283,7 +1289,7 @@ namespace Dal {
             }
             if (std::find(passive.dependencyComponentKeys_.begin(), passive.dependencyComponentKeys_.end(), item.componentKey_) ==
                 passive.dependencyComponentKeys_.end()) {
-                AddQuoteRiskGradient(item.index_, actualPvCcy.String(), Vector_<>(item.parameterCount_, 0.0), gradientSums);
+                static_cast<void>(EnsureQuoteRiskGradient(item.index_, actualPvCcy.String(), item.parameterCount_, gradientSums));
                 AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, true, true, String_(), result);
                 return;
             }
@@ -1297,6 +1303,19 @@ namespace Dal {
             AppendQuoteRiskMeta(trade, item, actualPvCcy, cell.pv_, true, false, String_(), result);
         }
 
+        void ProcessPricedQuoteRiskTrade(const RateTradeDefinition_& trade,
+                                         const RatePricingTradeResult_& passive,
+                                         const Vector_<PreparedQuoteRiskProvenance_>& prepared,
+                                         NodeSensitivitySweeper_* sweeper,
+                                         std::map<std::pair<int, String_>, Vector_<>>* gradientSums,
+                                         RatePortfolioQuoteRisk_* result) {
+            const Ccy_ actualPvCcy = ActualPvCurrency(trade);
+            if (UsablePassivePrice(passive))
+                result->pvByActualPvCcy_[actualPvCcy.String()] += passive.pv_;
+            for (const auto& item : prepared)
+                ProcessQuoteRiskTradeProvenance(trade, passive, item, actualPvCcy, sweeper, gradientSums, result);
+        }
+
         void ProcessQuoteRiskTrade(const RateTradeDefinition_& trade,
                                    bool hasActiveProvenance,
                                    const Vector_<PreparedQuoteRiskProvenance_>& prepared,
@@ -1304,12 +1323,11 @@ namespace Dal {
                                    NodeSensitivitySweeper_* sweeper,
                                    std::map<std::pair<int, String_>, Vector_<>>* gradientSums,
                                    RatePortfolioQuoteRisk_* result) {
-            const RatePricingTradeResult_ passive = hasActiveProvenance ? sweeper->PassivePrice(trade) : PriceRateTrade(trade, market);
-            const Ccy_ actualPvCcy = ActualPvCurrency(trade);
-            if (UsablePassivePrice(passive))
-                result->pvByActualPvCcy_[actualPvCcy.String()] += passive.pv_;
-            for (const auto& item : prepared)
-                ProcessQuoteRiskTradeProvenance(trade, passive, item, actualPvCcy, sweeper, gradientSums, result);
+            if (hasActiveProvenance) {
+                ProcessPricedQuoteRiskTrade(trade, sweeper->PassivePrice(trade), prepared, sweeper, gradientSums, result);
+                return;
+            }
+            ProcessPricedQuoteRiskTrade(trade, PriceRateTrade(trade, market), prepared, sweeper, gradientSums, result);
         }
 
         void AppendAllQuoteRiskBuckets(const Vector_<PreparedQuoteRiskProvenance_>& prepared,

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -14,6 +14,8 @@
 #include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveparameterization.hpp>
 #include <dal/curve/jointrate.hpp>
+#include <dal/curve/quoteriskaggregation.hpp>
+#include <dal/curve/quoteriskprovenance_internal.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
 #include <dal/curve/ratecashflowpricing_internal.hpp>
 #include <dal/curve/xccypricing.hpp>
@@ -21,6 +23,7 @@
 #include <dal/curve/yclogdf.hpp>
 #include <dal/curve/ycpwlf.hpp>
 #include <dal/curve/yczerorate.hpp>
+#include <dal/math/matrix/matrixarithmetic.hpp>
 #include <dal/time/dateincrement.hpp>
 
 namespace Dal {
@@ -733,6 +736,14 @@ namespace Dal {
                 return SweepSingleCurrency(trade, componentKey);
             }
 
+            const RatePricingTradeResult_& PassivePrice(const RateTradeDefinition_& trade) {
+                const auto found = passivePrices_.find(&trade);
+                if (found != passivePrices_.end())
+                    return found->second;
+                ++RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount;
+                return passivePrices_.emplace(&trade, PriceRateTrade(trade, market_)).first->second;
+            }
+
             // Axis source for aggregation: the preparation of a component key, or nullptr when the
             // key is unavailable, unrepresentable, or failed preparation (meta-table-only then).
             const NodeSensitivityPreparation_* PreparationForKey(const String_& key) {
@@ -786,14 +797,8 @@ namespace Dal {
             // the (trade, component) inner loop. Lazily priced on first need so trades whose every
             // cell fails an earlier gate are never priced at all.
             bool PassiveOk(const RateTradeDefinition_& trade) {
-                const auto found = passiveOk_.find(&trade);
-                if (found != passiveOk_.end())
-                    return found->second;
-                ++RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount;
-                const auto passive = PriceRateTrade(trade, market_);
-                const bool ok = passive.succeeded_ && std::isfinite(passive.pv_);
-                passiveOk_.emplace(&trade, ok);
-                return ok;
+                const auto& passive = PassivePrice(trade);
+                return passive.succeeded_ && std::isfinite(passive.pv_);
             }
 
             RateTradeNodeSensitivityResult_ SweepSingleCurrency(const RateTradeDefinition_& trade, const String_& componentKey) {
@@ -896,7 +901,7 @@ namespace Dal {
             std::map<String_, ComponentGate_> gates_;
             std::map<const DiscountCurve_*, NodeSensitivityPreparation_> prepared_;
             std::set<const DiscountCurve_*> preparationFailures_;
-            std::map<const RateTradeDefinition_*, bool> passiveOk_;
+            std::map<const RateTradeDefinition_*, RatePricingTradeResult_> passivePrices_;
             std::map<const RateTradeDefinition_*, Vector_<String_>> dependencyKeys_;
             std::map<const RateTradeDefinition_*, XccyNodeSensitivityHoist_> xccyHoists_;
         };
@@ -1117,6 +1122,221 @@ namespace Dal {
             result.components_.push_back(
                 AggregateComponentTensor(key, *preparation, found != accumulator.gradientSums_.end() ? found->second : zeros));
         }
+        return result;
+    }
+
+    namespace {
+        struct PreparedQuoteRiskProvenance_ {
+            int index_ = 0;
+            const RateQuoteRiskProvenance_* provenance_ = nullptr;
+            bool active_ = false;
+            String_ componentKey_;
+            int parameterCount_ = 0;
+        };
+
+        void AppendProvenanceFailure(const RateQuoteRiskProvenance_& provenance,
+                                     const String_& reason,
+                                     const String_& componentKey,
+                                     const String_& expected,
+                                     const String_& actual,
+                                     RatePortfolioQuoteRisk_* result) {
+            result->provenanceFailures_.push_back({provenance.CalibrationId(), reason, componentKey, expected, actual});
+        }
+
+        void ValidateSingleQuoteRiskShape(const RateQuoteRiskProvenance_& provenance) {
+            const auto& axis = provenance.Axis();
+            REQUIRE(axis.parameterRanges_.size() == 1 && axis.residualRanges_.size() == 1, "QUOTE_RISK_PROVENANCE_AXIS_INVALID");
+            REQUIRE(axis.parameterRanges_.front().offset_ == 0 && axis.parameterRanges_.front().size_ == static_cast<int>(axis.parameters_.size()),
+                    "QUOTE_RISK_PROVENANCE_AXIS_INVALID");
+            REQUIRE(axis.residualRanges_.front().offset_ == 0 && axis.residualRanges_.front().size_ == static_cast<int>(axis.quotes_.size()),
+                    "QUOTE_RISK_PROVENANCE_AXIS_INVALID");
+            REQUIRE(provenance.EffectiveInverse().Rows() == static_cast<int>(axis.parameters_.size()) &&
+                        provenance.EffectiveInverse().Cols() == static_cast<int>(axis.quotes_.size()),
+                    "QUOTE_RISK_PROVENANCE_INVERSE_SHAPE_INVALID");
+            REQUIRE(std::isfinite(provenance.Tolerance()) && provenance.Tolerance() > 0.0, "QUOTE_RISK_TOLERANCE_INVALID");
+        }
+
+        Vector_<PreparedQuoteRiskProvenance_> PrepareQuoteRiskProvenances(const Vector_<RateQuoteRiskProvenance_>& provenances,
+                                                                          const RatePricingMarket_& market,
+                                                                          RatePortfolioQuoteRisk_* result) {
+            Vector_<PreparedQuoteRiskProvenance_> prepared;
+            prepared.reserve(provenances.size());
+            std::set<String_> calibrationIds;
+            for (int index = 0; index < static_cast<int>(provenances.size()); ++index) {
+                const auto& provenance = provenances[index];
+                REQUIRE(calibrationIds.insert(provenance.CalibrationId()).second, "QUOTE_RISK_DUPLICATE_CALIBRATION_ID");
+                PreparedQuoteRiskProvenance_ entry{index, &provenance};
+                if (!provenance.Available()) {
+                    AppendProvenanceFailure(provenance, provenance.Reason(), String_(), String_(), String_(), result);
+                    prepared.push_back(entry);
+                    continue;
+                }
+                if (provenance.Kind() != "SINGLE_CURVE") {
+                    AppendProvenanceFailure(provenance, "QUOTE_RISK_AGGREGATION_KIND_NOT_SUPPORTED", String_(), String_(), String_(), result);
+                    prepared.push_back(entry);
+                    continue;
+                }
+
+                ValidateSingleQuoteRiskShape(provenance);
+                const auto& parameterRange = provenance.Axis().parameterRanges_.front();
+                const auto binding = provenance.ComponentKeyByParameterBlock().find(parameterRange.blockKey_);
+                REQUIRE(binding != provenance.ComponentKeyByParameterBlock().end(), "QUOTE_RISK_PROVENANCE_BINDING_INVALID");
+                REQUIRE(provenance.State().components_.size() == 1 && provenance.State().components_.front().componentKey_ == binding->second,
+                        "QUOTE_RISK_PROVENANCE_STATE_INVALID");
+                const auto actual = CurrentRateQuoteRiskComponentState(binding->second, market);
+                const auto& expected = provenance.State().components_.front();
+                if (actual.fingerprint_ != expected.fingerprint_) {
+                    AppendProvenanceFailure(provenance, "QUOTE_RISK_CALIBRATION_STATE_MISMATCH", binding->second, expected.fingerprint_,
+                                            actual.fingerprint_.empty() ? String_("MISSING") : actual.fingerprint_, result);
+                    prepared.push_back(entry);
+                    continue;
+                }
+                entry.active_ = true;
+                entry.componentKey_ = binding->second;
+                entry.parameterCount_ = parameterRange.size_;
+                prepared.push_back(entry);
+            }
+            return prepared;
+        }
+
+        void AddQuoteRiskGradient(int provenanceIndex,
+                                  const String_& currency,
+                                  const Vector_<>& gradient,
+                                  std::map<std::pair<int, String_>, Vector_<>>* sums) {
+            Vector_<>& sum = (*sums)[{provenanceIndex, currency}];
+            if (sum.empty()) {
+                sum.Resize(gradient.size());
+                std::fill(sum.begin(), sum.end(), 0.0);
+            }
+            REQUIRE(sum.size() == gradient.size(), "QUOTE_RISK_GRADIENT_WIDTH_MISMATCH");
+            for (int i = 0; i < static_cast<int>(gradient.size()); ++i) {
+                REQUIRE(std::isfinite(gradient[i]), "QUOTE_RISK_NON_FINITE_GRADIENT");
+                sum[i] += gradient[i];
+                REQUIRE(std::isfinite(sum[i]), "QUOTE_RISK_NON_FINITE_GRADIENT");
+            }
+        }
+
+        void AppendQuoteRiskMeta(const RateTradeDefinition_& trade,
+                                 const PreparedQuoteRiskProvenance_& prepared,
+                                 const Ccy_& actualPvCcy,
+                                 double pv,
+                                 bool eligible,
+                                 bool structuralZero,
+                                 const String_& originalReason,
+                                 RatePortfolioQuoteRisk_* result) {
+            RatePortfolioQuoteRiskMetaEntry_ meta;
+            meta.instrumentId_ = trade.instrumentId_;
+            meta.calibrationId_ = prepared.provenance_->CalibrationId();
+            meta.eligible_ = eligible;
+            meta.structuralZero_ = structuralZero;
+            meta.reason_ = eligible ? String_() : String_("QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE");
+            meta.failingComponentKey_ = eligible ? String_() : prepared.componentKey_;
+            meta.originalNodeRiskReason_ = originalReason;
+            meta.actualPvCcy_ = actualPvCcy;
+            meta.pv_ = pv;
+            result->meta_.push_back(std::move(meta));
+        }
+
+        void AppendQuoteRiskBuckets(const PreparedQuoteRiskProvenance_& prepared,
+                                    const String_& currency,
+                                    const Vector_<>& gradient,
+                                    RatePortfolioQuoteRisk_* result) {
+            const auto& provenance = *prepared.provenance_;
+            Vector_<> sensitivities;
+            Matrix::Multiply(gradient, provenance.EffectiveInverse(), &sensitivities);
+            REQUIRE(sensitivities.size() == provenance.Axis().quotes_.size(), "QUOTE_RISK_TRANSFORM_WIDTH_MISMATCH");
+            for (int i = 0; i < static_cast<int>(sensitivities.size()); ++i) {
+                const auto& quote = provenance.Axis().quotes_[i];
+                const double sensitivity = sensitivities[i] / provenance.Tolerance();
+                const double dv01 = sensitivity * 1.0e-4;
+                REQUIRE(std::isfinite(sensitivity) && std::isfinite(dv01), "QUOTE_RISK_NON_FINITE_OUTPUT");
+                RateQuoteRiskBucket_ bucket;
+                bucket.calibrationId_ = provenance.CalibrationId();
+                bucket.axisFingerprint_ = provenance.Axis().fingerprint_;
+                bucket.quoteKey_ = quote.blockKey_ + ":" + String::FromInt(quote.blockOrdinal_);
+                bucket.quoteName_ = quote.displayName_;
+                bucket.residualBlock_ = quote.blockKey_;
+                bucket.quoteOrdinal_ = quote.blockOrdinal_;
+                bucket.actualPvCcy_ = Ccy_(currency);
+                bucket.dPvDDecimalQuote_ = sensitivity;
+                bucket.dv01_ = dv01;
+                result->buckets_.push_back(std::move(bucket));
+            }
+        }
+
+        bool UsablePassivePrice(const RatePricingTradeResult_& passive) { return passive.succeeded_ && std::isfinite(passive.pv_); }
+
+        void ProcessQuoteRiskTradeProvenance(const RateTradeDefinition_& trade,
+                                             const RatePricingTradeResult_& passive,
+                                             const PreparedQuoteRiskProvenance_& item,
+                                             const Ccy_& actualPvCcy,
+                                             NodeSensitivitySweeper_* sweeper,
+                                             std::map<std::pair<int, String_>, Vector_<>>* gradientSums,
+                                             RatePortfolioQuoteRisk_* result) {
+            if (!item.active_)
+                return;
+            if (!UsablePassivePrice(passive)) {
+                const auto failed = sweeper->Sweep(trade, item.componentKey_);
+                AppendQuoteRiskMeta(trade, item, actualPvCcy, 0.0, false, false,
+                                    failed.reason_.empty() ? String_("TRADE_VALIDATION_FAILED") : failed.reason_, result);
+                return;
+            }
+            if (std::find(passive.dependencyComponentKeys_.begin(), passive.dependencyComponentKeys_.end(), item.componentKey_) ==
+                passive.dependencyComponentKeys_.end()) {
+                AddQuoteRiskGradient(item.index_, actualPvCcy.String(), Vector_<>(item.parameterCount_, 0.0), gradientSums);
+                AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, true, true, String_(), result);
+                return;
+            }
+            const auto cell = sweeper->Sweep(trade, item.componentKey_);
+            if (!cell.eligible_) {
+                AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, false, false, cell.reason_, result);
+                return;
+            }
+            REQUIRE(static_cast<int>(cell.gradient_.size()) == item.parameterCount_, "QUOTE_RISK_GRADIENT_WIDTH_MISMATCH");
+            AddQuoteRiskGradient(item.index_, actualPvCcy.String(), cell.gradient_, gradientSums);
+            AppendQuoteRiskMeta(trade, item, actualPvCcy, cell.pv_, true, false, String_(), result);
+        }
+
+        void ProcessQuoteRiskTrade(const RateTradeDefinition_& trade,
+                                   bool hasActiveProvenance,
+                                   const Vector_<PreparedQuoteRiskProvenance_>& prepared,
+                                   const RatePricingMarket_& market,
+                                   NodeSensitivitySweeper_* sweeper,
+                                   std::map<std::pair<int, String_>, Vector_<>>* gradientSums,
+                                   RatePortfolioQuoteRisk_* result) {
+            const RatePricingTradeResult_ passive = hasActiveProvenance ? sweeper->PassivePrice(trade) : PriceRateTrade(trade, market);
+            const Ccy_ actualPvCcy = ActualPvCurrency(trade);
+            if (UsablePassivePrice(passive))
+                result->pvByActualPvCcy_[actualPvCcy.String()] += passive.pv_;
+            for (const auto& item : prepared)
+                ProcessQuoteRiskTradeProvenance(trade, passive, item, actualPvCcy, sweeper, gradientSums, result);
+        }
+
+        void AppendAllQuoteRiskBuckets(const Vector_<PreparedQuoteRiskProvenance_>& prepared,
+                                       const std::map<std::pair<int, String_>, Vector_<>>& gradientSums,
+                                       RatePortfolioQuoteRisk_* result) {
+            for (const auto& item : prepared) {
+                if (!item.active_)
+                    continue;
+                for (const auto& [key, gradient] : gradientSums)
+                    if (key.first == item.index_)
+                        AppendQuoteRiskBuckets(item, key.second, gradient, result);
+            }
+        }
+    } // namespace
+
+    RatePortfolioQuoteRisk_ AggregateRatePortfolioQuoteRisk(const Vector_<RateTradeDefinition_>& trades,
+                                                            const RatePricingMarket_& market,
+                                                            const Vector_<RateQuoteRiskProvenance_>& provenances) {
+        RatePortfolioQuoteRisk_ result;
+        const auto prepared = PrepareQuoteRiskProvenances(provenances, market, &result);
+        const bool hasActiveProvenance = std::any_of(prepared.begin(), prepared.end(), [](const auto& item) { return item.active_; });
+        NodeSensitivitySweeper_ sweeper(market);
+        std::map<std::pair<int, String_>, Vector_<>> gradientSums;
+
+        for (const auto& trade : trades)
+            ProcessQuoteRiskTrade(trade, hasActiveProvenance, prepared, market, &sweeper, &gradientSums, &result);
+        AppendAllQuoteRiskBuckets(prepared, gradientSums, &result);
         return result;
     }
 

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -39,6 +39,7 @@ namespace Dal::RateCashflowPricingInternal {
     // for the same concurrent-caller reason.
     inline std::atomic<int> g_nodeSensitivityPassivePriceCount{0};
     inline std::atomic<int> g_nodeSensitivityPreparationCount{0};
+    inline std::atomic<int> g_nodeSensitivitySweepCount{0};
 
     using NodeSensitivityCurve_ = std::variant<std::monostate,
                                                const Tape::DiscountPWC_<double>*,
@@ -89,6 +90,7 @@ namespace Dal::RateCashflowPricingInternal {
     }
 
     template <class Runner_> RateTradeNodeSensitivityResult_ RunNodeSensitivityAADStage(int expectedParameterCount, Runner_&& runner) {
+        ++g_nodeSensitivitySweepCount;
         try {
             TapeGuard_ guard(AAD::Tape());
             NodeSensitivityCandidate_ candidate = std::forward<Runner_>(runner)();

--- a/dal-cpp/tests/curve/quoteriskaggregationheadercompile.cpp
+++ b/dal-cpp/tests/curve/quoteriskaggregationheadercompile.cpp
@@ -1,0 +1,15 @@
+//
+// Created by dal-implementer on 2026/9/1.
+//
+
+#include <dal/curve/quoteriskaggregation.hpp>
+
+#include <type_traits>
+
+namespace {
+    using Aggregate_ = Dal::RatePortfolioQuoteRisk_ (*)(const Dal::Vector_<Dal::RateTradeDefinition_>&,
+                                                        const Dal::RatePricingMarket_&,
+                                                        const Dal::Vector_<Dal::RateQuoteRiskProvenance_>&);
+
+    static_assert(std::is_same_v<decltype(&Dal::AggregateRatePortfolioQuoteRisk), Aggregate_>);
+} // namespace

--- a/dal-cpp/tests/curve/quoteriskaggregationheadercompile.cpp
+++ b/dal-cpp/tests/curve/quoteriskaggregationheadercompile.cpp
@@ -2,9 +2,9 @@
 // Created by dal-implementer on 2026/9/1.
 //
 
-#include <dal/curve/quoteriskaggregation.hpp>
-
 #include <type_traits>
+
+#include <dal/curve/quoteriskaggregation.hpp>
 
 namespace {
     using Aggregate_ = Dal::RatePortfolioQuoteRisk_ (*)(const Dal::Vector_<Dal::RateTradeDefinition_>&,

--- a/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
+++ b/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
@@ -4,17 +4,26 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cmath>
 #include <limits>
 #include <memory>
+#include <set>
 #include <string>
 #include <type_traits>
 
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
+#include <dal/curve/piecewiselinear.hpp>
+#include <dal/curve/quoteriskaggregation.hpp>
 #include <dal/curve/quoteriskprovenance.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
+#include <dal/curve/ratecashflowpricing_internal.hpp>
 #include <dal/curve/ycconst.hpp>
+#include <dal/curve/ycimp.hpp>
 #include <dal/curve/ycinstrument.hpp>
+#include <dal/curve/yclogdf.hpp>
+#include <dal/curve/yczerorate.hpp>
 #include <dal/platform/platform.hpp>
 #include <dal/protocol/collateraltype.hpp>
 #include <dal/storage/archive.hpp>
@@ -144,6 +153,240 @@ namespace {
 
     Dal::RateQuoteRiskProvenance_ BuildSingle(const SingleProvenanceInput_& input) {
         return Dal::BuildSingleCurveQuoteRiskProvenance(input.spec_, input.result_, input.options_, input.market_, input.config_);
+    }
+
+    Dal::RateTradeDefinition_ SingleDepositTrade(const SingleProvenanceInput_& input, const Dal::String_& instrumentId = "single-deposit") {
+        Dal::DepositTradeTerms_ terms;
+        terms.notional_ = 1'000'000.0;
+        terms.contractRate_ = 0.02;
+        terms.lend_ = true;
+        terms.index_ = SingleIndex();
+        terms.discountComponentKey_ = "discount";
+        return {instrumentId,
+                Dal::RateInstrumentType_::Value_::DEPOSIT,
+                input.spec_.today_,
+                input.spec_.today_,
+                input.spec_.knotDates_.back(),
+                Dal::Ccy_("USD"),
+                terms};
+    }
+
+    Dal::Handle_<Dal::DiscountCurve_> QuoteOracleCurve(const Dal::CurveCalibrationSpec_& spec) {
+        const int nKnots = static_cast<int>(spec.knotDates_.size());
+        switch (spec.parameterization_.Switch()) {
+        case Dal::CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD: {
+            Dal::Vector_<> forwards(nKnots);
+            for (int i = 0; i < nKnots; ++i)
+                forwards[i] = 0.012 + 0.0004 * i;
+            return Dal::Handle_<Dal::DiscountCurve_>(
+                Dal::NewDiscountPWC("quote_oracle_known", spec.ccy_, Dal::PiecewiseConstant_(spec.knotDates_, forwards)));
+        }
+        case Dal::CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD: {
+            Dal::Vector_<> left(nKnots), right(nKnots);
+            for (int i = 0; i < nKnots; ++i) {
+                left[i] = 0.011 + 0.0005 * i;
+                right[i] = left[i] + 0.0003;
+            }
+            return Dal::Handle_<Dal::DiscountCurve_>(
+                Dal::NewDiscountPWLF("quote_oracle_known", spec.ccy_, Dal::PiecewiseLinear_(spec.knotDates_, left, right)));
+        }
+        case Dal::CurveParameterization_::Value_::LOG_DISCOUNT: {
+            Dal::Vector_<> logDfs(nKnots);
+            for (int i = 0; i < nKnots; ++i)
+                logDfs[i] = -0.018 * spec.liborBasis_(spec.today_, spec.knotDates_[i], nullptr);
+            return Dal::Handle_<Dal::DiscountCurve_>(
+                Dal::NewDiscountLogDF("quote_oracle_known", spec.ccy_, spec.knotDates_, logDfs, spec.liborBasis_, spec.logDfScheme_));
+        }
+        case Dal::CurveParameterization_::Value_::ZERO_RATE: {
+            Dal::Vector_<> zeroRates(nKnots);
+            for (int i = 0; i < nKnots; ++i)
+                zeroRates[i] = 0.016 + 0.0002 * i;
+            return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountZeroRate("quote_oracle_known", spec.ccy_, spec.today_, spec.knotDates_,
+                                                                              zeroRates, spec.liborBasis_, spec.logDfScheme_));
+        }
+        }
+        THROW("Unsupported quote oracle parameterization");
+    }
+
+    SingleProvenanceInput_ MakeQuoteOracleInput(Dal::CurveParameterization_ parameterization, int quoteCount, Dal::CurveJacobianMode_ mode) {
+        SingleProvenanceInput_ input;
+        input.spec_.today_ = Dal::Date_(2025, 1, 2);
+        input.spec_.ccy_ = "USD";
+        input.spec_.curveName_ = "single_quote_oracle";
+        input.spec_.targetCollateral_ = Dal::CollateralType_(Dal::CollateralType_::Value_::OIS);
+        input.spec_.parameterization_ = parameterization;
+        input.spec_.knotPolicy_ = Dal::CurveKnotPolicy_::Value_::INPUT;
+        input.spec_.solveMode_ = Dal::CurveSolveMode_::Value_::EXACT;
+        input.spec_.liborBasis_ = Dal::DayBasis_("ACT_365F");
+        input.spec_.tolerance_ = 1.0e-10;
+        input.spec_.fitTolerance_ = 1.0e-8;
+        input.spec_.smoothingWeight_ = 1.0;
+        input.spec_.initialGuess_ = 0.018;
+        input.spec_.logDfScheme_ = Dal::LogDfScheme_::Value_::LOG_LINEAR;
+
+        Dal::Vector_<Dal::Date_> maturities;
+        for (int i = 1; i <= quoteCount; ++i)
+            maturities.push_back(Dal::Date::AddMonths(input.spec_.today_, 6 * i));
+        if (parameterization == Dal::CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD) {
+            input.spec_.knotDates_.push_back(input.spec_.today_);
+            for (const auto& maturity : maturities)
+                input.spec_.knotDates_.push_back(maturity);
+        } else if (parameterization == Dal::CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD) {
+            const int knotCount = (quoteCount + 1) / 2 + 1;
+            input.spec_.knotDates_.push_back(Dal::Date::AddMonths(input.spec_.today_, 3));
+            for (int i = 1; i < knotCount; ++i)
+                input.spec_.knotDates_.push_back(Dal::Date::AddMonths(input.spec_.today_, 12 * i));
+        } else {
+            input.spec_.knotDates_ = maturities;
+            if (parameterization == Dal::CurveParameterization_::Value_::LOG_DISCOUNT) {
+                Dal::Vector_<Dal::Date_> anchored = {input.spec_.today_};
+                for (const auto& maturity : maturities)
+                    anchored.push_back(maturity);
+                input.spec_.knotDates_ = std::move(anchored);
+            }
+        }
+
+        const auto known = QuoteOracleCurve(input.spec_);
+        const Dal::CurveBlock_ knownBlock(known, input.spec_.liborBasis_);
+        switch (parameterization.Switch()) {
+        case Dal::CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD:
+            for (int i = 0; i < static_cast<int>(input.spec_.knotDates_.size()); ++i)
+                input.spec_.initialGuessPerNode_.push_back(0.012 + 0.0004 * i);
+            break;
+        case Dal::CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD:
+            for (int i = 0; i < static_cast<int>(input.spec_.knotDates_.size()); ++i) {
+                input.spec_.initialGuessPerNode_.push_back(0.011 + 0.0005 * i);
+                input.spec_.initialGuessPerNode_.push_back(0.0113 + 0.0005 * i);
+            }
+            break;
+        case Dal::CurveParameterization_::Value_::LOG_DISCOUNT:
+            for (int i = 1; i < static_cast<int>(input.spec_.knotDates_.size()); ++i)
+                input.spec_.initialGuessPerNode_.push_back(-0.018 * input.spec_.liborBasis_(input.spec_.today_, input.spec_.knotDates_[i], nullptr));
+            break;
+        case Dal::CurveParameterization_::Value_::ZERO_RATE:
+            for (int i = 0; i < static_cast<int>(input.spec_.knotDates_.size()); ++i)
+                input.spec_.initialGuessPerNode_.push_back(0.016 + 0.0002 * i);
+            break;
+        }
+        const Dal::RateIndexConvention_ index = SingleIndex();
+        Dal::Handle_<Dal::YieldCurve_> empty;
+        for (const auto& maturity : maturities) {
+            const Dal::Handle_<Dal::YCInstrument_> prototype(new Dal::Deposit_(input.spec_.today_, input.spec_.today_, maturity, 0.0, index));
+            const double quote = (*prototype->Precompute(empty))(knownBlock);
+            input.spec_.instruments_.push_back(
+                Dal::Handle_<Dal::YCInstrument_>(new Dal::Deposit_(input.spec_.today_, input.spec_.today_, maturity, quote, index)));
+        }
+
+        input.options_.jacobianMode_ = mode;
+        try {
+            input.result_ = Dal::CalibrateYieldCurve(input.spec_, input.options_);
+        } catch (const std::exception& exception) {
+            THROW("Quote oracle baseline calibration failed: " + Dal::String_(exception.what()));
+        }
+        const auto alias = std::shared_ptr<const Dal::DiscountCurve_>(std::shared_ptr<void>(), input.result_.curve_.get());
+        input.market_.valuationTime_ = Dal::DateTime_(input.spec_.today_, 9, 0);
+        input.market_.resultCurrency_ = Dal::Ccy_("USD");
+        input.market_.curveComponents_["discount"] = Dal::Handle_<Dal::DiscountCurve_>(alias);
+        input.market_.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_());
+        input.config_.calibrationId_ = "single-quote-oracle";
+        input.config_.componentKeyByParameterBlock_[input.spec_.curveName_] = "discount";
+        return input;
+    }
+
+    struct QuoteOracleObservation_ {
+        double netPv_ = 0.0;
+        double grossAbsPv_ = 0.0;
+    };
+
+    QuoteOracleObservation_ PriceQuoteOracleTrades(const Dal::Vector_<Dal::RateTradeDefinition_>& trades, const Dal::RatePricingMarket_& market) {
+        QuoteOracleObservation_ observation;
+        for (const auto& priced : Dal::PriceRateTrades(trades, market)) {
+            REQUIRE(priced.succeeded_ && std::isfinite(priced.pv_), "Quote oracle trade failed to price");
+            observation.netPv_ += priced.pv_;
+            observation.grossAbsPv_ += std::abs(priced.pv_);
+        }
+        return observation;
+    }
+
+    QuoteOracleObservation_ RecalibrateAndPriceQuoteBump(const SingleProvenanceInput_& input,
+                                                         const Dal::Vector_<Dal::RateTradeDefinition_>& trades,
+                                                         int quoteIndex,
+                                                         double bump) {
+        Dal::CurveCalibrationSpec_ bumped = input.spec_;
+        const auto* original = dynamic_cast<const Dal::Deposit_*>(input.spec_.instruments_[quoteIndex].get());
+        REQUIRE(original, "Quote oracle expected deposit calibration instruments");
+        const auto span = original->TimeSpan();
+        bumped.instruments_[quoteIndex] = Dal::Handle_<Dal::YCInstrument_>(
+            new Dal::Deposit_(original->TradeDate(), span.first, span.second, original->MarketRate() + bump, original->FloatConvention()));
+        Dal::CurveCalibrationResult_ calibrated;
+        try {
+            calibrated = Dal::CalibrateYieldCurve(bumped, input.options_);
+        } catch (const std::exception& exception) {
+            THROW("Quote oracle bumped calibration failed for quote " + Dal::String::FromInt(quoteIndex) + " and bump " +
+                  Dal::String::FromDouble(bump) + ": " + Dal::String_(exception.what()));
+        }
+        REQUIRE(calibrated.diagnostics_.maxAbsResidual_ <= input.spec_.fitTolerance_, "Quote oracle calibration did not satisfy the fit gate");
+        Dal::RatePricingMarket_ market = input.market_;
+        const auto alias = std::shared_ptr<const Dal::DiscountCurve_>(std::shared_ptr<void>(), calibrated.curve_.get());
+        market.curveComponents_["discount"] = Dal::Handle_<Dal::DiscountCurve_>(alias);
+        return PriceQuoteOracleTrades(trades, market);
+    }
+
+    void AssertQuoteRiskOracle(Dal::CurveParameterization_ parameterization, int quoteCount, Dal::CurveJacobianMode_ mode) {
+        const auto input = MakeQuoteOracleInput(parameterization, quoteCount, mode);
+        if (parameterization == Dal::CurveParameterization_::Value_::ZERO_RATE) {
+            const auto* zero = dynamic_cast<const Dal::DiscountZeroRate_*>(input.result_.curve_.get());
+            ASSERT_NE(zero, nullptr);
+            ASSERT_EQ(zero->Name(), input.spec_.curveName_);
+            ASSERT_EQ(zero->ccy_.String(), input.spec_.ccy_);
+            ASSERT_EQ(zero->AnchorDate(), input.spec_.today_);
+            ASSERT_EQ(zero->NodeDates(), input.spec_.knotDates_);
+            ASSERT_EQ(zero->Scheme(), input.spec_.logDfScheme_);
+            ASSERT_EQ(zero->DayCount(), input.spec_.liborBasis_);
+        }
+        const auto provenance = BuildSingle(input);
+        const Dal::Vector_<Dal::RateTradeDefinition_> trades = {SingleDepositTrade(input, "oracle-deposit")};
+        const auto aggregate = Dal::AggregateRatePortfolioQuoteRisk(trades, input.market_, {provenance});
+        ASSERT_EQ(static_cast<int>(aggregate.buckets_.size()), quoteCount);
+        const auto baseline = PriceQuoteOracleTrades(trades, input.market_);
+        constexpr double h = 1.0e-6;
+        constexpr double b = 1.0e-4;
+        constexpr double epsilon = std::numeric_limits<double>::epsilon();
+        const double derivativeAbsFactor = quoteCount <= 5 ? 5.0e-6 : (quoteCount <= 10 ? 1.0e-4 : 1.0e-3);
+        const double relativeTolerance = derivativeAbsFactor;
+
+        for (int i = 0; i < quoteCount; ++i) {
+            const auto plusH = RecalibrateAndPriceQuoteBump(input, trades, i, h);
+            const auto minusH = RecalibrateAndPriceQuoteBump(input, trades, i, -h);
+            const auto plusB = RecalibrateAndPriceQuoteBump(input, trades, i, b);
+            const auto minusB = RecalibrateAndPriceQuoteBump(input, trades, i, -b);
+            const double priceScale =
+                std::max({1.0, baseline.grossAbsPv_, plusH.grossAbsPv_, minusH.grossAbsPv_, plusB.grossAbsPv_, minusB.grossAbsPv_});
+            const double derivativeOracle = (plusH.netPv_ - minusH.netPv_) / (2.0 * h);
+            const double dv01Oracle = (plusB.netPv_ - minusB.netPv_) / 2.0;
+            const auto& bucket = aggregate.buckets_[i];
+            ASSERT_TRUE(std::isfinite(bucket.dPvDDecimalQuote_));
+            ASSERT_TRUE(std::isfinite(bucket.dv01_));
+            ASSERT_TRUE(std::isfinite(derivativeOracle));
+            ASSERT_TRUE(std::isfinite(dv01Oracle));
+            const double unitError = std::abs(bucket.dv01_ - b * bucket.dPvDDecimalQuote_);
+            const double unitScale = std::max({priceScale * b, std::abs(bucket.dv01_), b * std::abs(bucket.dPvDDecimalQuote_)});
+            ASSERT_LE(unitError, 64.0 * epsilon * unitScale);
+            const double derivativeError = std::abs(bucket.dPvDDecimalQuote_ - derivativeOracle);
+            const double derivativeScale = std::max(std::abs(bucket.dPvDDecimalQuote_), std::abs(derivativeOracle));
+            const double derivativeRelative =
+                derivativeScale == 0.0 ? (derivativeError == 0.0 ? 0.0 : std::numeric_limits<double>::infinity()) : derivativeError / derivativeScale;
+            ASSERT_TRUE(derivativeError <= derivativeAbsFactor * priceScale || derivativeRelative <= relativeTolerance)
+                << "parameterization=" << parameterization.String() << " mode=" << mode.String() << " N=" << quoteCount << " quote=" << i
+                << " api=" << bucket.dPvDDecimalQuote_ << " oracle=" << derivativeOracle << " absError=" << derivativeError
+                << " relError=" << derivativeRelative;
+            const double dv01Error = std::abs(bucket.dv01_ - dv01Oracle);
+            const double dv01Scale = std::max(std::abs(bucket.dv01_), std::abs(dv01Oracle));
+            const double dv01Relative = dv01Scale == 0.0 ? (dv01Error == 0.0 ? 0.0 : std::numeric_limits<double>::infinity()) : dv01Error / dv01Scale;
+            ASSERT_TRUE(dv01Error <= derivativeAbsFactor * b * priceScale || dv01Relative <= relativeTolerance)
+                << "parameterization=" << parameterization.String() << " mode=" << mode.String() << " N=" << quoteCount << " quote=" << i
+                << " api=" << bucket.dv01_ << " oracle=" << dv01Oracle << " absError=" << dv01Error << " relError=" << dv01Relative;
+        }
     }
 
     void RecalibrateAndBindSingle(SingleProvenanceInput_* input) {
@@ -402,6 +645,237 @@ TEST(QuoteRiskProvenanceTest, TestSingleCurveAnalyticAndBumpedConstruction) {
             ASSERT_EQ(provenance.Axis().fingerprint_, analyticAxis);
         }
     }
+}
+
+TEST(QuoteRiskAggregationTest, TestSingleCurveProducesUnitBearingBuckets) {
+    const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    const auto trade = SingleDepositTrade(input);
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({trade}, input.market_, {provenance});
+
+    ASSERT_EQ(result.policy_, "UnconvertedByActualPvCcy");
+    ASSERT_EQ(result.buckets_.size(), provenance.Axis().quotes_.size());
+    ASSERT_EQ(result.meta_.size(), 1U);
+    ASSERT_TRUE(result.meta_.front().eligible_);
+    ASSERT_TRUE(result.provenanceFailures_.empty());
+    ASSERT_EQ(result.pvByActualPvCcy_.size(), 1U);
+    ASSERT_TRUE(result.pvByActualPvCcy_.count("USD"));
+    for (int i = 0; i < static_cast<int>(result.buckets_.size()); ++i) {
+        const auto& bucket = result.buckets_[i];
+        ASSERT_EQ(bucket.calibrationId_, provenance.CalibrationId());
+        ASSERT_EQ(bucket.axisFingerprint_, provenance.Axis().fingerprint_);
+        ASSERT_EQ(bucket.quoteName_, provenance.Axis().quotes_[i].displayName_);
+        ASSERT_EQ(bucket.residualBlock_, provenance.Axis().quotes_[i].blockKey_);
+        ASSERT_EQ(bucket.quoteOrdinal_, provenance.Axis().quotes_[i].blockOrdinal_);
+        ASSERT_EQ(bucket.actualPvCcy_, Dal::Ccy_("USD"));
+        ASSERT_TRUE(std::isfinite(bucket.dPvDDecimalQuote_));
+        ASSERT_NEAR(bucket.dv01_, bucket.dPvDDecimalQuote_ * 1.0e-4, 1.0e-12);
+    }
+}
+
+TEST(QuoteRiskAggregationTest, TestStaleStateFailsBeforeAnyNodeRiskWork) {
+    auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    input.market_.valuationTime_ = Dal::DateTime_(input.spec_.today_, 10, 0);
+    Dal::RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount.store(0);
+    Dal::RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.store(0);
+    Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.store(0);
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({SingleDepositTrade(input)}, input.market_, {provenance});
+
+    ASSERT_TRUE(result.buckets_.empty());
+    ASSERT_TRUE(result.meta_.empty());
+    ASSERT_EQ(result.provenanceFailures_.size(), 1U);
+    ASSERT_EQ(result.provenanceFailures_.front().reason_, "QUOTE_RISK_CALIBRATION_STATE_MISMATCH");
+    ASSERT_EQ(result.provenanceFailures_.front().componentKey_, "discount");
+    ASSERT_EQ(result.provenanceFailures_.front().expectedStateFingerprint_, provenance.State().components_.front().fingerprint_);
+    ASSERT_NE(result.provenanceFailures_.front().actualStateFingerprint_, result.provenanceFailures_.front().expectedStateFingerprint_);
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount.load(), 0);
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.load(), 0);
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(), 0);
+}
+
+TEST(QuoteRiskAggregationTest, TestDuplicateCalibrationIdsFailClosed) {
+    const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    try {
+        static_cast<void>(Dal::AggregateRatePortfolioQuoteRisk({SingleDepositTrade(input)}, input.market_, {provenance, provenance}));
+        FAIL() << "Expected duplicate calibration ids to fail";
+    } catch (const Dal::Exception_& exception) {
+        ASSERT_NE(std::string(exception.what()).find("QUOTE_RISK_DUPLICATE_CALIBRATION_ID"), std::string::npos) << exception.what();
+    }
+}
+
+TEST(QuoteRiskAggregationTest, TestUnavailableProvenanceIsReportedWithoutSweeping) {
+    auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    input.options_.computeEffJacobianInverse_ = false;
+    RecalibrateAndBindSingle(&input);
+    const auto provenance = BuildSingle(input);
+    ASSERT_FALSE(provenance.Available());
+    Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.store(0);
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({SingleDepositTrade(input)}, input.market_, {provenance});
+
+    ASSERT_TRUE(result.buckets_.empty());
+    ASSERT_TRUE(result.meta_.empty());
+    ASSERT_EQ(result.provenanceFailures_.size(), 1U);
+    ASSERT_EQ(result.provenanceFailures_.front().reason_, "QUOTE_RISK_INVERSE_NOT_REQUESTED");
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(), 0);
+}
+
+TEST(QuoteRiskAggregationTest, TestEmptyInputsRemainSuccessful) {
+    const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    const auto emptyTrades = Dal::AggregateRatePortfolioQuoteRisk({}, input.market_, {provenance});
+    ASSERT_TRUE(emptyTrades.buckets_.empty());
+    ASSERT_TRUE(emptyTrades.meta_.empty());
+    ASSERT_TRUE(emptyTrades.pvByActualPvCcy_.empty());
+    ASSERT_TRUE(emptyTrades.provenanceFailures_.empty());
+
+    const auto emptyProvenances = Dal::AggregateRatePortfolioQuoteRisk({SingleDepositTrade(input)}, input.market_, {});
+    ASSERT_TRUE(emptyProvenances.buckets_.empty());
+    ASSERT_TRUE(emptyProvenances.meta_.empty());
+    ASSERT_TRUE(emptyProvenances.provenanceFailures_.empty());
+    ASSERT_EQ(emptyProvenances.pvByActualPvCcy_.size(), 1U);
+    ASSERT_TRUE(emptyProvenances.pvByActualPvCcy_.count("USD"));
+}
+
+TEST(QuoteRiskAggregationTest, TestNonDependencyUsesStructuralZeroWithoutSweeping) {
+    auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    input.market_.curveComponents_["unrelated"] = input.market_.curveComponents_.at("discount");
+    auto trade = SingleDepositTrade(input);
+    std::get<Dal::DepositTradeTerms_>(trade.terms_).discountComponentKey_ = "unrelated";
+    Dal::RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.store(0);
+    Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.store(0);
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({trade}, input.market_, {provenance});
+
+    ASSERT_EQ(result.meta_.size(), 1U);
+    ASSERT_TRUE(result.meta_.front().eligible_);
+    ASSERT_TRUE(result.meta_.front().structuralZero_);
+    ASSERT_EQ(result.buckets_.size(), provenance.Axis().quotes_.size());
+    for (const auto& bucket : result.buckets_) {
+        ASSERT_DOUBLE_EQ(bucket.dPvDDecimalQuote_, 0.0);
+        ASSERT_DOUBLE_EQ(bucket.dv01_, 0.0);
+    }
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.load(), 0);
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(), 0);
+}
+
+TEST(QuoteRiskAggregationTest, TestTradeFailureDoesNotAffectSiblingTrade) {
+    const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    const auto good = SingleDepositTrade(input, "good-deposit");
+    auto bad = SingleDepositTrade(input, "bad-deposit");
+    std::get<Dal::DepositTradeTerms_>(bad.terms_).notional_ = 0.0;
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({bad, good}, input.market_, {provenance});
+
+    ASSERT_EQ(result.meta_.size(), 2U);
+    ASSERT_FALSE(result.meta_[0].eligible_);
+    ASSERT_EQ(result.meta_[0].reason_, "QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE");
+    ASSERT_EQ(result.meta_[0].failingComponentKey_, "discount");
+    ASSERT_EQ(result.meta_[0].originalNodeRiskReason_, "TRADE_VALIDATION_FAILED");
+    ASSERT_TRUE(result.meta_[1].eligible_);
+    ASSERT_EQ(result.buckets_.size(), provenance.Axis().quotes_.size());
+    ASSERT_EQ(result.pvByActualPvCcy_.size(), 1U);
+}
+
+TEST(QuoteRiskAggregationTest, TestActualPvCurrenciesRemainSeparateAndQuoteKeysIgnoreDuplicateNames) {
+    const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    ASSERT_EQ(provenance.Axis().quotes_[0].displayName_, provenance.Axis().quotes_[1].displayName_);
+    auto usd = SingleDepositTrade(input, "usd-deposit");
+    auto eur = SingleDepositTrade(input, "eur-deposit");
+    eur.currencyOrPair_ = Dal::Ccy_("EUR");
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({usd, eur}, input.market_, {provenance});
+
+    ASSERT_EQ(result.pvByActualPvCcy_.size(), 2U);
+    ASSERT_TRUE(result.pvByActualPvCcy_.count("USD"));
+    ASSERT_TRUE(result.pvByActualPvCcy_.count("EUR"));
+    ASSERT_EQ(result.buckets_.size(), provenance.Axis().quotes_.size() * 2U);
+    std::set<Dal::String_> keys;
+    std::set<Dal::String_> currencies;
+    for (const auto& bucket : result.buckets_) {
+        keys.insert(bucket.quoteKey_);
+        currencies.insert(bucket.actualPvCcy_.String());
+    }
+    ASSERT_EQ(keys.size(), provenance.Axis().quotes_.size());
+    ASSERT_EQ(currencies, (std::set<Dal::String_>{"EUR", "USD"}));
+}
+
+TEST(QuoteRiskAggregationTest, TestNegativeAndOffsettingTradesRemainValid) {
+    const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    auto lend = SingleDepositTrade(input, "lend");
+    auto borrow = SingleDepositTrade(input, "borrow");
+    std::get<Dal::DepositTradeTerms_>(borrow.terms_).lend_ = false;
+
+    const auto lendOnly = Dal::AggregateRatePortfolioQuoteRisk({lend}, input.market_, {provenance});
+    const auto borrowOnly = Dal::AggregateRatePortfolioQuoteRisk({borrow}, input.market_, {provenance});
+    ASSERT_LT(lendOnly.pvByActualPvCcy_.at("USD") * borrowOnly.pvByActualPvCcy_.at("USD"), 0.0);
+    ASSERT_NEAR(lendOnly.pvByActualPvCcy_.at("USD"), -borrowOnly.pvByActualPvCcy_.at("USD"), 1.0e-10);
+
+    const auto offsetting = Dal::AggregateRatePortfolioQuoteRisk({lend, borrow}, input.market_, {provenance});
+    ASSERT_NEAR(offsetting.pvByActualPvCcy_.at("USD"), 0.0, 1.0e-10);
+    for (const auto& bucket : offsetting.buckets_) {
+        ASSERT_NEAR(bucket.dPvDDecimalQuote_, 0.0, 1.0e-8);
+        ASSERT_NEAR(bucket.dv01_, 0.0, 1.0e-12);
+    }
+}
+
+TEST(QuoteRiskAggregationTest, TestStaleProvenanceDoesNotBlockFreshSibling) {
+    auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto stale = BuildSingle(input);
+    input.market_.valuationTime_ = Dal::DateTime_(input.spec_.today_, 10, 0);
+    input.config_.calibrationId_ = "fresh-calibration";
+    const auto fresh = BuildSingle(input);
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({SingleDepositTrade(input)}, input.market_, {stale, fresh});
+
+    ASSERT_EQ(result.provenanceFailures_.size(), 1U);
+    ASSERT_EQ(result.provenanceFailures_.front().calibrationId_, stale.CalibrationId());
+    ASSERT_EQ(result.provenanceFailures_.front().reason_, "QUOTE_RISK_CALIBRATION_STATE_MISMATCH");
+    ASSERT_EQ(result.buckets_.size(), fresh.Axis().quotes_.size());
+    for (const auto& bucket : result.buckets_)
+        ASSERT_EQ(bucket.calibrationId_, fresh.CalibrationId());
+}
+
+TEST(QuoteRiskAggregationTest, TestJointAndStagedAggregateSuccessWaitsForQr3) {
+    const auto joint = MakeJointInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto jointProvenance = Dal::BuildJointXccyQuoteRiskProvenance(joint.spec_, joint.result_, joint.options_, joint.market_, joint.config_);
+    const auto jointResult = Dal::AggregateRatePortfolioQuoteRisk({}, joint.market_, {jointProvenance});
+    ASSERT_TRUE(jointResult.buckets_.empty());
+    ASSERT_EQ(jointResult.provenanceFailures_.size(), 1U);
+    ASSERT_EQ(jointResult.provenanceFailures_.front().reason_, "QUOTE_RISK_AGGREGATION_KIND_NOT_SUPPORTED");
+
+    const auto staged = MakeStagedInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto stagedProvenance =
+        Dal::BuildStagedXccyBasisQuoteRiskProvenance(staged.spec_, *staged.result_, staged.options_, staged.market_, staged.config_);
+    const auto stagedResult = Dal::AggregateRatePortfolioQuoteRisk({}, staged.market_, {stagedProvenance});
+    ASSERT_TRUE(stagedResult.buckets_.empty());
+    ASSERT_EQ(stagedResult.provenanceFailures_.size(), 1U);
+    ASSERT_EQ(stagedResult.provenanceFailures_.front().reason_, "QUOTE_RISK_AGGREGATION_KIND_NOT_SUPPORTED");
+}
+
+TEST(QuoteRiskAggregationTest, TestFullRecalibrationOracleAtRequiredWidthsAndModes) {
+    for (const int quoteCount : {5, 10, 16})
+        for (const auto mode : {Dal::CurveJacobianMode_::Value_::ANALYTIC, Dal::CurveJacobianMode_::Value_::BUMPED})
+            for (const auto parameterization :
+                 {Dal::CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, Dal::CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD,
+                  Dal::CurveParameterization_::Value_::LOG_DISCOUNT, Dal::CurveParameterization_::Value_::ZERO_RATE}) {
+                SCOPED_TRACE(Dal::String_("N=") + Dal::String::FromInt(quoteCount) + " mode=" + Dal::CurveJacobianMode_(mode).String() +
+                             " parameterization=" + Dal::CurveParameterization_(parameterization).String());
+                try {
+                    AssertQuoteRiskOracle(parameterization, quoteCount, mode);
+                } catch (const std::exception& exception) {
+                    FAIL() << "N=" << quoteCount << " mode=" << Dal::CurveJacobianMode_(mode).String()
+                           << " parameterization=" << Dal::CurveParameterization_(parameterization).String() << ": " << exception.what();
+                }
+            }
 }
 
 TEST(QuoteRiskProvenanceTest, TestSingleCurveUnavailableReasonsRemainStructured) {


### PR DESCRIPTION
## Summary
- add the three-argument single-curve quote-risk aggregate with deterministic unit-bearing buckets, actual-PV-currency grouping, and isolated metadata/failure rows
- validate calibration provenance freshness before node-risk work, reuse the existing market-aware sweeper, and preserve structural-zero and trade/provenance atomicity contracts
- cover all four curve representations at 5/10/16 quotes for analytic and bumped inverse modes with independent full-recalibration oracles

## Test plan
- [x] `dal_cpp_tests --gtest_filter='QuoteRiskAggregationTest.*:QuoteRiskProvenanceTest.*:QuoteRiskProvenanceHeaderTest.*:InverseJacobianRiskTest.*'` (31 passed)
- [x] focused pricing/calibration/node-risk regression suite (167 passed)
- [x] full Release build and `ctest --test-dir build/Release-linux --output-on-failure` (1,481 passed)
- [x] `dal_check_generated`, documentation checks, clang-format, lizard, and `git diff --check`

Closes DAL-175
Closes #319
