### PR TITLE
feat: add DAL-178 Excel quote-risk surface

### DIFF
--- a/dal-excel/auto/MG_JointXccyQuoteRiskProvenance_New_public.htm
+++ b/dal-excel/auto/MG_JointXccyQuoteRiskProvenance_New_public.htm
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<title>JointXccyQuoteRiskProvenance_New</title>
+<link href="tablecloth/tablecloth.css" rel="stylesheet" type="text/css" media="screen" />
+<link href="hbk.css" rel="stylesheet" type="text/css" media="screen" />
+<script type="text/javascript" src="tablecloth/tablecloth.js"></script>
+</head>
+<body>
+<h1>JointXccyQuoteRiskProvenance_New (in Excel: JOINTXCCYQUOTERISKPROVENANCE.NEW)</h1>
+Freeze quote-risk provenance from one joint XCCY calibration result
+
+<h2>Inputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
+
+<tr><td>result</td><td>handle of type StorableJointXccyCalibrationResult</td><td></td><td>The exact result returned by CALIBRATE.JOINTXCCY</td></tr>
+<tr><td>calibrationId</td><td>string</td><td></td><td>Non-empty identifier used to join and order quote-risk rows</td></tr>
+<tr><td>parameterBlockKeys</td><td>vector of strings</td><td></td><td>Joint calibration parameter block keys, in calibration order</td></tr>
+<tr><td>componentKeys</td><td>vector of strings</td><td></td><td>Pricing-market component keys parallel to parameterBlockKeys</td></tr>
+<tr><td>market</td><td>handle of type StorableRatePricingMarket</td><td></td><td>The exact pricing market bound to all calibrated blocks</td></tr>
+
+</table>
+
+
+
+
+
+<h2>Outputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
+
+<tr><td>provenance</td><td>handle of type StorableRateQuoteRiskProvenance</td><td>Immutable joint-XCCY provenance; unavailable states retain their stable reason token</td></tr>
+</table>
+
+
+
+
+
+

--- a/dal-excel/auto/MG_JointXccyQuoteRiskProvenance_New_public.inc
+++ b/dal-excel/auto/MG_JointXccyQuoteRiskProvenance_New_public.inc
@@ -1,0 +1,52 @@
+
+
+extern "C" __declspec(dllexport) OPER_* xl_JointXccyQuoteRiskProvenance_New
+    (const OPER_* xl_result, const OPER_* xl_calibrationId, const OPER_* xl_parameterBlockKeys, const OPER_* xl_componentKeys, const OPER_* xl_market)	
+{
+    Excel::InitializeSessionIfNeeded();
+ENV_SEED_TYPE(ObjectAccess_);
+    const char* argName = 0;
+    try
+    {	
+        Logging::Write("JointXccyQuoteRiskProvenance_New");        
+        argName = "result (input #1)";
+        const Handle_<StorableJointXccyCalibrationResult_> result = Excel::ToHandle<StorableJointXccyCalibrationResult_>(_env, xl_result);
+        argName = "calibrationId (input #2)";
+        const String_ calibrationId = Excel::ToString(xl_calibrationId);
+        argName = "parameterBlockKeys (input #3)";
+        const Vector_<String_> parameterBlockKeys = Excel::ToStringVector(xl_parameterBlockKeys);
+        argName = "componentKeys (input #4)";
+        const Vector_<String_> componentKeys = Excel::ToStringVector(xl_componentKeys);
+        argName = "market (input #5)";
+        const Handle_<StorableRatePricingMarket_> market = Excel::ToHandle<StorableRatePricingMarket_>(_env, xl_market);
+        argName = 0;
+		Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        JointXccyQuoteRiskProvenance_New(result, calibrationId, parameterBlockKeys, componentKeys, market, &provenance);
+        Excel::Retval_ retval;
+        retval.Load(_env, provenance);
+        return retval.ToXloper();
+    }
+    catch (std::exception& e)
+    {
+        return Excel::Error(e.what(), argName);
+    }
+    catch (...)
+    {
+        return Excel::Error("Unknown error", argName);
+    }
+}
+
+struct XlRegister_JointXccyQuoteRiskProvenance_New_
+{
+    XlRegister_JointXccyQuoteRiskProvenance_New_()
+    {
+        Vector_<String_> argHelp;        
+        argHelp.push_back("The exact result returned by CALIBRATE.JOINTXCCY");
+        argHelp.push_back("Non-empty identifier used to join and order quote-risk rows");
+        argHelp.push_back("Joint calibration parameter block keys, in calibration order");
+        argHelp.push_back("Pricing-market component keys parallel to parameterBlockKeys");
+        argHelp.push_back("The exact pricing market bound to all calibrated blocks");
+        Excel::Register("Base", "xl_JointXccyQuoteRiskProvenance_New", "JOINTXCCYQUOTERISKPROVENANCE.NEW", "Freeze quote-risk provenance from one joint XCCY calibration result", "QQQQQQ", "result,calibrationId,parameterBlockKeys,componentKeys,market", argHelp, false);
+    }
+};
+static XlRegister_JointXccyQuoteRiskProvenance_New_ The_JointXccyQuoteRiskProvenance_New_XlRegisterer;

--- a/dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.htm
+++ b/dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.htm
@@ -1,0 +1,39 @@
+
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<title>RatePortfolioQuoteRisk_Spill</title>
+<link href="tablecloth/tablecloth.css" rel="stylesheet" type="text/css" media="screen" />
+<link href="hbk.css" rel="stylesheet" type="text/css" media="screen" />
+<script type="text/javascript" src="tablecloth/tablecloth.js"></script>
+</head>
+<body>
+<h1>RatePortfolioQuoteRisk_Spill (in Excel: RATEPORTFOLIOQUOTERISK.SPILL)</h1>
+Aggregate portfolio quote sensitivity and DV01 into a fixed long-form spill
+
+<h2>Inputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
+
+<tr><td>trades</td><td>vector of handles</td><td></td><td>Rate trade definition handles</td></tr>
+<tr><td>market</td><td>handle of type StorableRatePricingMarket</td><td></td><td>The rate pricing market used by the immutable provenance handles</td></tr>
+<tr><td>provenances</td><td>vector of handles</td><td></td><td>Quote-risk provenance handles with unique non-empty calibration identifiers</td></tr>
+
+</table>
+
+
+
+
+
+<h2>Outputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
+
+<tr><td>spill</td><td>matrix of cells</td><td>Ten columns in order: calibration, axis_fingerprint, quote_key, quote_name, block, currency, quote_sensitivity, dv01, availability, reason. Rows follow native deterministic bucket order, then provenance failures, trade/provenance failures, and excluded-domain failures.</td></tr>
+</table>
+
+
+
+
+
+

--- a/dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.inc
+++ b/dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.inc
@@ -1,0 +1,46 @@
+
+
+extern "C" __declspec(dllexport) OPER_* xl_RatePortfolioQuoteRisk_Spill
+    (const OPER_* xl_trades, const OPER_* xl_market, const OPER_* xl_provenances)	
+{
+    Excel::InitializeSessionIfNeeded();
+ENV_SEED_TYPE(ObjectAccess_);
+    const char* argName = 0;
+    try
+    {	
+        Logging::Write("RatePortfolioQuoteRisk_Spill");        
+        argName = "trades (input #1)";
+        const Vector_<Handle_<Storable_>> trades = Excel::ToHandleBaseVector(_env, xl_trades);
+        argName = "market (input #2)";
+        const Handle_<StorableRatePricingMarket_> market = Excel::ToHandle<StorableRatePricingMarket_>(_env, xl_market);
+        argName = "provenances (input #3)";
+        const Vector_<Handle_<Storable_>> provenances = Excel::ToHandleBaseVector(_env, xl_provenances);
+        argName = 0;
+		Matrix_<Cell_> spill;
+        RatePortfolioQuoteRisk_Spill(trades, market, provenances, &spill);
+        Excel::Retval_ retval;
+        retval.Load(spill);
+        return retval.ToXloper();
+    }
+    catch (std::exception& e)
+    {
+        return Excel::Error(e.what(), argName);
+    }
+    catch (...)
+    {
+        return Excel::Error("Unknown error", argName);
+    }
+}
+
+struct XlRegister_RatePortfolioQuoteRisk_Spill_
+{
+    XlRegister_RatePortfolioQuoteRisk_Spill_()
+    {
+        Vector_<String_> argHelp;        
+        argHelp.push_back("Rate trade definition handles");
+        argHelp.push_back("The rate pricing market used by the immutable provenance handles");
+        argHelp.push_back("Quote-risk provenance handles with unique non-empty calibration identifiers");
+        Excel::Register("Base", "xl_RatePortfolioQuoteRisk_Spill", "RATEPORTFOLIOQUOTERISK.SPILL", "Aggregate portfolio quote sensitivity and DV01 into a fixed long-form spill", "QQQQ", "trades,market,provenances", argHelp, false);
+    }
+};
+static XlRegister_RatePortfolioQuoteRisk_Spill_ The_RatePortfolioQuoteRisk_Spill_XlRegisterer;

--- a/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.htm
+++ b/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.htm
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<title>RateQuoteRiskProvenance_New</title>
+<link href="tablecloth/tablecloth.css" rel="stylesheet" type="text/css" media="screen" />
+<link href="hbk.css" rel="stylesheet" type="text/css" media="screen" />
+<script type="text/javascript" src="tablecloth/tablecloth.js"></script>
+</head>
+<body>
+<h1>RateQuoteRiskProvenance_New (in Excel: RATEQUOTERISKPROVENANCE.NEW)</h1>
+Dispatch quote-risk provenance construction from a calibration-result handle
+
+<h2>Inputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
+
+<tr><td>result</td><td>handle</td><td></td><td>A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result</td></tr>
+<tr><td>calibrationId</td><td>string</td><td></td><td>Non-empty identifier used to join and order quote-risk rows</td></tr>
+<tr><td>parameterBlockKeys</td><td>vector of strings</td><td></td><td>Calibration parameter block keys, in calibration order</td></tr>
+<tr><td>componentKeys</td><td>vector of strings</td><td></td><td>Pricing-market component keys parallel to parameterBlockKeys</td></tr>
+<tr><td>market</td><td>handle of type StorableRatePricingMarket</td><td></td><td>The exact pricing market bound to the calibration result</td></tr>
+
+</table>
+
+
+
+
+
+<h2>Outputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
+
+<tr><td>provenance</td><td>handle of type StorableRateQuoteRiskProvenance</td><td>Immutable provenance; excluded domains return frozen unavailable reason tokens</td></tr>
+</table>
+
+
+
+
+
+

