### PR TITLE
feat: expose quote risk to public C++ and Python (DAL-177)

### DIFF
--- a/dal-public/src/curvepricing.cpp
+++ b/dal-public/src/curvepricing.cpp
@@ -9,4 +9,20 @@ namespace Dal {
         static const Vector_<RateInstrumentType_> result = RateInstrumentTypeListAll();
         return result;
     }
+
+    RateQuoteRiskProvenance_ BuildSingleCurveQuoteRiskProvenance(const CurveCalibrationSpec_& spec,
+                                                                 const CalibrationResult_& result,
+                                                                 const CurveCalibrationOptions_& options,
+                                                                 const RatePricingMarket_& boundMarket,
+                                                                 const RateQuoteRiskProvenanceConfig_& config) {
+        REQUIRE(result.curve_, "QUOTE_RISK_CALIBRATION_RESULT_CURVE_EMPTY");
+        std::unique_ptr<YCComponent_> cloned = result.curve_->Clone(result.curve_->Name(), {});
+        auto* curve = dynamic_cast<DiscountCurve_*>(cloned.get());
+        REQUIRE(curve, "QUOTE_RISK_CALIBRATION_RESULT_CURVE_INVALID");
+
+        CurveCalibrationResult_ coreResult;
+        coreResult.curve_.reset(static_cast<DiscountCurve_*>(cloned.release()));
+        coreResult.diagnostics_ = result.diagnostics_;
+        return BuildSingleCurveQuoteRiskProvenance(spec, coreResult, options, boundMarket, config);
+    }
 } // namespace Dal

--- a/dal-public/src/curvepricing.hpp
+++ b/dal-public/src/curvepricing.hpp
@@ -4,8 +4,18 @@
 
 #pragma once
 
+#include <dal/curve/quoteriskaggregation.hpp>
+#include <dal/curve/quoteriskprovenance.hpp>
 #include <dal/curve/ratecashflowpricing.hpp>
+
+#include <dal-public/src/curvespec.hpp>
 
 namespace Dal {
     const Vector_<RateInstrumentType_>& CurvePricingFamilyRegistry();
+
+    RateQuoteRiskProvenance_ BuildSingleCurveQuoteRiskProvenance(const CurveCalibrationSpec_& spec,
+                                                                 const CalibrationResult_& result,
+                                                                 const CurveCalibrationOptions_& options,
+                                                                 const RatePricingMarket_& boundMarket,
+                                                                 const RateQuoteRiskProvenanceConfig_& config);
 } // namespace Dal

--- a/dal-public/tests/test_curvepricing.cpp
+++ b/dal-public/tests/test_curvepricing.cpp
@@ -93,3 +93,32 @@ TEST(CurvePricingPublicTest, TestBatchAndAggregationEntryPointsRemainCallableThr
     ASSERT_TRUE(aggregateDefaults.pvByActualPvCcy_.empty());
     ASSERT_TRUE(aggregateDefaults.meta_.empty());
 }
+
+TEST(CurvePricingPublicTest, TestQuoteRiskEntryPointsRemainCallableThroughPublicHeader) {
+    using CoreSingleFactory_ = Dal::RateQuoteRiskProvenance_ (*)(const Dal::CurveCalibrationSpec_&, const Dal::CurveCalibrationResult_&,
+                                                                 const Dal::CurveCalibrationOptions_&, const Dal::RatePricingMarket_&,
+                                                                 const Dal::RateQuoteRiskProvenanceConfig_&);
+    using PublicSingleFactory_ =
+        Dal::RateQuoteRiskProvenance_ (*)(const Dal::CurveCalibrationSpec_&, const Dal::CalibrationResult_&, const Dal::CurveCalibrationOptions_&,
+                                          const Dal::RatePricingMarket_&, const Dal::RateQuoteRiskProvenanceConfig_&);
+    using JointFactory_ = Dal::RateQuoteRiskProvenance_ (*)(const Dal::JointXccyCalibrationSpec_&, const Dal::JointXccyCalibrationResult_&,
+                                                            const Dal::JointXccyCalibrationOptions_&, const Dal::RatePricingMarket_&,
+                                                            const Dal::RateQuoteRiskProvenanceConfig_&);
+    using StagedFactory_ = Dal::RateQuoteRiskProvenance_ (*)(const Dal::CrossCurrencyCalibrationSpec_&, const Dal::CrossCurrencyCalibrationResult_&,
+                                                             const Dal::CrossCurrencyCalibrationOptions_&, const Dal::RatePricingMarket_&,
+                                                             const Dal::RateQuoteRiskProvenanceConfig_&);
+    using Aggregate_ = Dal::RatePortfolioQuoteRisk_ (*)(const Dal::Vector_<Dal::RateTradeDefinition_>&, const Dal::RatePricingMarket_&,
+                                                        const Dal::Vector_<Dal::RateQuoteRiskProvenance_>&);
+
+    const CoreSingleFactory_ coreSingle = static_cast<CoreSingleFactory_>(&Dal::BuildSingleCurveQuoteRiskProvenance);
+    const PublicSingleFactory_ publicSingle = static_cast<PublicSingleFactory_>(&Dal::BuildSingleCurveQuoteRiskProvenance);
+    const JointFactory_ joint = &Dal::BuildJointXccyQuoteRiskProvenance;
+    const StagedFactory_ staged = &Dal::BuildStagedXccyBasisQuoteRiskProvenance;
+    const Aggregate_ aggregate = &Dal::AggregateRatePortfolioQuoteRisk;
+
+    ASSERT_NE(coreSingle, nullptr);
+    ASSERT_NE(publicSingle, nullptr);
+    ASSERT_NE(joint, nullptr);
+    ASSERT_NE(staged, nullptr);
+    ASSERT_NE(aggregate, nullptr);
+}

--- a/dal-public/tests/test_curvespec.cpp
+++ b/dal-public/tests/test_curvespec.cpp
@@ -6,6 +6,7 @@
 
 #include <dal-public/src/curvedata.hpp>
 #include <dal-public/src/curveinstrument.hpp>
+#include <dal-public/src/curvepricing.hpp>
 #include <dal-public/src/curveprotocol.hpp>
 #include <dal-public/src/curvespec.hpp>
 
