### PR TITLE
ci: strengthen performance gate evidence

### DIFF
--- a/.codex/references/benchmark-workflow.md
+++ b/.codex/references/benchmark-workflow.md
@@ -26,8 +26,8 @@ substitute for correctness review.
 - `DAL_CPP_BUILD_BENCHMARKS` defaults to `ON` in `dal-cpp/CMakeLists.txt`, but the shared `base`
   CMake preset overrides it to `OFF`. Every preset-based performance build must therefore pass
   `-DDAL_CPP_BUILD_BENCHMARKS=ON` explicitly.
-- The Linux CI job builds and smoke-runs all current benchmark targets. Its paired PR regression
-  gate is the nine-target closed set in
+- The Linux CI job builds and smoke-runs all current benchmark targets. Its paired pull-request
+  and `master`-push regression gate is the nine-target closed set in
   `.github/scripts/check_benchmark_regressions.py`.
 - Installed binaries under `build/stage/.../bin/` change only after `cmake --install`. They can
   be stale after a rebuild and are not valid for branch-versus-baseline comparison.
@@ -50,7 +50,8 @@ The regression gate is exactly these nine executables:
 - `banded_perf`: banded tridiagonal matrix-vector multiplication at size 10K.
 - `cholesky_perf`: dense Cholesky decomposition of a 200 by 200 SPD matrix.
 - `rate_risk_perf`: rate pricing, node-risk aggregation, and steady-state quote-risk aggregation
-  for single-curve, joint-XCCY, and staged-XCCY-basis provenance.
+  for single-curve, joint-XCCY, and staged-XCCY-basis provenance, including production portfolio
+  shapes with analytic and bumped inverses at N=5/10/16.
 
 Do not add another executable to the regression verdict ad hoc. The paired gate rejects names
 outside this allowlist.
@@ -159,8 +160,9 @@ is `inconclusive`, not `regression`.
 ## Current CI Reproduction
 
 The current executable gate defaults to ten samples, two confirmation rounds, and a 4% threshold.
-The Linux PR workflow passes those values explicitly. Two rounds of ten means twenty interleaved
-process samples per case and side.
+The Linux workflow passes those values explicitly for pull requests and `master` pushes. For a
+pull request the baseline is its base SHA; for a push it is `github.event.before`. Two rounds of
+ten means twenty interleaved process samples per case and side.
 
 Reproduce it against the isolated build roots:
 
@@ -187,6 +189,11 @@ The script:
 
 Use the script's nonzero exit as the current repository gate result, but still inspect and report
 its raw samples and failures.
+
+The Linux and Windows benchmark jobs upload `benchmark-results/` for 30 days. Both artifacts
+contain `environment.json` with source SHAs, runner and CPU identity, toolchain, AAD backend, and
+thread settings. Linux additionally retains each smoke run's `/usr/bin/time --verbose` resource
+record and the paired gate's raw outputs, `results.json`, and `summary.md`.
 
 ## Threshold And Verdict
 

--- a/.github/scripts/check_docs.py
+++ b/.github/scripts/check_docs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 import tomllib
@@ -467,6 +468,79 @@ def check_benchmark_case_policy(errors: list[str]) -> None:
         errors.append("CONTRIBUTING.md: benchmark case-set policy does not describe head-only coverage")
 
 
+def cmake_benchmark_targets(text: str, errors: list[str]) -> set[str]:
+    match = re.search(r"set\(DAL_BENCHMARK_TARGETS\s+(.*?)\)", text, flags=re.DOTALL)
+    if match is None:
+        errors.append("dal-cpp/benchmarks/CMakeLists.txt: DAL_BENCHMARK_TARGETS was not found")
+        return set()
+    return set(match.group(1).split())
+
+
+def gated_benchmark_targets(text: str, errors: list[str]) -> set[str]:
+    tree = ast.parse(text)
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "BENCHMARKS" for target in node.targets
+        ):
+            value = ast.literal_eval(node.value)
+            return set(value)
+    errors.append(".github/scripts/check_benchmark_regressions.py: BENCHMARKS was not found")
+    return set()
+
+
+def reference_benchmark_targets(text: str) -> set[str]:
+    section = text.split("## Regression Gate And Module Map", maxsplit=1)[-1]
+    section = section.split("Do not add another executable", maxsplit=1)[0]
+    return set(re.findall(r"(?m)^- `([^`]+)`:", section))
+
+
+def documented_benchmark_inventory(text: str, errors: list[str]) -> tuple[int, set[str]]:
+    match = re.search(r"\(([0-9]+) total: ([^)]+)\)", text)
+    if match is None:
+        errors.append("CLAUDE.md: benchmark total and inventory were not found")
+        return 0, set()
+    return int(match.group(1)), {f"{name.strip()}_perf" for name in match.group(2).split(",")}
+
+
+def check_benchmark_inventory_texts(
+    cmake: str, gate: str, reference: str, claude: str, errors: list[str]
+) -> None:
+    cmake_targets = cmake_benchmark_targets(cmake, errors)
+    gate_targets = gated_benchmark_targets(gate, errors)
+    reference_targets = reference_benchmark_targets(reference)
+    documented_count, documented_targets = documented_benchmark_inventory(claude, errors)
+    if gate_targets != reference_targets:
+        errors.append(
+            ".codex/references/benchmark-workflow.md: gated target inventory drift: "
+            f"script={sorted(gate_targets)!r}, documented={sorted(reference_targets)!r}"
+        )
+    if not gate_targets.issubset(cmake_targets):
+        errors.append(
+            ".github/scripts/check_benchmark_regressions.py: gated targets are absent from CMake: "
+            f"{sorted(gate_targets - cmake_targets)!r}"
+        )
+    if documented_count != len(cmake_targets):
+        errors.append(
+            f"CLAUDE.md: declares {documented_count} total benchmarks but CMake registers "
+            f"{len(cmake_targets)}"
+        )
+    if documented_targets != cmake_targets:
+        errors.append(
+            "CLAUDE.md: benchmark target inventory drift: "
+            f"cmake={sorted(cmake_targets)!r}, documented={sorted(documented_targets)!r}"
+        )
+
+
+def check_benchmark_inventory(errors: list[str]) -> None:
+    check_benchmark_inventory_texts(
+        (ROOT / "dal-cpp/benchmarks/CMakeLists.txt").read_text(encoding="utf-8"),
+        (ROOT / ".github/scripts/check_benchmark_regressions.py").read_text(encoding="utf-8"),
+        (ROOT / ".codex/references/benchmark-workflow.md").read_text(encoding="utf-8"),
+        (ROOT / "CLAUDE.md").read_text(encoding="utf-8"),
+        errors,
+    )
+
+
 def check_python_project_metadata(errors: list[str], metadata: dict) -> None:
     project = metadata["project"]
     if "scikit-build-core==1.0.3" not in metadata["build-system"]["requires"]:
@@ -892,6 +966,7 @@ def main() -> int:
     check_agent_paths(AGENT_DOCS, ROOT, errors)
     check_current_state_doc_locations(errors)
     check_ci_compiler_inventory(errors)
+    check_benchmark_inventory(errors)
     check_repository_workflows(errors)
 
     if errors:

--- a/.github/scripts/tests/test_benchmark_metadata.py
+++ b/.github/scripts/tests/test_benchmark_metadata.py
@@ -1,14 +1,24 @@
 """Tests for reproducible benchmark-environment metadata."""
 
+import importlib.util
 import json
 from pathlib import Path