--- a/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.inc
+++ b/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.inc
@@ -1,0 +1,52 @@
+
+
+extern "C" __declspec(dllexport) OPER_* xl_RateQuoteRiskProvenance_New
+    (const OPER_* xl_result, const OPER_* xl_calibrationId, const OPER_* xl_parameterBlockKeys, const OPER_* xl_componentKeys, const OPER_* xl_market)	
+{
+    Excel::InitializeSessionIfNeeded();
+ENV_SEED_TYPE(ObjectAccess_);
+    const char* argName = 0;
+    try
+    {	
+        Logging::Write("RateQuoteRiskProvenance_New");        
+        argName = "result (input #1)";
+        const Handle_<Storable_> result = Excel::ToHandleBase(_env, xl_result);
+        argName = "calibrationId (input #2)";
+        const String_ calibrationId = Excel::ToString(xl_calibrationId);
+        argName = "parameterBlockKeys (input #3)";
+        const Vector_<String_> parameterBlockKeys = Excel::ToStringVector(xl_parameterBlockKeys);
+        argName = "componentKeys (input #4)";
+        const Vector_<String_> componentKeys = Excel::ToStringVector(xl_componentKeys);
+        argName = "market (input #5)";
+        const Handle_<StorableRatePricingMarket_> market = Excel::ToHandle<StorableRatePricingMarket_>(_env, xl_market);
+        argName = 0;
+		Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        RateQuoteRiskProvenance_New(result, calibrationId, parameterBlockKeys, componentKeys, market, &provenance);
+        Excel::Retval_ retval;
+        retval.Load(_env, provenance);
+        return retval.ToXloper();
+    }
+    catch (std::exception& e)
+    {
+        return Excel::Error(e.what(), argName);
+    }
+    catch (...)
+    {
+        return Excel::Error("Unknown error", argName);
+    }
+}
+
+struct XlRegister_RateQuoteRiskProvenance_New_
+{
+    XlRegister_RateQuoteRiskProvenance_New_()
+    {
+        Vector_<String_> argHelp;        
+        argHelp.push_back("A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result");
+        argHelp.push_back("Non-empty identifier used to join and order quote-risk rows");
+        argHelp.push_back("Calibration parameter block keys, in calibration order");
+        argHelp.push_back("Pricing-market component keys parallel to parameterBlockKeys");
+        argHelp.push_back("The exact pricing market bound to the calibration result");
+        Excel::Register("Base", "xl_RateQuoteRiskProvenance_New", "RATEQUOTERISKPROVENANCE.NEW", "Dispatch quote-risk provenance construction from a calibration-result handle", "QQQQQQ", "result,calibrationId,parameterBlockKeys,componentKeys,market", argHelp, false);
+    }
+};
+static XlRegister_RateQuoteRiskProvenance_New_ The_RateQuoteRiskProvenance_New_XlRegisterer;

--- a/dal-excel/auto/MG_SingleCurveQuoteRiskProvenance_New_public.htm
+++ b/dal-excel/auto/MG_SingleCurveQuoteRiskProvenance_New_public.htm
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<title>SingleCurveQuoteRiskProvenance_New</title>
+<link href="tablecloth/tablecloth.css" rel="stylesheet" type="text/css" media="screen" />
+<link href="hbk.css" rel="stylesheet" type="text/css" media="screen" />
+<script type="text/javascript" src="tablecloth/tablecloth.js"></script>
+</head>
+<body>
+<h1>SingleCurveQuoteRiskProvenance_New (in Excel: SINGLECURVEQUOTERISKPROVENANCE.NEW)</h1>
+Freeze quote-risk provenance from one single-curve calibration result
+
+<h2>Inputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
+
+<tr><td>result</td><td>handle of type StorableCurveCalibrationResult</td><td></td><td>The exact result returned by CALIBRATE.SINGLECURVE</td></tr>
+<tr><td>calibrationId</td><td>string</td><td></td><td>Non-empty identifier used to join and order quote-risk rows</td></tr>
+<tr><td>parameterBlockKeys</td><td>vector of strings</td><td></td><td>Calibration parameter block keys, in calibration order</td></tr>
+<tr><td>componentKeys</td><td>vector of strings</td><td></td><td>Pricing-market component keys parallel to parameterBlockKeys</td></tr>
+<tr><td>market</td><td>handle of type StorableRatePricingMarket</td><td></td><td>The exact pricing market bound to the calibrated curve</td></tr>
+
+</table>
+
+
+
+
+
+<h2>Outputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
+
+<tr><td>provenance</td><td>handle of type StorableRateQuoteRiskProvenance</td><td>Immutable single-curve provenance; unavailable states retain their stable reason token</td></tr>
+</table>
+
+
+
+
+
+

--- a/dal-excel/auto/MG_SingleCurveQuoteRiskProvenance_New_public.inc
+++ b/dal-excel/auto/MG_SingleCurveQuoteRiskProvenance_New_public.inc
@@ -1,0 +1,52 @@
+
+
+extern "C" __declspec(dllexport) OPER_* xl_SingleCurveQuoteRiskProvenance_New
+    (const OPER_* xl_result, const OPER_* xl_calibrationId, const OPER_* xl_parameterBlockKeys, const OPER_* xl_componentKeys, const OPER_* xl_market)	
+{
+    Excel::InitializeSessionIfNeeded();
+ENV_SEED_TYPE(ObjectAccess_);
+    const char* argName = 0;
+    try
+    {	
+        Logging::Write("SingleCurveQuoteRiskProvenance_New");        
+        argName = "result (input #1)";
+        const Handle_<StorableCurveCalibrationResult_> result = Excel::ToHandle<StorableCurveCalibrationResult_>(_env, xl_result);
+        argName = "calibrationId (input #2)";
+        const String_ calibrationId = Excel::ToString(xl_calibrationId);
+        argName = "parameterBlockKeys (input #3)";
+        const Vector_<String_> parameterBlockKeys = Excel::ToStringVector(xl_parameterBlockKeys);
+        argName = "componentKeys (input #4)";
+        const Vector_<String_> componentKeys = Excel::ToStringVector(xl_componentKeys);
+        argName = "market (input #5)";
+        const Handle_<StorableRatePricingMarket_> market = Excel::ToHandle<StorableRatePricingMarket_>(_env, xl_market);
+        argName = 0;
+		Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        SingleCurveQuoteRiskProvenance_New(result, calibrationId, parameterBlockKeys, componentKeys, market, &provenance);
+        Excel::Retval_ retval;
+        retval.Load(_env, provenance);
+        return retval.ToXloper();
+    }
+    catch (std::exception& e)
+    {
+        return Excel::Error(e.what(), argName);
+    }
+    catch (...)
+    {
+        return Excel::Error("Unknown error", argName);
+    }
+}
+
+struct XlRegister_SingleCurveQuoteRiskProvenance_New_
+{
+    XlRegister_SingleCurveQuoteRiskProvenance_New_()
+    {
+        Vector_<String_> argHelp;        
+        argHelp.push_back("The exact result returned by CALIBRATE.SINGLECURVE");
+        argHelp.push_back("Non-empty identifier used to join and order quote-risk rows");
+        argHelp.push_back("Calibration parameter block keys, in calibration order");
+        argHelp.push_back("Pricing-market component keys parallel to parameterBlockKeys");
+        argHelp.push_back("The exact pricing market bound to the calibrated curve");
+        Excel::Register("Base", "xl_SingleCurveQuoteRiskProvenance_New", "SINGLECURVEQUOTERISKPROVENANCE.NEW", "Freeze quote-risk provenance from one single-curve calibration result", "QQQQQQ", "result,calibrationId,parameterBlockKeys,componentKeys,market", argHelp, false);
+    }
+};
+static XlRegister_SingleCurveQuoteRiskProvenance_New_ The_SingleCurveQuoteRiskProvenance_New_XlRegisterer;

--- a/dal-excel/auto/MG_StagedXccyBasisQuoteRiskProvenance_New_public.htm
+++ b/dal-excel/auto/MG_StagedXccyBasisQuoteRiskProvenance_New_public.htm
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<title>StagedXccyBasisQuoteRiskProvenance_New</title>
+<link href="tablecloth/tablecloth.css" rel="stylesheet" type="text/css" media="screen" />
+<link href="hbk.css" rel="stylesheet" type="text/css" media="screen" />
+<script type="text/javascript" src="tablecloth/tablecloth.js"></script>
+</head>
+<body>
+<h1>StagedXccyBasisQuoteRiskProvenance_New (in Excel: STAGEDXCCYBASISQUOTERISKPROVENANCE.NEW)</h1>
+Freeze quote-risk provenance from one staged XCCY basis calibration result
+
+<h2>Inputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
+
+<tr><td>result</td><td>handle of type StorableCrossCurrencyCalibrationResult</td><td></td><td>The exact result returned by CALIBRATE.XCCYMARKET</td></tr>
+<tr><td>calibrationId</td><td>string</td><td></td><td>Non-empty identifier used to join and order quote-risk rows</td></tr>
+<tr><td>parameterBlockKeys</td><td>vector of strings</td><td></td><td>Staged basis parameter block key</td></tr>
+<tr><td>componentKeys</td><td>vector of strings</td><td></td><td>Pricing-market basis component key parallel to parameterBlockKeys</td></tr>
+<tr><td>market</td><td>handle of type StorableRatePricingMarket</td><td></td><td>The exact pricing market bound to the calibrated basis curve</td></tr>
+
+</table>
+
+
+
+
+
+<h2>Outputs:</h2>
+<table border="1" cellpadding="3">
+<tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
+
+<tr><td>provenance</td><td>handle of type StorableRateQuoteRiskProvenance</td><td>Immutable staged-XCCY-basis provenance; unavailable states retain their stable reason token</td></tr>
+</table>
+
+
+
+
+
+

