### PR TITLE
DAL-185: unify quote-risk GIL execution protocol

### DIFF
--- a/dal-python/src/bindings/curve.cpp
+++ b/dal-python/src/bindings/curve.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <thread>
 #include <type_traits>
+#include <utility>
 
 #include <dal/curve/calibration.hpp>
 #include <dal/curve/xccycalibration.hpp>
@@ -63,10 +64,10 @@ namespace {
             std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
     }
 
-    template <class Callable_> auto RunQuoteRiskWithReleasedGil(Callable_&& callable) -> decltype(callable()) {
+    template <class Callable_> decltype(auto) RunQuoteRiskWithReleasedGil(Callable_&& callable) {
         py::gil_scoped_release release;
         RunQuoteRiskGilBarrierForTesting();
-        return callable();
+        return std::forward<Callable_>(callable)();
     }
 
     // Component keys convert under the GIL from a py::list -- the parameter deliberately avoids

--- a/dal-python/src/bindings/curve.cpp
+++ b/dal-python/src/bindings/curve.cpp
@@ -63,6 +63,12 @@ namespace {
             std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
     }
 
+    template <class Callable_> auto RunQuoteRiskWithReleasedGil(Callable_&& callable) -> decltype(callable()) {
+        py::gil_scoped_release release;
+        RunQuoteRiskGilBarrierForTesting();
+        return callable();
+    }
+
     // Component keys convert under the GIL from a py::list -- the parameter deliberately avoids
     // std::vector<std::string>: core.cpp binds that container opaque, and a generic list_caster
     // instantiation in this TU would ODR-split against it (MSVC folds the two instantiations,
@@ -109,9 +115,7 @@ namespace {
                                                                     const CurveCalibrationOptions_& options,
                                                                     const RatePricingMarket_& boundMarket,
                                                                     const RateQuoteRiskProvenanceConfig_& config) {
-        py::gil_scoped_release release;
-        RunQuoteRiskGilBarrierForTesting();
-        return BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        return RunQuoteRiskWithReleasedGil([&]() { return BuildSingleCurveQuoteRiskProvenance(spec, result, options, boundMarket, config); });
     }
 
     RateQuoteRiskProvenance_ RunBuildJointXccyQuoteRiskProvenance(const JointXccyCalibrationSpec_& spec,
@@ -119,9 +123,7 @@ namespace {
                                                                   const JointXccyCalibrationOptions_& options,
                                                                   const RatePricingMarket_& boundMarket,
                                                                   const RateQuoteRiskProvenanceConfig_& config) {
-        py::gil_scoped_release release;
-        RunQuoteRiskGilBarrierForTesting();
-        return BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        return RunQuoteRiskWithReleasedGil([&]() { return BuildJointXccyQuoteRiskProvenance(spec, result, options, boundMarket, config); });
     }
 
     RateQuoteRiskProvenance_ RunBuildStagedXccyBasisQuoteRiskProvenance(const CrossCurrencyCalibrationSpec_& spec,
@@ -129,9 +131,7 @@ namespace {
                                                                         const CrossCurrencyCalibrationOptions_& options,
                                                                         const RatePricingMarket_& boundMarket,
                                                                         const RateQuoteRiskProvenanceConfig_& config) {
-        py::gil_scoped_release release;
-        RunQuoteRiskGilBarrierForTesting();
-        return BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config);
+        return RunQuoteRiskWithReleasedGil([&]() { return BuildStagedXccyBasisQuoteRiskProvenance(spec, result, options, boundMarket, config); });
     }
 
     RatePortfolioQuoteRisk_ RunAggregateRatePortfolioQuoteRisk(const std::vector<RateTradeDefinition_>& trades,
@@ -139,13 +139,7 @@ namespace {
                                                                const std::vector<RateQuoteRiskProvenance_>& provenances) {
         const Vector_<RateTradeDefinition_> nativeTrades(trades.begin(), trades.end());
         const Vector_<RateQuoteRiskProvenance_> nativeProvenances(provenances.begin(), provenances.end());
-        RatePortfolioQuoteRisk_ aggregate;
-        {
-            py::gil_scoped_release release;
-            RunQuoteRiskGilBarrierForTesting();
-            aggregate = AggregateRatePortfolioQuoteRisk(nativeTrades, market, nativeProvenances);
-        }
-        return aggregate;
+        return RunQuoteRiskWithReleasedGil([&]() { return AggregateRatePortfolioQuoteRisk(nativeTrades, market, nativeProvenances); });
     }
 
     template <class Class_, class Member_>

--- a/dal-python/tests/test_quote_risk.py
+++ b/dal-python/tests/test_quote_risk.py
@@ -70,6 +70,39 @@ def _single_quote_risk_inputs(*, compute_inverse=True):
     return spec, options, calibrated, fixings, market, config, provenance, trade
 
 
+def _run_with_quote_risk_gil_heartbeat(operation):
+    import sys
+    import threading
+
+    started = threading.Event()
+    ready = threading.Event()
+    stopped = threading.Event()
+    heartbeat_count = [0]
+
+    def heartbeat() -> None:
+        ready.set()
+        assert started.wait(timeout=5.0)  # nosec B101
+        while not stopped.is_set():
+            heartbeat_count[0] += 1
+
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1.0)
+    try:
+        thread = threading.Thread(target=heartbeat)
+        thread.start()
+        assert ready.wait(timeout=5.0)  # nosec B101
+        dal._dal._QuoteRiskGilBarrier_EnableForTesting(75)
+        started.set()
+        result = operation()
+    finally:
+        stopped.set()
+        sys.setswitchinterval(previous_interval)
+        thread.join(timeout=5.0)
+    assert not thread.is_alive()  # nosec B101
+    assert heartbeat_count[0] > 0  # nosec B101
+    return result
+
+
 def test_quote_risk_factories_and_aggregate_are_keyword_only():
     signatures = {
         "BuildSingleCurveQuoteRiskProvenance": ("spec", "result", "options", "bound_market", "config"),
@@ -171,51 +204,23 @@ def test_quote_risk_provenance_survives_intermediate_result_and_market_gc():
     assert len(result.buckets) == 3  # nosec B101
 
 
-def test_quote_risk_aggregate_and_factories_release_gil_for_the_complete_native_operation():
-    import sys
-    import threading
-
+def test_quote_risk_aggregate_and_single_factory_release_gil_for_the_complete_native_operation():
     spec, options, calibrated, _, market, config, provenance, trade = _single_quote_risk_inputs()
-    started = threading.Event()
-    ready = threading.Event()
-    stopped = threading.Event()
-    heartbeat_count = [0]
-
-    def heartbeat() -> None:
-        ready.set()
-        assert started.wait(timeout=5.0)  # nosec B101
-        while not stopped.is_set():
-            heartbeat_count[0] += 1
-
-    previous_interval = sys.getswitchinterval()
-    sys.setswitchinterval(1.0)
-    try:
-        thread = threading.Thread(target=heartbeat)
-        thread.start()
-        assert ready.wait(timeout=5.0)  # nosec B101
-        dal._dal._QuoteRiskGilBarrier_EnableForTesting(75)
-        started.set()
-        dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=market, provenances=[provenance])
-        aggregate_count = heartbeat_count[0]
-        dal._dal._QuoteRiskGilBarrier_EnableForTesting(75)
-        dal.BuildSingleCurveQuoteRiskProvenance(
+    _run_with_quote_risk_gil_heartbeat(
+        lambda: dal.AggregateRatePortfolioQuoteRisk(trades=[trade], market=market, provenances=[provenance])
+    )
+    _run_with_quote_risk_gil_heartbeat(
+        lambda: dal.BuildSingleCurveQuoteRiskProvenance(
             spec=spec,
             result=calibrated,
             options=options,
             bound_market=market,
             config=config,
         )
-        factory_count = heartbeat_count[0]
-    finally:
-        stopped.set()
-        sys.setswitchinterval(previous_interval)
-        thread.join(timeout=5.0)
-    assert not thread.is_alive()  # nosec B101
-    assert aggregate_count > 0  # nosec B101
-    assert factory_count > aggregate_count  # nosec B101
+    )
 
 
-def test_joint_and_staged_xccy_factories_expose_the_native_domain_shapes():
+def test_joint_and_staged_xccy_factories_release_gil_and_expose_the_native_domain_shapes():
     from test_xccy_calibration import _make_xccy_spec, _today as staged_today
     from test_xccy_joint import _joint_spec, _today as joint_today
 
@@ -246,15 +251,17 @@ def test_joint_and_staged_xccy_factories_expose_the_native_domain_shapes():
         xccy_market=joint_xccy_market,
         fixings=joint_fixings,
     )
-    joint_provenance = dal.BuildJointXccyQuoteRiskProvenance(
-        spec=joint_spec,
-        result=joint_result,
-        options=joint_options,
-        bound_market=joint_market,
-        config=dal.RateQuoteRiskProvenanceConfig_(
-            calibration_id="python-joint-xccy",
-            component_key_by_parameter_block=joint_bindings,
-        ),
+    joint_provenance = _run_with_quote_risk_gil_heartbeat(
+        lambda: dal.BuildJointXccyQuoteRiskProvenance(
+            spec=joint_spec,
+            result=joint_result,
+            options=joint_options,
+            bound_market=joint_market,
+            config=dal.RateQuoteRiskProvenanceConfig_(
+                calibration_id="python-joint-xccy",
+                component_key_by_parameter_block=joint_bindings,
+            ),
+        )
     )
 
     assert joint_provenance.available is True  # nosec B101
@@ -275,15 +282,17 @@ def test_joint_and_staged_xccy_factories_expose_the_native_domain_shapes():
         curve_components={"staged-basis": staged_result.basis_curve},
         xccy_market=staged_result.market,
     )
-    staged_provenance = dal.BuildStagedXccyBasisQuoteRiskProvenance(
-        spec=staged_spec,
-        result=staged_result,
-        options=staged_options,
-        bound_market=staged_market,
-        config=dal.RateQuoteRiskProvenanceConfig_(
-            calibration_id="python-staged-xccy",
-            component_key_by_parameter_block={"basis:xccy_basis_USD": "staged-basis"},
-        ),
+    staged_provenance = _run_with_quote_risk_gil_heartbeat(
+        lambda: dal.BuildStagedXccyBasisQuoteRiskProvenance(
+            spec=staged_spec,
+            result=staged_result,
+            options=staged_options,
+            bound_market=staged_market,
+            config=dal.RateQuoteRiskProvenanceConfig_(
+                calibration_id="python-staged-xccy",
+                component_key_by_parameter_block={"basis:xccy_basis_USD": "staged-basis"},
+            ),
+        )
     )
 
     assert staged_provenance.available is True  # nosec B101

--- a/dal-python/tests/test_quote_risk.py
+++ b/dal-python/tests/test_quote_risk.py
@@ -72,6 +72,7 @@ def _single_quote_risk_inputs(*, compute_inverse=True):
 
 def _run_with_quote_risk_gil_heartbeat(operation):
     import sys
+    import time
     import threading
 
     started = threading.Event()
@@ -84,6 +85,7 @@ def _run_with_quote_risk_gil_heartbeat(operation):
         assert started.wait(timeout=5.0)  # nosec B101
         while not stopped.is_set():
             heartbeat_count[0] += 1
+            time.sleep(0)
 
     previous_interval = sys.getswitchinterval()
     sys.setswitchinterval(1.0)


### PR DESCRIPTION
## Summary

- Add one anonymous-namespace callable helper for the quote-risk execution protocol: release the GIL, run the one-shot test barrier, construct and return the native result.
- Route aggregate plus the single, joint-XCCY, and staged-XCCY factories through that helper.
- Extend the heartbeat regression harness to exercise all four entry points.

## 4 -> 1 evidence

- Before: four quote-risk wrappers each owned a `py::gil_scoped_release` and called `RunQuoteRiskGilBarrierForTesting()`.
- After: `RunQuoteRiskWithReleasedGil` is the sole owner and sole runtime caller of that barrier; the wrappers only provide their native callable.

## Behavior preservation

- Public pybind names, keyword-only signatures, and binding definitions are untouched.
- Every wrapper still returns the native result directly.
- Aggregate still converts Python-owned `std::vector` arguments to DAL `Vector_` values before entering the GIL-free helper; Python/native marshalling boundaries are unchanged.
- The helper invokes each lambda synchronously, constructs its native return value while the GIL is released, then lets `py::gil_scoped_release` reacquire the GIL before returning to pybind.

## Tests

- Baseline before edits: `python3 -m pytest ../../../dal-python/tests/test_quote_risk.py -q` (`6 passed in 2.19s`).
- Expanded heartbeat characterization before production refactor: same command (`6 passed in 4.35s`).
- Rebuild: `cmake --build build/Release-linux --target _dal --parallel 4`.
- Final focused suite: same pytest command (`6 passed in 4.34s`).
- `git diff --check`.

## Risk

Low and localized to GIL lifetime plumbing. The helper is file-private and synchronous; the heartbeat test now guards aggregate and all three factories against protocol drift.

Closes DAL-185