-import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "write_benchmark_metadata.py"
+
+
+def load_metadata_script():
+    spec = importlib.util.spec_from_file_location("write_benchmark_metadata", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class BenchmarkMetadataTest(unittest.TestCase):
@@ -16,31 +26,25 @@ class BenchmarkMetadataTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "environment.json"
 
-            completed = subprocess.run(
-                [
-                    sys.executable,
-                    str(SCRIPT),
-                    "--output",
-                    str(output),
-                    "--head-sha",
-                    "head-sha",
-                    "--base-sha",
-                    "base-sha",
-                    "--compiler",
-                    sys.executable,
-                    "--aad-backend",
-                    "aadet",
-                    "--threads",
-                    "4",
-                    "--runner-image",
-                    "test-image",
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-
-            self.assertEqual(completed.returncode, 0, completed.stderr)
+            argv = [
+                str(SCRIPT),
+                "--output",
+                str(output),
+                "--head-sha",
+                "head-sha",
+                "--base-sha",
+                "base-sha",
+                "--compiler",
+                "python3",
+                "--aad-backend",
+                "aadet",
+                "--threads",
+                "4",
+                "--runner-image",
+                "test-image",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                self.assertEqual(load_metadata_script().main(), 0)
             metadata = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(metadata["head_sha"], "head-sha")
             self.assertEqual(metadata["base_sha"], "base-sha")

--- a/.github/scripts/tests/test_benchmark_metadata.py
+++ b/.github/scripts/tests/test_benchmark_metadata.py
@@ -1,0 +1,56 @@
+"""Tests for reproducible benchmark-environment metadata."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "write_benchmark_metadata.py"
+
+
+class BenchmarkMetadataTest(unittest.TestCase):
+    def test_cli_records_provenance_and_toolchain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "environment.json"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--output",
+                    str(output),
+                    "--head-sha",
+                    "head-sha",
+                    "--base-sha",
+                    "base-sha",
+                    "--compiler",
+                    sys.executable,
+                    "--aad-backend",
+                    "aadet",
+                    "--threads",
+                    "4",
+                    "--runner-image",
+                    "test-image",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            metadata = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["head_sha"], "head-sha")
+            self.assertEqual(metadata["base_sha"], "base-sha")
+            self.assertEqual(metadata["aad_backend"], "aadet")
+            self.assertEqual(metadata["dal_num_threads"], 4)
+            self.assertEqual(metadata["runner_image"], "test-image")
+            self.assertTrue(metadata["cpu_model"])
+            self.assertIn("Python", metadata["compiler_version"])
+            self.assertIn("cmake", metadata["cmake_version"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_check_docs.py
+++ b/.github/scripts/tests/test_check_docs.py
@@ -195,9 +195,34 @@ class SemanticConsistencyTest(unittest.TestCase):
         errors: list[str] = []
         CHECK_DOCS.check_current_state_doc_locations(errors)
         CHECK_DOCS.check_ci_compiler_inventory(errors)
+        CHECK_DOCS.check_benchmark_inventory(errors)
         CHECK_DOCS.check_repository_workflows(errors)
 
         self.assertEqual(errors, [])
+
+    def test_benchmark_inventory_rejects_documented_count_drift(self):
+        errors: list[str] = []
+        CHECK_DOCS.check_benchmark_inventory_texts(
+            "set(DAL_BENCHMARK_TARGETS\n    tape_perf\n    rate_risk_perf)",
+            'BENCHMARKS = ("tape_perf", "rate_risk_perf")',
+            "- `tape_perf`: tape\n- `rate_risk_perf`: risk\n",
+            "(1 total: tape, rate_risk)",
+            errors,
+        )
+
+        self.assertTrue(any("declares 1 total" in error for error in errors))
+
+    def test_benchmark_inventory_rejects_gate_reference_drift(self):
+        errors: list[str] = []
+        CHECK_DOCS.check_benchmark_inventory_texts(
+            "set(DAL_BENCHMARK_TARGETS\n    tape_perf\n    rate_risk_perf)",
+            'BENCHMARKS = ("tape_perf", "rate_risk_perf")',
+            "- `tape_perf`: tape\n",
+            "(2 total: tape, rate_risk)",
+            errors,
+        )
+
+        self.assertTrue(any("gated target inventory drift" in error for error in errors))
 
 
 class PythonReleaseContractTest(unittest.TestCase):

--- a/.github/scripts/tests/test_classify_ci_changes.py
+++ b/.github/scripts/tests/test_classify_ci_changes.py
@@ -212,6 +212,33 @@ class CiWorkflowFastPathTest(unittest.TestCase):
             with self.subTest(gate_dependency=job_id):
                 self.assertIn(f"needs.{job_id}.result", gate)
 
+    def test_benchmark_jobs_persist_environment_and_results(self):
+        for workflow_name in ("cmake-linux.yml", "cmake-windows.yml"):
+            with self.subTest(workflow=workflow_name):
+                benchmark = self.job(self.workflow(workflow_name), "benchmark")
+                self.assertIn("write_benchmark_metadata.py", benchmark)
+                self.assertIn("--head-sha", benchmark)
+                self.assertIn("--base-sha", benchmark)
+                self.assertIn("--aad-backend aadet", benchmark)
+                self.assertIn("--threads 4", benchmark)
+                self.assertIn("actions/upload-artifact@", benchmark)
+                self.assertIn("if: always()", benchmark)
+                self.assertIn("path: benchmark-results", benchmark)
+                self.assertIn("retention-days: 30", benchmark)
+
+        linux_benchmark = self.job(self.workflow("cmake-linux.yml"), "benchmark")
+        self.assertIn("/usr/bin/time --verbose", linux_benchmark)
+        self.assertIn('resource_file="benchmark-results/${bench}.resources.txt"', linux_benchmark)
+
+    def test_linux_benchmark_pairs_pull_requests_and_master_pushes(self):
+        benchmark = self.job(self.workflow("cmake-linux.yml"), "benchmark")
+
+        self.assertIn(
+            "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}",
+            benchmark,
+        )
+        self.assertNotIn("if: github.event_name == 'pull_request'", benchmark)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/write_benchmark_metadata.py
+++ b/.github/scripts/write_benchmark_metadata.py
@@ -14,13 +14,24 @@ import subprocess
 
 def command_version(command: str) -> str:
     try:
-        completed = subprocess.run(
-            [command, "--version"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        if command == "gcc-14":
+            completed = subprocess.run(
+                ["gcc-14", "--version"], check=False, capture_output=True, text=True, timeout=30
+            )
+        elif command == "cl":
+            completed = subprocess.run(
+                ["cl", "--version"], check=False, capture_output=True, text=True, timeout=30
+            )
+        elif command == "python3":
+            completed = subprocess.run(
+                ["python3", "--version"], check=False, capture_output=True, text=True, timeout=30
+            )
+        elif command == "cmake":
+            completed = subprocess.run(
+                ["cmake", "--version"], check=False, capture_output=True, text=True, timeout=30
+            )
+        else:
+            return f"unsupported command: {command}"
     except (OSError, subprocess.TimeoutExpired) as error:
         return f"unavailable: {error}"
     output = f"{completed.stdout}\n{completed.stderr}"
@@ -44,8 +55,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--head-sha", required=True)
     parser.add_argument("--base-sha", required=True)
-    parser.add_argument("--compiler", required=True)
-    parser.add_argument("--cmake", default="cmake")
+    parser.add_argument("--compiler", required=True, choices=("gcc-14", "cl", "python3"))
     parser.add_argument("--aad-backend", required=True)
     parser.add_argument("--threads", required=True, type=int)
     parser.add_argument("--runner-image", required=True)
@@ -79,8 +89,8 @@ def main() -> int:
         "github_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", "local"),
         "compiler_command": args.compiler,
         "compiler_version": command_version(args.compiler),
-        "cmake_command": args.cmake,
-        "cmake_version": command_version(args.cmake),
+        "cmake_command": "cmake",
+        "cmake_version": command_version("cmake"),
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/.github/scripts/write_benchmark_metadata.py
+++ b/.github/scripts/write_benchmark_metadata.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Write reproducible, non-secret benchmark environment metadata."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+
+
+def command_version(command: str) -> str:
+    try:
+        completed = subprocess.run(
+            [command, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return f"unavailable: {error}"
+    output = f"{completed.stdout}\n{completed.stderr}"
+    return next((line.strip() for line in output.splitlines() if line.strip()), "unavailable")
+
+
+def cpu_model() -> str:
+    identifier = os.environ.get("PROCESSOR_IDENTIFIER")
+    if identifier:
+        return identifier
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.is_file():
+        for line in cpuinfo.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.lower().startswith("model name") and ":" in line:
+                return line.split(":", maxsplit=1)[1].strip()
+    return platform.processor() or platform.machine() or "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--compiler", required=True)
+    parser.add_argument("--cmake", default="cmake")
+    parser.add_argument("--aad-backend", required=True)
+    parser.add_argument("--threads", required=True, type=int)
+    parser.add_argument("--runner-image", required=True)
+    parser.add_argument("--build-type", default="Release")
+    parser.add_argument("--native-arch", choices=("on", "off"), default="on")
+    parser.add_argument("--shared-libraries", choices=("on", "off"), default="off")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    metadata = {
+        "schema": "dal.benchmark-environment/1",
+        "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+        "head_sha": args.head_sha,
+        "base_sha": args.base_sha,
+        "build_type": args.build_type,
+        "shared_libraries": args.shared_libraries,
+        "native_arch": args.native_arch,
+        "aad_backend": args.aad_backend,
+        "dal_num_threads": args.threads,
+        "cpu_model": cpu_model(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "runner_image": args.runner_image,
+        "runner_os": os.environ.get("RUNNER_OS", platform.system()),
+        "runner_arch": os.environ.get("RUNNER_ARCH", platform.machine()),
+        "runner_name": os.environ.get("RUNNER_NAME", "local"),
+        "github_event_name": os.environ.get("GITHUB_EVENT_NAME", "local"),
+        "github_run_id": os.environ.get("GITHUB_RUN_ID", "local"),
+        "github_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", "local"),
+        "compiler_command": args.compiler,
+        "compiler_version": command_version(args.compiler),
+        "cmake_command": args.cmake,
+        "cmake_version": command_version(args.cmake),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -498,16 +498,32 @@ jobs:
           submodules: recursive
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        if: github.event_name == 'pull_request'
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           path: benchmark-base
           submodules: recursive
 
       - name: Setup
         run: |
-          sudo apt install -y gcc-14 g++-14 make cmake \
+          sudo apt install -y gcc-14 g++-14 make cmake time \
             libc++-dev autotools-dev autoconf libtool
+
+      - name: Capture benchmark environment
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          resolved_base="$BASE_SHA"
+          if [ -d benchmark-base ]; then
+            resolved_base="$(git -C benchmark-base rev-parse HEAD)"
+          fi
+          python3 .github/scripts/write_benchmark_metadata.py \
+            --output benchmark-results/environment.json \
+            --head-sha "$(git rev-parse HEAD)" \
+            --base-sha "$resolved_base" \
+            --compiler gcc-14 \
+            --aad-backend aadet \
+            --threads 4 \
+            --runner-image "${ImageOS:-unknown}/${ImageVersion:-unknown}"
 
       - name: Test benchmark regression gate
         run: |
@@ -533,7 +549,6 @@ jobs:
           cmake --build build/benchmark-head --parallel
 
       - name: Build base benchmarks
-        if: github.event_name == 'pull_request'
         env:
           CC: gcc-14
           CXX: g++-14
@@ -577,7 +592,9 @@ jobs:
           for bench in "${benchmarks[@]}"; do
             echo "========== $bench =========="
             result_file="benchmark-results/${bench}.txt"
-            if "./build/benchmark-head/dal-cpp/benchmarks/$bench/$bench" > "$result_file" 2>&1; then
+            resource_file="benchmark-results/${bench}.resources.txt"
+            if /usr/bin/time --verbose --output="$resource_file" \
+              "./build/benchmark-head/dal-cpp/benchmarks/$bench/$bench" > "$result_file" 2>&1; then
               status=0
             else
               status=$?
@@ -603,7 +620,6 @@ jobs:
           exit "$benchmark_failure"
 
       - name: Compare base and head performance
-        if: github.event_name == 'pull_request'
         env:
           DAL_NUM_THREADS: 4
         run: |
@@ -615,6 +631,15 @@ jobs:
             --samples 10 \
             --confirmation-rounds 2 \
             --threshold-percent 4
+
+      - name: Upload benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-linux-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-results
+          if-no-files-found: warn
+          retention-days: 30
 
   linux-gate:
     name: Linux CI gate

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -418,7 +418,7 @@ jobs:
             slug: tsan
             sanitizers: thread
             flags: -O2 -g
-            core-filter: ConcurrencyTest.TestConcurrentQueuePushAndPop:ConcurrencyTest.TestThreadPoolStartsLazily:ConcurrencyTest.TestThreadPoolStartStopLifecycle:ConcurrencyTest.TestThreadPoolUsesEnvironmentLimit:ConcurrencyTest.TestThreadPoolTaskCannotStopOrRestartPool:ConcurrencyTest.TestThreadPoolStopDrainsClaimedCallerAndCancelsQueuedTasks:StorageTest.TestEvaluationDateScopeOwnsBarrierButAllowsConcurrentRead:StorageTest.TestEvaluationDateWorkersObserveOneStableDateWhileSetterWaits:ScriptTest.TestSimulationTaskGroupDrainsOnSubmissionFailureAndPoolRecovers:ScriptTest.TestAadSimulationPropagatesTaskFailureAndRemainsUsable
+            core-filter: ConcurrencyTest.TestConcurrentQueuePushAndPop:ConcurrencyTest.TestThreadPoolStartsLazily:ConcurrencyTest.TestThreadPoolStartStopLifecycle:ConcurrencyTest.TestThreadPoolUsesEnvironmentLimit:ConcurrencyTest.TestThreadPoolTaskCannotStopOrRestartPool:ConcurrencyTest.TestThreadPoolStopDrainsClaimedCallerAndCancelsQueuedTasks:StorageTest.TestEvaluationDateScopeOwnsBarrierButAllowsConcurrentRead:StorageTest.TestEvaluationDateWorkersObserveOneStableDateWhileSetterWaits:ScriptTest.TestSimulationTaskGroupDrainsOnSubmissionFailureAndPoolRecovers:ScriptTest.TestAadSimulationPropagatesTaskFailureAndRemainsUsable:RateCashflowPricingTest.TestNodeSensitivityTapeObservationIsScopedAndConcurrent
             public-filter: ""
 
     steps:

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -230,7 +230,8 @@ jobs:
 
   # Benchmark job: builds and runs all performance benchmarks on one
   # representative configuration (msvc, native/AADet backend).
-  # Results appear in the CI logs and job summary; timings are not a pass/fail gate.
+  # Results appear in the CI logs, job summary, and retained benchmark artifact;
+  # timings are not a pass/fail gate.
   benchmark:
     name: Benchmarks
     needs: changes
@@ -269,6 +270,20 @@ jobs:
               }
             }
           }
+
+      - name: Capture benchmark environment
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          python3 .github/scripts/write_benchmark_metadata.py \
+            --output benchmark-results/environment.json \
+            --head-sha "$(git rev-parse HEAD)" \
+            --base-sha "$BASE_SHA" \
+            --compiler cl \
+            --aad-backend aadet \
+            --threads 4 \
+            --runner-image "${ImageOS:-unknown}/${ImageVersion:-unknown}"
 
       - name: Build Machinist
         shell: bash
@@ -350,6 +365,15 @@ jobs:
           done
 
           exit "$benchmark_failure"
+
+      - name: Upload benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-windows-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-results
+          if-no-files-found: warn
+          retention-days: 30
 
   windows-gate:
     name: Windows CI gate

--- a/dal-cpp/benchmarks/rate_risk_perf/quoteriskbenchfixtures.cpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/quoteriskbenchfixtures.cpp
@@ -152,7 +152,10 @@ namespace Dal::RateRiskPerf {
         }
     } // namespace
 
-    QuoteRiskBenchmarkCase_ MakeSingleCurveQuoteRiskCase() {
+    QuoteRiskBenchmarkCase_ MakeSingleCurveQuoteRiskCase() { return MakeSingleCurveQuoteRiskCase(2, CurveJacobianMode_::Value_::ANALYTIC, 1); }
+
+    QuoteRiskBenchmarkCase_ MakeSingleCurveQuoteRiskCase(int quoteCount, CurveJacobianMode_ mode, int tradeCount) {
+        REQUIRE(quoteCount > 0 && tradeCount > 0, "Single quote-risk benchmark dimensions must be positive");
         QuoteRiskBenchmarkCase_ result;
         CurveCalibrationSpec_ spec;
         spec.today_ = Date_(2025, 1, 2);
@@ -165,13 +168,18 @@ namespace Dal::RateRiskPerf {
         spec.liborBasis_ = DayBasis_("ACT_365F");
         spec.tolerance_ = 1.0e-10;
         spec.initialGuess_ = 0.02;
-        spec.knotDates_ = {Date::AddMonths(spec.today_, 6), Date::AddMonths(spec.today_, 12)};
-        const auto known = Pwc("single_quote_bench_known", Ccy_(spec.ccy_), spec.knotDates_, {0.02, 0.025});
+        Vector_<> knownForwards;
+        for (int i = 0; i < quoteCount; ++i) {
+            spec.knotDates_.push_back(Date::AddMonths(spec.today_, 6 * (i + 1)));
+            knownForwards.push_back(0.02 + 0.0005 * i);
+        }
+        const auto known = Pwc("single_quote_bench_known", Ccy_(spec.ccy_), spec.knotDates_, knownForwards);
         const CurveBlock_ knownBlock(known, spec.liborBasis_);
         for (const auto& maturity : spec.knotDates_)
             spec.instruments_.push_back(DepositInstrument(spec.today_, maturity, Index(false), knownBlock));
 
         CurveCalibrationOptions_ options;
+        options.jacobianMode_ = mode;
         options.computeForwardJacobian_ = false;
         auto calibration = std::make_shared<CurveCalibrationResult_>(CalibrateYieldCurve(spec, options));
         result.market_.valuationTime_ = DateTime_(spec.today_, 9, 0);
@@ -183,24 +191,41 @@ namespace Dal::RateRiskPerf {
         config.calibrationId_ = "single-quote-bench";
         config.componentKeyByParameterBlock_[spec.curveName_] = "discount";
         result.provenances_.push_back(BuildSingleCurveQuoteRiskProvenance(spec, *calibration, options, result.market_, config));
-        result.trades_.push_back(DepositTrade(spec.today_, spec.knotDates_.back(), Ccy_(spec.ccy_), "discount", "single-quote-bench-trade"));
+        for (int i = 0; i < tradeCount; ++i)
+            result.trades_.push_back(
+                DepositTrade(spec.today_, spec.knotDates_.back(), Ccy_(spec.ccy_), "discount", "single-quote-bench-trade-" + String::FromInt(i)));
         result.calibrationLifetime_ = calibration;
+        result.expectedPassivePriceCount_ = tradeCount;
+        result.expectedPreparationCount_ = 1;
+        result.expectedSweepCount_ = tradeCount;
         return result;
     }
 
-    QuoteRiskBenchmarkCase_ MakeJointXccyQuoteRiskCase() {
+    QuoteRiskBenchmarkCase_ MakeJointXccyQuoteRiskCase() { return MakeJointXccyQuoteRiskCase(2, CurveJacobianMode_::Value_::ANALYTIC, 1); }
+
+    QuoteRiskBenchmarkCase_ MakeJointXccyQuoteRiskCase(int quoteCount, CurveJacobianMode_ mode, int tradeCount) {
+        REQUIRE(quoteCount > 0 && tradeCount > 0, "Joint quote-risk benchmark dimensions must be positive");
         QuoteRiskBenchmarkCase_ result;
         const Date_ today(2025, 1, 16);
-        const Vector_<Date_> maturities{Date::AddMonths(today, 12), Date::AddMonths(today, 24)};
-        const Vector_<Date_> knots{Date::AddMonths(today, 6), Date::AddMonths(today, 18)};
-        const Vector_<Date_> basisMaturities{Date::AddMonths(today, 18), Date::AddMonths(today, 30)};
-        const Vector_<Date_> basisKnots{Date::AddMonths(today, 12), Date::AddMonths(today, 24)};
+        Vector_<Date_> maturities, knots, basisMaturities, basisKnots;
+        Vector_<> domesticDiscount, domesticForward, foreignDiscount, foreignForward, basisParameters;
+        for (int i = 0; i < quoteCount; ++i) {
+            maturities.push_back(Date::AddMonths(today, 12 * (i + 1)));
+            knots.push_back(Date::AddMonths(today, 6 + 12 * i));
+            basisMaturities.push_back(Date::AddMonths(today, 12 * (i + 1) + 6));
+            basisKnots.push_back(Date::AddMonths(today, 12 * (i + 1)));
+            domesticDiscount.push_back(0.015 + 0.0005 * i);
+            domesticForward.push_back(0.024 + 0.0005 * i);
+            foreignDiscount.push_back(0.010 + 0.0004 * i);
+            foreignForward.push_back(0.019 + 0.0004 * i);
+            basisParameters.push_back(0.0010 + 0.0002 * i);
+        }
         const CurrencyPair_ pair(Ccy_("USD"), Ccy_("EUR"));
-        const auto domestic = Block("usd_true_quote_bench", pair.domestic_, knots, {0.015, 0.0155}, {0.024, 0.0245});
-        const auto foreign = Block("eur_true_quote_bench", pair.foreign_, knots, {0.010, 0.0104}, {0.019, 0.0194});
+        const auto domestic = Block("usd_true_quote_bench", pair.domestic_, knots, domesticDiscount, domesticForward);
+        const auto foreign = Block("eur_true_quote_bench", pair.foreign_, knots, foreignDiscount, foreignForward);
         const Handle_<MarketFixingSnapshot_> fixings(new MarketFixingSnapshot_());
         CrossCurrencyMarket_ quoteMarket(domestic, foreign, 1.10, DateTime_(today, 9, 0), pair.domestic_, fixings);
-        quoteMarket.SetBasisCurve(Pwc("basis_true_quote_bench", pair.domestic_, basisKnots, {0.0010, 0.0012}));
+        quoteMarket.SetBasisCurve(Pwc("basis_true_quote_bench", pair.domestic_, basisKnots, basisParameters));
 
         JointXccyCalibrationSpec_ spec;
         spec.valuationTime_ = DateTime_(today, 9, 0);
@@ -223,6 +248,7 @@ namespace Dal::RateRiskPerf {
         }
 
         JointXccyCalibrationOptions_ options;
+        options.jacobianMode_ = mode;
         options.computeForwardJacobian_ = false;
         auto calibration = std::make_shared<JointXccyCalibrationResult_>(CalibrateJointXccyMarket(spec, options));
         RateQuoteRiskProvenanceConfig_ config;
@@ -231,22 +257,40 @@ namespace Dal::RateRiskPerf {
             config.componentKeyByParameterBlock_[calibration->parameterRanges_[i].name_] = "joint-quote-bench-" + String::FromInt(i);
         result.market_ = JointMarket(spec, *calibration, config);
         result.provenances_.push_back(BuildJointXccyQuoteRiskProvenance(spec, *calibration, options, result.market_, config));
-        result.trades_.push_back(XccyTrade(today, basisKnots.back(), pair, "joint-quote-bench-trade"));
+        for (int i = 0; i < tradeCount; ++i)
+            result.trades_.push_back(XccyTrade(today, basisKnots.back(), pair, "joint-quote-bench-trade-" + String::FromInt(i)));
         result.calibrationLifetime_ = calibration;
+        result.expectedPassivePriceCount_ = tradeCount;
+        result.expectedPreparationCount_ = 5;
+        result.expectedSweepCount_ = 5 * tradeCount;
         return result;
     }
 
     QuoteRiskBenchmarkCase_ MakeStagedXccyBasisQuoteRiskCase() {
+        return MakeStagedXccyBasisQuoteRiskCase(2, CurveJacobianMode_::Value_::ANALYTIC, 1);
+    }
+
+    QuoteRiskBenchmarkCase_ MakeStagedXccyBasisQuoteRiskCase(int quoteCount, CurveJacobianMode_ mode, int tradeCount) {
+        REQUIRE(quoteCount > 0 && tradeCount > 0, "Staged quote-risk benchmark dimensions must be positive");
         QuoteRiskBenchmarkCase_ result;
         const Date_ today(2025, 1, 16);
-        const Vector_<Date_> knots{Date::AddMonths(today, 12), Date::AddMonths(today, 24)};
+        Vector_<Date_> knots;
+        Vector_<> domesticDiscount, domesticForward, foreignDiscount, foreignForward, basisParameters;
+        for (int i = 0; i < quoteCount; ++i) {
+            knots.push_back(Date::AddMonths(today, 12 * (i + 1)));
+            domesticDiscount.push_back(0.015 + 0.0003 * i);
+            domesticForward.push_back(0.024 + 0.0003 * i);
+            foreignDiscount.push_back(0.010 + 0.0002 * i);
+            foreignForward.push_back(0.019 + 0.0002 * i);
+            basisParameters.push_back(0.0010 + 0.0001 * i);
+        }
         const CurrencyPair_ pair(Ccy_("USD"), Ccy_("EUR"));
-        const auto domestic = Block("usd_staged_quote_bench", pair.domestic_, knots, {0.015, 0.0153}, {0.024, 0.0243});
-        const auto foreign = Block("eur_staged_quote_bench", pair.foreign_, knots, {0.010, 0.0102}, {0.019, 0.0192});
+        const auto domestic = Block("usd_staged_quote_bench", pair.domestic_, knots, domesticDiscount, domesticForward);
+        const auto foreign = Block("eur_staged_quote_bench", pair.foreign_, knots, foreignDiscount, foreignForward);
         const Handle_<MarketFixingSnapshot_> fixings(new MarketFixingSnapshot_());
         const auto xccyConfig = XccyConfig(pair);
         CrossCurrencyMarket_ quoteMarket(domestic, foreign, 1.10, DateTime_(today, 9, 0), pair.domestic_, fixings);
-        quoteMarket.SetBasisCurve(Pwc("known_staged_quote_bench", pair.domestic_, knots, {0.0010, 0.0011}));
+        quoteMarket.SetBasisCurve(Pwc("known_staged_quote_bench", pair.domestic_, knots, basisParameters));
 
         CrossCurrencyCalibrationSpec_ spec;
         spec.today_ = today;
@@ -268,6 +312,7 @@ namespace Dal::RateRiskPerf {
         }
 
         CrossCurrencyCalibrationOptions_ options;
+        options.jacobianMode_ = mode;
         options.computeForwardJacobian_ = false;
         auto calibration = std::make_shared<CrossCurrencyCalibrationResult_>(CalibrateCrossCurrencyMarket(spec, options));
         const auto basis = calibration->basisCurves_.at(pair);
@@ -280,8 +325,12 @@ namespace Dal::RateRiskPerf {
         config.calibrationId_ = "staged-quote-bench";
         config.componentKeyByParameterBlock_["basis:xccy_basis_USD"] = "staged-basis-quote-bench";
         result.provenances_.push_back(BuildStagedXccyBasisQuoteRiskProvenance(spec, *calibration, options, result.market_, config));
-        result.trades_.push_back(XccyTrade(today, Date::AddMonths(knots.back(), 6), pair, "staged-quote-bench-trade"));
+        for (int i = 0; i < tradeCount; ++i)
+            result.trades_.push_back(XccyTrade(today, Date::AddMonths(knots.back(), 6), pair, "staged-quote-bench-trade-" + String::FromInt(i)));
         result.calibrationLifetime_ = calibration;
+        result.expectedPassivePriceCount_ = tradeCount;
+        result.expectedPreparationCount_ = 5;
+        result.expectedSweepCount_ = tradeCount;
         return result;
     }
 } // namespace Dal::RateRiskPerf

--- a/dal-cpp/benchmarks/rate_risk_perf/quoteriskbenchfixtures.hpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/quoteriskbenchfixtures.hpp
@@ -14,9 +14,15 @@ namespace Dal::RateRiskPerf {
         RatePricingMarket_ market_;
         Vector_<RateQuoteRiskProvenance_> provenances_;
         std::shared_ptr<void> calibrationLifetime_;
+        int expectedPassivePriceCount_ = 0;
+        int expectedPreparationCount_ = 0;
+        int expectedSweepCount_ = 0;
     };
 
     QuoteRiskBenchmarkCase_ MakeSingleCurveQuoteRiskCase();
+    QuoteRiskBenchmarkCase_ MakeSingleCurveQuoteRiskCase(int quoteCount, CurveJacobianMode_ mode, int tradeCount);
     QuoteRiskBenchmarkCase_ MakeJointXccyQuoteRiskCase();
+    QuoteRiskBenchmarkCase_ MakeJointXccyQuoteRiskCase(int quoteCount, CurveJacobianMode_ mode, int tradeCount);
     QuoteRiskBenchmarkCase_ MakeStagedXccyBasisQuoteRiskCase();
+    QuoteRiskBenchmarkCase_ MakeStagedXccyBasisQuoteRiskCase(int quoteCount, CurveJacobianMode_ mode, int tradeCount);
 } // namespace Dal::RateRiskPerf

--- a/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
@@ -151,15 +151,51 @@ namespace {
     }
 
     void RunQuoteRiskCase(const char* name, const RateRiskPerf::QuoteRiskBenchmarkCase_& input) {
+        constexpr int kWarmup = 3;
+        constexpr int kRepeats = 10;
+        constexpr int kInvocationCount = kWarmup + kRepeats;
         const int calibrationCount = CurveCalibrationInvocationCount();
+        const int passivePriceCount = RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount.load(std::memory_order_relaxed);
+        const int preparationCount = RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.load(std::memory_order_relaxed);
+        const int sweepCount = RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(std::memory_order_relaxed);
+#if DAL_RATE_RISK_NATIVE_AAD
+        int tapeHighWater = 0;
+        RateCashflowPricingInternal::g_nodeSensitivityTapeSizeSink = &tapeHighWater;
+#endif
         double sink = 0.0;
-        const auto result = Bench::Run(name, [&]() {
-            const auto risk = AggregateRatePortfolioQuoteRisk(input.trades_, input.market_, input.provenances_);
-            REQUIRE(!risk.buckets_.empty(), "Quote-risk benchmark produced no buckets");
-            sink += risk.buckets_.front().dv01_ + risk.buckets_.back().dPvDDecimalQuote_;
-        });
-        REQUIRE(CurveCalibrationInvocationCount() == calibrationCount, "Quote-risk benchmark aggregate recalibrated inside the timed region");
+        const auto result = Bench::Run(
+            name,
+            [&]() {
+                const auto risk = AggregateRatePortfolioQuoteRisk(input.trades_, input.market_, input.provenances_);
+                REQUIRE(!risk.buckets_.empty(), "Quote-risk benchmark produced no buckets");
+                REQUIRE(risk.provenanceFailures_.empty(), "Quote-risk benchmark reported a stale provenance");
+                REQUIRE(risk.meta_.size() == input.trades_.size(), "Quote-risk benchmark did not produce one observation per trade");
+                sink += risk.buckets_.front().dv01_ + risk.buckets_.back().dPvDDecimalQuote_;
+            },
+            kWarmup, kRepeats);
+#if DAL_RATE_RISK_NATIVE_AAD
+        RateCashflowPricingInternal::g_nodeSensitivityTapeSizeSink = nullptr;
+#endif
+        const int passivePriceDelta =
+            RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount.load(std::memory_order_relaxed) - passivePriceCount;
+        const int preparationDelta =
+            RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.load(std::memory_order_relaxed) - preparationCount;
+        const int sweepDelta = RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(std::memory_order_relaxed) - sweepCount;
+        const int observedPassivePrices = passivePriceDelta / kInvocationCount;
+        const int observedPreparations = preparationDelta / kInvocationCount;
+        const int observedSweeps = sweepDelta / kInvocationCount;
         Bench::Print(result);
+#if DAL_RATE_RISK_NATIVE_AAD
+        std::fprintf(stderr, "%s observations: passive=%d preparations=%d sweeps=%d tape_high_water=%d\n", name, observedPassivePrices,
+                     observedPreparations, observedSweeps, tapeHighWater);
+#else
+        std::fprintf(stderr, "%s observations: passive=%d preparations=%d sweeps=%d\n", name, observedPassivePrices, observedPreparations,
+                     observedSweeps);
+#endif
+        REQUIRE(CurveCalibrationInvocationCount() == calibrationCount, "Quote-risk benchmark aggregate recalibrated inside the timed region");
+        REQUIRE(passivePriceDelta == kInvocationCount * input.expectedPassivePriceCount_, "Quote-risk benchmark passive-price count drifted");
+        REQUIRE(preparationDelta == kInvocationCount * input.expectedPreparationCount_, "Quote-risk benchmark preparation count drifted");
+        REQUIRE(sweepDelta == kInvocationCount * input.expectedSweepCount_, "Quote-risk benchmark sweep count drifted");
         Bench::DoNotOptimize(&sink);
     }
 } // namespace
@@ -174,6 +210,12 @@ int main() {
     const auto singleQuoteRisk = RateRiskPerf::MakeSingleCurveQuoteRiskCase();
     const auto jointQuoteRisk = RateRiskPerf::MakeJointXccyQuoteRiskCase();
     const auto stagedQuoteRisk = RateRiskPerf::MakeStagedXccyBasisQuoteRiskCase();
+    const auto singleAnalyticPortfolio = RateRiskPerf::MakeSingleCurveQuoteRiskCase(5, CurveJacobianMode_::Value_::ANALYTIC, 120);
+    const auto singleBumpedPortfolio = RateRiskPerf::MakeSingleCurveQuoteRiskCase(16, CurveJacobianMode_::Value_::BUMPED, 120);
+    const auto jointAnalyticPortfolio = RateRiskPerf::MakeJointXccyQuoteRiskCase(10, CurveJacobianMode_::Value_::ANALYTIC, 24);
+    const auto jointBumpedPortfolio = RateRiskPerf::MakeJointXccyQuoteRiskCase(10, CurveJacobianMode_::Value_::BUMPED, 24);
+    const auto stagedAnalyticPortfolio = RateRiskPerf::MakeStagedXccyBasisQuoteRiskCase(16, CurveJacobianMode_::Value_::ANALYTIC, 24);
+    const auto stagedBumpedPortfolio = RateRiskPerf::MakeStagedXccyBasisQuoteRiskCase(5, CurveJacobianMode_::Value_::BUMPED, 24);
 
     Vector_<RateTradeDefinition_> trades;
     trades.reserve(kBatchTrades);
@@ -263,5 +305,11 @@ int main() {
     RunQuoteRiskCase("Quote risk aggregate (single curve)", singleQuoteRisk);
     RunQuoteRiskCase("Quote risk aggregate (joint XCCY)", jointQuoteRisk);
     RunQuoteRiskCase("Quote risk aggregate (staged XCCY basis)", stagedQuoteRisk);
+    RunQuoteRiskCase("Quote risk portfolio single ANALYTIC (120 deposits x N=5)", singleAnalyticPortfolio);
+    RunQuoteRiskCase("Quote risk portfolio single BUMPED (120 deposits x N=16)", singleBumpedPortfolio);
+    RunQuoteRiskCase("Quote risk portfolio joint ANALYTIC (24 XCCY x N=10/block)", jointAnalyticPortfolio);
+    RunQuoteRiskCase("Quote risk portfolio joint BUMPED (24 XCCY x N=10/block)", jointBumpedPortfolio);
+    RunQuoteRiskCase("Quote risk portfolio staged ANALYTIC (24 XCCY x N=16)", stagedAnalyticPortfolio);
+    RunQuoteRiskCase("Quote risk portfolio staged BUMPED (24 XCCY x N=5)", stagedBumpedPortfolio);
     return 0;
 }

--- a/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/rate_risk_perf.cpp
@@ -7,6 +7,7 @@
 // active-typed assembly shape (frozen P0 contract 8).
 
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <memory>
 
@@ -159,8 +160,8 @@ namespace {
         const int preparationCount = RateCashflowPricingInternal::g_nodeSensitivityPreparationCount.load(std::memory_order_relaxed);
         const int sweepCount = RateCashflowPricingInternal::g_nodeSensitivitySweepCount.load(std::memory_order_relaxed);
 #if DAL_RATE_RISK_NATIVE_AAD
-        int tapeHighWater = 0;
-        RateCashflowPricingInternal::g_nodeSensitivityTapeSizeSink = &tapeHighWater;
+        std::atomic<int> tapeHighWater{0};
+        RateCashflowPricingInternal::NodeSensitivityTapeSizeObservation_ tapeObservation(tapeHighWater);
 #endif
         double sink = 0.0;
         const auto result = Bench::Run(
@@ -173,9 +174,6 @@ namespace {
                 sink += risk.buckets_.front().dv01_ + risk.buckets_.back().dPvDDecimalQuote_;
             },
             kWarmup, kRepeats);
-#if DAL_RATE_RISK_NATIVE_AAD
-        RateCashflowPricingInternal::g_nodeSensitivityTapeSizeSink = nullptr;
-#endif
         const int passivePriceDelta =
             RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount.load(std::memory_order_relaxed) - passivePriceCount;
         const int preparationDelta =
@@ -187,7 +185,7 @@ namespace {
         Bench::Print(result);
 #if DAL_RATE_RISK_NATIVE_AAD
         std::fprintf(stderr, "%s observations: passive=%d preparations=%d sweeps=%d tape_high_water=%d\n", name, observedPassivePrices,
-                     observedPreparations, observedSweeps, tapeHighWater);
+                     observedPreparations, observedSweeps, tapeHighWater.load(std::memory_order_relaxed));
 #else
         std::fprintf(stderr, "%s observations: passive=%d preparations=%d sweeps=%d\n", name, observedPassivePrices, observedPreparations,
                      observedSweeps);
@@ -271,11 +269,14 @@ int main() {
     {
         // Informational (stderr, not a gated row): the native tape node count of one OIS
         // daily-compounding sweep — the per-sweep high-water the latency cases above stand in for.
-        int tapeNodes = 0;
-        RateCashflowPricingInternal::g_nodeSensitivityTapeSizeSink = &tapeNodes;
-        const auto sensitivity = RateTradeNodeSensitivities(OisTrade(today, start, dailyMaturity), market, keys[0]);
-        RateCashflowPricingInternal::g_nodeSensitivityTapeSizeSink = nullptr;
-        std::fprintf(stderr, "OIS daily sweep native tape nodes: %d (eligible=%d)\n", tapeNodes, static_cast<int>(sensitivity.eligible_));
+        std::atomic<int> tapeNodes{0};
+        bool eligible = false;
+        {
+            RateCashflowPricingInternal::NodeSensitivityTapeSizeObservation_ observation(tapeNodes);
+            eligible = RateTradeNodeSensitivities(OisTrade(today, start, dailyMaturity), market, keys[0]).eligible_;
+        }
+        std::fprintf(stderr, "OIS daily sweep native tape nodes: %d (eligible=%d)\n", tapeNodes.load(std::memory_order_relaxed),
+                     static_cast<int>(eligible));
     }
 #endif
 

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <exception>
@@ -25,8 +26,8 @@
 
 namespace Dal::RateCashflowPricingInternal {
 #if DAL_RATE_RISK_NATIVE_AAD
-    // Test-only observation seam: when non-null, every completed node-sensitivity sweep stores the
-    // native tape's live node count here (measured after propagation, before the TapeGuard_ rewind).
+    // Test-only observation seam: when non-null, completed node-sensitivity sweeps retain the
+    // native tape's largest live node count (measured after propagation, before the TapeGuard_ rewind).
     // An unregistered-constant AAD::Number_ passive curve still yields correct values and gradient
     // width, so only this direct count distinguishes it from a truly passive double curve.
     // Atomic because library code reads it on every sweep; P0 is serial, but callers may sweep
@@ -99,7 +100,7 @@ namespace Dal::RateCashflowPricingInternal {
             NodeSensitivityCandidate_ candidate = std::forward<Runner_>(runner)();
 #if DAL_RATE_RISK_NATIVE_AAD
             if (int* sink = g_nodeSensitivityTapeSizeSink.load(std::memory_order_relaxed))
-                *sink = AAD::Tape()->nodes_.Size();
+                *sink = std::max(*sink, AAD::Tape()->nodes_.Size());
 #endif
             return FinalizeNodeSensitivityCandidate(std::move(candidate), expectedParameterCount);
         } catch (const std::exception&) {

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <exception>
@@ -26,13 +25,40 @@
 
 namespace Dal::RateCashflowPricingInternal {
 #if DAL_RATE_RISK_NATIVE_AAD
-    // Test-only observation seam: when non-null, completed node-sensitivity sweeps retain the
-    // native tape's largest live node count (measured after propagation, before the TapeGuard_ rewind).
-    // An unregistered-constant AAD::Number_ passive curve still yields correct values and gradient
-    // width, so only this direct count distinguishes it from a truly passive double curve.
-    // Atomic because library code reads it on every sweep; P0 is serial, but callers may sweep
-    // concurrently on separate threads.
-    inline std::atomic<int*> g_nodeSensitivityTapeSizeSink{nullptr};
+    // Test-only observation seam: registration is serial, but observed sweeps may be concurrent.
+    // The pointed-to atomic retains the largest live node count measured after propagation and
+    // before the TapeGuard_ rewind. An unregistered-constant AAD::Number_ passive curve still
+    // yields correct values and gradient width, so only this direct count distinguishes it from
+    // a truly passive double curve.
+    inline std::atomic<std::atomic<int>*> g_nodeSensitivityTapeSizeSink{nullptr};
+
+    inline void RecordNodeSensitivityTapeSize(int observed) {
+        if (auto* sink = g_nodeSensitivityTapeSizeSink.load(std::memory_order_relaxed)) {
+            int current = sink->load(std::memory_order_relaxed);
+            while (current < observed && !sink->compare_exchange_weak(current, observed, std::memory_order_relaxed)) {
+            }
+        }
+    }
+
+    class NodeSensitivityTapeSizeObservation_ {
+    public:
+        explicit NodeSensitivityTapeSizeObservation_(std::atomic<int>& sink) : sink_(&sink) {
+            std::atomic<int>* expected = nullptr;
+            REQUIRE(g_nodeSensitivityTapeSizeSink.compare_exchange_strong(expected, sink_, std::memory_order_relaxed),
+                    "A node-sensitivity tape observation is already active");
+        }
+
+        ~NodeSensitivityTapeSizeObservation_() noexcept {
+            std::atomic<int>* expected = sink_;
+            g_nodeSensitivityTapeSizeSink.compare_exchange_strong(expected, nullptr, std::memory_order_relaxed);
+        }
+
+        NodeSensitivityTapeSizeObservation_(const NodeSensitivityTapeSizeObservation_&) = delete;
+        NodeSensitivityTapeSizeObservation_& operator=(const NodeSensitivityTapeSizeObservation_&) = delete;
+
+    private:
+        std::atomic<int>* sink_;
+    };
 #endif
 
     // Test instrumentation for the sweep engine shared by the single-trade and batch entry points:
@@ -99,8 +125,7 @@ namespace Dal::RateCashflowPricingInternal {
             TapeGuard_ guard(AAD::Tape());
             NodeSensitivityCandidate_ candidate = std::forward<Runner_>(runner)();
 #if DAL_RATE_RISK_NATIVE_AAD
-            if (int* sink = g_nodeSensitivityTapeSizeSink.load(std::memory_order_relaxed))
-                *sink = std::max(*sink, AAD::Tape()->nodes_.Size());
+            RecordNodeSensitivityTapeSize(AAD::Tape()->nodes_.Size());
 #endif
             return FinalizeNodeSensitivityCandidate(std::move(candidate), expectedParameterCount);
         } catch (const std::exception&) {

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -3187,6 +3187,13 @@ TEST(RateCashflowPricingTest, TestNodeSensitivitySweepTapeSizeIndependentOfPassi
     ASSERT_EQ(fraSmallTape, fraDenseTape) << "FRA sweep tape grows with passive discount node count";
     ASSERT_EQ(oisSmallTape, oisDenseTape) << "OIS sweep tape grows with passive discount node count";
     ASSERT_GT(oisSmallTape, fraSmallTape) << "OIS daily compounding shapes the recording";
+
+    int mixedHighWater = 0;
+    internal::g_nodeSensitivityTapeSizeSink = &mixedHighWater;
+    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
+    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
+    internal::g_nodeSensitivityTapeSizeSink = nullptr;
+    ASSERT_EQ(mixedHighWater, oisSmallTape) << "The tape observation seam did not retain the per-sweep high-water mark";
 }
 #endif
 

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -3157,43 +3157,81 @@ TEST(RateCashflowPricingTest, TestNodeSensitivitySweepTapeSizeIndependentOfPassi
     const Dal::Date_ today(2026, 1, 15);
     const Dal::Date_ start(2026, 10, 15);
     const Dal::Date_ maturity(2029, 1, 15);
-    const auto forecast = Dal::Handle_<Dal::DiscountCurve_>(
-        Dal::NewDiscountPWC("pwc", "USD", Dal::PiecewiseConstant_({Dal::Date_(2026, 7, 15), Dal::Date_(2027, 7, 15), Dal::Date_(2028, 7, 15)}, {0.01, -0.005, 0.03})));
+    const auto forecast = Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC(
+        "pwc", "USD", Dal::PiecewiseConstant_({Dal::Date_(2026, 7, 15), Dal::Date_(2027, 7, 15), Dal::Date_(2028, 7, 15)}, {0.01, -0.005, 0.03})));
     Dal::Vector_<Dal::Date_> denseKnots;
     for (Dal::Date_ knot = Dal::Date_(2026, 2, 15); knot <= Dal::Date_(2029, 12, 15); knot = knot.AddDays(30))
         denseKnots.push_back(knot);
-    const auto denseDiscount = Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC("dense", "USD", Dal::PiecewiseConstant_(denseKnots, Dal::Vector_<>(denseKnots.size(), 0.03))));
+    const auto denseDiscount = Dal::Handle_<Dal::DiscountCurve_>(
+        Dal::NewDiscountPWC("dense", "USD", Dal::PiecewiseConstant_(denseKnots, Dal::Vector_<>(denseKnots.size(), 0.03))));
     const auto smallDiscount = FlatCurve(maturity, 0.03);
 
-    int fraSmallTape = 0;
-    int fraDenseTape = 0;
-    int oisSmallTape = 0;
-    int oisDenseTape = 0;
+    std::atomic<int> fraSmallTape{0};
+    std::atomic<int> fraDenseTape{0};
+    std::atomic<int> oisSmallTape{0};
+    std::atomic<int> oisDenseTape{0};
     const auto fraTrade = Trade(Dal::RateInstrumentType_("FRA"), today, start, maturity, FraTerms());
     const auto oisTrade = Trade(Dal::RateInstrumentType_("OIS"), today, start, maturity, Dal::OisTradeTerms_{FixedFloatTerms()});
 
-    internal::g_nodeSensitivityTapeSizeSink = &fraSmallTape;
-    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
-    internal::g_nodeSensitivityTapeSizeSink = &fraDenseTape;
-    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, denseDiscount), "forecast").eligible_);
-    internal::g_nodeSensitivityTapeSizeSink = &oisSmallTape;
-    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
-    internal::g_nodeSensitivityTapeSizeSink = &oisDenseTape;
-    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, denseDiscount), "forecast").eligible_);
-    internal::g_nodeSensitivityTapeSizeSink = nullptr;
+    {
+        internal::NodeSensitivityTapeSizeObservation_ observation(fraSmallTape);
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
+    }
+    {
+        internal::NodeSensitivityTapeSizeObservation_ observation(fraDenseTape);
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, denseDiscount), "forecast").eligible_);
+    }
+    {
+        internal::NodeSensitivityTapeSizeObservation_ observation(oisSmallTape);
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
+    }
+    {
+        internal::NodeSensitivityTapeSizeObservation_ observation(oisDenseTape);
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, denseDiscount), "forecast").eligible_);
+    }
 
-    ASSERT_GT(fraSmallTape, 0);
-    ASSERT_GT(oisSmallTape, 0);
-    ASSERT_EQ(fraSmallTape, fraDenseTape) << "FRA sweep tape grows with passive discount node count";
-    ASSERT_EQ(oisSmallTape, oisDenseTape) << "OIS sweep tape grows with passive discount node count";
-    ASSERT_GT(oisSmallTape, fraSmallTape) << "OIS daily compounding shapes the recording";
+    ASSERT_GT(fraSmallTape.load(), 0);
+    ASSERT_GT(oisSmallTape.load(), 0);
+    ASSERT_EQ(fraSmallTape.load(), fraDenseTape.load()) << "FRA sweep tape grows with passive discount node count";
+    ASSERT_EQ(oisSmallTape.load(), oisDenseTape.load()) << "OIS sweep tape grows with passive discount node count";
+    ASSERT_GT(oisSmallTape.load(), fraSmallTape.load()) << "OIS daily compounding shapes the recording";
 
-    int mixedHighWater = 0;
-    internal::g_nodeSensitivityTapeSizeSink = &mixedHighWater;
-    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
-    ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
-    internal::g_nodeSensitivityTapeSizeSink = nullptr;
-    ASSERT_EQ(mixedHighWater, oisSmallTape) << "The tape observation seam did not retain the per-sweep high-water mark";
+    std::atomic<int> mixedHighWater{0};
+    {
+        internal::NodeSensitivityTapeSizeObservation_ observation(mixedHighWater);
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(oisTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
+        ASSERT_TRUE(Dal::RateTradeNodeSensitivities(fraTrade, ComponentMarket(today, forecast, smallDiscount), "forecast").eligible_);
+    }
+    ASSERT_EQ(mixedHighWater.load(), oisSmallTape.load()) << "The tape observation seam did not retain the per-sweep high-water mark";
+}
+
+TEST(RateCashflowPricingTest, TestNodeSensitivityTapeObservationIsScopedAndConcurrent) {
+    namespace internal = Dal::RateCashflowPricingInternal;
+    std::atomic<int> highWater{0};
+    {
+        internal::NodeSensitivityTapeSizeObservation_ observation(highWater);
+        std::thread low([]() {
+            for (int i = 0; i < 100; ++i)
+                internal::RecordNodeSensitivityTapeSize(37);
+        });
+        std::thread high([]() {
+            for (int i = 0; i < 100; ++i)
+                internal::RecordNodeSensitivityTapeSize(83);
+        });
+        low.join();
+        high.join();
+        ASSERT_EQ(highWater.load(), 83);
+    }
+    ASSERT_EQ(internal::g_nodeSensitivityTapeSizeSink.load(), nullptr);
+
+    EXPECT_THROW(
+        {
+            std::atomic<int> ignored{0};
+            internal::NodeSensitivityTapeSizeObservation_ observation(ignored);
+            throw std::runtime_error("injected observation failure");
+        },
+        std::runtime_error);
+    ASSERT_EQ(internal::g_nodeSensitivityTapeSizeSink.load(), nullptr);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- run the nine-target paired performance gate for pull requests and `master` pushes, retain raw benchmark evidence for 30 days, and record reproducible runner/toolchain metadata
- keep the CMake, executable-gate, and documentation benchmark inventories synchronized through repository checks
- extend `rate_risk_perf` with production-sized single, joint-XCCY, and staged-XCCY quote-risk cases plus recalibration, sweep, preparation, and native-tape high-water assertions
- make tape high-water observation atomic and exception-safe, with the concurrent regression case included in the Linux TSan matrix

## Test plan
- [x] `bash ./build_linux.sh` — 1508/1508 tests passed
- [x] quote-risk provenance/aggregation and tape observation filters — 43/43 tests passed
- [x] tape observer concurrency/exception regression under ThreadSanitizer
- [x] `.github/scripts` unit suite — 126 passed, 6 Windows-only tests skipped
- [x] documentation consistency check, Ruff, and Python complexity checks
- [x] GCC 14 native AADET and Adept `rate_risk_perf` builds and runs
- [x] updated native `rate_risk_perf` build and run with all observation assertions satisfied
- [x] nine-target paired gate against `b79c74d0e3165eef30cfeccf0f23f124b4e6047a` — 30 comparable cases passed; Sobol precise/fast 8.10x