--- a/dal-excel/auto/MG_StagedXccyBasisQuoteRiskProvenance_New_public.inc
+++ b/dal-excel/auto/MG_StagedXccyBasisQuoteRiskProvenance_New_public.inc
@@ -1,0 +1,52 @@
+
+
+extern "C" __declspec(dllexport) OPER_* xl_StagedXccyBasisQuoteRiskProvenance_New
+    (const OPER_* xl_result, const OPER_* xl_calibrationId, const OPER_* xl_parameterBlockKeys, const OPER_* xl_componentKeys, const OPER_* xl_market)	
+{
+    Excel::InitializeSessionIfNeeded();
+ENV_SEED_TYPE(ObjectAccess_);
+    const char* argName = 0;
+    try
+    {	
+        Logging::Write("StagedXccyBasisQuoteRiskProvenance_New");        
+        argName = "result (input #1)";
+        const Handle_<StorableCrossCurrencyCalibrationResult_> result = Excel::ToHandle<StorableCrossCurrencyCalibrationResult_>(_env, xl_result);
+        argName = "calibrationId (input #2)";
+        const String_ calibrationId = Excel::ToString(xl_calibrationId);
+        argName = "parameterBlockKeys (input #3)";
+        const Vector_<String_> parameterBlockKeys = Excel::ToStringVector(xl_parameterBlockKeys);
+        argName = "componentKeys (input #4)";
+        const Vector_<String_> componentKeys = Excel::ToStringVector(xl_componentKeys);
+        argName = "market (input #5)";
+        const Handle_<StorableRatePricingMarket_> market = Excel::ToHandle<StorableRatePricingMarket_>(_env, xl_market);
+        argName = 0;
+		Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        StagedXccyBasisQuoteRiskProvenance_New(result, calibrationId, parameterBlockKeys, componentKeys, market, &provenance);
+        Excel::Retval_ retval;
+        retval.Load(_env, provenance);
+        return retval.ToXloper();
+    }
+    catch (std::exception& e)
+    {
+        return Excel::Error(e.what(), argName);
+    }
+    catch (...)
+    {
+        return Excel::Error("Unknown error", argName);
+    }
+}
+
+struct XlRegister_StagedXccyBasisQuoteRiskProvenance_New_
+{
+    XlRegister_StagedXccyBasisQuoteRiskProvenance_New_()
+    {
+        Vector_<String_> argHelp;        
+        argHelp.push_back("The exact result returned by CALIBRATE.XCCYMARKET");
+        argHelp.push_back("Non-empty identifier used to join and order quote-risk rows");
+        argHelp.push_back("Staged basis parameter block key");
+        argHelp.push_back("Pricing-market basis component key parallel to parameterBlockKeys");
+        argHelp.push_back("The exact pricing market bound to the calibrated basis curve");
+        Excel::Register("Base", "xl_StagedXccyBasisQuoteRiskProvenance_New", "STAGEDXCCYBASISQUOTERISKPROVENANCE.NEW", "Freeze quote-risk provenance from one staged XCCY basis calibration result", "QQQQQQ", "result,calibrationId,parameterBlockKeys,componentKeys,market", argHelp, false);
+    }
+};
+static XlRegister_StagedXccyBasisQuoteRiskProvenance_New_ The_StagedXccyBasisQuoteRiskProvenance_New_XlRegisterer;

--- a/dal-excel/src/__curve_storable.hpp
+++ b/dal-excel/src/__curve_storable.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "__platform.hpp"
 #include <dal-public/src/curvepricing.hpp>
 #include <dal-public/src/curveprotocol.hpp>
@@ -13,6 +15,7 @@
 #include <dal-public/src/xccycalibration.hpp>
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/curveblock.hpp>
+#include <dal/curve/jointcalibration.hpp>
 #include <dal/curve/xccycalibration.hpp>
 #include <dal/curve/xccyinstrument.hpp>
 #include <dal/curve/yc.hpp>
