### PR TITLE
chore: release dal-python 2026.9.5

### DIFF
--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -135,10 +135,10 @@ The source archive is created under `dist/`.
 
 Install from source (requires C++ build tools):
 ```bash
-pip install dist/dal_python-2026.8.14.tar.gz \
+pip install dist/dal_python-2026.9.5.tar.gz \
   "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 # or
-uv pip install dist/dal_python-2026.8.14.tar.gz \
+uv pip install dist/dal_python-2026.9.5.tar.gz \
   "--config-settings=cmake.define.DAL_INSTALL_PREFIX=/absolute/path/to/Derivatives-Algorithms-Lib/build/stage/<platform-preset>"
 ```
 

--- a/dal-python/pyproject.toml
+++ b/dal-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "dal-python"
-version = "2026.8.14"
+version = "2026.9.5"
 description = "Python bindings for the DAL quantitative finance library"
 requires-python = ">=3.9,<3.14"
 readme = "README.md"

--- a/dal-python/src/dal/__init__.py
+++ b/dal-python/src/dal/__init__.py
@@ -8,4 +8,4 @@ from .api import *
 
 __author__ = 'The Derivatives Algorithms Group'
 __email__ = 'wegamekinglc@hotmail.com'
-__version__ = "2026.8.14"
+__version__ = "2026.9.5"


### PR DESCRIPTION
## Summary
- Bump dal-python `2026.8.14` → `2026.9.5` in `pyproject.toml` and `dal.__version__`
- Refresh the README sdist example filenames to match
- Prepares the `dal-python-v2026.9.5` tag release: carries the recent quote-risk Python surface (#331) and the DAL-185 GIL execution protocol (#336), plus the Krylov converged-guess fix (#340) in the bundled native library

## Test plan
- [x] `python3 dal-python/scripts/verify_release.py --version-only --tag dal-python-v2026.9.5 --check-pypi` passes locally (version consistency, tag policy, version absent from PyPI)
- [ ] Tag pipeline (`dal-python-v2026.9.5` on the merge commit) builds cp39–cp313 wheels for linux-x86_64 + windows-amd64, verifies the manifest, and publishes to PyPI
