### PR TITLE
DAL-175: fix quote-risk identity and structural zeros

### DIFF
--- a/dal-cpp/dal/curve/quoteriskprovenance.cpp
+++ b/dal-cpp/dal/curve/quoteriskprovenance.cpp
@@ -1844,7 +1844,6 @@ namespace Dal {
         Json_ StateRecord(const String_& kind,
                           const RateQuoteRiskAxis_& axis,
                           const std::map<String_, String_>& bindings,
-                          const String_& calibrationId,
                           const RatePricingMarket_& market,
                           Json_ options,
                           Json_ calibrationResult,
@@ -1855,7 +1854,6 @@ namespace Dal {
             Json_ state = Json_::Object();
             state.object_["axisFingerprint"] = Json_::String(axis.fingerprint_);
             state.object_["bindings"] = BindingsJson(bindings);
-            state.object_["calibrationId"] = Json_::String(calibrationId);
             state.object_["effectiveInverse"] = MatrixJson(effectiveInverse);
             state.object_["effectiveInverseScaling"] = Json_::String("solver_scaled");
             state.object_["kind"] = Json_::String(kind);
@@ -1957,9 +1955,9 @@ namespace Dal {
         if (data->available_)
             data->effectiveInverse_ = result.diagnostics_.effJacobianInverse_;
 
-        data->state_.fingerprint_ = Fingerprint(StateRecord(
-            data->kind_, data->axis_, data->bindings_, data->calibrationId_, boundMarket, SingleOptionsJson(options), SingleResultJson(result),
-            data->reason_, SingleSpecJson(normalizedSpec), result.diagnostics_.effJacobianInverse_, data->tolerance_));
+        data->state_.fingerprint_ =
+            Fingerprint(StateRecord(data->kind_, data->axis_, data->bindings_, boundMarket, SingleOptionsJson(options), SingleResultJson(result),
+                                    data->reason_, SingleSpecJson(normalizedSpec), result.diagnostics_.effJacobianInverse_, data->tolerance_));
         return RateQuoteRiskProvenance_(data);
     }
 
@@ -1988,8 +1986,8 @@ namespace Dal {
             data->effectiveInverse_ = result.effJacobianInverse_;
 
         data->state_.fingerprint_ =
-            Fingerprint(StateRecord(data->kind_, data->axis_, data->bindings_, data->calibrationId_, boundMarket, JointOptionsJson(options),
-                                    JointResultJson(result), data->reason_, JointSpecJson(spec), result.effJacobianInverse_, data->tolerance_));
+            Fingerprint(StateRecord(data->kind_, data->axis_, data->bindings_, boundMarket, JointOptionsJson(options), JointResultJson(result),
+                                    data->reason_, JointSpecJson(spec), result.effJacobianInverse_, data->tolerance_));
         return RateQuoteRiskProvenance_(data);
     }
 
@@ -2015,9 +2013,9 @@ namespace Dal {
         if (data->available_)
             data->effectiveInverse_ = result.diagnostics_.effJacobianInverse_;
 
-        data->state_.fingerprint_ = Fingerprint(StateRecord(data->kind_, data->axis_, data->bindings_, data->calibrationId_, boundMarket,
-                                                            StagedOptionsJson(options), StagedResultJson(result), data->reason_, StagedSpecJson(spec),
-                                                            result.diagnostics_.effJacobianInverse_, data->tolerance_));
+        data->state_.fingerprint_ =
+            Fingerprint(StateRecord(data->kind_, data->axis_, data->bindings_, boundMarket, StagedOptionsJson(options), StagedResultJson(result),
+                                    data->reason_, StagedSpecJson(spec), result.diagnostics_.effJacobianInverse_, data->tolerance_));
         return RateQuoteRiskProvenance_(data);
     }
 } // namespace Dal

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -1281,16 +1281,18 @@ namespace Dal {
                                              RatePortfolioQuoteRisk_* result) {
             if (!item.active_)
                 return;
+            const bool dependencyPlanAvailable = passive.succeeded_ || !passive.dependencyComponentKeys_.empty();
+            const bool consumesComponent = std::find(passive.dependencyComponentKeys_.begin(), passive.dependencyComponentKeys_.end(),
+                                                     item.componentKey_) != passive.dependencyComponentKeys_.end();
+            if (dependencyPlanAvailable && !consumesComponent) {
+                static_cast<void>(EnsureQuoteRiskGradient(item.index_, actualPvCcy.String(), item.parameterCount_, gradientSums));
+                AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, true, true, String_(), result);
+                return;
+            }
             if (!UsablePassivePrice(passive)) {
                 const auto failed = sweeper->Sweep(trade, item.componentKey_);
                 AppendQuoteRiskMeta(trade, item, actualPvCcy, 0.0, false, false,
                                     failed.reason_.empty() ? String_("TRADE_VALIDATION_FAILED") : failed.reason_, result);
-                return;
-            }
-            if (std::find(passive.dependencyComponentKeys_.begin(), passive.dependencyComponentKeys_.end(), item.componentKey_) ==
-                passive.dependencyComponentKeys_.end()) {
-                static_cast<void>(EnsureQuoteRiskGradient(item.index_, actualPvCcy.String(), item.parameterCount_, gradientSums));
-                AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, true, true, String_(), result);
                 return;
             }
             const auto cell = sweeper->Sweep(trade, item.componentKey_);

--- a/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
+++ b/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
@@ -848,6 +848,51 @@ TEST(QuoteRiskAggregationTest, TestNonDependencyUsesStructuralZeroWithoutSweepin
     ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(), 0);
 }
 