@@ -78,6 +79,57 @@ TEST(CurveSpecTest, TestSingleCurveOptionsOverloadIsPublicAndAdditive) {
     ASSERT_EQ(options.jacobianMode_, Dal::CurveJacobianMode_::Value_::ANALYTIC);
     ASSERT_TRUE(options.computeForwardJacobian_);
     ASSERT_TRUE(options.computeEffJacobianInverse_);
+}
+
+TEST(CurveSpecTest, TestPublicQuoteRiskOverloadMatchesCoreProvenance) {
+    CurveCalibrationSpecBuilder_ builder;
+    builder.today_ = Today();
+    builder.ccy_ = "USD";
+    builder.curveName_ = "public_quote_risk";
+    builder.calibrateDiscountCurve_ = true;
+    builder.tolerance_ = 1.0e-10;
+    builder.initialGuess_ = 0.02;
+    builder.parameterization_ = CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD;
+
+    const RateIndexConvention_ index = RateIndexConvention_New(PeriodLength_New("3M"), DayBasis_New("ACT_365F"), CollateralType_OIS());
+    for (int months : {6, 12}) {
+        const Date_ maturity = Dal::Date::AddMonths(Today(), months);
+        builder.knotDates_.push_back(maturity);
+        builder.instruments_.push_back(DepositNew(Today(), Today(), maturity, 0.02 + months * 1.0e-4, index));
+    }
+
+    const Dal::CurveCalibrationSpec_ spec = builder.Build();
+    const Dal::CurveCalibrationOptions_ options;
+    const CalibrationResult_ publicResult = CalibrateSingleCurve(spec, options);
+    Dal::RatePricingMarket_ market;
+    market.valuationTime_ = Dal::DateTime_(Today(), 9, 0);
+    market.resultCurrency_ = Dal::Ccy_("USD");
+    market.curveComponents_["discount"] = publicResult.curve_;
+    market.fixings_ = Dal::Handle_<Dal::MarketFixingSnapshot_>(new Dal::MarketFixingSnapshot_());
+    Dal::RateQuoteRiskProvenanceConfig_ config;
+    config.calibrationId_ = "public-calibration";
+    config.componentKeyByParameterBlock_[spec.curveName_] = "discount";
+
+    const Dal::RateQuoteRiskProvenance_ publicProvenance = Dal::BuildSingleCurveQuoteRiskProvenance(spec, publicResult, options, market, config);
+
+    std::unique_ptr<Dal::YCComponent_> cloned = publicResult.curve_->Clone(publicResult.curve_->Name(), {});
+    auto* discount = dynamic_cast<Dal::DiscountCurve_*>(cloned.get());
+    ASSERT_NE(discount, nullptr);
+    Dal::CurveCalibrationResult_ coreResult;
+    coreResult.curve_.reset(static_cast<Dal::DiscountCurve_*>(cloned.release()));
+    coreResult.diagnostics_ = publicResult.diagnostics_;
+    const Dal::RateQuoteRiskProvenance_ coreProvenance = Dal::BuildSingleCurveQuoteRiskProvenance(spec, coreResult, options, market, config);
+
+    ASSERT_TRUE(publicProvenance.Available());
+    ASSERT_EQ(publicProvenance.Kind(), coreProvenance.Kind());
+    ASSERT_EQ(publicProvenance.Reason(), coreProvenance.Reason());
+    ASSERT_EQ(publicProvenance.Axis().fingerprint_, coreProvenance.Axis().fingerprint_);
+    ASSERT_EQ(publicProvenance.State().fingerprint_, coreProvenance.State().fingerprint_);
+    ASSERT_EQ(publicProvenance.EffectiveInverse().Rows(), coreProvenance.EffectiveInverse().Rows());
+    ASSERT_EQ(publicProvenance.EffectiveInverse().Cols(), coreProvenance.EffectiveInverse().Cols());
+    for (int row = 0; row < publicProvenance.EffectiveInverse().Rows(); ++row)
+        for (int col = 0; col < publicProvenance.EffectiveInverse().Cols(); ++col)
+            ASSERT_DOUBLE_EQ(publicProvenance.EffectiveInverse()(row, col), coreProvenance.EffectiveInverse()(row, col));
 }
 
 // Single-curve calibration (EXACT, PIECEWISE_LINEAR_FWD)

--- a/dal-python/examples/007.xccy_joint_calibration.py
+++ b/dal-python/examples/007.xccy_joint_calibration.py
@@ -190,10 +190,51 @@ def print_ranges(label: str, ranges) -> None:
         print(f"  {block.name}: [{block.offset}, {block.offset + block.size})")
 
 
+def build_quote_risk_provenance(spec, result, options):
+    """Bind the three solved joint blocks to one immutable market snapshot."""
+    curve_by_block = {
+        "domestic:usd_ois": next(iter(result.domestic_curve_block.discount_curves.values())),
+        "foreign:eur_ois": next(iter(result.foreign_curve_block.discount_curves.values())),
+        "basis:usd_eur_basis": result.basis_curve,
+    }
+    bindings = {name: f"joint/{name}" for name in curve_by_block}
+    components = {bindings[name]: curve for name, curve in curve_by_block.items()}
+    xccy_market = dal.CrossCurrencyMarket_New(
+        domestic_block=result.domestic_curve_block,
+        foreign_block=result.foreign_curve_block,
+        fx_spot=1.10,
+        valuation_time=VALUATION_TIME,
+        collateral_currency="USD",
+        fixings=result.fixings,
+        basis_curve=result.basis_curve,
+    )
+    market = dal.RatePricingMarket_(
+        valuation_time=VALUATION_TIME,
+        result_currency="USD",
+        curve_components=components,
+        xccy_market=xccy_market,
+        fixings=result.fixings,
+    )
+    return dal.BuildJointXccyQuoteRiskProvenance(
+        spec=spec,
+        result=result,
+        options=options,
+        bound_market=market,
+        config=dal.RateQuoteRiskProvenanceConfig_(
+            calibration_id="usd-eur-joint",
+            component_key_by_parameter_block=bindings,
+        ),
+    )
+
+
 def main() -> int:
     """Run and validate the installed-surface joint calibration example."""