@@ -126,7 +129,24 @@ namespace Dal {
 
     struct StorableCurveCalibrationResult_ : public Storable_ {
         CalibrationResult_ val_;
-        explicit StorableCurveCalibrationResult_(const CalibrationResult_& v) : Storable_("CurveCalibrationResult", String_()), val_(v) {}
+        CurveCalibrationSpec_ spec_;
+        CurveCalibrationOptions_ options_;
+        StorableCurveCalibrationResult_(const CalibrationResult_& v, const CurveCalibrationSpec_& spec, const CurveCalibrationOptions_& options)
+            : Storable_("CurveCalibrationResult", String_()), val_(v), spec_(spec), options_(options) {}
+        void Write(Archive::Store_&) const override {}
+    };
+
+    struct StorableMultiCurveCalibrationResult_ : public Storable_ {
+        MultiCurveCalibrationResult_ val_;
+        explicit StorableMultiCurveCalibrationResult_(const MultiCurveCalibrationResult_& v)
+            : Storable_("MultiCurveCalibrationResult", String_()), val_(v) {}
+        void Write(Archive::Store_&) const override {}
+    };
+
+    struct StorableJointMultiCurveCalibrationResult_ : public Storable_ {
+        JointMultiCurveCalibrationResult_ val_;
+        explicit StorableJointMultiCurveCalibrationResult_(const JointMultiCurveCalibrationResult_& v)
+            : Storable_("JointMultiCurveCalibrationResult", String_()), val_(v) {}
         void Write(Archive::Store_&) const override {}
     };
 
@@ -141,21 +161,50 @@ namespace Dal {
     // Holds the full result plus the basis curve resolved for the calibrated pair.
     struct StorableCrossCurrencyCalibrationResult_ : public Storable_ {
         CrossCurrencyCalibrationResult_ val_;
+        CrossCurrencyCalibrationSpec_ spec_;
+        CrossCurrencyCalibrationOptions_ options_;
         Handle_<DiscountCurve_> basisCurve_;
-        explicit StorableCrossCurrencyCalibrationResult_(const CrossCurrencyCalibrationResult_& v, const Handle_<DiscountCurve_>& basis)
-            : Storable_("CrossCurrencyCalibrationResult", String_()), val_(v), basisCurve_(basis) {}
+        StorableCrossCurrencyCalibrationResult_(const CrossCurrencyCalibrationResult_& v,
+                                                const CrossCurrencyCalibrationSpec_& spec,
+                                                const CrossCurrencyCalibrationOptions_& options,
+                                                const Handle_<DiscountCurve_>& basis)
+            : Storable_("CrossCurrencyCalibrationResult", String_()), val_(v), spec_(spec), options_(options), basisCurve_(basis) {}
         void Write(Archive::Store_&) const override {}
     };
 
     struct StorableJointXccyCalibrationResult_ : public Storable_ {
         JointXccyCalibrationResult_ val_;
+        JointXccyCalibrationSpec_ spec_;
+        JointXccyCalibrationOptions_ options_;
         Handle_<CurveBlock_> domesticBlock_;
         Handle_<CurveBlock_> foreignBlock_;
         Handle_<DiscountCurve_> basisCurve_;
 
-        explicit StorableJointXccyCalibrationResult_(const JointXccyCalibrationResult_& v)
-            : Storable_("JointXccyCalibrationResult", String_()), val_(v), domesticBlock_(JointXccyResultDomesticBlock(val_)),
-              foreignBlock_(JointXccyResultForeignBlock(val_)), basisCurve_(JointXccyResultBasisCurve(val_)) {}
+        StorableJointXccyCalibrationResult_(const JointXccyCalibrationResult_& v,
+                                            const JointXccyCalibrationSpec_& spec,
+                                            const JointXccyCalibrationOptions_& options)
+            : Storable_("JointXccyCalibrationResult", String_()), val_(v), spec_(spec), options_(options),
+              domesticBlock_(JointXccyResultDomesticBlock(val_)), foreignBlock_(JointXccyResultForeignBlock(val_)),
+              basisCurve_(JointXccyResultBasisCurve(val_)) {}
+        void Write(Archive::Store_&) const override {}
+    };
+
+    struct StorableRateQuoteRiskProvenance_ : public Storable_ {
+        const std::shared_ptr<const RateQuoteRiskProvenance_> val_;
+        const String_ calibrationId_;
+        const String_ kind_;
+        const String_ reason_;
+
+        explicit StorableRateQuoteRiskProvenance_(const RateQuoteRiskProvenance_& value)
+            : Storable_("RateQuoteRiskProvenance", String_()), val_(std::make_shared<const RateQuoteRiskProvenance_>(value)),
+              calibrationId_(value.CalibrationId()), kind_(value.Kind()), reason_(value.Reason()) {}
+        StorableRateQuoteRiskProvenance_(const String_& calibrationId, const String_& kind, const String_& reason)
+            : Storable_("RateQuoteRiskProvenance", String_()), calibrationId_(calibrationId), kind_(kind), reason_(reason) {}
+        [[nodiscard]] bool Native() const { return static_cast<bool>(val_); }
+        [[nodiscard]] const String_& AxisFingerprint() const {
+            static const String_ empty;
+            return val_ ? val_->Axis().fingerprint_ : empty;
+        }
         void Write(Archive::Store_&) const override {}
     };
 

--- a/dal-excel/src/__curvepricing.cpp
+++ b/dal-excel/src/__curvepricing.cpp
@@ -14,6 +14,7 @@
 #include <dal/curve/curveblock.hpp>
 #include <dal/math/cell.hpp>
 #include <dal/utilities/exceptions.hpp>
+#include <set>
 
 // clang-format off
 /*IF--------------------------------------------------------------------------
@@ -275,6 +276,99 @@ spill is cell[][]
     component's dense tensor, one aggregate row per actual PV currency carrying the
     UnconvertedByActualPvCcy policy label, and one reason row per failed (trade, component) cell.
 -IF-------------------------------------------------------------------------*/
+
+/*IF--------------------------------------------------------------------------
+public SingleCurveQuoteRiskProvenance_New
+    Freeze quote-risk provenance from one single-curve calibration result
+&inputs
+result is handle StorableCurveCalibrationResult
+    The exact result returned by CALIBRATE.SINGLECURVE
+calibrationId is string
+    Non-empty identifier used to join and order quote-risk rows
+parameterBlockKeys is string[]
+    Calibration parameter block keys, in calibration order
+componentKeys is string[]
+    Pricing-market component keys parallel to parameterBlockKeys
+market is handle StorableRatePricingMarket
+    The exact pricing market bound to the calibrated curve
+&outputs
+provenance is handle StorableRateQuoteRiskProvenance
+    Immutable single-curve provenance; unavailable states retain their stable reason token
+-IF-------------------------------------------------------------------------*/
+
+/*IF--------------------------------------------------------------------------
+public JointXccyQuoteRiskProvenance_New
+    Freeze quote-risk provenance from one joint XCCY calibration result
+&inputs
+result is handle StorableJointXccyCalibrationResult
+    The exact result returned by CALIBRATE.JOINTXCCY
+calibrationId is string
+    Non-empty identifier used to join and order quote-risk rows
+parameterBlockKeys is string[]
+    Joint calibration parameter block keys, in calibration order
+componentKeys is string[]
+    Pricing-market component keys parallel to parameterBlockKeys
+market is handle StorableRatePricingMarket
+    The exact pricing market bound to all calibrated blocks
+&outputs
+provenance is handle StorableRateQuoteRiskProvenance
+    Immutable joint-XCCY provenance; unavailable states retain their stable reason token
+-IF-------------------------------------------------------------------------*/
+
+/*IF--------------------------------------------------------------------------
+public StagedXccyBasisQuoteRiskProvenance_New
+    Freeze quote-risk provenance from one staged XCCY basis calibration result
+&inputs
+result is handle StorableCrossCurrencyCalibrationResult
+    The exact result returned by CALIBRATE.XCCYMARKET
+calibrationId is string
+    Non-empty identifier used to join and order quote-risk rows
+parameterBlockKeys is string[]
+    Staged basis parameter block key
+componentKeys is string[]
+    Pricing-market basis component key parallel to parameterBlockKeys
+market is handle StorableRatePricingMarket
+    The exact pricing market bound to the calibrated basis curve
+&outputs
+provenance is handle StorableRateQuoteRiskProvenance
+    Immutable staged-XCCY-basis provenance; unavailable states retain their stable reason token
+-IF-------------------------------------------------------------------------*/
+
+/*IF--------------------------------------------------------------------------
+public RateQuoteRiskProvenance_New
+    Dispatch quote-risk provenance construction from a calibration-result handle
+&inputs
+result is handle
+    A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result
+calibrationId is string
+    Non-empty identifier used to join and order quote-risk rows
+parameterBlockKeys is string[]
+    Calibration parameter block keys, in calibration order
+componentKeys is string[]
+    Pricing-market component keys parallel to parameterBlockKeys
+market is handle StorableRatePricingMarket
+    The exact pricing market bound to the calibration result
+&outputs
+provenance is handle StorableRateQuoteRiskProvenance
+    Immutable provenance; excluded domains return frozen unavailable reason tokens
+-IF-------------------------------------------------------------------------*/
+
+/*IF--------------------------------------------------------------------------
+public RatePortfolioQuoteRisk_Spill
+    Aggregate portfolio quote sensitivity and DV01 into a fixed long-form spill
+&inputs
+trades is handle[]
+    Rate trade definition handles
+market is handle StorableRatePricingMarket
+    The rate pricing market used by the immutable provenance handles
+provenances is handle[]
+    Quote-risk provenance handles with unique non-empty calibration identifiers
+&outputs
+spill is cell[][]
+    Ten columns in order: calibration, axis_fingerprint, quote_key, quote_name, block,
+    currency, quote_sensitivity, dv01, availability, reason. Rows follow native deterministic
+    bucket order, then provenance failures, trade/provenance failures, and excluded-domain failures.
+-IF-------------------------------------------------------------------------*/
 // clang-format on
 
 namespace Dal {
@@ -337,6 +431,18 @@ namespace Dal {
                 const auto* trade = dynamic_cast<const StorableRateTradeDefinition_*>(handle.get());
                 REQUIRE(trade, "Rate risk inputs must be rate trade definition handles (created with the RATExxxTRADE.NEW builders)");
                 result.push_back(trade->val_);
+            }
+            return result;
+        }
+
+        RateQuoteRiskProvenanceConfig_
+        QuoteRiskConfig(const String_& calibrationId, const Vector_<String_>& parameterBlockKeys, const Vector_<String_>& componentKeys) {
+            REQUIRE(parameterBlockKeys.size() == componentKeys.size(), "Quote-risk parameter blocks and component keys must be parallel arrays");
+            RateQuoteRiskProvenanceConfig_ result;
+            result.calibrationId_ = calibrationId;
+            for (int index = 0; index < static_cast<int>(parameterBlockKeys.size()); ++index) {
+                const auto inserted = result.componentKeyByParameterBlock_.emplace(parameterBlockKeys[index], componentKeys[index]);
+                REQUIRE(inserted.second, "Quote-risk parameter block keys must be unique");
             }
             return result;
         }
@@ -449,6 +555,109 @@ namespace Dal {
                 (*spill)(*row, 6) = Cell_(meta.actualPvCcy_.String());
                 ++(*row);
             }
+        }
+
+        constexpr int QUOTE_RISK_COLUMN_COUNT = 10;
+
+        Vector_<Handle_<StorableRateQuoteRiskProvenance_>> QuoteRiskProvenancesFromHandles(const Vector_<Handle_<Storable_>>& provenances) {
+            Vector_<Handle_<StorableRateQuoteRiskProvenance_>> result;
+            result.reserve(provenances.size());
+            std::set<String_> calibrationIds;
+            for (const auto& handle : provenances) {
+                const auto provenance = handle_cast<StorableRateQuoteRiskProvenance_>(handle);
+                REQUIRE(provenance, "Quote-risk inputs must be quote-risk provenance handles");
+                REQUIRE(!provenance->calibrationId_.empty(), "QUOTE_RISK_CALIBRATION_ID_EMPTY");
+                REQUIRE(calibrationIds.insert(provenance->calibrationId_).second, "QUOTE_RISK_DUPLICATE_CALIBRATION_ID");
+                result.push_back(provenance);
+            }
+            return result;
+        }
+
+        Vector_<RateQuoteRiskProvenance_> NativeQuoteRiskProvenances(const Vector_<Handle_<StorableRateQuoteRiskProvenance_>>& provenances) {
+            Vector_<RateQuoteRiskProvenance_> result;
+            for (const auto& provenance : provenances)
+                if (provenance->Native())
+                    result.push_back(*provenance->val_);
+            return result;
+        }
+
+        const StorableRateQuoteRiskProvenance_* FindQuoteRiskProvenance(const Vector_<Handle_<StorableRateQuoteRiskProvenance_>>& provenances,
+                                                                        const String_& calibrationId) {
+            for (const auto& provenance : provenances)
+                if (provenance->calibrationId_ == calibrationId)
+                    return provenance.get();
+            return nullptr;
+        }
+
+        void WriteQuoteRiskBucketRow(const RateQuoteRiskBucket_& bucket, Matrix_<Cell_>* spill, int* row) {
+            (*spill)(*row, 0) = Cell_(bucket.calibrationId_);
+            (*spill)(*row, 1) = Cell_(bucket.axisFingerprint_);
+            (*spill)(*row, 2) = Cell_(bucket.quoteKey_);
+            (*spill)(*row, 3) = Cell_(bucket.quoteName_);
+            (*spill)(*row, 4) = Cell_(bucket.residualBlock_);
+            (*spill)(*row, 5) = Cell_(bucket.actualPvCcy_.String());
+            (*spill)(*row, 6) = Cell_(bucket.dPvDDecimalQuote_);
+            (*spill)(*row, 7) = Cell_(bucket.dv01_);
+            (*spill)(*row, 8) = Cell_("available");
+            (*spill)(*row, 9) = Cell_();
+            ++(*row);
+        }
+
+        void WriteQuoteRiskFailureRow(const String_& calibrationId,
+                                      const String_& axisFingerprint,
+                                      const String_& subject,
+                                      const String_& detail,
+                                      const String_& block,
+                                      const String_& currency,
+                                      const String_& reason,
+                                      Matrix_<Cell_>* spill,
+                                      int* row) {
+            (*spill)(*row, 0) = Cell_(calibrationId);
+            (*spill)(*row, 1) = axisFingerprint.empty() ? Cell_() : Cell_(axisFingerprint);
+            (*spill)(*row, 2) = subject.empty() ? Cell_() : Cell_(subject);
+            (*spill)(*row, 3) = detail.empty() ? Cell_() : Cell_(detail);
+            (*spill)(*row, 4) = block.empty() ? Cell_() : Cell_(block);
+            (*spill)(*row, 5) = currency.empty() ? Cell_() : Cell_(currency);
+            (*spill)(*row, 6) = Cell_();
+            (*spill)(*row, 7) = Cell_();
+            (*spill)(*row, 8) = Cell_("unavailable");
+            (*spill)(*row, 9) = Cell_(reason);
+            ++(*row);
+        }
+
+        int QuoteRiskRowCount(const RatePortfolioQuoteRisk_& aggregate, const Vector_<Handle_<StorableRateQuoteRiskProvenance_>>& provenances) {
+            int result = static_cast<int>(aggregate.buckets_.size() + aggregate.provenanceFailures_.size());
+            for (const auto& meta : aggregate.meta_)
+                if (!meta.eligible_)
+                    ++result;
+            for (const auto& provenance : provenances)
+                if (!provenance->Native())
+                    ++result;
+            return result;
+        }
+
+        void WriteQuoteRiskFailureRows(const RatePortfolioQuoteRisk_& aggregate,
+                                       const Vector_<Handle_<StorableRateQuoteRiskProvenance_>>& provenances,
+                                       Matrix_<Cell_>* spill,
+                                       int* row) {
+            for (const auto& failure : aggregate.provenanceFailures_) {
+                const auto* provenance = FindQuoteRiskProvenance(provenances, failure.calibrationId_);
+                WriteQuoteRiskFailureRow(failure.calibrationId_, provenance ? provenance->AxisFingerprint() : String_(),
+                                         failure.expectedStateFingerprint_, failure.actualStateFingerprint_, failure.componentKey_, String_(),
+                                         failure.reason_, spill, row);
+            }
+            for (const auto& meta : aggregate.meta_) {
+                if (meta.eligible_)
+                    continue;
+                const auto* provenance = FindQuoteRiskProvenance(provenances, meta.calibrationId_);
+                WriteQuoteRiskFailureRow(meta.calibrationId_, provenance ? provenance->AxisFingerprint() : String_(), meta.instrumentId_,
+                                         meta.originalNodeRiskReason_, meta.failingComponentKey_, meta.actualPvCcy_.String(), meta.reason_, spill,
+                                         row);
+            }
+            for (const auto& provenance : provenances)
+                if (!provenance->Native())
+                    WriteQuoteRiskFailureRow(provenance->calibrationId_, String_(), String_(), String_(), provenance->kind_, String_(),
+                                             provenance->reason_, spill, row);
         }
     } // namespace
 
