### PR TITLE
Fix quote-risk review follow-ups: gate baseline, evidence sharding, test hygiene

### DIFF
--- a/.github/scripts/tests/test_benchmark_metadata.py
+++ b/.github/scripts/tests/test_benchmark_metadata.py
@@ -3,6 +3,7 @@
 import importlib.util
 import json
 from pathlib import Path
+import shutil
 import sys
 import tempfile
 import unittest
@@ -53,7 +54,12 @@ class BenchmarkMetadataTest(unittest.TestCase):
             self.assertEqual(metadata["runner_image"], "test-image")
             self.assertTrue(metadata["cpu_model"])
             self.assertIn("Python", metadata["compiler_version"])
-            self.assertIn("cmake", metadata["cmake_version"].lower())
+            # cmake is absent on some contributor machines; the script records
+            # "unavailable: ..." there, so assert against the environment we have.
+            if shutil.which("cmake") is None:
+                self.assertTrue(metadata["cmake_version"].startswith("unavailable"))
+            else:
+                self.assertIn("cmake", metadata["cmake_version"].lower())
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_classify_ci_changes.py
+++ b/.github/scripts/tests/test_classify_ci_changes.py
@@ -233,10 +233,11 @@ class CiWorkflowFastPathTest(unittest.TestCase):
     def test_linux_benchmark_pairs_pull_requests_and_master_pushes(self):
         benchmark = self.job(self.workflow("cmake-linux.yml"), "benchmark")
 
-        self.assertIn(
-            "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}",
-            benchmark,
-        )
+        self.assertIn("PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}", benchmark)
+        self.assertIn("EVENT_BEFORE: ${{ github.event.before }}", benchmark)
+        self.assertIn('base_sha="${PR_BASE_SHA:-$EVENT_BEFORE}"', benchmark)
+        self.assertIn('[[ "$base_sha" =~ ^0+$ ]]', benchmark)
+        self.assertIn("ref: ${{ env.BASE_SHA }}", benchmark)
         self.assertNotIn("if: github.event_name == 'pull_request'", benchmark)
 
 

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -322,7 +322,12 @@ jobs:
         run: |
           ./build/Release-linux/dal-cpp/dal_cpp_tests \
             --gtest_filter='QuoteRiskAggregationTest.TestFullRecalibrationOracleAtRequiredWidthsAndModes:QuoteRiskAggregationTest.TestXccyFullRecalibrationOracleAtRequiredWidthsAndModes'
-          awk -F, 'NF != 21 { exit 1 } END { if (NR != 497) exit 1 }' "$DAL_QUOTE_RISK_EVIDENCE_FILE"
+          # Expected rows: 1 header + 496 evidence rows =
+          #   (5 + 10 + 16) quotes x 2 Jacobian modes x
+          #   (4 single-curve parameterizations + 2 XCCY domains x 2 currency portfolios).
+          # Keep in sync with the two oracle tests filtered above.
+          expected_rows=$((1 + (5 + 10 + 16) * 2 * (4 + 2 * 2)))
+          awk -F, -v expected="$expected_rows" 'NF != 21 { exit 1 } END { if (NR != expected) exit 1 }' "$DAL_QUOTE_RISK_EVIDENCE_FILE"
 
       - name: Upload quote-risk oracle evidence
         if: always()
@@ -496,10 +501,26 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           submodules: recursive
+          # Depth 2 keeps HEAD~1 available: the base-SHA fallback for a branch's
+          # first push (all-zero github.event.before) resolves to the head's parent.
+          fetch-depth: 2
+
+      - name: Resolve benchmark base SHA
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          base_sha="${PR_BASE_SHA:-$EVENT_BEFORE}"
+          # A branch's first push reports an all-zero 'before'; fall back to the head's
+          # first parent so the paired gate still has a baseline to compare against.
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-parse HEAD~1)"
+          fi
+          echo "BASE_SHA=$base_sha" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          ref: ${{ env.BASE_SHA }}
           path: benchmark-base
           submodules: recursive
 
@@ -510,7 +531,7 @@ jobs:
 
       - name: Capture benchmark environment
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ env.BASE_SHA }}
         run: |
           resolved_base="$BASE_SHA"
           if [ -d benchmark-base ]; then

