### PR TITLE
fix: skip Krylov iteration from an already-converged initial guess

### DIFF
--- a/dal-cpp/dal/curve/curvejacobian.hpp
+++ b/dal-cpp/dal/curve/curvejacobian.hpp
@@ -45,6 +45,8 @@ namespace Dal {
         void SecantUpdate(const Vector_<>& dx, const Vector_<>& df) override {
             const auto nf = df.size();
             const double x2 = InnerProduct(dx, dx);
+            if (x2 == 0.0) // a zero step carries no secant information
+                return;
             for (int ii = 0; ii < nf; ++ii) {
                 auto row = j_.Row(ii);
                 const double excess = df[ii] - InnerProduct(dx, row);

--- a/dal-cpp/dal/math/matrix/bcg.cpp
+++ b/dal-cpp/dal/math/matrix/bcg.cpp
@@ -965,7 +965,11 @@ namespace Dal {
                     s.rr_[i] = s.r_[i];
             if (initialResidualNorm.mantissa_ == 0.0)
                 return;
-            if (biConjugate && convergence.IsConverged(s.r_, initialResidualNorm))
+            // A guess that already meets the requested tolerance is the answer for both solvers:
+            // iterating anyway is not a harmless refinement on a numerically singular system — the
+            // first alpha can explode along the near-null direction, after which the recursive and
+            // direct residuals decouple and the confirmation guard fires spuriously.
+            if (convergence.IsConverged(s.r_, initialResidualNorm))
                 return;
 
             for (int iteration = 0; iteration < maxIterations; ++iteration) {

--- a/dal-cpp/dal/math/optimization/underdetermined.cpp
+++ b/dal-cpp/dal/math/optimization/underdetermined.cpp
@@ -74,6 +74,8 @@ namespace Dal {
             void SecantUpdate(const Vector_<>& dx, const Vector_<>& df) override {
                 const auto nf = df.size();
                 const double x2 = InnerProduct(dx, dx);
+                if (x2 == 0.0) // a zero step carries no secant information
+                    return;
                 for (int ii = 0; ii < nf; ++ii) {
                     auto row = j_.Row(ii);
                     const double excess = df[ii] - InnerProduct(dx, row);

--- a/dal-cpp/tests/math/matrix/test_bcg.cpp
+++ b/dal-cpp/tests/math/matrix/test_bcg.cpp
@@ -1541,17 +1541,20 @@ TEST(MatrixTest, TestCGSolveAndBCGSolveInitialAndExhaustionCounts) {
         }
     }
 
-    CallbackCounts_ counts;
-    HookedPreconditionedDiagonal_ matrix({1.0, 2.0}, &counts);
-    const Vector_<> b = {1e-12, 0.0};
-    Vector_<> x = {0.0, 0.0};
-    RunSolver(true, matrix, b, 0.0, 1e-10, 10, &x);
-    ASSERT_EQ(1, counts.left_);
-    ASSERT_EQ(0, counts.right_);
-    ASSERT_EQ(0, counts.preconditionerLeft_);
-    ASSERT_EQ(0, counts.preconditionerRight_);
-    ASSERT_DOUBLE_EQ(0.0, x[0]);
-    ASSERT_DOUBLE_EQ(0.0, x[1]);
+    for (const bool biConjugate : {false, true}) {
+        SCOPED_TRACE(SolverName(biConjugate));
+        CallbackCounts_ counts;
+        HookedPreconditionedDiagonal_ matrix({1.0, 2.0}, &counts);
+        const Vector_<> b = {1e-12, 0.0};
+        Vector_<> x = {0.0, 0.0};
+        RunSolver(biConjugate, matrix, b, 0.0, 1e-10, 10, &x);
+        ASSERT_EQ(1, counts.left_);
+        ASSERT_EQ(0, counts.right_);
+        ASSERT_EQ(0, counts.preconditionerLeft_);
+        ASSERT_EQ(0, counts.preconditionerRight_);
+        ASSERT_DOUBLE_EQ(0.0, x[0]);
+        ASSERT_DOUBLE_EQ(0.0, x[1]);
+    }
 }
 
 TEST(MatrixTest, TestCGSolveAndBCGSolveRejectDirectResidualMismatchWithoutCommit) {


### PR DESCRIPTION
## Summary
- **Root cause** of the `curve_calibration_perf` APPROXIMATE crash (`CGSolve: numerical breakdown: direct residual confirmation`, bcg.cpp): the failing penalty solve started with ||b||=0.177 — already inside the caller's absolute tolerance (`sqrt(24)≈4.9` in `XDecompByCG_`) — but CG iterated anyway, because the initial-convergence short-circuit added in #261 covers only BCG. On the numerically singular `W + JᵀJ` system (residuals scaled by 1/1e-10 swamp the smoothing weights) the first alpha explodes along the near-null direction (residual 0.177 → 139), recursive and direct residuals decouple, and the DAL-64 confirmation guard fired on the marginal mismatch (recursive 3.65 vs direct 5.06 across the 4.9 threshold)
- **Fix 1 (bcg.cpp)**: drop the `biConjugate &&` asymmetry — both solvers now return early when the initial guess already meets the requested tolerance. An already-converged guess is by definition an acceptable answer; "refining" it on a degenerate system is what produced the explosion. The #275 confirmation guard is unchanged and still catches genuine mid-solve breakdown
- **Fix 2 (latent bug exposed by Fix 1)**: early return makes a zero QP step reachable, and `SecantUpdate` then divided by `InnerProduct(dx,dx)=0` (0/0 → NaN), poisoning the Jacobian and surfacing later as `CGSolve: non-finite input: b`. Both Jacobian implementations (`XJDense_`, `CurveJacobian_`) now skip secant updates for zero steps — a zero step carries no secant information
- Extend the initial-convergence callback-count test (previously BCG-only) to CG

## Test plan
- [x] `curve_calibration_perf` now completes: `LOG_LINEAR APPROXIMATE (23 swaps)` runs at ~12.6 ms median, exit 0 (previously aborted deterministically)
- [x] `dal_cpp_tests --gtest_filter='MatrixTest.*'` — 103/103 pass (bcg solvers)
- [x] `dal_cpp_tests --gtest_filter='*Underdetermined*:*Approximate*:*APPROXIMATE*'` — 26/26 pass
- [x] Full `ctest --test-dir build/Release-linux -LE benchmark` — 1508/1508 pass
- [x] Full benchmark label `ctest -L benchmark` — 20/20 pass