@@ -689,6 +898,89 @@ namespace Dal {
         WriteAggregateRows(aggregate, spill, &row);
     }
 
+    void RatePortfolioQuoteRisk_Spill(const Vector_<Handle_<Storable_>>& trades,
+                                      const Handle_<StorableRatePricingMarket_>& market,
+                                      const Vector_<Handle_<Storable_>>& provenances,
+                                      Matrix_<Cell_>* spill) {
+        REQUIRE(market, "Invalid rate pricing market handle");
+        const auto handles = QuoteRiskProvenancesFromHandles(provenances);
+        const auto aggregate = AggregateRatePortfolioQuoteRisk(TradesFromHandles(trades), market->val_, NativeQuoteRiskProvenances(handles));
+        spill->Resize(QuoteRiskRowCount(aggregate, handles), QUOTE_RISK_COLUMN_COUNT);
+        int row = 0;
+        for (const auto& bucket : aggregate.buckets_)
+            WriteQuoteRiskBucketRow(bucket, spill, &row);
+        WriteQuoteRiskFailureRows(aggregate, handles, spill, &row);
+    }
+
+    void SingleCurveQuoteRiskProvenance_New(const Handle_<StorableCurveCalibrationResult_>& result,
+                                            const String_& calibrationId,
+                                            const Vector_<String_>& parameterBlockKeys,
+                                            const Vector_<String_>& componentKeys,
+                                            const Handle_<StorableRatePricingMarket_>& market,
+                                            Handle_<StorableRateQuoteRiskProvenance_>* provenance) {
+        REQUIRE(result, "Invalid single-curve calibration result handle");
+        REQUIRE(market, "Invalid rate pricing market handle");
+        provenance->reset(new StorableRateQuoteRiskProvenance_(BuildSingleCurveQuoteRiskProvenance(
+            result->spec_, result->val_, result->options_, market->val_, QuoteRiskConfig(calibrationId, parameterBlockKeys, componentKeys))));
+    }
+
+    void RateQuoteRiskProvenance_New(const Handle_<Storable_>& result,
+                                     const String_& calibrationId,
+                                     const Vector_<String_>& parameterBlockKeys,
+                                     const Vector_<String_>& componentKeys,
+                                     const Handle_<StorableRatePricingMarket_>& market,
+                                     Handle_<StorableRateQuoteRiskProvenance_>* provenance) {
+        REQUIRE(result, "Invalid calibration result handle");
+        REQUIRE(market, "Invalid rate pricing market handle");
+        if (const auto single = handle_cast<StorableCurveCalibrationResult_>(result)) {
+            SingleCurveQuoteRiskProvenance_New(single, calibrationId, parameterBlockKeys, componentKeys, market, provenance);
+            return;
+        }
+        if (const auto jointXccy = handle_cast<StorableJointXccyCalibrationResult_>(result)) {
+            JointXccyQuoteRiskProvenance_New(jointXccy, calibrationId, parameterBlockKeys, componentKeys, market, provenance);
+            return;
+        }
+        if (const auto stagedXccy = handle_cast<StorableCrossCurrencyCalibrationResult_>(result)) {
+            StagedXccyBasisQuoteRiskProvenance_New(stagedXccy, calibrationId, parameterBlockKeys, componentKeys, market, provenance);
+            return;
+        }
+        REQUIRE(!calibrationId.empty(), "QUOTE_RISK_CALIBRATION_ID_EMPTY");
+        if (handle_cast<StorableMultiCurveCalibrationResult_>(result)) {
+            provenance->reset(
+                new StorableRateQuoteRiskProvenance_(calibrationId, "STAGED_MULTI_CURVE", "QUOTE_RISK_NOT_AVAILABLE_FOR_STAGED_CHAIN_RULE"));
+            return;
+        }
+        if (handle_cast<StorableJointMultiCurveCalibrationResult_>(result)) {
+            provenance->reset(new StorableRateQuoteRiskProvenance_(calibrationId, "JOINT_MULTI_CURVE", "QUOTE_RISK_EFFECTIVE_INVERSE_UNAVAILABLE"));
+            return;
+        }
+        THROW("Unsupported quote-risk calibration result handle");
+    }
+
+    void JointXccyQuoteRiskProvenance_New(const Handle_<StorableJointXccyCalibrationResult_>& result,
+                                          const String_& calibrationId,
+                                          const Vector_<String_>& parameterBlockKeys,
+                                          const Vector_<String_>& componentKeys,
+                                          const Handle_<StorableRatePricingMarket_>& market,
+                                          Handle_<StorableRateQuoteRiskProvenance_>* provenance) {
+        REQUIRE(result, "Invalid joint XCCY calibration result handle");
+        REQUIRE(market, "Invalid rate pricing market handle");
+        provenance->reset(new StorableRateQuoteRiskProvenance_(BuildJointXccyQuoteRiskProvenance(
+            result->spec_, result->val_, result->options_, market->val_, QuoteRiskConfig(calibrationId, parameterBlockKeys, componentKeys))));
+    }
+
+    void StagedXccyBasisQuoteRiskProvenance_New(const Handle_<StorableCrossCurrencyCalibrationResult_>& result,
+                                                const String_& calibrationId,
+                                                const Vector_<String_>& parameterBlockKeys,
+                                                const Vector_<String_>& componentKeys,
+                                                const Handle_<StorableRatePricingMarket_>& market,
+                                                Handle_<StorableRateQuoteRiskProvenance_>* provenance) {
+        REQUIRE(result, "Invalid staged XCCY calibration result handle");
+        REQUIRE(market, "Invalid rate pricing market handle");
+        provenance->reset(new StorableRateQuoteRiskProvenance_(BuildStagedXccyBasisQuoteRiskProvenance(
+            result->spec_, result->val_, result->options_, market->val_, QuoteRiskConfig(calibrationId, parameterBlockKeys, componentKeys))));
+    }
+
     // clang-format off
 #ifdef _WIN32
 #include <dal-excel/auto/MG_RateTradeHeader_New_public.inc>
@@ -702,6 +994,11 @@ namespace Dal {
 #include <dal-excel/auto/MG_RatePricingMarket_New_public.inc>
 #include <dal-excel/auto/MG_RateTradeNodeSensitivitiesBatch_Spill_public.inc>
 #include <dal-excel/auto/MG_RatePortfolioNodeRisk_Spill_public.inc>
+#include <dal-excel/auto/MG_SingleCurveQuoteRiskProvenance_New_public.inc>
+#include <dal-excel/auto/MG_JointXccyQuoteRiskProvenance_New_public.inc>
+#include <dal-excel/auto/MG_StagedXccyBasisQuoteRiskProvenance_New_public.inc>
+#include <dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.inc>
+#include <dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.inc>
 #endif
     // clang-format on
 } // namespace Dal