-    result = dal.CalibrateJointXccyMarket(make_spec())
+    spec = make_spec()
+    options = dal.JointXccyCalibrationOptions_()
+    result = dal.CalibrateJointXccyMarket(spec, options)
     validate_result(result)
+    provenance = build_quote_risk_provenance(spec, result, options)
+    require(provenance.available, provenance.reason)
 
     jacobian = result.jacobian_at_solution
     print(f"Converged: {result.converged}")
@@ -206,6 +247,10 @@ def main() -> int:
         result.fx_forward_curve.dates, result.fx_forward_curve.forwards
     ):
         print(f"  {date}: {forward:.12g}")
+    print(f"Quote-risk axis fingerprint: {provenance.axis.fingerprint}")
+    print("Quote-risk blocks:")
+    for block in provenance.axis.parameter_ranges:
+        print(f"  {block.block_key}: [{block.offset}, {block.offset + block.size})")
     return 0
 
 

--- a/dal-python/examples/009.quote_risk.py
+++ b/dal-python/examples/009.quote_risk.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Calibrate one USD curve and aggregate quote-space DV01."""
+
+import dal
+
+
+TODAY = dal.Date_(2025, 6, 20)
+SPOT = TODAY.AddDays(2)
+
+
+def make_spec():
+    """Build an exact three-quote OIS calibration."""
+    fixed_leg = dal.RateLegConvention_New(
+        dal.PeriodLength_New("6M"), dal.DayBasis_New("ACT_365F")
+    )
+    float_leg = dal.RateLegConvention_New(
+        dal.PeriodLength_New("3M"), dal.DayBasis_New("ACT_360")
+    )
+    overnight_index = dal.RateIndexConvention_New(
+        dal.PeriodLength_New("12M"),
+        dal.DayBasis_New("ACT_360"),
+        dal.CollateralType_OIS(),
+    )
+    maturities = [SPOT.AddDays(years * 365) for years in (2, 5, 10)]
+
+    builder = dal.CurveCalibrationSpecBuilder_()
+    builder.today_ = TODAY
+    builder.ccy_ = dal.String_("USD")
+    builder.curveName_ = dal.String_("usd_ois")
+    builder.calibrateDiscountCurve_ = True
+    builder.initialGuess_ = 0.04
+    builder.instruments_ = [
+        dal.OISSwap_New(
+            TODAY,
+            SPOT,
+            maturity,
+            0.04,
+            fixed_leg,
+            overnight_index,
+            float_leg,
+        )
+        for maturity in maturities
+    ]
+    builder.knotDates_ = maturities
+    return builder.Build(), maturities
+
+
+def make_trade(maturity):
+    """Build a deposit whose PV depends on the calibrated component."""
+    index = dal.RateIndexConvention_New(
+        dal.PeriodLength_New("3M"),
+        dal.DayBasis_New("ACT_365F"),
+        dal.CollateralType_OIS(),
+    )
+    terms = dal.DepositTradeTerms_(
+        notional=1_000_000.0,
+        contract_rate=0.022,
+        lend=True,
+        index=index,
+        discount_component_key="discount",
+    )
+    return dal.RateTradeDefinition_(
+        instrument_id="deposit-1",
+        instrument_type=dal.RateInstrumentType.DEPOSIT,
+        trade_date=TODAY,
+        start_date=TODAY,
+        maturity_date=maturity,
+        currency="USD",
+        terms=terms,
+    )
+
+
+def main() -> int:
+    """Run the supported single-curve provenance and aggregation workflow."""
+    spec, maturities = make_spec()
+    options = dal.CurveCalibrationOptions_()
+    calibrated = dal.CalibrateSingleCurve(spec, options)
+    fixings = dal.MarketFixingSnapshot_New({})
+    market = dal.RatePricingMarket_(
+        valuation_time=dal.DateTime_(TODAY, 9, 0),
+        result_currency="USD",
+        curve_components={"discount": calibrated.curve_},
+        fixings=fixings,
+    )
+    provenance = dal.BuildSingleCurveQuoteRiskProvenance(
+        spec=spec,
+        result=calibrated,
+        options=options,
+        bound_market=market,
+        config=dal.RateQuoteRiskProvenanceConfig_(
+            calibration_id="usd-ois-calibration",
+            component_key_by_parameter_block={"usd_ois": "discount"},
+        ),
+    )
+    risk = dal.AggregateRatePortfolioQuoteRisk(
+        trades=[make_trade(maturities[0])],
+        market=market,
+        provenances=[provenance],
+    )
+
+    print(f"Axis fingerprint: {provenance.axis.fingerprint}")
+    print(f"State fingerprint: {provenance.state.fingerprint}")
+    print("Quote risk (decimal quote sensitivity, DV01):")
+    for bucket in risk.buckets:
+        print(
+            f"  {bucket.quote_key}: "
+            f"{bucket.d_pv_d_decimal_quote:.10g}, {bucket.dv01:.10g} {bucket.actual_pv_ccy}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dal-python/src/bindings/curve.cpp
+++ b/dal-python/src/bindings/curve.cpp
@@ -40,6 +40,7 @@ using namespace Dal;
 
 namespace {
     std::atomic<int> s_curveCalibrationGilBarrierMilliseconds{0};
+    std::atomic<int> s_quoteRiskGilBarrierMilliseconds{0};
     std::atomic<int> s_rateRiskGilBarrierMilliseconds{0};
 
     void RunCurveCalibrationGilBarrierForTesting() {
@@ -52,6 +53,12 @@ namespace {
     // native execution; mirrors the calibration-side paradigm.
     void RunRateRiskGilBarrierForTesting() {
         const int milliseconds = s_rateRiskGilBarrierMilliseconds.exchange(0);
+        if (milliseconds > 0)
+            std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+    }
+
+    void RunQuoteRiskGilBarrierForTesting() {
+        const int milliseconds = s_quoteRiskGilBarrierMilliseconds.exchange(0);
         if (milliseconds > 0)
             std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
     }
@@ -93,6 +100,47 @@ namespace {
             py::gil_scoped_release release;
             RunRateRiskGilBarrierForTesting();
             aggregate = AggregateRatePortfolioNodeRisk(nativeTrades, market, componentKeys);
+        }
+        return aggregate;
+    }
+
+    RateQuoteRiskProvenance_ RunBuildSingleCurveQuoteRiskProvenance(const CurveCalibrationSpec_& spec,
+                                                                    const CalibrationResult_& result,
+                                                                    const CurveCalibrationOptions_& options,
+                                                                    const RatePricingMarket_& boundMarket,
+                                                                    const RateQuoteRiskProvenanceConfig_& config) {
+        py::gil_scoped_release release;
+        return BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config);
+    }
+
+    RateQuoteRiskProvenance_ RunBuildJointXccyQuoteRiskProvenance(const JointXccyCalibrationSpec_& spec,
+                                                                  const JointXccyCalibrationResult_& result,
+                                                                  const JointXccyCalibrationOptions_& options,
+                                                                  const RatePricingMarket_& boundMarket,
+                                                                  const RateQuoteRiskProvenanceConfig_& config) {
+        py::gil_scoped_release release;
+        return BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config);
+    }
+
+    RateQuoteRiskProvenance_ RunBuildStagedXccyBasisQuoteRiskProvenance(const CrossCurrencyCalibrationSpec_& spec,
+                                                                        const CrossCurrencyCalibrationResult_& result,
+                                                                        const CrossCurrencyCalibrationOptions_& options,
+                                                                        const RatePricingMarket_& boundMarket,
+                                                                        const RateQuoteRiskProvenanceConfig_& config) {
+        py::gil_scoped_release release;
+        return BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config);
+    }
+
+    RatePortfolioQuoteRisk_ RunAggregateRatePortfolioQuoteRisk(const std::vector<RateTradeDefinition_>& trades,
+                                                               const RatePricingMarket_& market,
+                                                               const std::vector<RateQuoteRiskProvenance_>& provenances) {
+        const Vector_<RateTradeDefinition_> nativeTrades(trades.begin(), trades.end());
+        const Vector_<RateQuoteRiskProvenance_> nativeProvenances(provenances.begin(), provenances.end());
+        RatePortfolioQuoteRisk_ aggregate;
+        {
+            py::gil_scoped_release release;
+            RunQuoteRiskGilBarrierForTesting();
+            aggregate = AggregateRatePortfolioQuoteRisk(nativeTrades, market, nativeProvenances);
         }
         return aggregate;
     }
@@ -1888,6 +1936,142 @@ namespace {
 
         AddMatrixSnakeCaseAliases(m);
     }
+
+    void init_bindings_curve_quote_risk(py::module_& m) {
+        py::class_<RateQuoteRiskProvenanceConfig_>(m, "RateQuoteRiskProvenanceConfig_")
+            .def(py::init([](const std::string& calibrationId, const std::map<std::string, std::string>& bindings) {
+                     RateQuoteRiskProvenanceConfig_ result;
+                     result.calibrationId_ = String_(calibrationId);
+                     for (const auto& [block, component] : bindings)
+                         result.componentKeyByParameterBlock_[String_(block)] = String_(component);
+                     return result;
+                 }),
+                 py::kw_only(), py::arg("calibration_id"), py::arg("component_key_by_parameter_block"))
+            .def_property_readonly("calibration_id", [](const RateQuoteRiskProvenanceConfig_& value) { return StdString(value.calibrationId_); })
+            .def_property_readonly("component_key_by_parameter_block", [](const RateQuoteRiskProvenanceConfig_& value) {
+                std::map<std::string, std::string> result;
+                for (const auto& [block, component] : value.componentKeyByParameterBlock_)
+                    result[StdString(block)] = StdString(component);
+                return result;
+            });
+
+        py::class_<RateQuoteRiskRange_>(m, "RateQuoteRiskRange_")
+            .def_property_readonly("block_key", [](const RateQuoteRiskRange_& value) { return StdString(value.blockKey_); })
+            .def_property_readonly("offset", [](const RateQuoteRiskRange_& value) { return value.offset_; })
+            .def_property_readonly("size", [](const RateQuoteRiskRange_& value) { return value.size_; });
+
+        py::class_<RateQuoteRiskParameterCoordinate_>(m, "RateQuoteRiskParameterCoordinate_")
+            .def_property_readonly("block_key", [](const RateQuoteRiskParameterCoordinate_& value) { return StdString(value.blockKey_); })
+            .def_property_readonly("block_ordinal", [](const RateQuoteRiskParameterCoordinate_& value) { return value.blockOrdinal_; })
+            .def_property_readonly("global_ordinal", [](const RateQuoteRiskParameterCoordinate_& value) { return value.globalOrdinal_; })
+            .def_property_readonly("date", [](const RateQuoteRiskParameterCoordinate_& value) { return value.date_; })
+            .def_property_readonly("component", [](const RateQuoteRiskParameterCoordinate_& value) { return value.component_.Switch(); });
+
+        py::class_<RateQuoteRiskQuoteCoordinate_>(m, "RateQuoteRiskQuoteCoordinate_")
+            .def_property_readonly("block_key", [](const RateQuoteRiskQuoteCoordinate_& value) { return StdString(value.blockKey_); })
+            .def_property_readonly("block_ordinal", [](const RateQuoteRiskQuoteCoordinate_& value) { return value.blockOrdinal_; })
+            .def_property_readonly("global_ordinal", [](const RateQuoteRiskQuoteCoordinate_& value) { return value.globalOrdinal_; })
+            .def_property_readonly("display_name", [](const RateQuoteRiskQuoteCoordinate_& value) { return StdString(value.displayName_); })
+            .def_property_readonly("unit", [](const RateQuoteRiskQuoteCoordinate_& value) { return StdString(value.unit_); });
+
+        py::class_<RateQuoteRiskAxis_>(m, "RateQuoteRiskAxis_")
+            .def_property_readonly("scheme", [](const RateQuoteRiskAxis_& value) { return StdString(value.scheme_); })
+            .def_property_readonly("fingerprint", [](const RateQuoteRiskAxis_& value) { return StdString(value.fingerprint_); })
+            .def_property_readonly("parameter_ranges", [](const RateQuoteRiskAxis_& value) { return ValuesToTuple(value.parameterRanges_); })
+            .def_property_readonly("residual_ranges", [](const RateQuoteRiskAxis_& value) { return ValuesToTuple(value.residualRanges_); })
+            .def_property_readonly("parameters", [](const RateQuoteRiskAxis_& value) { return ValuesToTuple(value.parameters_); })
+            .def_property_readonly("quotes", [](const RateQuoteRiskAxis_& value) { return ValuesToTuple(value.quotes_); });
+
+        py::class_<RateQuoteRiskComponentState_>(m, "RateQuoteRiskComponentState_")
+            .def_property_readonly("component_key", [](const RateQuoteRiskComponentState_& value) { return StdString(value.componentKey_); })
+            .def_property_readonly("fingerprint", [](const RateQuoteRiskComponentState_& value) { return StdString(value.fingerprint_); });
+
+        py::class_<RateQuoteRiskState_>(m, "RateQuoteRiskState_")
+            .def_property_readonly("scheme", [](const RateQuoteRiskState_& value) { return StdString(value.scheme_); })
+            .def_property_readonly("fingerprint", [](const RateQuoteRiskState_& value) { return StdString(value.fingerprint_); })
+            .def_property_readonly("components", [](const RateQuoteRiskState_& value) { return ValuesToTuple(value.components_); });
+
+        py::class_<RateQuoteRiskProvenance_>(m, "RateQuoteRiskProvenance_")
+            .def_property_readonly("kind", [](const RateQuoteRiskProvenance_& value) { return StdString(value.Kind()); })
+            .def_property_readonly("available", [](const RateQuoteRiskProvenance_& value) { return value.Available(); })
+            .def_property_readonly("reason", [](const RateQuoteRiskProvenance_& value) { return StdString(value.Reason()); })
+            .def_property_readonly("calibration_id", [](const RateQuoteRiskProvenance_& value) { return StdString(value.CalibrationId()); })
+            .def_property_readonly("component_key_by_parameter_block",
+                                   [](const RateQuoteRiskProvenance_& value) {
+                                       std::map<std::string, std::string> result;
+                                       for (const auto& [block, component] : value.ComponentKeyByParameterBlock())
+                                           result[StdString(block)] = StdString(component);
+                                       return result;
+                                   })
+            .def_property_readonly("axis", [](const RateQuoteRiskProvenance_& value) { return value.Axis(); })
+            .def_property_readonly("state", [](const RateQuoteRiskProvenance_& value) { return value.State(); })
+            .def_property_readonly("effective_inverse", [](const RateQuoteRiskProvenance_& value) { return Matrix_<>(value.EffectiveInverse()); })
+            .def_property_readonly("tolerance", [](const RateQuoteRiskProvenance_& value) { return value.Tolerance(); });
+
+        py::class_<RateQuoteRiskBucket_>(m, "RateQuoteRiskBucket_")
+            .def_property_readonly("calibration_id", [](const RateQuoteRiskBucket_& value) { return StdString(value.calibrationId_); })
+            .def_property_readonly("axis_fingerprint", [](const RateQuoteRiskBucket_& value) { return StdString(value.axisFingerprint_); })
+            .def_property_readonly("quote_key", [](const RateQuoteRiskBucket_& value) { return StdString(value.quoteKey_); })
+            .def_property_readonly("quote_name", [](const RateQuoteRiskBucket_& value) { return StdString(value.quoteName_); })
+            .def_property_readonly("residual_block", [](const RateQuoteRiskBucket_& value) { return StdString(value.residualBlock_); })
+            .def_property_readonly("quote_ordinal", [](const RateQuoteRiskBucket_& value) { return value.quoteOrdinal_; })
+            .def_property_readonly("actual_pv_ccy", [](const RateQuoteRiskBucket_& value) { return std::string(value.actualPvCcy_.String()); })
+            .def_property_readonly("d_pv_d_decimal_quote", [](const RateQuoteRiskBucket_& value) { return value.dPvDDecimalQuote_; })
+            .def_property_readonly("dv01", [](const RateQuoteRiskBucket_& value) { return value.dv01_; });
+
+        py::class_<RatePortfolioQuoteRiskMetaEntry_>(m, "RatePortfolioQuoteRiskMetaEntry_")
+            .def_property_readonly("instrument_id", [](const RatePortfolioQuoteRiskMetaEntry_& value) { return StdString(value.instrumentId_); })
+            .def_property_readonly("calibration_id", [](const RatePortfolioQuoteRiskMetaEntry_& value) { return StdString(value.calibrationId_); })
+            .def_property_readonly("eligible", [](const RatePortfolioQuoteRiskMetaEntry_& value) { return value.eligible_; })
+            .def_property_readonly("structural_zero", [](const RatePortfolioQuoteRiskMetaEntry_& value) { return value.structuralZero_; })
+            .def_property_readonly("reason", [](const RatePortfolioQuoteRiskMetaEntry_& value) { return StdString(value.reason_); })
+            .def_property_readonly("failing_component_key",
+                                   [](const RatePortfolioQuoteRiskMetaEntry_& value) { return StdString(value.failingComponentKey_); })
+            .def_property_readonly("original_node_risk_reason",
+                                   [](const RatePortfolioQuoteRiskMetaEntry_& value) { return StdString(value.originalNodeRiskReason_); })
+            .def_property_readonly("actual_pv_ccy",
+                                   [](const RatePortfolioQuoteRiskMetaEntry_& value) { return std::string(value.actualPvCcy_.String()); })
+            .def_property_readonly("pv", [](const RatePortfolioQuoteRiskMetaEntry_& value) { return value.pv_; });
+
+        py::class_<RateQuoteRiskProvenanceFailure_>(m, "RateQuoteRiskProvenanceFailure_")
+            .def_property_readonly("calibration_id", [](const RateQuoteRiskProvenanceFailure_& value) { return StdString(value.calibrationId_); })
+            .def_property_readonly("reason", [](const RateQuoteRiskProvenanceFailure_& value) { return StdString(value.reason_); })
+            .def_property_readonly("component_key", [](const RateQuoteRiskProvenanceFailure_& value) { return StdString(value.componentKey_); })
+            .def_property_readonly("expected_state_fingerprint",
+                                   [](const RateQuoteRiskProvenanceFailure_& value) { return StdString(value.expectedStateFingerprint_); })
+            .def_property_readonly("actual_state_fingerprint",
+                                   [](const RateQuoteRiskProvenanceFailure_& value) { return StdString(value.actualStateFingerprint_); });
+
+        py::class_<RatePortfolioQuoteRisk_>(m, "RatePortfolioQuoteRisk_")
+            .def_property_readonly("policy", [](const RatePortfolioQuoteRisk_& value) { return StdString(value.policy_); })
+            .def_property_readonly("buckets", [](const RatePortfolioQuoteRisk_& value) { return ValuesToTuple(value.buckets_); })
+            .def_property_readonly("pv_by_actual_pv_ccy",
+                                   [](const RatePortfolioQuoteRisk_& value) {
+                                       py::dict result;
+                                       for (const auto& [currency, pv] : value.pvByActualPvCcy_)
+                                           result[py::str(StdString(currency))] = pv;
+                                       return result;
+                                   })
+            .def_property_readonly("meta", [](const RatePortfolioQuoteRisk_& value) { return ValuesToTuple(value.meta_); })
+            .def_property_readonly("provenance_failures",
+                                   [](const RatePortfolioQuoteRisk_& value) { return ValuesToTuple(value.provenanceFailures_); });
+
+        m.def("RateQuoteRiskAxisFingerprintScheme", []() { return StdString(RateQuoteRiskAxisFingerprintScheme()); });
+        m.def("RateQuoteRiskStateFingerprintScheme", []() { return StdString(RateQuoteRiskStateFingerprintScheme()); });
+        m.def("BuildSingleCurveQuoteRiskProvenance", &RunBuildSingleCurveQuoteRiskProvenance, py::kw_only(), py::arg("spec"), py::arg("result"),
+              py::arg("options"), py::arg("bound_market"), py::arg("config"));
+        m.def("BuildJointXccyQuoteRiskProvenance", &RunBuildJointXccyQuoteRiskProvenance, py::kw_only(), py::arg("spec"), py::arg("result"),
+              py::arg("options"), py::arg("bound_market"), py::arg("config"));
+        m.def("BuildStagedXccyBasisQuoteRiskProvenance", &RunBuildStagedXccyBasisQuoteRiskProvenance, py::kw_only(), py::arg("spec"),
+              py::arg("result"), py::arg("options"), py::arg("bound_market"), py::arg("config"));
+        m.def("AggregateRatePortfolioQuoteRisk", &RunAggregateRatePortfolioQuoteRisk, py::kw_only(), py::arg("trades"), py::arg("market"),
+              py::arg("provenances"));
+        m.def("_QuoteRiskGilBarrier_EnableForTesting", [](int milliseconds) {
+            if (milliseconds <= 0)
+                throw std::invalid_argument("quote-risk GIL barrier duration must be positive");
+            s_quoteRiskGilBarrierMilliseconds.store(milliseconds);
+        });
+    }
 } // anonymous namespace
 
 void init_bindings_curve(py::module_& m) {
@@ -1902,4 +2086,5 @@ void init_bindings_curve(py::module_& m) {
     init_bindings_curve_calibration_diagnostics(m);
     init_bindings_curve_calibration_results(m);
     init_bindings_curve_xccy(m);
+    init_bindings_curve_quote_risk(m);
 }

--- a/dal-python/tests/test_quote_risk.py
+++ b/dal-python/tests/test_quote_risk.py
@@ -1,0 +1,282 @@
+"""Public Python quote-risk contracts."""
+
+import gc
+import math
+
+import dal
+import pytest
+
+
+def _single_quote_risk_inputs(*, compute_inverse=True):
+    today = dal.Date_(2025, 6, 20)
+    spot = today.AddDays(2)
+    maturities = [spot.AddDays(years * 365) for years in (2, 5, 10)]
+    fixed_leg = dal.RateLegConvention_New(dal.PeriodLength_New("6M"), dal.DayBasis_New("ACT_365F"))
+    float_leg = dal.RateLegConvention_New(dal.PeriodLength_New("3M"), dal.DayBasis_New("ACT_360"))
+    overnight_index = dal.RateIndexConvention_New(
+        dal.PeriodLength_New("12M"), dal.DayBasis_New("ACT_360"), dal.CollateralType_OIS()
+    )
+    index = dal.RateIndexConvention_New(
+        dal.PeriodLength_New("3M"), dal.DayBasis_New("ACT_365F"), dal.CollateralType_OIS()
+    )
+    builder = dal.CurveCalibrationSpecBuilder_()
+    builder.today_ = today
+    builder.ccy_ = dal.String_("USD")
+    builder.curveName_ = dal.String_("python_quote_risk")
+    builder.calibrateDiscountCurve_ = True
+    builder.initialGuess_ = 0.04
+    builder.instruments_ = [
+        dal.OISSwap_New(today, spot, maturity, 0.04, fixed_leg, overnight_index, float_leg) for maturity in maturities
+    ]
+    builder.knotDates_ = maturities
+    spec = builder.Build()
+    options = dal.CurveCalibrationOptions_()
+    options.compute_eff_jacobian_inverse = compute_inverse
+    calibrated = dal.CalibrateSingleCurve(spec, options)
+    fixings = dal.MarketFixingSnapshot_New({})
+    market = dal.RatePricingMarket_(
+        valuation_time=dal.DateTime_(today, 9, 0),
+        result_currency="USD",
+        curve_components={"discount": calibrated.curve_},
+        fixings=fixings,
+    )
+    config = dal.RateQuoteRiskProvenanceConfig_(
+        calibration_id="python-calibration",
+        component_key_by_parameter_block={"python_quote_risk": "discount"},
+    )
+    provenance = dal.BuildSingleCurveQuoteRiskProvenance(
+        spec=spec,
+        result=calibrated,
+        options=options,
+        bound_market=market,
+        config=config,
+    )
+    terms = dal.DepositTradeTerms_(
+        notional=1_000_000.0,
+        contract_rate=0.022,
+        lend=True,
+        index=index,
+        discount_component_key="discount",
+    )
+    trade = dal.RateTradeDefinition_(
+        instrument_id="python-deposit",
+        instrument_type=dal.RateInstrumentType.DEPOSIT,
+        trade_date=today,
+        start_date=today,
+        maturity_date=maturities[0],
+        currency="USD",
+        terms=terms,
+    )
+    return spec, options, calibrated, fixings, market, config, provenance, trade
+
+
+def test_quote_risk_factories_and_aggregate_are_keyword_only():
+    signatures = {
+        "BuildSingleCurveQuoteRiskProvenance": ("spec", "result", "options", "bound_market", "config"),
+        "BuildJointXccyQuoteRiskProvenance": ("spec", "result", "options", "bound_market", "config"),
+        "BuildStagedXccyBasisQuoteRiskProvenance": ("spec", "result", "options", "bound_market", "config"),
+        "AggregateRatePortfolioQuoteRisk": ("trades", "market", "provenances"),
+    }
+
+    for name, arguments in signatures.items():
+        signature = getattr(dal, name).__doc__.splitlines()[0]
+        assert signature.startswith(f"{name}(*, ")  # nosec B101
+        positions = [signature.index(f"{argument}: ") for argument in arguments]
+        assert positions == sorted(positions)  # nosec B101
+
+    assert not hasattr(dal, "BuildMultiCurveQuoteRiskProvenance")  # nosec B101
+    assert not hasattr(dal, "BuildJointMultiCurveQuoteRiskProvenance")  # nosec B101
+
+    with pytest.raises(TypeError):
+        dal.RateQuoteRiskProvenanceConfig_("calibration", {"curve": "discount"})
+
+
+def test_single_curve_quote_risk_exposes_immutable_provenance_and_unit_bearing_results():
+    _, _, _, _, market, config, provenance, trade = _single_quote_risk_inputs()
+
+    assert config.calibration_id == "python-calibration"  # nosec B101
+    assert config.component_key_by_parameter_block == {"python_quote_risk": "discount"}  # nosec B101
+    assert provenance.kind == "SINGLE_CURVE"  # nosec B101
+    assert provenance.available is True  # nosec B101
+    assert provenance.reason == ""  # nosec B101
+    assert provenance.axis.scheme == dal.RateQuoteRiskAxisFingerprintScheme()  # nosec B101
+    assert provenance.state.scheme == dal.RateQuoteRiskStateFingerprintScheme()  # nosec B101
+    assert provenance.axis.fingerprint.startswith("sha256:")  # nosec B101
+    assert provenance.state.fingerprint.startswith("sha256:")  # nosec B101
+    assert len(provenance.axis.parameter_ranges) == 1  # nosec B101
+    assert len(provenance.axis.residual_ranges) == 1  # nosec B101
+    assert all(quote.unit == "DECIMAL_QUOTE" for quote in provenance.axis.quotes)  # nosec B101
+
+    aggregate = dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=market, provenances=[provenance])
+
+    assert aggregate.policy == "UnconvertedByActualPvCcy"  # nosec B101
+    assert set(aggregate.pv_by_actual_pv_ccy) == {"USD"}  # nosec B101
+    assert aggregate.provenance_failures == ()  # nosec B101
+    assert len(aggregate.meta) == 1  # nosec B101
+    assert aggregate.meta[0].eligible is True  # nosec B101
+    assert len(aggregate.buckets) == len(provenance.axis.quotes)  # nosec B101
+    for bucket in aggregate.buckets:
+        assert bucket.calibration_id == provenance.calibration_id  # nosec B101
+        assert bucket.axis_fingerprint == provenance.axis.fingerprint  # nosec B101
+        assert bucket.actual_pv_ccy == "USD"  # nosec B101
+        assert math.isfinite(bucket.d_pv_d_decimal_quote)  # nosec B101
+        assert bucket.dv01 == pytest.approx(bucket.d_pv_d_decimal_quote * 1.0e-4, abs=1.0e-12)  # nosec B101
+
+    original_inverse = provenance.effective_inverse[0, 0]
+    detached_inverse = provenance.effective_inverse
+    detached_inverse[0, 0] = original_inverse + 1.0
+    assert provenance.effective_inverse[0, 0] == original_inverse  # nosec B101
+    with pytest.raises(AttributeError):
+        config.calibration_id = "changed"
+    with pytest.raises(AttributeError):
+        provenance.available = False
+    with pytest.raises(AttributeError):
+        provenance.axis.fingerprint = "changed"
+    with pytest.raises(AttributeError):
+        aggregate.buckets[0].dv01 = 0.0
+
+
+def test_single_curve_quote_risk_reports_inverse_unavailable_without_buckets():
+    _, _, _, _, market, _, provenance, trade = _single_quote_risk_inputs(compute_inverse=False)
+
+    assert provenance.available is False  # nosec B101
+    assert provenance.reason == "QUOTE_RISK_INVERSE_NOT_REQUESTED"  # nosec B101
+    assert provenance.effective_inverse.rows() == 0  # nosec B101
+    result = dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=market, provenances=[provenance])
+    assert result.buckets == ()  # nosec B101
+    assert result.meta == ()  # nosec B101
+    assert len(result.provenance_failures) == 1  # nosec B101
+    assert result.provenance_failures[0].reason == "QUOTE_RISK_INVERSE_NOT_REQUESTED"  # nosec B101
+
+
+def test_quote_risk_provenance_survives_intermediate_result_and_market_gc():
+    _, _, calibrated, fixings, market, _, provenance, trade = _single_quote_risk_inputs()
+    curve = calibrated.curve_
+    fingerprint = provenance.state.fingerprint
+    del calibrated
+    del market
+    gc.collect()
+
+    replacement_market = dal.RatePricingMarket_(
+        valuation_time=dal.DateTime_(dal.Date_(2025, 6, 20), 9, 0),
+        result_currency="USD",
+        curve_components={"discount": curve},
+        fixings=fixings,
+    )
+    result = dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=replacement_market, provenances=[provenance])
+    assert provenance.state.fingerprint == fingerprint  # nosec B101
+    assert len(result.buckets) == 3  # nosec B101
+
+
+def test_quote_risk_aggregate_releases_gil_for_the_complete_native_operation():
+    import sys
+    import threading
+
+    _, _, _, _, market, _, provenance, trade = _single_quote_risk_inputs()
+    started = threading.Event()
+    ready = threading.Event()
+    stopped = threading.Event()
+    heartbeat_count = [0]
+
+    def heartbeat() -> None:
+        ready.set()
+        assert started.wait(timeout=5.0)  # nosec B101
+        while not stopped.is_set():
+            heartbeat_count[0] += 1
+
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1.0)
+    try:
+        thread = threading.Thread(target=heartbeat)
+        thread.start()
+        assert ready.wait(timeout=5.0)  # nosec B101
+        dal._dal._QuoteRiskGilBarrier_EnableForTesting(75)
+        started.set()
+        dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=market, provenances=[provenance])
+        count_seen_on_return = heartbeat_count[0]
+    finally:
+        stopped.set()
+        sys.setswitchinterval(previous_interval)
+        thread.join(timeout=5.0)
+    assert not thread.is_alive()  # nosec B101
+    assert count_seen_on_return > 0  # nosec B101
+
+
+def test_joint_and_staged_xccy_factories_expose_the_native_domain_shapes():
+    from test_xccy_calibration import _make_xccy_spec, _today as staged_today
+    from test_xccy_joint import _joint_spec, _today as joint_today
+
+    joint_spec = _joint_spec()
+    joint_options = dal.JointXccyCalibrationOptions_()
+    joint_result = dal.CalibrateJointXccyMarket(joint_spec, joint_options)
+    joint_curves = {
+        "domestic:usd_ois": next(iter(joint_result.domestic_curve_block.discount_curves.values())),
+        "foreign:eur_ois": next(iter(joint_result.foreign_curve_block.discount_curves.values())),
+        "basis:usd_eur_basis": joint_result.basis_curve,
+    }
+    joint_bindings = {item.name: f"joint-component-{index}" for index, item in enumerate(joint_result.parameter_ranges)}
+    joint_components = {joint_bindings[name]: curve for name, curve in joint_curves.items()}
+    joint_fixings = joint_result.fixings
+    joint_xccy_market = dal.CrossCurrencyMarket_New(
+        domestic_block=joint_result.domestic_curve_block,
+        foreign_block=joint_result.foreign_curve_block,
+        fx_spot=1.10,
+        valuation_time=dal.DateTime_(joint_today(), 0, 0),
+        collateral_currency="USD",
+        fixings=joint_fixings,
+        basis_curve=joint_result.basis_curve,
+    )
+    joint_market = dal.RatePricingMarket_(
+        valuation_time=dal.DateTime_(joint_today(), 0, 0),
+        result_currency="USD",
+        curve_components=joint_components,
+        xccy_market=joint_xccy_market,
+        fixings=joint_fixings,
+    )
+    joint_provenance = dal.BuildJointXccyQuoteRiskProvenance(
+        spec=joint_spec,
+        result=joint_result,
+        options=joint_options,
+        bound_market=joint_market,
+        config=dal.RateQuoteRiskProvenanceConfig_(
+            calibration_id="python-joint-xccy",
+            component_key_by_parameter_block=joint_bindings,
+        ),
+    )
+
+    assert joint_provenance.available is True  # nosec B101
+    assert joint_provenance.kind == "JOINT_XCCY"  # nosec B101
+    assert tuple(item.block_key for item in joint_provenance.axis.parameter_ranges) == tuple(  # nosec B101
+        item.name for item in joint_result.parameter_ranges
+    )
+    assert tuple(item.block_key for item in joint_provenance.axis.residual_ranges) == tuple(  # nosec B101
+        item.name for item in joint_result.residual_ranges
+    )
+
+    staged_spec, _ = _make_xccy_spec(dal.CurveSolveMode.EXACT, years=(2,))
+    staged_options = dal.CrossCurrencyCalibrationOptions_()
+    staged_result = dal.CalibrateXccyMarket(staged_spec, staged_options)
+    staged_market = dal.RatePricingMarket_(
+        valuation_time=dal.DateTime_(staged_today(), 0, 0),
+        result_currency="USD",
+        curve_components={"staged-basis": staged_result.basis_curve},
+        xccy_market=staged_result.market,
+    )
+    staged_provenance = dal.BuildStagedXccyBasisQuoteRiskProvenance(
+        spec=staged_spec,
+        result=staged_result,
+        options=staged_options,
+        bound_market=staged_market,
+        config=dal.RateQuoteRiskProvenanceConfig_(
+            calibration_id="python-staged-xccy",
+            component_key_by_parameter_block={"basis:xccy_basis_USD": "staged-basis"},
+        ),
+    )
+
+    assert staged_provenance.available is True  # nosec B101
+    assert staged_provenance.kind == "STAGED_XCCY_BASIS"  # nosec B101
+    assert len(staged_provenance.axis.parameter_ranges) == 1  # nosec B101
+    assert len(staged_provenance.axis.residual_ranges) == 1  # nosec B101
+    assert staged_provenance.component_key_by_parameter_block == {  # nosec B101
+        "basis:xccy_basis_USD": "staged-basis"
+    }


### PR DESCRIPTION
## Summary
- expose all supported quote-risk provenance factories and aggregation through the public C++ header, including the `CalibrationResult_` single-curve adapter
- add immutable, keyword-only Python quote-risk contracts with whole-operation GIL release and ownership-safe value views
- add public/Python regression coverage and runnable single-curve and joint-XCCY examples

Multica: DAL-177
Closes #321

## Test plan
- [x] `./build/Release-linux/dal-public/dal_public_tests --gtest_filter='CurveSpecTest.TestPublicQuoteRiskOverloadMatchesCoreProvenance:CurvePricingPublicTest.TestQuoteRiskEntryPointsRemainCallableThroughPublicHeader'` (2 passed)
- [x] `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='*QuoteRisk*:*InverseJacobianRisk*'` (42 passed)
- [x] `PYTHONPATH=build/python-dev/dal-python python3 -m pytest dal-python/tests/test_quote_risk.py -q` (6 passed)
- [x] `ctest --test-dir build/Release-linux --output-on-failure -E 'dal_excel_portable_tests_NOT_BUILT'` (1480 passed)
- [x] Python suite excluding three isolated pre-existing Monte Carlo AAD failures (280 passed, 3 deselected); the unfiltered run reports those same 3 failures
- [x] run `dal-python/examples/007.xccy_joint_calibration.py` and `dal-python/examples/009.quote_risk.py`
