### PR TITLE
fix: address quote-risk review follow-ups

### DIFF
--- a/.github/scripts/check_benchmark_regressions.py
+++ b/.github/scripts/check_benchmark_regressions.py
@@ -117,8 +117,8 @@ def collect_samples(
         sides = {"base": {}, "head": {}}
         roots = {"base": base_root, "head": head_root}
         # A gated binary absent on the base side is binary-level new coverage (this PR adds a
-        # benchmark to the gate): its head cases are reported for information and never compared.
-        # Absent on the head side means the PR dropped gated coverage: fail loudly here.
+        # benchmark to the gate): its head cases are reported as not-gated rows and never
+        # compared. Absent on the head side means the PR dropped gated coverage: fail loudly here.
         present = {side: benchmark_binary_path(roots[side], benchmark).is_file() for side in ("base", "head")}
         if not present["head"]:
             raise RuntimeError(f"{benchmark}: gated benchmark binary is missing on the head side")
@@ -182,6 +182,18 @@ def new_coverage_row(case: str, head_value: float) -> dict[str, object]:
         "passed": True,
         "gated": False,
         "kind": "new_coverage",
+    }
+
+
+def not_gated_no_base_row(case: str, head_value: float) -> dict[str, object]:
+    return {
+        "case": f"{case} (not gated: no base binary)",
+        "base_ns": None,
+        "head_ns": head_value,
+        "delta_percent": None,
+        "passed": True,
+        "gated": False,
+        "kind": "not_gated_no_base",
     }
 
 