--- a/dal-excel/src/__curvepricing_test_api.hpp
+++ b/dal-excel/src/__curvepricing_test_api.hpp
@@ -15,6 +15,8 @@
 #endif
 
 namespace Dal {
+    struct StorableRateQuoteRiskProvenance_;
+
     DAL_EXCEL_TEST_API void RateTradeHeader_New(const String_& instrumentId,
                                                 const Date_& tradeDate,
                                                 const Date_& start,
@@ -111,6 +113,39 @@ namespace Dal {
                                                         const Vector_<String_>& componentKeys,
                                                         const Handle_<StorableRatePricingMarket_>& market,
                                                         Matrix_<Cell_>* spill);
+
+    DAL_EXCEL_TEST_API void RatePortfolioQuoteRisk_Spill(const Vector_<Handle_<Storable_>>& trades,
+                                                         const Handle_<StorableRatePricingMarket_>& market,
+                                                         const Vector_<Handle_<Storable_>>& provenances,
+                                                         Matrix_<Cell_>* spill);
+
+    DAL_EXCEL_TEST_API void SingleCurveQuoteRiskProvenance_New(const Handle_<StorableCurveCalibrationResult_>& result,
+                                                               const String_& calibrationId,
+                                                               const Vector_<String_>& parameterBlockKeys,
+                                                               const Vector_<String_>& componentKeys,
+                                                               const Handle_<StorableRatePricingMarket_>& market,
+                                                               Handle_<StorableRateQuoteRiskProvenance_>* provenance);
+
+    DAL_EXCEL_TEST_API void RateQuoteRiskProvenance_New(const Handle_<Storable_>& result,
+                                                        const String_& calibrationId,
+                                                        const Vector_<String_>& parameterBlockKeys,
+                                                        const Vector_<String_>& componentKeys,
+                                                        const Handle_<StorableRatePricingMarket_>& market,
+                                                        Handle_<StorableRateQuoteRiskProvenance_>* provenance);
+
+    DAL_EXCEL_TEST_API void JointXccyQuoteRiskProvenance_New(const Handle_<StorableJointXccyCalibrationResult_>& result,
+                                                             const String_& calibrationId,
+                                                             const Vector_<String_>& parameterBlockKeys,
+                                                             const Vector_<String_>& componentKeys,
+                                                             const Handle_<StorableRatePricingMarket_>& market,
+                                                             Handle_<StorableRateQuoteRiskProvenance_>* provenance);
+
+    DAL_EXCEL_TEST_API void StagedXccyBasisQuoteRiskProvenance_New(const Handle_<StorableCrossCurrencyCalibrationResult_>& result,
+                                                                   const String_& calibrationId,
+                                                                   const Vector_<String_>& parameterBlockKeys,
+                                                                   const Vector_<String_>& componentKeys,
+                                                                   const Handle_<StorableRatePricingMarket_>& market,
+                                                                   Handle_<StorableRateQuoteRiskProvenance_>* provenance);
 } // namespace Dal
 
 #undef DAL_EXCEL_TEST_API

--- a/dal-excel/src/__curvespec.cpp
+++ b/dal-excel/src/__curvespec.cpp
@@ -179,10 +179,11 @@ namespace Dal {
 
             // Build spec and calibrate via the dal-public interface
             auto spec = builder.Build();
-            auto calibrated = Dal::CalibrateSingleCurve(spec);
+            CurveCalibrationOptions_ options;
+            auto calibrated = Dal::CalibrateSingleCurve(spec, options);
 
             // Bundle curve + diagnostics into a single storable result handle
-            result->reset(new StorableCurveCalibrationResult_(calibrated));
+            result->reset(new StorableCurveCalibrationResult_(calibrated, spec, options));
         }
 
         void CalibrationResult_Get_Curve(const Handle_<StorableCurveCalibrationResult_>& result,

--- a/dal-excel/src/__excel_test_api.hpp
+++ b/dal-excel/src/__excel_test_api.hpp
@@ -22,7 +22,9 @@ namespace Dal {
         String_ xlName_;
         String_ argTypes_;
         String_ argNames_;
+        String_ help_;
         int argHelpCount_;
+        int maxArgHelpLength_;
         bool volatile_;
     };
 

--- a/dal-excel/src/__xccycalibration.cpp
+++ b/dal-excel/src/__xccycalibration.cpp
@@ -574,7 +574,7 @@ namespace Dal {
         // Resolve the basis curve for the calibrated currency pair
         auto it = calibrated.basisCurves_.find(pair);
         REQUIRE(it != calibrated.basisCurves_.end(), "Basis curve not found for requested currency pair");
-        result->reset(new StorableCrossCurrencyCalibrationResult_(calibrated, it->second));
+        result->reset(new StorableCrossCurrencyCalibrationResult_(calibrated, spec, options, it->second));
     }
 
     void XccyCalibrationResult_Get_BasisCurve(const Handle_<StorableCrossCurrencyCalibrationResult_>& result,
@@ -648,7 +648,8 @@ namespace Dal {
         if (!settings.Empty())
             ApplyJointSettings(SettingsDictionary(settings), builder, options);
 
-        result->reset(new StorableJointXccyCalibrationResult_(Dal::CalibrateJointXccyMarket(builder.Build(), options)));
+        const auto spec = builder.Build();
+        result->reset(new StorableJointXccyCalibrationResult_(Dal::CalibrateJointXccyMarket(spec, options), spec, options));
     }
 
     void JointXccyCalibrationResult_Get_DomesticBlock(const Handle_<StorableJointXccyCalibrationResult_>& result,

--- a/dal-excel/src/_excel.cpp
+++ b/dal-excel/src/_excel.cpp
@@ -1559,9 +1559,13 @@ func_with_args is string
 
     Vector_<ExcelFuncRegistration_> RegisteredFunctionsForTest() {
         Vector_<ExcelFuncRegistration_> retval;
-        for (const auto& func : TheFunctions())
-            retval.push_back(ExcelFuncRegistration_{func.cName_, func.xlName_, func.argTypes_, func.argNames_,
-                                                    static_cast<int>(func.argHelp_.size()), func.volatile_});
+        for (const auto& func : TheFunctions()) {
+            int maxArgHelpLength = 0;
+            for (const auto& help : func.argHelp_)
+                maxArgHelpLength = std::max(maxArgHelpLength, static_cast<int>(help.size()));
+            retval.push_back(ExcelFuncRegistration_{func.cName_, func.xlName_, func.argTypes_, func.argNames_, func.help_,
+                                                    static_cast<int>(func.argHelp_.size()), maxArgHelpLength, func.volatile_});
+        }
         return retval;
     }
 

--- a/dal-excel/tests/test_curvepricing.cpp
+++ b/dal-excel/tests/test_curvepricing.cpp
@@ -7,12 +7,15 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <set>
 #include <string>
 
 #include <dal-excel/src/__curve_storable.hpp>
 #include <dal-excel/src/__curvepricing_test_api.hpp>
 #include <dal-public/src/curvedata.hpp>
+#include <dal-public/src/curveinstrument.hpp>
 #include <dal-public/src/curveprotocol.hpp>
+#include <dal-public/src/curvespec.hpp>
 
 namespace {
     using namespace Dal;
@@ -65,6 +68,43 @@ namespace {
         RateFixedFloatTrade_New(header, "IRS", 1'000'000.0, 0.03, true, AnnualLeg(), AnnualLeg(), QuarterlyIndex(), SofrFixing(), "forecast",
                                 "discount", &trade);
         return trade;
+    }
+
+    struct SingleQuoteRiskFixture_ {
+        Handle_<StorableCurveCalibrationResult_> result_;
+        Handle_<StorableRatePricingMarket_> market_;
+        Handle_<StorableRateTradeDefinition_> trade_;
+    };
+
+    SingleQuoteRiskFixture_ SingleQuoteRiskFixture(const CurveCalibrationOptions_& options = CurveCalibrationOptions_()) {
+        CurveCalibrationSpecBuilder_ builder;
+        builder.today_ = Today();
+        builder.ccy_ = "USD";
+        builder.curveName_ = "single_quote_risk";
+        builder.parameterization_ = CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD;
+        builder.knotDates_ = {Date::AddMonths(builder.today_, 6), Date::AddMonths(builder.today_, 12)};
+        const auto known = DiscountPWCNew(builder.curveName_, builder.ccy_, builder.knotDates_, {0.02, 0.025});
+        const CurveBlock_ knownBlock(known, DayBasis_New("ACT_365F"));
+        const RateIndexConvention_ index = QuarterlyIndex()->val_;
+        for (const auto& maturity : builder.knotDates_) {
+            const auto prototype = DepositNew(builder.today_, builder.today_, maturity, 0.0, index);
+            const double quote = (*prototype->Precompute(Handle_<YieldCurve_>()))(knownBlock);
+            builder.instruments_.push_back(DepositNew(builder.today_, builder.today_, maturity, quote, index));
+        }
+
+        const auto spec = builder.Build();
+        const auto calibrated = CalibrateSingleCurve(spec, options);
+        SingleQuoteRiskFixture_ result;
+        result.result_ = Handle_<StorableCurveCalibrationResult_>(new StorableCurveCalibrationResult_(calibrated, spec, options));
+
+        RatePricingMarket_ market;
+        market.valuationTime_ = DateTime_(builder.today_, 10, 30);
+        market.resultCurrency_ = Ccy_("USD");
+        market.curveComponents_["discount"] = calibrated.curve_;
+        market.fixings_ = Handle_<MarketFixingSnapshot_>(new MarketFixingSnapshot_());
+        result.market_ = Handle_<StorableRatePricingMarket_>(new StorableRatePricingMarket_(market));
+        result.trade_ = DepositTrade(builder.today_, builder.knotDates_.back(), 1'000'000.0);
+        return result;
     }
 
     Vector_<Handle_<Storable_>> TradeHandles(const Vector_<Handle_<StorableRateTradeDefinition_>>& trades) {
@@ -189,6 +229,183 @@ TEST(ExcelCurvePricingTest, TestSpillsCarryNoInternalObjectStructure) {
                     ASSERT_TRUE(reason == "UnconvertedByActualPvCcy" || tokens.count(reason)) << "unexpected reason token: " << reason;
                 }
             }
+    }
+}
+
+TEST(ExcelCurvePricingTest, TestQuoteRiskEmptySpillKeepsFixedColumnShape) {
+    const Date_ today = Today();
+    const Date_ maturity(2027, 1, 15);
+    Matrix_<Cell_> spill;
+
+    RatePortfolioQuoteRisk_Spill({}, Market(today, maturity), {}, &spill);
+
+    ASSERT_EQ(spill.Rows(), 0);
+    ASSERT_EQ(spill.Cols(), 10);
+}
+
+TEST(ExcelCurvePricingTest, TestSingleCurveQuoteRiskProvenanceRejectsMissingHandles) {
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    ASSERT_THROW(SingleCurveQuoteRiskProvenance_New({}, "single", {"curve"}, {"discount"}, {}, &provenance), Exception_);
+}
+
+TEST(ExcelCurvePricingTest, TestExcludedCalibrationDomainsSpillFrozenUnavailableReasons) {
+    const auto market = Market(Today(), Date_(2027, 1, 15));
+    const Vector_<Handle_<Storable_>> results = {
+        Handle_<Storable_>(new StorableMultiCurveCalibrationResult_(MultiCurveCalibrationResult_())),
+        Handle_<Storable_>(new StorableJointMultiCurveCalibrationResult_(JointMultiCurveCalibrationResult_())),
+    };
+    Vector_<Handle_<Storable_>> provenances;
+    for (int index = 0; index < static_cast<int>(results.size()); ++index) {
+        Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        RateQuoteRiskProvenance_New(results[index], String_("excluded-") + String::FromInt(index), {}, {}, market, &provenance);
+        provenances.push_back(Handle_<Storable_>(provenance));
+    }
+
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill({}, market, provenances, &spill);
+
+    ASSERT_EQ(spill.Rows(), 2);
+    ASSERT_EQ(spill.Cols(), 10);
+    ASSERT_EQ(Cell::ToString(spill(0, 0)), String_("excluded-0"));
+    ASSERT_EQ(Cell::ToString(spill(0, 8)), String_("unavailable"));
+    ASSERT_EQ(Cell::ToString(spill(0, 9)), String_("QUOTE_RISK_NOT_AVAILABLE_FOR_STAGED_CHAIN_RULE"));
+    ASSERT_EQ(Cell::ToString(spill(1, 0)), String_("excluded-1"));
+    ASSERT_EQ(Cell::ToString(spill(1, 8)), String_("unavailable"));
+    ASSERT_EQ(Cell::ToString(spill(1, 9)), String_("QUOTE_RISK_EFFECTIVE_INVERSE_UNAVAILABLE"));
+    for (int row = 0; row < spill.Rows(); ++row) {
+        ASSERT_TRUE(Cell::IsEmpty(spill(row, 6)));
+        ASSERT_TRUE(Cell::IsEmpty(spill(row, 7)));
+    }
+}
+
+TEST(ExcelCurvePricingTest, TestUnavailableSingleProvenanceSpillsReasonWithoutBuckets) {
+    CurveCalibrationOptions_ options;
+    options.computeEffJacobianInverse_ = false;
+    const auto fixture = SingleQuoteRiskFixture(options);
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    SingleCurveQuoteRiskProvenance_New(fixture.result_, "single", {fixture.result_->spec_.curveName_}, {"discount"}, fixture.market_, &provenance);
+    ASSERT_FALSE(provenance->val_->Available());
+
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill(TradeHandles({fixture.trade_}), fixture.market_, {Handle_<Storable_>(provenance)}, &spill);
+
+    ASSERT_EQ(spill.Rows(), 1);
+    ASSERT_EQ(spill.Cols(), 10);
+    ASSERT_EQ(Cell::ToString(spill(0, 0)), String_("single"));
+    ASSERT_EQ(Cell::ToString(spill(0, 1)), provenance->val_->Axis().fingerprint_);
+    ASSERT_TRUE(Cell::IsEmpty(spill(0, 6)));
+    ASSERT_TRUE(Cell::IsEmpty(spill(0, 7)));
+    ASSERT_EQ(Cell::ToString(spill(0, 8)), String_("unavailable"));
+    ASSERT_EQ(Cell::ToString(spill(0, 9)), String_("QUOTE_RISK_INVERSE_NOT_REQUESTED"));
+}
+
+TEST(ExcelCurvePricingTest, TestStaleProvenanceSpillsOneDeterministicFailureRow) {
+    const auto fixture = SingleQuoteRiskFixture();
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    SingleCurveQuoteRiskProvenance_New(fixture.result_, "single", {fixture.result_->spec_.curveName_}, {"discount"}, fixture.market_, &provenance);
+    RatePricingMarket_ stale = fixture.market_->val_;
+    stale.valuationTime_ = DateTime_(Today(), 11, 0);
+    const Handle_<StorableRatePricingMarket_> staleMarket(new StorableRatePricingMarket_(stale));
+
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill(TradeHandles({fixture.trade_}), staleMarket, {Handle_<Storable_>(provenance)}, &spill);
+
+    ASSERT_EQ(spill.Rows(), 1);
+    ASSERT_EQ(spill.Cols(), 10);
+    ASSERT_EQ(Cell::ToString(spill(0, 0)), String_("single"));
+    ASSERT_EQ(Cell::ToString(spill(0, 1)), provenance->val_->Axis().fingerprint_);
+    ASSERT_EQ(Cell::ToString(spill(0, 4)), String_("discount"));
+    ASSERT_TRUE(Cell::IsEmpty(spill(0, 6)));
+    ASSERT_TRUE(Cell::IsEmpty(spill(0, 7)));
+    ASSERT_EQ(Cell::ToString(spill(0, 8)), String_("unavailable"));
+    ASSERT_EQ(Cell::ToString(spill(0, 9)), String_("QUOTE_RISK_CALIBRATION_STATE_MISMATCH"));
+}
+
+TEST(ExcelCurvePricingTest, TestIncompleteTradeSpillsOneFailureAndOnlyScalarCells) {
+    const auto fixture = SingleQuoteRiskFixture();
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    SingleCurveQuoteRiskProvenance_New(fixture.result_, "single", {fixture.result_->spec_.curveName_}, {"discount"}, fixture.market_, &provenance);
+    auto invalid = fixture.trade_->val_;
+    std::get<DepositTradeTerms_>(invalid.terms_).notional_ = 0.0;
+    const Vector_<Handle_<Storable_>> trades{Handle_<Storable_>(new StorableRateTradeDefinition_(invalid))};
+
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill(trades, fixture.market_, {Handle_<Storable_>(provenance)}, &spill);
+
+    ASSERT_EQ(spill.Rows(), 1);
+    ASSERT_EQ(spill.Cols(), 10);
+    ASSERT_EQ(Cell::ToString(spill(0, 2)), invalid.instrumentId_);
+    ASSERT_EQ(Cell::ToString(spill(0, 3)), String_("TRADE_VALIDATION_FAILED"));
+    ASSERT_EQ(Cell::ToString(spill(0, 8)), String_("unavailable"));
+    ASSERT_EQ(Cell::ToString(spill(0, 9)), String_("QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE"));
+    for (int col = 0; col < spill.Cols(); ++col)
+        ASSERT_TRUE(Cell::IsEmpty(spill(0, col)) || Cell::IsString(spill(0, col)) || Cell::IsDouble(spill(0, col)))
+            << "non-scalar quote-risk spill cell in column " << col;
+}
+
+TEST(ExcelCurvePricingTest, TestDuplicateQuoteRiskCalibrationIdsFailClosed) {
+    const auto fixture = SingleQuoteRiskFixture();
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    SingleCurveQuoteRiskProvenance_New(fixture.result_, "single", {fixture.result_->spec_.curveName_}, {"discount"}, fixture.market_, &provenance);
+    try {
+        Matrix_<Cell_> spill;
+        RatePortfolioQuoteRisk_Spill(TradeHandles({fixture.trade_}), fixture.market_,
+                                     {Handle_<Storable_>(provenance), Handle_<Storable_>(provenance)}, &spill);
+        FAIL() << "Expected duplicate calibration ids to fail";
+    } catch (const Exception_& exception) {
+        ASSERT_NE(std::string(exception.what()).find("QUOTE_RISK_DUPLICATE_CALIBRATION_ID"), std::string::npos) << exception.what();
+    }
+}
+
+TEST(ExcelCurvePricingTest, TestQuoteRiskMixedCurrenciesRemainSeparateAndOrderedLikePublicAggregate) {
+    const auto fixture = SingleQuoteRiskFixture();
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    SingleCurveQuoteRiskProvenance_New(fixture.result_, "single", {fixture.result_->spec_.curveName_}, {"discount"}, fixture.market_, &provenance);
+    auto eurTrade = fixture.trade_->val_;
+    eurTrade.instrumentId_ = "eur-deposit";
+    eurTrade.currencyOrPair_ = Ccy_("EUR");
+    const Handle_<StorableRateTradeDefinition_> eur(new StorableRateTradeDefinition_(eurTrade));
+
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill(TradeHandles({fixture.trade_, eur}), fixture.market_, {Handle_<Storable_>(provenance)}, &spill);
+    const auto native = AggregateRatePortfolioQuoteRisk({fixture.trade_->val_, eurTrade}, fixture.market_->val_, {*provenance->val_});
+
+    ASSERT_EQ(spill.Rows(), static_cast<int>(native.buckets_.size()));
+    ASSERT_EQ(spill.Cols(), 10);
+    std::set<String_> currencies;
+    for (int row = 0; row < spill.Rows(); ++row) {
+        ASSERT_EQ(Cell::ToString(spill(row, 2)), native.buckets_[row].quoteKey_);
+        ASSERT_EQ(Cell::ToString(spill(row, 5)), native.buckets_[row].actualPvCcy_.String());
+        ASSERT_DOUBLE_EQ(Cell::ToDouble(spill(row, 6)), native.buckets_[row].dPvDDecimalQuote_);
+        ASSERT_DOUBLE_EQ(Cell::ToDouble(spill(row, 7)), native.buckets_[row].dv01_);
+        currencies.insert(Cell::ToString(spill(row, 5)));
+    }
+    ASSERT_EQ(currencies, (std::set<String_>{"EUR", "USD"}));
+}
+
+TEST(ExcelCurvePricingTest, TestSingleCurveQuoteRiskSpillMatchesPublicAggregate) {
+    const auto fixture = SingleQuoteRiskFixture();
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    SingleCurveQuoteRiskProvenance_New(fixture.result_, "single", {fixture.result_->spec_.curveName_}, {"discount"}, fixture.market_, &provenance);
+
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill(TradeHandles({fixture.trade_}), fixture.market_, {Handle_<Storable_>(provenance)}, &spill);
+
+    const auto native = AggregateRatePortfolioQuoteRisk({fixture.trade_->val_}, fixture.market_->val_, {*provenance->val_});
+    ASSERT_EQ(spill.Rows(), static_cast<int>(native.buckets_.size()));
+    ASSERT_EQ(spill.Cols(), 10);
+    for (int row = 0; row < spill.Rows(); ++row) {
+        const auto& bucket = native.buckets_[row];
+        ASSERT_EQ(Cell::ToString(spill(row, 0)), bucket.calibrationId_);
+        ASSERT_EQ(Cell::ToString(spill(row, 1)), bucket.axisFingerprint_);
+        ASSERT_EQ(Cell::ToString(spill(row, 2)), bucket.quoteKey_);
+        ASSERT_EQ(Cell::ToString(spill(row, 3)), bucket.quoteName_);
+        ASSERT_EQ(Cell::ToString(spill(row, 4)), bucket.residualBlock_);
+        ASSERT_EQ(Cell::ToString(spill(row, 5)), bucket.actualPvCcy_.String());
+        ASSERT_DOUBLE_EQ(Cell::ToDouble(spill(row, 6)), bucket.dPvDDecimalQuote_);
+        ASSERT_DOUBLE_EQ(Cell::ToDouble(spill(row, 7)), bucket.dv01_);
+        ASSERT_EQ(Cell::ToString(spill(row, 8)), String_("available"));
+        ASSERT_TRUE(Cell::IsEmpty(spill(row, 9)));
     }
 }
 #endif

--- a/dal-excel/tests/test_excel_api.cpp
+++ b/dal-excel/tests/test_excel_api.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include <dal-excel/src/__curve_storable.hpp>
+#include <dal-excel/src/__curvepricing_test_api.hpp>
 #include <dal-excel/src/__xccy_test_api.hpp>
 #include <dal-public/src/curvedata.hpp>
 #include <dal-public/src/curveinstrument.hpp>
@@ -113,6 +114,44 @@ namespace {
     }
 
     Handle_<StorableCrossCurrencyCalibrationResult_> StagedResult() { return StagedResult(StagedSettings()); }
+
+    Handle_<StorableRatePricingMarket_>
+    JointPricingMarket(const Handle_<StorableJointXccyCalibrationResult_>& result, Vector_<String_>* blockKeys, Vector_<String_>* componentKeys) {
+        const CollateralType_ ois(CollateralType_::Value_::OIS);
+        const Vector_<Handle_<DiscountCurve_>> curves = {
+            result->domesticBlock_->DiscountCurves().at(ois),
+            result->foreignBlock_->DiscountCurves().at(ois),
+            result->basisCurve_,
+        };
+        REQUIRE(curves.size() == result->val_.parameterRanges_.size(), "Unexpected joint XCCY parameter range count");
+        RatePricingMarket_ market;
+        market.valuationTime_ = result->spec_.valuationTime_;
+        market.resultCurrency_ = result->spec_.pair_.domestic_;
+        market.fixings_ = result->val_.fixings_;
+        for (int index = 0; index < static_cast<int>(curves.size()); ++index) {
+            blockKeys->push_back(result->val_.parameterRanges_[index].name_);
+            componentKeys->push_back("joint-component-" + String::FromInt(index));
+            market.curveComponents_[componentKeys->back()] = curves[index];
+        }
+        auto xccy = std::make_shared<CrossCurrencyMarket_>(result->domesticBlock_, result->foreignBlock_, result->spec_.fxSpot_,
+                                                          result->spec_.valuationTime_, result->spec_.collateralCurrency_, result->val_.fixings_);
+        xccy->SetBasisCurve(result->basisCurve_);
+        market.xccyMarket_ = xccy;
+        return Handle_<StorableRatePricingMarket_>(new StorableRatePricingMarket_(market));
+    }
+
+    Handle_<StorableRatePricingMarket_>
+    StagedPricingMarket(const Handle_<StorableCrossCurrencyCalibrationResult_>& result, Vector_<String_>* blockKeys, Vector_<String_>* componentKeys) {
+        blockKeys->push_back(String_("basis:xccy_basis_") + result->spec_.basisPair_.domestic_.String());
+        componentKeys->push_back("staged-basis-component");
+        RatePricingMarket_ market;
+        market.valuationTime_ = result->spec_.valuationTime_.IsValid() ? result->spec_.valuationTime_ : DateTime_(result->spec_.today_);
+        market.resultCurrency_ = result->spec_.basisPair_.domestic_;
+        market.curveComponents_[componentKeys->front()] = result->basisCurve_;
+        market.fixings_ = result->val_.market_.Fixings();
+        market.xccyMarket_ = std::make_shared<CrossCurrencyMarket_>(result->val_.market_);
+        return Handle_<StorableRatePricingMarket_>(new StorableRatePricingMarket_(market));
+    }
 } // namespace
 
 TEST(ExcelApiTest, TestConfiguredCrossCurrencySwapConstruction) {
@@ -322,6 +361,29 @@ TEST(ExcelApiTest, TestStagedCalibrationExposesFrozenSensitivityViews) {
     Matrix_<Cell_> tolerance;
     XccyCalibrationResult_Get(result, "residualTolerance", &tolerance);
     ASSERT_DOUBLE_EQ(Cell::ToDouble(tolerance(0, 0)), 1.0e-8);
+}
+
+TEST(ExcelApiTest, TestJointAndStagedQuoteRiskProvenanceHandlesUsePublicFactories) {
+    {
+        const auto result = JointResult();
+        Vector_<String_> blockKeys;
+        Vector_<String_> componentKeys;
+        const auto market = JointPricingMarket(result, &blockKeys, &componentKeys);
+        Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        JointXccyQuoteRiskProvenance_New(result, "joint", blockKeys, componentKeys, market, &provenance);
+        ASSERT_TRUE(provenance->val_->Available());
+        ASSERT_EQ(provenance->val_->Kind(), String_("JOINT_XCCY"));
+    }
+    {
+        const auto result = StagedResult();
+        Vector_<String_> blockKeys;
+        Vector_<String_> componentKeys;
+        const auto market = StagedPricingMarket(result, &blockKeys, &componentKeys);
+        Handle_<StorableRateQuoteRiskProvenance_> provenance;
+        StagedXccyBasisQuoteRiskProvenance_New(result, "staged", blockKeys, componentKeys, market, &provenance);
+        ASSERT_TRUE(provenance->val_->Available());
+        ASSERT_EQ(provenance->val_->Kind(), String_("STAGED_XCCY_BASIS"));
+    }
 }
 
 TEST(ExcelApiTest, TestStagedAvailabilitySeparatesRequestFlagsAndMode) {

--- a/dal-excel/tests/test_registration.cpp
+++ b/dal-excel/tests/test_registration.cpp
@@ -2,9 +2,21 @@
 // Created by wegam on 2026/7/19.
 //
 
-#ifdef _WIN32
-
 #include <gtest/gtest.h>
+
+#include <string>
+
+#include <dal/string/strings.hpp>
+
+namespace {
+    std::string CaseSensitive(const Dal::String_& value) { return std::string(value.c_str()); }
+} // namespace
+
+TEST(ExcelRegistrationPortableTest, TestCaseSensitiveComparisonRejectsLowercaseExcelName) {
+    ASSERT_NE(CaseSensitive(Dal::String_("rateportfolioquoterisk.spill")), "RATEPORTFOLIOQUOTERISK.SPILL");
+}
+
+#ifdef _WIN32
 
 #define NOMINMAX
 #include <Windows.h>
@@ -12,7 +24,6 @@
 #include <algorithm>
 #include <cctype>
 #include <set>
-#include <string>
 
 #include <dal-excel/src/__excel_test_api.hpp>
 
@@ -59,7 +70,7 @@ TEST(ExcelRegistrationTest, TestQuoteRiskFunctionsRetainLongNamesAndHelpMetadata
             return registration.cName_ == cName;
         });
         ASSERT_NE(found, registrations.end()) << cName.c_str();
-        ASSERT_EQ(found->xlName_, String_(UpperDotted(cName.substr(3)).c_str()));
+        ASSERT_EQ(CaseSensitive(found->xlName_), UpperDotted(cName.substr(3)));
         ASSERT_FALSE(found->help_.empty());
         ASSERT_EQ(DeclaredArgCount(*found), found->argHelpCount_);
         ASSERT_LE(found->maxArgHelpLength_, 255);

--- a/dal-excel/tests/test_registration.cpp
+++ b/dal-excel/tests/test_registration.cpp
@@ -42,7 +42,33 @@ namespace {
 } // namespace
 
 TEST(ExcelRegistrationTest, TestRegistrationTableIsPopulated) {
-    ASSERT_GE(RegisteredFunctionsForTest().size(), 62);
+    ASSERT_GE(RegisteredFunctionsForTest().size(), 67);
+}
+
+TEST(ExcelRegistrationTest, TestQuoteRiskFunctionsRetainLongNamesAndHelpMetadata) {
+    const auto registrations = RegisteredFunctionsForTest();
+    const Vector_<String_> cNames = {
+        "xl_SingleCurveQuoteRiskProvenance_New",
+        "xl_JointXccyQuoteRiskProvenance_New",
+        "xl_StagedXccyBasisQuoteRiskProvenance_New",
+        "xl_RateQuoteRiskProvenance_New",
+        "xl_RatePortfolioQuoteRisk_Spill",
+    };
+    for (const auto& cName : cNames) {
+        const auto found = std::find_if(registrations.begin(), registrations.end(), [&](const auto& registration) {
+            return registration.cName_ == cName;
+        });
+        ASSERT_NE(found, registrations.end()) << cName.c_str();
+        ASSERT_EQ(found->xlName_, String_(UpperDotted(cName.substr(3)).c_str()));
+        ASSERT_FALSE(found->help_.empty());
+        ASSERT_EQ(DeclaredArgCount(*found), found->argHelpCount_);
+        ASSERT_LE(found->maxArgHelpLength_, 255);
+    }
+    const auto staged = std::find_if(registrations.begin(), registrations.end(), [](const auto& registration) {
+        return registration.cName_ == "xl_StagedXccyBasisQuoteRiskProvenance_New";
+    });
+    ASSERT_NE(staged, registrations.end());
+    ASSERT_EQ(staged->argNames_, String_("result,calibrationId,parameterBlockKeys,componentKeys,market"));
 }
 
 TEST(ExcelRegistrationTest, TestEveryRegisteredFunctionResolvesToAnEntryPoint) {


### PR DESCRIPTION
## Summary

- retain exact single, joint-XCCY, and staged-XCCY calibration inputs in immutable Excel provenance handles backed by the public facade
- add a deterministic ten-column portfolio quote-sensitivity/DV01 spill with stable failure rows and excluded-domain reason tokens
- regenerate Machinist wrappers/help and extend portable plus Windows registration contracts

## Test plan

- [x] Portable Excel focused and full suite (24/24)
- [x] Full `ctest --test-dir build/Release-linux --output-on-failure` (1504/1504)
- [x] `cmake --build build/Release-linux --target dal_check_generated -j 8`
- [x] `python3 .github/scripts/check_docs.py`
- [x] Confirmed `dal_excel` links through `${DAL_PUBLIC_TARGET}` only

Closes DAL-178
