### PR TITLE
ci: aggregate benchmark output into a single summary table

### DIFF
--- a/.github/scripts/tests/test_write_benchmark_summary.py
+++ b/.github/scripts/tests/test_write_benchmark_summary.py
@@ -1,0 +1,109 @@
+"""Tests for the aggregated benchmark step-summary table writer."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "write_benchmark_summary.py"
+SPEC = importlib.util.spec_from_file_location("write_benchmark_summary", SCRIPT)
+SUMMARY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SUMMARY)
+
+
+TIMED_OUTPUT = """\
+starting DAL with: 4 threads.
+Benchmark                                                                             Median               Min               Max      Reps
+-------------------------------------------------------------------------------------------------------------------------------------------
+CholeskyDecompose (200x200)                                                        420.821 us        395.497 us        602.254 us        20
+Fast case                                                                              120 ns           100 ns           130 ns       1000
+"""
+
+PER_ITER_OUTPUT = """\
+preprocess (stage 1)               392.175 us/iter
+parse (stage 2)                    399.595 us/iter
+"""
+
+OBSERVATION_OUTPUT = """\
+Quote risk aggregate (single curve)                                                  8.505 us          8.322 us          8.954 us        10
+Quote risk aggregate (single curve) observations: passive=1 preparations=1 sweeps=1 tape_high_water=11
+"""
+
+
+class ParseRowsTest(unittest.TestCase):
+    def test_parses_timed_rows_and_skips_noise(self):
+        rows = SUMMARY.parse_rows(TIMED_OUTPUT)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["case"], "CholeskyDecompose (200x200)")
+        self.assertEqual(rows[0]["median"], "420.821 us")
+        self.assertEqual(rows[0]["minimum"], "395.497 us")
+        self.assertEqual(rows[0]["maximum"], "602.254 us")
+        self.assertEqual(rows[0]["reps"], "20")
+        self.assertEqual(rows[1]["median"], "120 ns")
+
+    def test_parses_per_iter_rows(self):
+        rows = SUMMARY.parse_rows(PER_ITER_OUTPUT)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["case"], "preprocess (stage 1)")
+        self.assertEqual(rows[0]["median"], "392.175 us/iter")
+        self.assertEqual(rows[0]["reps"], "—")
+
+    def test_skips_observation_lines(self):
+        rows = SUMMARY.parse_rows(OBSERVATION_OUTPUT)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["case"], "Quote risk aggregate (single curve)")
+
+
+class BuildReportTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.results_dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, benchmark, output, status=None):
+        (self.results_dir / f"{benchmark}.txt").write_text(output, encoding="utf-8")
+        if status is not None:
+            (self.results_dir / f"{benchmark}.status").write_text(f"{status}\n", encoding="utf-8")
+
+    def test_single_table_combines_all_benchmarks(self):
+        self._write("cholesky_perf", TIMED_OUTPUT)
+        self._write("script_perf", PER_ITER_OUTPUT)
+
+        report = SUMMARY.build_report(["cholesky_perf", "script_perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertEqual(report.count("| Benchmark | Case | Median | Min | Max | Reps |"), 1)
+        self.assertNotIn("### cholesky_perf", report)
+        self.assertIn("| cholesky_perf | CholeskyDecompose (200x200) | 420.821 us |", report)
+        self.assertIn("| script_perf | preprocess (stage 1) | 392.175 us/iter | — | — | — |", report)
+        self.assertIn("All benchmarks exited cleanly.", report)
+
+    def test_failed_benchmark_is_noted_but_rows_still_appear(self):
+        self._write("curve_calibration_perf", TIMED_OUTPUT, status=134)
+
+        report = SUMMARY.build_report(["curve_calibration_perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertIn("| curve_calibration_perf | CholeskyDecompose (200x200) | 420.821 us |", report)
+        self.assertIn("`curve_calibration_perf` (exit code 134)", report)
+        self.assertNotIn("All benchmarks exited cleanly.", report)
+
+    def test_missing_output_file_gets_placeholder_row(self):
+        report = SUMMARY.build_report(["ghost_perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertIn("| ghost_perf | (no output captured) |", report)
+
+    def test_unparseable_output_gets_placeholder_row(self):
+        self._write("krylov_perf", "no table here\n")
+
+        report = SUMMARY.build_report(["krylov_perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertIn("| krylov_perf | (no parseable result rows) |", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_write_benchmark_summary.py
+++ b/.github/scripts/tests/test_write_benchmark_summary.py
@@ -4,6 +4,7 @@ import importlib.util
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "write_benchmark_summary.py"
@@ -101,6 +102,48 @@ class BuildReportTest(unittest.TestCase):
         self._write("krylov_perf", "no table here\n")
 
         report = SUMMARY.build_report(["krylov_perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertIn("| krylov_perf | (no parseable result rows) |", report)
+
+    def test_pipe_characters_in_cells_are_escaped(self):
+        output = "Case with | pipe             1.100 ms        900.000 us          1.300 ms        10\n"
+        self._write("weird|perf", output)
+
+        report = SUMMARY.build_report(["weird|perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertIn("| weird\\|perf | Case with \\| pipe | 1.100 ms |", report)
+        for line in report.splitlines():
+            if line.startswith("| weird"):
+                # 6 columns => exactly 7 unescaped pipe delimiters
+                self.assertEqual(line.count("|") - line.count("\\|"), 7)
+
+    def test_unreadable_status_file_is_not_a_failure(self):
+        self._write("banded_perf", TIMED_OUTPUT, status=0)
+        (self.results_dir / "banded_perf.status").write_text("garbage\n", encoding="utf-8")
+
+        report = SUMMARY.build_report(["banded_perf"], self.results_dir, "gcc-14, Release.")
+
+        self.assertIn("All benchmarks exited cleanly.", report)
+
+    def test_status_file_oserror_is_not_a_failure(self):
+        self._write("banded_perf", TIMED_OUTPUT)
+
+        with mock.patch.object(Path, "read_text", side_effect=OSError("transient")):
+            status = SUMMARY.read_status(self.results_dir, "banded_perf")
+
+        self.assertIsNone(status)
+
+    def test_output_file_oserror_gets_placeholder_row(self):
+        self._write("krylov_perf", TIMED_OUTPUT)
+        original = Path.read_text
+
+        def flaky_read(self, *args, **kwargs):
+            if self.name == "krylov_perf.txt":
+                raise OSError("partial artifact")
+            return original(self, *args, **kwargs)
+
+        with mock.patch.object(Path, "read_text", flaky_read):
+            report = SUMMARY.build_report(["krylov_perf"], self.results_dir, "gcc-14, Release.")
 
         self.assertIn("| krylov_perf | (no parseable result rows) |", report)
 

--- a/.github/scripts/write_benchmark_summary.py
+++ b/.github/scripts/write_benchmark_summary.py
@@ -69,13 +69,17 @@ def parse_rows(text: str) -> list[dict[str, str]]:
     return rows
 
 
+def escape_cell(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
 def read_status(results_dir: Path, benchmark: str) -> int | None:
     status_file = results_dir / f"{benchmark}.status"
     if not status_file.is_file():
         return None
     try:
         return int(status_file.read_text(encoding="utf-8").strip())
-    except ValueError:
+    except (OSError, ValueError):
         return None
 
 
@@ -96,9 +100,13 @@ def build_report(benchmarks: list[str], results_dir: Path, configuration: str) -
             failures.append((benchmark, status))
         result_file = results_dir / f"{benchmark}.txt"
         if not result_file.is_file():
-            lines.append(f"| {benchmark} | (no output captured) | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} |")
+            lines.append(f"| {escape_cell(benchmark)} | (no output captured) | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} |")
             continue
-        rows = parse_rows(result_file.read_text(encoding="utf-8", errors="replace"))
+        try:
+            output = result_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            output = ""
+        rows = parse_rows(output)
         if not rows:
             rows = [
                 {
@@ -111,7 +119,7 @@ def build_report(benchmarks: list[str], results_dir: Path, configuration: str) -
             ]
         for row in rows:
             lines.append(
-                f"| {benchmark} | {row['case']} | {row['median']} | "
+                f"| {escape_cell(benchmark)} | {escape_cell(row['case'])} | {row['median']} | "
                 f"{row['minimum']} | {row['maximum']} | {row['reps']} |"
             )
     if failures:

--- a/.github/scripts/write_benchmark_summary.py
+++ b/.github/scripts/write_benchmark_summary.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Aggregate raw DAL benchmark outputs into one step-summary table.
+
+The CI benchmark jobs run each benchmark binary on its own and capture stdout/stderr
+into <results-dir>/<bench>.txt, plus the process exit code in <bench>.status. This
+script parses every captured file and appends a single markdown table (one row per
+benchmark case) to the GitHub step summary, replacing the old per-benchmark sections
+that each repeated their own header.
+
+Two row formats are recognised:
+
+- Dal::Bench table rows: "<case> <median> <unit> <min> <unit> <max> <unit> <reps>"
+- script_perf-style per-iteration rows: "<case> <value> <unit>/iter"
+
+Anything else (init banners, observation counters, table headers) stays available in
+the CI log and the uploaded artifact but is not a table row.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+
+
+NUMBER = r"[0-9]+(?:\.[0-9]+)?"
+UNIT = r"(?:ns|us|ms|s)"
+TIMED_ROW = re.compile(
+    rf"^(?P<case>\S(?:.*?\S)?)\s+"
+    rf"(?P<median>{NUMBER})\s+(?P<median_unit>{UNIT})\s+"
+    rf"(?P<minimum>{NUMBER})\s+(?P<minimum_unit>{UNIT})\s+"
+    rf"(?P<maximum>{NUMBER})\s+(?P<maximum_unit>{UNIT})\s+"
+    rf"(?P<reps>[0-9]+)\s*$"
+)
+PER_ITER_ROW = re.compile(
+    rf"^(?P<case>\S(?:.*?\S)?)\s+(?P<value>{NUMBER})\s+(?P<unit>{UNIT})/iter\s*$"
+)
+
+EMPTY_CELL = "—"
+
+
+def parse_rows(text: str) -> list[dict[str, str]]:
+    """Parse one benchmark's raw output into table rows, preserving print order."""
+    rows = []
+    for line in text.splitlines():
+        match = TIMED_ROW.match(line)
+        if match:
+            rows.append(
+                {
+                    "case": match.group("case"),
+                    "median": f"{match.group('median')} {match.group('median_unit')}",
+                    "minimum": f"{match.group('minimum')} {match.group('minimum_unit')}",
+                    "maximum": f"{match.group('maximum')} {match.group('maximum_unit')}",
+                    "reps": match.group("reps"),
+                }
+            )
+            continue
+        match = PER_ITER_ROW.match(line)
+        if match:
+            rows.append(
+                {
+                    "case": match.group("case"),
+                    "median": f"{match.group('value')} {match.group('unit')}/iter",
+                    "minimum": EMPTY_CELL,
+                    "maximum": EMPTY_CELL,
+                    "reps": EMPTY_CELL,
+                }
+            )
+    return rows
+
+
+def read_status(results_dir: Path, benchmark: str) -> int | None:
+    status_file = results_dir / f"{benchmark}.status"
+    if not status_file.is_file():
+        return None
+    try:
+        return int(status_file.read_text(encoding="utf-8").strip())
+    except ValueError:
+        return None
+
+
+def build_report(benchmarks: list[str], results_dir: Path, configuration: str) -> str:
+    lines = [
+        "## Benchmark Results",
+        "",
+        f"Configuration: {configuration}",
+        f"Discovered {len(benchmarks)} benchmark(s) via CTest label 'benchmark'.",
+        "",
+        "| Benchmark | Case | Median | Min | Max | Reps |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    failures = []
+    for benchmark in benchmarks:
+        status = read_status(results_dir, benchmark)
+        if status:
+            failures.append((benchmark, status))
+        result_file = results_dir / f"{benchmark}.txt"
+        if not result_file.is_file():
+            lines.append(f"| {benchmark} | (no output captured) | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} |")
+            continue
+        rows = parse_rows(result_file.read_text(encoding="utf-8", errors="replace"))
+        if not rows:
+            rows = [
+                {
+                    "case": "(no parseable result rows)",
+                    "median": EMPTY_CELL,
+                    "minimum": EMPTY_CELL,
+                    "maximum": EMPTY_CELL,
+                    "reps": EMPTY_CELL,
+                }
+            ]
+        for row in rows:
+            lines.append(
+                f"| {benchmark} | {row['case']} | {row['median']} | "
+                f"{row['minimum']} | {row['maximum']} | {row['reps']} |"
+            )
+    if failures:
+        formatted = ", ".join(f"`{name}` (exit code {status})" for name, status in failures)
+        lines.extend(["", f"Benchmarks that did not exit cleanly: {formatted}."])
+    else:
+        lines.extend(["", "All benchmarks exited cleanly."])
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", type=Path, required=True)
+    parser.add_argument("--summary-file", type=Path)
+    parser.add_argument("--configuration", required=True)
+    parser.add_argument("--benchmarks", nargs="+", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(args.benchmarks, args.results_dir, args.configuration)
+    if args.summary_file:
+        with args.summary_file.open("a", encoding="utf-8") as summary:
+            summary.write(report)
+    print(report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/write_benchmark_summary.py
+++ b/.github/scripts/write_benchmark_summary.py
@@ -83,6 +83,28 @@ def read_status(results_dir: Path, benchmark: str) -> int | None:
         return None
 
 
+def placeholder_row(case: str) -> dict[str, str]:
+    return {
+        "case": case,
+        "median": EMPTY_CELL,
+        "minimum": EMPTY_CELL,
+        "maximum": EMPTY_CELL,
+        "reps": EMPTY_CELL,
+    }
+
+
+def benchmark_rows(benchmark: str, results_dir: Path) -> list[dict[str, str]]:
+    result_file = results_dir / f"{benchmark}.txt"
+    if not result_file.is_file():
+        return [placeholder_row("(no output captured)")]
+    try:
+        output = result_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        output = ""
+    rows = parse_rows(output)
+    return rows if rows else [placeholder_row("(no parseable result rows)")]
+
+
 def build_report(benchmarks: list[str], results_dir: Path, configuration: str) -> str:
     lines = [
         "## Benchmark Results",
@@ -98,26 +120,7 @@ def build_report(benchmarks: list[str], results_dir: Path, configuration: str) -
         status = read_status(results_dir, benchmark)
         if status:
             failures.append((benchmark, status))
-        result_file = results_dir / f"{benchmark}.txt"
-        if not result_file.is_file():
-            lines.append(f"| {escape_cell(benchmark)} | (no output captured) | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} | {EMPTY_CELL} |")
-            continue
-        try:
-            output = result_file.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            output = ""
-        rows = parse_rows(output)
-        if not rows:
-            rows = [
-                {
-                    "case": "(no parseable result rows)",
-                    "median": EMPTY_CELL,
-                    "minimum": EMPTY_CELL,
-                    "maximum": EMPTY_CELL,
-                    "reps": EMPTY_CELL,
-                }
-            ]
-        for row in rows:
+        for row in benchmark_rows(benchmark, results_dir):
             lines.append(
                 f"| {escape_cell(benchmark)} | {escape_cell(row['case'])} | {row['median']} | "
                 f"{row['minimum']} | {row['maximum']} | {row['reps']} |"

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -601,14 +601,6 @@ jobs:
           fi
 
           mkdir -p benchmark-results
-          {
-            echo "## Benchmark Results"
-            echo
-            echo "Configuration: gcc-14, native CPU tuning, AADet backend, Release."
-            echo "Discovered ${#benchmarks[@]} benchmark(s) via CTest label 'benchmark'."
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-
           benchmark_failure=0
           for bench in "${benchmarks[@]}"; do
             echo "========== $bench =========="
@@ -621,22 +613,18 @@ jobs:
               status=$?
               benchmark_failure=1
             fi
+            echo "$status" > "benchmark-results/${bench}.status"
             cat "$result_file"
             echo
-
-            {
-              echo "### $bench"
-              echo
-              echo '```text'
-              cat "$result_file"
-              echo '```'
-              if [ "$status" -ne 0 ]; then
-                echo
-                echo "Exit code: $status."
-              fi
-              echo
-            } >> "$GITHUB_STEP_SUMMARY"
           done
+
+          # One aggregated table for the whole run, replacing the old per-benchmark
+          # summary sections that each repeated their own header.
+          python3 .github/scripts/write_benchmark_summary.py \
+            --results-dir benchmark-results \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            --configuration "gcc-14, native CPU tuning, AADet backend, Release." \
+            --benchmarks "${benchmarks[@]}"
 
           exit "$benchmark_failure"
 

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -329,14 +329,6 @@ jobs:
           fi
 
           mkdir -p benchmark-results
-          {
-            echo "## Benchmark Results"
-            echo
-            echo "Configuration: msvc, native/AADet backend."
-            echo "Discovered ${#benchmarks[@]} benchmark(s) via CTest label 'benchmark'."
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-
           benchmark_failure=0
           for bench in "${benchmarks[@]}"; do
             echo "========== $bench =========="
@@ -347,22 +339,18 @@ jobs:
               status=$?
               benchmark_failure=1
             fi
+            echo "$status" > "benchmark-results/${bench}.status"
             cat "$result_file"
             echo
-
-            {
-              echo "### $bench"
-              echo
-              echo '```text'
-              cat "$result_file"
-              echo '```'
-              if [ "$status" -ne 0 ]; then
-                echo
-                echo "Exit code: $status."
-              fi
-              echo
-            } >> "$GITHUB_STEP_SUMMARY"
           done
+
+          # One aggregated table for the whole run (same as cmake-linux.yml),
+          # replacing the old per-benchmark summary sections.
+          python3 .github/scripts/write_benchmark_summary.py \
+            --results-dir benchmark-results \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            --configuration "msvc, native/AADet backend." \
+            --benchmarks "${benchmarks[@]}"
 
           exit "$benchmark_failure"
 


### PR DESCRIPTION
## Summary
- Add `.github/scripts/write_benchmark_summary.py`: parses every captured benchmark output (standard `Dal::Bench` Median/Min/Max/Reps rows plus `script_perf`-style `us/iter` rows) and appends **one** combined markdown table to the GitHub step summary, replacing the previous per-binary `### <bench>` sections that each repeated their own header
- Non-clean benchmark exits are still surfaced — rows printed before a crash remain in the table, and failing binaries are listed with their exit codes below it
- Update the Linux and Windows benchmark jobs to record per-binary exit codes (`<bench>.status`) and call the aggregator once after the run loop; raw per-binary output remains in the CI log and the uploaded `benchmark-results` artifact
- Gating semantics unchanged: a non-zero benchmark exit still fails the job, and the paired regression gate (`check_benchmark_regressions.py`) output is untouched
- Add `test_write_benchmark_summary.py` covering row parsing (timed, per-iter, noise skipping), single-table assembly, failure annotation, and missing/unparseable output placeholders

## Test plan
- [x] `python3 -m unittest discover -s .github/scripts/tests` — 135 tests pass (includes the 7 new ones; this is the same suite the CI "Test benchmark regression gate" step runs)
- [x] End-to-end simulation of the new workflow step against a local Release build: all 20 discovered benchmarks aggregated into one 136-row table; the crashing `curve_calibration_perf` keeps its partial rows, is annotated with exit code 134, and still propagates a failing job status
- [x] Both workflow files parse as valid YAML