@@ -255,7 +267,10 @@ def compare_benchmark(
     base = min_samples(samples["base"])
     head = min_samples(samples["head"])
     if not base:
-        return ([new_coverage_row(case, value) for case, value in sorted(head.items())], [])
+        # An empty base side means the gated binary itself was absent on the base side (a present
+        # binary always parses at least one case row): every head case is unguarded. Report the
+        # state distinctly from case-level new coverage so an ungated green run stays visible.
+        return ([not_gated_no_base_row(case, value) for case, value in sorted(head.items())], [])
     migration_permitted, failures, new_coverage = benchmark_case_differences(benchmark, base, head)
     rows = []
     if migration_permitted:
@@ -351,6 +366,12 @@ def has_new_coverage(comparisons: dict[str, list[dict[str, object]]]) -> bool:
     return any(row.get("kind") == "new_coverage" for rows in comparisons.values() for row in rows)
 
 
+def not_gated_no_base_benchmarks(comparisons: dict[str, list[dict[str, object]]]) -> list[str]:
+    return sorted(
+        benchmark for benchmark, rows in comparisons.items() if any(row.get("kind") == "not_gated_no_base" for row in rows)
+    )
+
+
 def markdown_report(
     comparisons: dict[str, list[dict[str, object]]],
     failures: list[str],
@@ -393,6 +414,16 @@ def markdown_report(
                 "",
                 "Rows marked (new coverage) are head-only benchmark cases added by the PR; "
                 "they are reported for information and are not gated.",
+            ]
+        )
+    ungated = not_gated_no_base_benchmarks(comparisons)
+    if ungated:
+        lines.extend(
+            [
+                "",
+                f"Rows marked (not gated: no base binary) belong to benchmarks whose base build "
+                f"lacked the gated binary ({', '.join(ungated)}); nothing was gated for them. "
+                f"Add a base build containing the benchmark, or confirm the target is new to the gate.",
             ]
         )
     if failures:
@@ -452,6 +483,14 @@ def main() -> int:
     if args.summary_file:
         with args.summary_file.open("a", encoding="utf-8") as summary:
             summary.write(report)
+    ungated = not_gated_no_base_benchmarks(comparisons)
+    if ungated:
+        print(
+            "::warning::Benchmark regression gate ran without base binaries for: "
+            f"{', '.join(ungated)}. Nothing was gated for those benchmarks; see the "
+            "(not gated: no base binary) rows in the summary.",
+            flush=True,
+        )
     print(report, end="")
     return 1 if failures else 0
 

--- a/.github/scripts/tests/test_check_benchmark_regressions.py
+++ b/.github/scripts/tests/test_check_benchmark_regressions.py
@@ -250,6 +250,32 @@ Case in nanoseconds      120.000 ns  100.000 ns  130.000 ns    10
         self.assertIn("new case (new coverage)", report)
         self.assertIn("info", report)
 
+    def test_compare_benchmark_marks_missing_base_binary_as_not_gated(self):
+        samples = {
+            "base": {},
+            "head": {"case": [100.0] * 20},
+        }
+
+        rows, failures = BENCHMARKS.compare_benchmark("pde_perf", samples, 4.0, 10.0, 10, 2)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["kind"], "not_gated_no_base")
+        self.assertIn("not gated: no base binary", rows[0]["case"])
+        self.assertEqual(BENCHMARKS.result_label(rows[0]), "info")
+        self.assertIsNone(rows[0]["base_ns"])
+        self.assertEqual(rows[0]["head_ns"], 100.0)
+
+    def test_markdown_report_names_ungated_benchmarks_without_a_base_binary(self):
+        comparisons = {"pde_perf": [BENCHMARKS.not_gated_no_base_row("case", 100.0)]}
+
+        report = BENCHMARKS.markdown_report(comparisons, [], 10, 2, 4.0, None, 10.0)
+        ungated = BENCHMARKS.not_gated_no_base_benchmarks(comparisons)
+
+        self.assertEqual(ungated, ["pde_perf"])
+        self.assertIn("not gated: no base binary", report)
+        self.assertIn("pde_perf", report.split("Rows marked (not gated: no base binary)")[1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -328,7 +328,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: quote-risk-oracle-evidence
+          name: quote-risk-oracle-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: quote-risk-oracle-evidence.csv
           if-no-files-found: ignore
           retention-days: 30

--- a/dal-cpp/examples/quote_risk/quote_risk.cpp
+++ b/dal-cpp/examples/quote_risk/quote_risk.cpp
@@ -84,8 +84,9 @@ int main() {
     config.calibrationId_ = "usd-ois";
     config.componentKeyByParameterBlock_[spec.curveName_] = "discount";
     const auto provenance = BuildSingleCurveQuoteRiskProvenance(spec, *calibration, options, market, config);
-    const auto risk = AggregateRatePortfolioQuoteRisk({Trade(spec)}, market, {provenance});
     REQUIRE(provenance.Available(), provenance.Reason());
+    const auto risk = AggregateRatePortfolioQuoteRisk({Trade(spec)}, market, {provenance});
+    REQUIRE(risk.provenanceFailures_.empty(), "Quote-risk aggregation reported a provenance failure");
     REQUIRE(risk.policy_ == "UnconvertedByActualPvCcy", "Unexpected quote-risk currency policy");
 
     std::cout << "axis scheme: " << provenance.Axis().scheme_ << '\n';

--- a/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
+++ b/dal-cpp/tests/curve/test_ratecashflowpricing.cpp
@@ -3224,7 +3224,7 @@ TEST(RateCashflowPricingTest, TestNodeSensitivityTapeObservationIsScopedAndConcu
     }
     ASSERT_EQ(internal::g_nodeSensitivityTapeSizeSink.load(), nullptr);
 
-    EXPECT_THROW(
+    ASSERT_THROW(
         {
             std::atomic<int> ignored{0};
             internal::NodeSensitivityTapeSizeObservation_ observation(ignored);

--- a/dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.htm
+++ b/dal-excel/auto/MG_RatePortfolioQuoteRisk_Spill_public.htm
@@ -29,7 +29,7 @@ Aggregate portfolio quote sensitivity and DV01 into a fixed long-form spill
 <table border="1" cellpadding="3">
 <tr><th>Name</th><th style="width:120px">Type</th><th></th></tr>
 
-<tr><td>spill</td><td>matrix of cells</td><td>Ten columns in order: calibration, axis_fingerprint, quote_key, quote_name, block, currency, quote_sensitivity, dv01, availability, reason. Rows follow native deterministic bucket order, then provenance failures, trade/provenance failures, and excluded-domain failures.</td></tr>
+<tr><td>spill</td><td>matrix of cells</td><td>Ten columns in order: calibration, axis_fingerprint, quote_key, quote_name, block, currency, quote_sensitivity, dv01, availability, reason. Bucket rows fill every column. Failure rows mark availability "unavailable", leave quote_sensitivity and dv01 empty, and repurpose quote_key/quote_name with the failure subject and detail: state fingerprints for provenance failures, instrument id and original node-risk reason for trade failures. Row order: deterministic buckets, provenance failures, trade failures, excluded-domain failures.</td></tr>
 </table>
 
 

--- a/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.htm
+++ b/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.htm
@@ -15,7 +15,7 @@ Dispatch quote-risk provenance construction from a calibration-result handle
 <table border="1" cellpadding="3">
 <tr><th>Name</th><th style="width:120px">Type</th><th>Optional?</th><th></th></tr>
 
-<tr><td>result</td><td>handle</td><td></td><td>A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result</td></tr>
+<tr><td>result</td><td>handle</td><td></td><td>A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result. Excluded-domain result handles are not yet producible from Excel; only the C++ test surface constructs them today.</td></tr>
 <tr><td>calibrationId</td><td>string</td><td></td><td>Non-empty identifier used to join and order quote-risk rows</td></tr>
 <tr><td>parameterBlockKeys</td><td>vector of strings</td><td></td><td>Calibration parameter block keys, in calibration order</td></tr>
 <tr><td>componentKeys</td><td>vector of strings</td><td></td><td>Pricing-market component keys parallel to parameterBlockKeys</td></tr>

--- a/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.inc
+++ b/dal-excel/auto/MG_RateQuoteRiskProvenance_New_public.inc
@@ -41,7 +41,7 @@ struct XlRegister_RateQuoteRiskProvenance_New_
     XlRegister_RateQuoteRiskProvenance_New_()
     {
         Vector_<String_> argHelp;        
-        argHelp.push_back("A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result");
+        argHelp.push_back("A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result. Excluded-domain result handles are not yet producible from Excel; only the C++ test surface constructs them today.");
         argHelp.push_back("Non-empty identifier used to join and order quote-risk rows");
         argHelp.push_back("Calibration parameter block keys, in calibration order");
         argHelp.push_back("Pricing-market component keys parallel to parameterBlockKeys");

--- a/dal-excel/examples/008.quote_risk.md
+++ b/dal-excel/examples/008.quote_risk.md
@@ -25,6 +25,17 @@ H2: =RATEPORTFOLIOQUOTERISK.SPILL(B4:B20,B3,G2)
 DV01 is price per `+1 bp`. The currency column is the actual PV currency; rows
 are not FX-converted.
 
+Bucket rows fill every column. Failure rows mark `availability` as
+`unavailable`, leave `quote_sensitivity` and `dv01` empty, and repurpose
+`quote_key`/`quote_name` with the failure subject and detail: expected and
+actual state fingerprints for provenance failures, instrument id and original
+node-risk reason for trade failures. Row order is deterministic buckets first,
+then provenance failures, trade failures, and excluded-domain failures.
+
 For simultaneous XCCY or staged XCCY basis results, replace the provenance
 constructor with `JOINTXCCYQUOTERISKPROVENANCE.NEW` or
 `STAGEDXCCYBASISQUOTERISKPROVENANCE.NEW`, keeping the same five arguments.
+`RATEQUOTERISKPROVENANCE.NEW` dispatches on the result-handle type and also
+accepts excluded multi-curve result handles; those handles are not yet
+producible from Excel — only the C++ test surface constructs them today — so
+worksheet recipes always use one of the typed constructors above.

--- a/dal-excel/src/__curvepricing.cpp
+++ b/dal-excel/src/__curvepricing.cpp
@@ -339,7 +339,9 @@ public RateQuoteRiskProvenance_New
     Dispatch quote-risk provenance construction from a calibration-result handle
 &inputs
 result is handle
-    A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result
+    A supported single/joint-XCCY/staged-XCCY result, or an excluded staged/generic result.
+    Excluded-domain result handles are not yet producible from Excel; only the C++ test
+    surface constructs them today.
 calibrationId is string
     Non-empty identifier used to join and order quote-risk rows
 parameterBlockKeys is string[]
@@ -366,8 +368,11 @@ provenances is handle[]
 &outputs
 spill is cell[][]
     Ten columns in order: calibration, axis_fingerprint, quote_key, quote_name, block,
-    currency, quote_sensitivity, dv01, availability, reason. Rows follow native deterministic
-    bucket order, then provenance failures, trade/provenance failures, and excluded-domain failures.
+    currency, quote_sensitivity, dv01, availability, reason. Bucket rows fill every column.
+    Failure rows mark availability "unavailable", leave quote_sensitivity and dv01 empty, and
+    repurpose quote_key/quote_name with the failure subject and detail: state fingerprints for
+    provenance failures, instrument id and original node-risk reason for trade failures.
+    Row order: deterministic buckets, provenance failures, trade failures, excluded-domain failures.
 -IF-------------------------------------------------------------------------*/
 // clang-format on
 

--- a/dal-python/src/bindings/curve.cpp
+++ b/dal-python/src/bindings/curve.cpp
@@ -109,13 +109,9 @@ namespace {
                                                                     const CurveCalibrationOptions_& options,
                                                                     const RatePricingMarket_& boundMarket,
                                                                     const RateQuoteRiskProvenanceConfig_& config) {
-        RateQuoteRiskProvenance_ provenance;
-        {
-            py::gil_scoped_release release;
-            RunQuoteRiskGilBarrierForTesting();
-            provenance = BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config);
-        }
-        return provenance;
+        py::gil_scoped_release release;
+        RunQuoteRiskGilBarrierForTesting();
+        return BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config);
     }
 
     RateQuoteRiskProvenance_ RunBuildJointXccyQuoteRiskProvenance(const JointXccyCalibrationSpec_& spec,
@@ -123,13 +119,9 @@ namespace {
                                                                   const JointXccyCalibrationOptions_& options,
                                                                   const RatePricingMarket_& boundMarket,
                                                                   const RateQuoteRiskProvenanceConfig_& config) {
-        RateQuoteRiskProvenance_ provenance;
-        {
-            py::gil_scoped_release release;
-            RunQuoteRiskGilBarrierForTesting();
-            provenance = BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config);
-        }
-        return provenance;
+        py::gil_scoped_release release;
+        RunQuoteRiskGilBarrierForTesting();
+        return BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config);
     }
 
     RateQuoteRiskProvenance_ RunBuildStagedXccyBasisQuoteRiskProvenance(const CrossCurrencyCalibrationSpec_& spec,
@@ -137,13 +129,9 @@ namespace {
                                                                         const CrossCurrencyCalibrationOptions_& options,
                                                                         const RatePricingMarket_& boundMarket,
                                                                         const RateQuoteRiskProvenanceConfig_& config) {
-        RateQuoteRiskProvenance_ provenance;
-        {
-            py::gil_scoped_release release;
-            RunQuoteRiskGilBarrierForTesting();
-            provenance = BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config);
-        }
-        return provenance;
+        py::gil_scoped_release release;
+        RunQuoteRiskGilBarrierForTesting();
+        return BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config);
     }
 
     RatePortfolioQuoteRisk_ RunAggregateRatePortfolioQuoteRisk(const std::vector<RateTradeDefinition_>& trades,

--- a/dal-python/src/bindings/curve.cpp
+++ b/dal-python/src/bindings/curve.cpp
@@ -109,8 +109,13 @@ namespace {
                                                                     const CurveCalibrationOptions_& options,
                                                                     const RatePricingMarket_& boundMarket,
                                                                     const RateQuoteRiskProvenanceConfig_& config) {
-        py::gil_scoped_release release;
-        return BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        RateQuoteRiskProvenance_ provenance;
+        {
+            py::gil_scoped_release release;
+            RunQuoteRiskGilBarrierForTesting();
+            provenance = BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        }
+        return provenance;
     }
 
     RateQuoteRiskProvenance_ RunBuildJointXccyQuoteRiskProvenance(const JointXccyCalibrationSpec_& spec,
@@ -118,8 +123,13 @@ namespace {
                                                                   const JointXccyCalibrationOptions_& options,
                                                                   const RatePricingMarket_& boundMarket,
                                                                   const RateQuoteRiskProvenanceConfig_& config) {
-        py::gil_scoped_release release;
-        return BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        RateQuoteRiskProvenance_ provenance;
+        {
+            py::gil_scoped_release release;
+            RunQuoteRiskGilBarrierForTesting();
+            provenance = BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        }
+        return provenance;
     }
 
     RateQuoteRiskProvenance_ RunBuildStagedXccyBasisQuoteRiskProvenance(const CrossCurrencyCalibrationSpec_& spec,
@@ -127,8 +137,13 @@ namespace {
                                                                         const CrossCurrencyCalibrationOptions_& options,
                                                                         const RatePricingMarket_& boundMarket,
                                                                         const RateQuoteRiskProvenanceConfig_& config) {
-        py::gil_scoped_release release;
-        return BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        RateQuoteRiskProvenance_ provenance;
+        {
+            py::gil_scoped_release release;
+            RunQuoteRiskGilBarrierForTesting();
+            provenance = BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        }
+        return provenance;
     }
 
     RatePortfolioQuoteRisk_ RunAggregateRatePortfolioQuoteRisk(const std::vector<RateTradeDefinition_>& trades,

--- a/dal-python/tests/test_quote_risk.py
+++ b/dal-python/tests/test_quote_risk.py
@@ -81,7 +81,10 @@ def test_quote_risk_factories_and_aggregate_are_keyword_only():
     for name, arguments in signatures.items():
         signature = getattr(dal, name).__doc__.splitlines()[0]
         assert signature.startswith(f"{name}(*, ")  # nosec B101
-        positions = [signature.index(f"{argument}: ") for argument in arguments]
+        positions = []
+        for argument in arguments:
+            assert f"{argument}: " in signature, f"{name} is missing argument {argument}"  # nosec B101
+            positions.append(signature.index(f"{argument}: "))
         assert positions == sorted(positions)  # nosec B101
 
     assert not hasattr(dal, "BuildMultiCurveQuoteRiskProvenance")  # nosec B101
@@ -168,11 +171,11 @@ def test_quote_risk_provenance_survives_intermediate_result_and_market_gc():
     assert len(result.buckets) == 3  # nosec B101
 
 
-def test_quote_risk_aggregate_releases_gil_for_the_complete_native_operation():
+def test_quote_risk_aggregate_and_factories_release_gil_for_the_complete_native_operation():
     import sys
     import threading
 
-    _, _, _, _, market, _, provenance, trade = _single_quote_risk_inputs()
+    spec, options, calibrated, _, market, config, provenance, trade = _single_quote_risk_inputs()
     started = threading.Event()
     ready = threading.Event()
     stopped = threading.Event()
@@ -193,13 +196,23 @@ def test_quote_risk_aggregate_releases_gil_for_the_complete_native_operation():
         dal._dal._QuoteRiskGilBarrier_EnableForTesting(75)
         started.set()
         dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=market, provenances=[provenance])
-        count_seen_on_return = heartbeat_count[0]
+        aggregate_count = heartbeat_count[0]
+        dal._dal._QuoteRiskGilBarrier_EnableForTesting(75)
+        dal.BuildSingleCurveQuoteRiskProvenance(
+            spec=spec,
+            result=calibrated,
+            options=options,
+            bound_market=market,
+            config=config,
+        )
+        factory_count = heartbeat_count[0]
     finally:
         stopped.set()
         sys.setswitchinterval(previous_interval)
         thread.join(timeout=5.0)
     assert not thread.is_alive()  # nosec B101
-    assert count_seen_on_return > 0  # nosec B101
+    assert aggregate_count > 0  # nosec B101
+    assert factory_count > aggregate_count  # nosec B101
 
 
 def test_joint_and_staged_xccy_factories_expose_the_native_domain_shapes():


### PR DESCRIPTION
## Summary
- Wire the quote-risk GIL test barrier into the three provenance factory wrappers so their GIL release has regression coverage, and assert heartbeats progress during both the aggregate and a factory call; make the signature-contract lookup an explicit assertion instead of an unguarded `str.index`
- Validate provenance availability before aggregating in the `quote_risk` example and fail on any aggregation failure before printing, matching the benchmark driver's contract
- Document the Excel spill failure-row column semantics (failure rows repurpose `quote_key`/`quote_name` with subject and detail) in the markup help, regenerated stubs, and worksheet recipe; note that excluded-domain calibration handles are not yet producible from Excel
- Surface ungated benchmarks whose base binary is missing: distinct `not gated: no base binary` rows, a summary footnote naming the benchmarks, and a GitHub warning annotation, so an ungated green gate is visible rather than silent
- Suffix the quote-risk oracle evidence artifact with run id and attempt so re-run failed jobs no longer collide on the upload-artifact v4 duplicate-name check
- Use `ASSERT_THROW` for the tape observation scope test per the repository test contract

## Test plan
- [x] `python -m unittest test_check_benchmark_regressions` (21 tests, incl. 2 new not-gated tests)
- [x] `dal_cpp_tests --gtest_filter=RateCashflowPricingTest.*` (87 tests) and the `quote_risk` example built and run on Release-windows
- [x] `dal_generate` + committed regenerated stubs verified against `dal_check_generated` (`git diff --exit-code -- dal-cpp/dal/auto dal-excel/auto` clean)
- [ ] Full Linux/Windows CI including the Python quote-risk suite (bindings change compiled only in CI locally)