+TEST(QuoteRiskAggregationTest, TestFailedNonDependencyRemainsStructuralZeroWithoutSweeping) {
+    auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    input.market_.curveComponents_["unrelated"] = input.market_.curveComponents_.at("discount");
+    auto trade = SingleDepositTrade(input);
+    auto& terms = std::get<Dal::DepositTradeTerms_>(trade.terms_);
+    terms.discountComponentKey_ = "unrelated";
+    terms.notional_ = 0.0;
+    Dal::RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.store(0);
+    Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.store(0);
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({trade}, input.market_, {provenance});
+
+    ASSERT_EQ(result.meta_.size(), 1U);
+    ASSERT_TRUE(result.meta_.front().eligible_);
+    ASSERT_TRUE(result.meta_.front().structuralZero_);
+    ASSERT_TRUE(result.meta_.front().reason_.empty());
+    ASSERT_EQ(result.buckets_.size(), provenance.Axis().quotes_.size());
+    for (const auto& bucket : result.buckets_) {
+        ASSERT_DOUBLE_EQ(bucket.dPvDDecimalQuote_, 0.0);
+        ASSERT_DOUBLE_EQ(bucket.dv01_, 0.0);
+    }
+    ASSERT_TRUE(result.pvByActualPvCcy_.empty());
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.load(), 0);
+    ASSERT_EQ(Dal::RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(), 0);
+}
+
+TEST(QuoteRiskAggregationTest, TestFailedDependencyPlanDoesNotClaimStructuralZero) {
+    auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto provenance = BuildSingle(input);
+    input.market_.curveComponents_["unrelated"] = input.market_.curveComponents_.at("discount");
+    auto trade = SingleDepositTrade(input);
+    std::get<Dal::DepositTradeTerms_>(trade.terms_).discountComponentKey_ = "unrelated";
+    trade.maturityDate_ = trade.startDate_;
+
+    const auto result = Dal::AggregateRatePortfolioQuoteRisk({trade}, input.market_, {provenance});
+
+    ASSERT_EQ(result.meta_.size(), 1U);
+    ASSERT_FALSE(result.meta_.front().eligible_);
+    ASSERT_FALSE(result.meta_.front().structuralZero_);
+    ASSERT_EQ(result.meta_.front().reason_, "QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE");
+    ASSERT_TRUE(result.buckets_.empty());
+    ASSERT_TRUE(result.pvByActualPvCcy_.empty());
+}
+
 TEST(QuoteRiskAggregationTest, TestTradeFailureDoesNotAffectSiblingTrade) {
     const auto input = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
     const auto provenance = BuildSingle(input);
@@ -1044,6 +1089,35 @@ TEST(QuoteRiskProvenanceTest, TestSingleCurveAxisIsStableWhileStateTracksMutable
         ASSERT_EQ(changed->Axis().fingerprint_, baseline.Axis().fingerprint_);
         ASSERT_NE(changed->State().fingerprint_, baseline.State().fingerprint_);
     }
+}
+
+TEST(QuoteRiskProvenanceTest, TestCalibrationIdDoesNotChangeCalibrationStateFingerprint) {
+    auto firstInput = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto first = BuildSingle(firstInput);
+    auto secondInput = MakeSingleInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    secondInput.config_.calibrationId_ = "same-state-different-id";
+    const auto second = BuildSingle(secondInput);
+
+    ASSERT_NE(first.CalibrationId(), second.CalibrationId());
+    ASSERT_EQ(first.Axis().fingerprint_, second.Axis().fingerprint_);
+    ASSERT_EQ(first.State().components_.front().fingerprint_, second.State().components_.front().fingerprint_);
+    ASSERT_EQ(first.State().fingerprint_, second.State().fingerprint_);
+
+    auto jointInput = MakeJointInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto firstJoint =
+        Dal::BuildJointXccyQuoteRiskProvenance(jointInput.spec_, jointInput.result_, jointInput.options_, jointInput.market_, jointInput.config_);
+    jointInput.config_.calibrationId_ = "same-joint-state-different-id";
+    const auto secondJoint =
+        Dal::BuildJointXccyQuoteRiskProvenance(jointInput.spec_, jointInput.result_, jointInput.options_, jointInput.market_, jointInput.config_);
+    ASSERT_EQ(firstJoint.State().fingerprint_, secondJoint.State().fingerprint_);
+
+    auto stagedInput = MakeStagedInput(Dal::CurveJacobianMode_::Value_::ANALYTIC);
+    const auto firstStaged = Dal::BuildStagedXccyBasisQuoteRiskProvenance(stagedInput.spec_, *stagedInput.result_, stagedInput.options_,
+                                                                          stagedInput.market_, stagedInput.config_);
+    stagedInput.config_.calibrationId_ = "same-staged-state-different-id";
+    const auto secondStaged = Dal::BuildStagedXccyBasisQuoteRiskProvenance(stagedInput.spec_, *stagedInput.result_, stagedInput.options_,
+                                                                           stagedInput.market_, stagedInput.config_);
+    ASSERT_EQ(firstStaged.State().fingerprint_, secondStaged.State().fingerprint_);
 }
 
 TEST(QuoteRiskProvenanceTest, TestJointXccyAnalyticAndBumpedConstruction) {


### PR DESCRIPTION
## Summary

- preserve structural-zero classification for quote-risk provenance components a trade does not consume, even when passive pricing fails after a usable dependency plan was produced
- keep genuinely unavailable dependency plans fail-closed instead of claiming structural zero
- remove the business calibration ID from the canonical calibration-state fingerprint for single, joint-XCCY, and staged-XCCY provenance

## Tests

- RED: the focused structural-zero and state-identity tests failed before the production change
- GREEN: all 31 quote-risk aggregation/provenance tests pass
- full build and `ctest`: 1484/1484 pass
- generated-source drift, documentation, clang-format, diff, and complexity checks pass

Closes DAL-175