--- a/dal-cpp/dal/curve/calibration.cpp
+++ b/dal-cpp/dal/curve/calibration.cpp
@@ -47,6 +47,10 @@ namespace Dal {
 
     namespace {
         constexpr int MAX_RELEVANT_DATES_PER_INSTRUMENT = 2;
+        // Benchmark/test observation seam: counts calibrations so the quote-risk performance gate
+        // can assert the timed aggregate never recalibrates. Exported across the library boundary on
+        // purpose -- a header-inline counter would split into one instance per module on Windows.
+        // The count is process-global, so observing it requires a quiescent process.
         std::atomic<int> calibrationInvocationCount{0};
 
         void AddAnalyticIssue(AnalyticEligibilityReport_* report,

--- a/dal-cpp/dal/curve/calibration_internal.hpp
+++ b/dal-cpp/dal/curve/calibration_internal.hpp
@@ -23,7 +23,8 @@
 
 namespace Dal {
 
-    // Internal observation seam shared across the DAL library boundary.
+    // Internal observation seam shared across the DAL library boundary. Test/benchmark support
+    // only: the counter is process-global, so observers must run in a quiescent process.
     BASE_EXPORT void RecordCurveCalibrationInvocation();
     BASE_EXPORT void ResetCurveCalibrationInvocationCount();
     BASE_EXPORT int CurveCalibrationInvocationCount();

--- a/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
+++ b/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
@@ -462,10 +462,15 @@ namespace {
         const char* path = std::getenv("DAL_QUOTE_RISK_EVIDENCE_FILE");
         if (!path || !*path)
             return;
+        // One process owns truncate-on-first-write and with it the header row; sharded runners
+        // instead set DAL_QUOTE_RISK_EVIDENCE_APPEND=1 so every shard appends data rows to the
+        // shared file, and the orchestrator owns truncating the file and writing the header.
+        const char* append = std::getenv("DAL_QUOTE_RISK_EVIDENCE_APPEND");
+        static const bool appendMode = append && *append && std::string(append) != "0";
         static bool initialized = false;
-        std::ofstream output(path, initialized ? std::ios::app : std::ios::trunc);
+        std::ofstream output(path, (initialized || appendMode) ? std::ios::app : std::ios::trunc);
         REQUIRE(output.good(), "Unable to open quote-risk oracle evidence file");
-        if (!initialized) {
+        if (!initialized && !appendMode) {
             output << "domain,mode,currency,N,quote_index,quote_key,P_i,api_derivative,oracle_derivative,derivative_absolute_error,"
                       "derivative_relative_error,derivative_absolute_threshold,derivative_relative_threshold,api_dv01,oracle_dv01,"
                       "dv01_absolute_error,dv01_relative_error,dv01_absolute_threshold,dv01_relative_threshold,unit_error,unit_threshold\n";

--- a/dal-excel/src/__curvepricing.cpp
+++ b/dal-excel/src/__curvepricing.cpp
@@ -10,11 +10,11 @@
 #include "__settingskeys.hpp"
 #include <algorithm>
 #include <cmath>
+#include <set>
 #include <dal-public/src/curvepricing.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/math/cell.hpp>
 #include <dal/utilities/exceptions.hpp>
-#include <set>
 
 // clang-format off
 /*IF--------------------------------------------------------------------------

--- a/dal-python/tests/test_quote_risk.py
+++ b/dal-python/tests/test_quote_risk.py
@@ -79,17 +79,25 @@ def _run_with_quote_risk_gil_heartbeat(operation):
     ready = threading.Event()
     stopped = threading.Event()
     heartbeat_count = [0]
+    heartbeat_errors = []
 
     def heartbeat() -> None:
+        # Failures inside the worker would otherwise surface only as a zero heartbeat
+        # count on the main thread; capture and re-raise them where the test asserts.
         ready.set()
-        assert started.wait(timeout=5.0)  # nosec B101
-        while not stopped.is_set():
-            heartbeat_count[0] += 1
-            time.sleep(0)
+        try:
+            assert started.wait(timeout=5.0)  # nosec B101
+            while not stopped.is_set():
+                heartbeat_count[0] += 1
+                time.sleep(0)
+        except BaseException as error:
+            heartbeat_errors.append(error)
 
     previous_interval = sys.getswitchinterval()
     sys.setswitchinterval(1.0)
     try:
+        # Non-daemon by design: `stopped` is always set in the finally below, so the
+        # worker cannot outlive the test even when an assertion aborts the operation.
         thread = threading.Thread(target=heartbeat)
         thread.start()
         assert ready.wait(timeout=5.0)  # nosec B101
@@ -101,6 +109,8 @@ def _run_with_quote_risk_gil_heartbeat(operation):
         sys.setswitchinterval(previous_interval)
         thread.join(timeout=5.0)
     assert not thread.is_alive()  # nosec B101
+    if heartbeat_errors:
+        raise heartbeat_errors[0]
     assert heartbeat_count[0] > 0  # nosec B101
     return result
 


### PR DESCRIPTION
## Summary
- Harden the Linux benchmark gate baseline resolution: a branch's first push reports an all-zero `github.event.before`, which previously failed the base checkout and turned the whole benchmark job red; fall back to the head's first parent so the paired gate always has a baseline.
- Replace the magic oracle-evidence row count `497` in `cmake-linux.yml` with its derivation (1 header + (5+10+16) quotes × 2 Jacobian modes × (4 single-curve parameterizations + 2 XCCY domains × 2 currency portfolios)) and update the guarding contract test in `test_classify_ci_changes.py`.
- Support sharded oracle-evidence collection: `DAL_QUOTE_RISK_EVIDENCE_APPEND=1` makes `SaveQuoteOracleEvidence` append data rows instead of truncating, with the orchestrator owning the header row.
- Document the calibration-invocation observation seam as benchmark/test-only, exported across the library boundary on purpose, and process-global (observers must run in a quiescent process); move `<set>` ahead of the DAL headers in `__curvepricing.cpp` per the project include order.
- Make Python tests hermetic and diagnosable: `test_benchmark_metadata` now asserts the recorded `unavailable` marker when cmake is absent from PATH instead of failing; `_run_with_quote_risk_gil_heartbeat` captures heartbeat-worker exceptions and re-raises them at the assertion site instead of surfacing them as a bare zero heartbeat count.

## Test plan
- [x] `python -m unittest discover -s .github/scripts/tests` — all non-environmental tests pass locally (remaining failures are pre-existing POSIX-helper/cmake-absence environment issues on Windows; `test_benchmark_metadata` now passes without cmake)
- [x] Built `dal_cpp_tests` (Release-windows, MSVC) with the changes — compiles clean
- [x] `QuoteRiskAggregationTest.TestAggregateDoesNotRecalibrateOrMutateQuotesOrBoundCurve` and `TestCalibrationObservationCrossesLibraryBoundary` pass
- [x] `TestFullRecalibrationOracleAtRequiredWidthsAndModes` writes 249 evidence rows (1 header + 248), and a second run with `DAL_QUOTE_RISK_EVIDENCE_APPEND=1` yields 497 rows with exactly one header
- [ ] Full `dal_cpp_tests` and Linux CI gates (left to CI on this PR)
