### PR TITLE
perf: add Python benchmarks and paired CI regression gate

### DIFF
--- a/.github/scripts/check_dal_python_syntax.py
+++ b/.github/scripts/check_dal_python_syntax.py
@@ -17,6 +17,7 @@ SOURCE_ROOTS = (
     ROOT / "dal-python" / "tests",
     ROOT / "dal-python" / "scripts",
     ROOT / "dal-python" / "examples",
+    ROOT / "dal-python" / "benchmarks",
 )
 
 

--- a/.github/scripts/check_python_benchmark_regressions.py
+++ b/.github/scripts/check_python_benchmark_regressions.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Gate the complete Python suite against independent base/head DAL builds."""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+TIMEOUT_SECONDS = 600
+ROOT = Path(__file__).resolve().parents[2]
+WORKER = Path(__file__).with_name("python_benchmark_worker.py")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_report(report):
+    require(isinstance(report, dict), "benchmark report must be an object")
+    require(
+        report.get("schema") == "dal.python-benchmarks/1",
+        "unknown Python benchmark schema",
+    )
+    require(
+        report.get("status") == "passed" and report.get("profile") == "full",
+        "failed, incomplete or smoke benchmark report",
+    )
+    require(
+        report.get("samples") == 1 and report.get("warmups") == 2,
+        "expected one measured sample and two warmups per process",
+    )
+    rows = report.get("results", [])
+    require(isinstance(rows, list) and bool(rows), "no Python benchmark cases")
+    values, descriptions = {}, {}
+    for row in rows:
+        require(isinstance(row, dict), "benchmark case must be an object")
+        name = row["name"]
+        require(
+            name not in values and row.get("status") == "passed",
+            f"duplicate or failed case: {name}",
+        )
+        samples = row.get("samples_ns", [])
+        require(len(samples) == 1, f"incomplete samples: {name}")
+        value = samples[0]
+        require(
+            type(value) in (int, float) and math.isfinite(value) and value > 0,
+            f"invalid duration: {name}",
+        )
+        require(row.get("min_ns") == value, f"minimum differs from raw sample: {name}")
+        require(row["workload"].get("profile") == "full", f"non-full workload: {name}")
+        values[name] = value
+        descriptions[name] = {
+            key: row[key] for key in ("name", "cpp_target", "workload")
+        }
+    environment = report["environment"]
+    require(isinstance(environment, dict), "benchmark environment must be an object")
+    require(
+        bool(environment.get("suite_sha256"))
+        and bool(environment.get("native_sha256")),
+        "missing source/module hashes",
+    )
+    require(
+        bool(environment.get("python"))
+        and bool(environment.get("thread_environment", {}).get("DAL_NUM_THREADS")),
+        "missing Python or native thread configuration",
+    )
+    return values, descriptions
+
+
+def removed_cases(base_inventory, head_inventory):
+    base = {case["name"] for case in base_inventory}
+    head = {case["name"] for case in head_inventory}
+    require(bool(base) and bool(head), "empty benchmark inventory")
+    require(
+        len(base) == len(base_inventory) and len(head) == len(head_inventory),
+        "duplicate inventory cases",
+    )
+    return sorted(base - head)
+
+
+def run_worker(suite, package, output, inventory=False):
+    output.mkdir(parents=True, exist_ok=True)
+    path = output / ("inventory.json" if inventory else "results.json")
+    path.unlink(missing_ok=True)
+    command = [
+        sys.executable,
+        "-s",
+        str(WORKER),
+        "--suite",
+        str(suite.resolve()),
+        "--package",
+        str(package.resolve()),
+        "--output",
+        str(output.resolve()),
+    ]
+    if inventory:
+        command.append("--inventory")
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = ""
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment.setdefault("DAL_NUM_THREADS", "4")
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=output,
+            env=environment,
+            shell=False,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as error:
+        (output / "worker.log").write_text(
+            f"worker timed out after {TIMEOUT_SECONDS}s\n{error.stdout or ''}\n{error.stderr or ''}\n",
+            encoding="utf-8",
+        )
+        raise RuntimeError(
+            f"Python benchmark worker timed out; see {output}"
+        ) from error
+    (output / "worker.log").write_text(
+        completed.stdout + completed.stderr, encoding="utf-8"
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            f"Python benchmark worker exited {completed.returncode}; see {output}"
+        )
+    report = json.loads(path.read_text(encoding="utf-8"))
+    if not inventory:
+        validate_report(report)
+        native = Path(report["environment"]["native_module"]).resolve()
+        require(
+            native.is_relative_to(package.resolve() / "dal"),
+            "reported native module is outside selected build",
+        )
+        require(
+            hashlib.sha256(native.read_bytes()).hexdigest()
+            == report["environment"]["native_sha256"],
+            "reported native module hash changed",
+        )
+    return report
+
+
+def collect(suite, packages, sample_count, output):
+    collected = {"base": [], "head": []}
+    for sample in range(sample_count):
+        order = ("base", "head") if sample % 2 == 0 else ("head", "base")
+        for side in order:
+            print(
+                f"Python gate: process {sample + 1}/{sample_count} {side}", flush=True
+            )
+            result = run_worker(
+                suite, packages[side], output / "raw" / f"{sample + 1:02d}-{side}"
+            )
+            collected[side].append(result)
+    return collected
+
+
+def comparable_samples(base, head):
+    baseline_environment = base[0]["environment"]
+    _, expected = validate_report(base[0])
+    values = {"base": {}, "head": {}}
+    for side, reports in (("base", base), ("head", head)):
+        first = reports[0]["environment"]
+        for report in reports:
+            samples, descriptions = validate_report(report)
+            require(
+                descriptions == expected,
+                "case inventory or workload differs between processes/sides",
+            )
+            environment = report["environment"]
+            require(
+                environment["native_sha256"] == first["native_sha256"],
+                f"{side} native binary changed during sampling",
+            )
+            for key in ("suite_sha256", "python", "thread_environment"):
+                require(
+                    environment.get(key) == baseline_environment.get(key),
+                    f"incomparable {key} between processes/sides",
+                )
+            for name, duration in samples.items():
+                values[side].setdefault(name, []).append(duration)
+    return values
+
+
+def evaluate(base, head, samples, rounds, threshold):
+    require(len(base) == len(head) == samples * rounds, "incomplete process samples")
+    require(samples > 0 and rounds > 0, "empty sampling schedule")
+    values = comparable_samples(base, head)
+    rows, failures = [], []
+    for name in sorted(values["base"]):
+        base_values, head_values = values["base"][name], values["head"][name]
+        round_minima = [
+            (
+                min(base_values[i * samples : (i + 1) * samples]),
+                min(head_values[i * samples : (i + 1) * samples]),
+            )
+            for i in range(rounds)
+        ]
+        deltas = [100 * (h - b) / b for b, h in round_minima]
+        # Cross multiplication preserves the strict boundary at exactly +4%.
+        passed = not all(100 * h > (100 + threshold) * b for b, h in round_minima)
+        rows.append(
+            {
+                "case": name,
+                "base_ns": min(base_values),
+                "head_ns": min(head_values),
+                "round_delta_percent": deltas,
+                "round_minima_ns": round_minima,
+                "passed": passed,
+            }
+        )
+        if not passed:
+            failures.append(
+                f"{name}: every confirmation round exceeds +{threshold:g}% ({', '.join(f'{x:+.2f}%' for x in deltas)})"
+            )
+    return rows, failures
+
+
+def build_configuration(build, source):
+    cache = {}
+    for line in (build / "CMakeCache.txt").read_text(encoding="utf-8").splitlines():
+        if "=" in line and not line.startswith(("#", "//")):
+            key, value = line.split("=", 1)
+            cache[key.split(":", 1)[0]] = value
+    require(cache.get("CMAKE_BUILD_TYPE") == "Release", f"not a Release build: {build}")
+    require(
+        cache.get("DAL_BUILD_PYTHON", "").upper() == "ON", f"Python disabled: {build}"
+    )
+    require(
+        Path(cache["CMAKE_HOME_DIRECTORY"]).resolve() == source.resolve(),
+        f"build/source mismatch: {build}",
+    )
+    return {
+        key: value
+        for key, value in cache.items()
+        if key.startswith(("DAL_USE_", "CMAKE_CXX_FLAGS", "DAL_ENABLE_NATIVE_ARCH"))
+        or key
+        in (
+            "CMAKE_BUILD_TYPE",
+            "CMAKE_CXX_COMPILER",
+            "BUILD_SHARED_LIBS",
+            "Python3_EXECUTABLE",
+        )
+    }
+
+
+def source_sha(source):
+    return subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=10,
+    ).stdout.strip()
+
+
+def write_report(output, result, summary_file=None):
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "results.json").write_text(
+        json.dumps(result, indent=2, allow_nan=False) + "\n", encoding="utf-8"
+    )
+    lines = [
+        "## Python interface performance regression gate",
+        "",
+        f"Status: **{result['status']}**.",
+        "",
+        f"{result['rounds']} rounds x {result['samples']} interleaved processes per side; best-of-N, strict +{result['threshold_percent']:g}% in every round.",
+        "",
+        "Both native builds run the same head benchmark suite at full scale. Every current case is compared, including on first introduction.",
+        "",
+        "| Case | Base min (ms) | Head min (ms) | Round changes | Result |",
+        "|---|---:|---:|---|---|",
+    ]
+    for row in result.get("comparisons", []):
+        changes = ", ".join(f"{value:+.2f}%" for value in row["round_delta_percent"])
+        lines.append(
+            f"| {row['case']} | {row['base_ns'] / 1e6:.6f} | {row['head_ns'] / 1e6:.6f} | {changes} | {'pass' if row['passed'] else 'FAIL'} |"
+        )
+    lines += [
+        "",
+        *[f"- {failure}" for failure in result.get("failures", [])],
+        "",
+        "Raw per-process reports and logs are in `raw/`; source/build identities and sampling data are in `results.json`.",
+        "",
+    ]
+    rendered = "\n".join(lines)
+    (output / "summary.md").write_text(rendered, encoding="utf-8")
+    if summary_file:
+        with summary_file.open("a", encoding="utf-8") as stream:
+            stream.write(rendered)
+
+
+def arguments(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-root", type=Path, required=True)
+    parser.add_argument("--head-root", type=Path, required=True)
+    parser.add_argument("--base-source", type=Path, required=True)
+    parser.add_argument("--head-source", type=Path, default=ROOT)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--summary-file", type=Path)
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--confirmation-rounds", type=int, default=2)
+    parser.add_argument("--threshold-percent", type=float, default=4)
+    args = parser.parse_args(argv)
+    if args.samples < 10 or args.confirmation_rounds < 2:
+        parser.error("at least 10 samples and 2 confirmation rounds are required")
+    if not math.isfinite(args.threshold_percent) or args.threshold_percent < 0:
+        parser.error("threshold must be finite and nonnegative")
+    return args
+
+
+def run_gate(args, result):
+    builds = {"base": args.base_root.resolve(), "head": args.head_root.resolve()}
+    sources = {"base": args.base_source.resolve(), "head": args.head_source.resolve()}
+    require(
+        builds["base"] != builds["head"],
+        "base and head must use independent build roots",
+    )
+    configurations = {
+        side: build_configuration(builds[side], sources[side]) for side in builds
+    }
+    require(
+        configurations["base"] == configurations["head"],
+        "base/head build configurations differ",
+    )
+    result["builds"] = {
+        side: {
+            "path": str(builds[side]),
+            "source": str(sources[side]),
+            "sha": source_sha(sources[side]),
+            "configuration": configurations[side],
+        }
+        for side in builds
+    }
+    packages = {side: build / "dal-python" for side, build in builds.items()}
+    suite = sources["head"] / "dal-python/benchmarks"
+    inventory = run_worker(
+        suite, packages["head"], args.output_dir / "head-inventory", inventory=True
+    )
+    removed_cases(
+        inventory, inventory
+    )  # Validate nonempty, unique head inventory on first introduction too.
+    base_suite = sources["base"] / "dal-python/benchmarks"
+    if base_suite.exists():
+        base_inventory = run_worker(
+            base_suite,
+            packages["base"],
+            args.output_dir / "base-inventory",
+            inventory=True,
+        )
+        removed = removed_cases(base_inventory, inventory)
+        require(not removed, f"removed baseline cases: {removed}")
+    result["baseline_has_suite"] = base_suite.exists()
+    collected = collect(
+        suite, packages, args.samples * args.confirmation_rounds, args.output_dir
+    )
+    result["comparisons"], result["failures"] = evaluate(
+        collected["base"],
+        collected["head"],
+        args.samples,
+        args.confirmation_rounds,
+        args.threshold_percent,
+    )
+    _, measured_descriptions = validate_report(collected["head"][0])
+    require(
+        measured_descriptions == {row["name"]: row for row in inventory},
+        "sampled cases differ from head inventory",
+    )
+    result["environments"] = {
+        side: reports[0]["environment"] for side, reports in collected.items()
+    }
+    result["raw_samples_ns"] = comparable_samples(collected["base"], collected["head"])
+    result["status"] = "failed" if result["failures"] else "passed"
+
+
+def main(argv=None):
+    args = arguments(argv)
+    args.output_dir = args.output_dir.resolve()
+    result = {
+        "schema": "dal.python-performance-gate/1",
+        "status": "running",
+        "samples": args.samples,
+        "rounds": args.confirmation_rounds,
+        "threshold_percent": args.threshold_percent,
+        "comparisons": [],
+        "failures": [],
+    }
+    write_report(args.output_dir, result)
+    try:
+        run_gate(args, result)
+    except (
+        OSError,
+        ValueError,
+        KeyError,
+        TypeError,
+        RuntimeError,
+        subprocess.SubprocessError,
+    ) as error:
+        result["status"] = "failed"
+        result["failures"].append(f"{type(error).__name__}: {error}")
+    write_report(args.output_dir, result, args.summary_file)
+    print(
+        f"Python performance gate: {result['status']}; {len(result['comparisons'])} cases; {args.output_dir}"
+    )
+    for failure in result["failures"]:
+        print(failure, file=sys.stderr)
+    return 0 if result["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_python_benchmark_regressions.py
+++ b/.github/scripts/check_python_benchmark_regressions.py
@@ -21,6 +21,36 @@ def require(condition, message):
         raise ValueError(message)
 
 
+def validate_case(row):
+    require(isinstance(row, dict), "benchmark case must be an object")
+    name = row["name"]
+    require(row.get("status") == "passed", f"failed case: {name}")
+    samples = row.get("samples_ns", [])
+    require(len(samples) == 1, f"incomplete samples: {name}")
+    value = samples[0]
+    require(
+        type(value) in (int, float) and math.isfinite(value) and value > 0,
+        f"invalid duration: {name}",
+    )
+    require(row.get("min_ns") == value, f"minimum differs from raw sample: {name}")
+    require(row["workload"].get("profile") == "full", f"non-full workload: {name}")
+    return value
+
+
+def validate_environment(environment):
+    require(isinstance(environment, dict), "benchmark environment must be an object")
+    require(
+        bool(environment.get("suite_sha256"))
+        and bool(environment.get("native_sha256")),
+        "missing source/module hashes",
+    )
+    require(
+        bool(environment.get("python"))
+        and bool(environment.get("thread_environment", {}).get("DAL_NUM_THREADS")),
+        "missing Python or native thread configuration",
+    )
+
+
 def validate_report(report):
     require(isinstance(report, dict), "benchmark report must be an object")
     require(
@@ -39,37 +69,14 @@ def validate_report(report):
     require(isinstance(rows, list) and bool(rows), "no Python benchmark cases")
     values, descriptions = {}, {}
     for row in rows:
-        require(isinstance(row, dict), "benchmark case must be an object")
+        value = validate_case(row)
         name = row["name"]
-        require(
-            name not in values and row.get("status") == "passed",
-            f"duplicate or failed case: {name}",
-        )
-        samples = row.get("samples_ns", [])
-        require(len(samples) == 1, f"incomplete samples: {name}")
-        value = samples[0]
-        require(
-            type(value) in (int, float) and math.isfinite(value) and value > 0,
-            f"invalid duration: {name}",
-        )
-        require(row.get("min_ns") == value, f"minimum differs from raw sample: {name}")
-        require(row["workload"].get("profile") == "full", f"non-full workload: {name}")
+        require(name not in values, f"duplicate case: {name}")
         values[name] = value
         descriptions[name] = {
             key: row[key] for key in ("name", "cpp_target", "workload")
         }
-    environment = report["environment"]
-    require(isinstance(environment, dict), "benchmark environment must be an object")
-    require(
-        bool(environment.get("suite_sha256"))
-        and bool(environment.get("native_sha256")),
-        "missing source/module hashes",
-    )
-    require(
-        bool(environment.get("python"))
-        and bool(environment.get("thread_environment", {}).get("DAL_NUM_THREADS")),
-        "missing Python or native thread configuration",
-    )
+    validate_environment(report["environment"])
     return values, descriptions
 
 
@@ -106,7 +113,9 @@ def run_worker(suite, package, output, inventory=False):
     environment["PYTHONNOUSERSITE"] = "1"
     environment.setdefault("DAL_NUM_THREADS", "4")
     try:
-        completed = subprocess.run(
+        # The interpreter and worker are fixed by this process; paths are separate
+        # arguments and no shell interprets them, as in the native benchmark gate.
+        completed = subprocess.run(  # nosemgrep
             command,
             cwd=output,
             env=environment,

--- a/.github/scripts/python_benchmark_worker.py
+++ b/.github/scripts/python_benchmark_worker.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Load one explicitly selected DAL build in a fresh benchmark process."""
+
+import argparse
+from importlib.machinery import EXTENSION_SUFFIXES
+import json
+from pathlib import Path
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", type=Path, required=True)
+    parser.add_argument("--package", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--inventory", action="store_true")
+    args = parser.parse_args()
+    package = args.package.resolve()
+    if not (package / "dal/__init__.py").is_file():
+        raise ValueError(f"build-tree DAL package missing: {package}")
+    sys.path[:0] = [str(package), str(args.suite.resolve())]
+    import dal
+
+    if not any(
+        str(dal._dal.__file__).endswith(suffix) for suffix in EXTENSION_SUFFIXES
+    ):
+        raise ValueError("DAL benchmark requires the compiled native extension")
+    for path in (dal.__file__, dal._dal.__file__):
+        if not Path(path).resolve().is_relative_to(package / "dal"):
+            raise ValueError(f"DAL import escaped the selected build: {path}")
+    from dal_benchmarks.cases import build_cases
+    from dal_benchmarks.runner import main as run_benchmarks
+
+    if args.inventory:
+        args.output.mkdir(parents=True, exist_ok=True)
+        manifest = [case.description() for case in build_cases(smoke=False)]
+        (args.output / "inventory.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+        return 0
+    return run_benchmarks(
+        ["--samples", "1", "--warmups", "2", "--output-dir", str(args.output)]
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_python_benchmark_regressions.py
+++ b/.github/scripts/tests/test_python_benchmark_regressions.py
@@ -1,0 +1,288 @@
+"""Fail-closed contracts for the Python-interface paired performance gate."""
+
+import copy
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location(
+    "python_gate", SCRIPTS / "check_python_benchmark_regressions.py"
+)
+GATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GATE)
+
+
+def report(duration=100):
+    return {
+        "schema": "dal.python-benchmarks/1",
+        "profile": "full",
+        "status": "passed",
+        "samples": 1,
+        "warmups": 2,
+        "environment": {
+            "suite_sha256": {"cases.py": "suite"},
+            "native_sha256": "binary",
+            "python": "3.13",
+            "thread_environment": {"DAL_NUM_THREADS": "4"},
+        },
+        "results": [
+            {
+                "name": "case",
+                "cpp_target": "rng_perf",
+                "workload": {"profile": "full", "paths": 100000},
+                "status": "passed",
+                "samples_ns": [duration],
+                "min_ns": duration,
+            }
+        ],
+    }
+
+
+class PythonBenchmarkRegressionTest(unittest.TestCase):
+    def test_threshold_requires_two_independent_best_of_ten_failures(self):
+        base = [report()] * 20
+        head = [report(105)] * 20
+        rows, failures = GATE.evaluate(base, head, 10, 2, 4)
+        self.assertFalse(rows[0]["passed"])
+        self.assertEqual(len(failures), 1)
+        head[-1] = report(100)
+        rows, failures = GATE.evaluate(base, head, 10, 2, 4)
+        self.assertTrue(rows[0]["passed"])
+        self.assertEqual(failures, [])
+
+    def test_minimum_not_median_and_strict_threshold(self):
+        base = [report()] * 20
+        head = [report(100), report(150)] * 10
+        self.assertEqual(GATE.evaluate(base, head, 10, 2, 4)[1], [])
+        rows, failures = GATE.evaluate(base, [report(104)] * 20, 10, 2, 4)
+        self.assertEqual(failures, [])
+        self.assertEqual(rows[0]["round_delta_percent"], [4.0, 4.0])
+
+    def test_rejects_missing_processes_cases_and_mismatched_workloads(self):
+        with self.assertRaisesRegex(ValueError, "process samples"):
+            GATE.evaluate([report()] * 19, [report()] * 20, 10, 2, 4)
+        for change in (
+            lambda r: r["results"].clear(),
+            lambda r: r["results"][0]["workload"].update(paths=1),
+            lambda r: r["results"][0].update(name="renamed"),
+            lambda r: r["environment"]["suite_sha256"].update(other="changed"),
+        ):
+            head = [report() for _ in range(20)]
+            change(head[-1])
+            with self.assertRaises(ValueError):
+                GATE.evaluate([report()] * 20, head, 10, 2, 4)
+
+    def test_rejects_smoke_failed_nonfinite_duplicate_and_partial_rows(self):
+        changes = [
+            lambda r: r.update(profile="smoke"),
+            lambda r: r.update(status="running"),
+            lambda r: r["results"][0].update(status="failed"),
+            lambda r: r["results"][0].update(samples_ns=[float("nan")]),
+            lambda r: r["results"][0].update(samples_ns=[0]),
+            lambda r: r["results"][0].update(samples_ns=[True]),
+            lambda r: r["results"].append(copy.deepcopy(r["results"][0])),
+            lambda r: r["results"][0].update(samples_ns=[100, 100]),
+            lambda r: r["results"][0].update(min_ns=50),
+        ]
+        for change in changes:
+            invalid = report()
+            change(invalid)
+            with self.subTest(change=change), self.assertRaises(ValueError):
+                GATE.validate_report(invalid)
+
+    def test_rejects_native_binary_and_thread_drift_between_samples(self):
+        for key, value in (
+            ("native_sha256", "changed"),
+            ("thread_environment", {"DAL_NUM_THREADS": "8"}),
+        ):
+            head = [report() for _ in range(20)]
+            head[-1]["environment"][key] = value
+            with self.assertRaises(ValueError):
+                GATE.evaluate([report()] * 20, head, 10, 2, 4)
+
+    def test_baseline_inventory_rejects_removed_case_but_allows_new_cases(self):
+        base = [{"name": "old"}]
+        self.assertEqual(
+            GATE.removed_cases(base, [{"name": "old"}, {"name": "new"}]), []
+        )
+        self.assertEqual(GATE.removed_cases(base, [{"name": "new"}]), ["old"])
+
+    def test_collect_interleaves_processes_and_uses_head_suite_for_both_sides(self):
+        calls = []
+
+        def run(suite, package, output, inventory=False):
+            calls.append((suite, package, output))
+            return report()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with mock.patch.object(GATE, "run_worker", side_effect=run):
+                collected = GATE.collect(
+                    root / "suite",
+                    {"base": root / "base", "head": root / "head"},
+                    4,
+                    root,
+                )
+        self.assertEqual(
+            [call[1].name for call in calls],
+            ["base", "head", "head", "base", "base", "head", "head", "base"],
+        )
+        self.assertTrue(all(call[0].name == "suite" for call in calls))
+        self.assertEqual(len(collected["base"]), 4)
+
+    def test_worker_timeout_and_nonzero_exit_fail_and_retain_logs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            failure = mock.Mock(
+                returncode=1, stdout="partial output", stderr="bad native call"
+            )
+            with mock.patch.object(GATE.subprocess, "run", return_value=failure):
+                with self.assertRaisesRegex(RuntimeError, "exited"):
+                    GATE.run_worker(root, root, root / "failed")
+            self.assertIn("bad native call", (root / "failed/worker.log").read_text())
+            with mock.patch.object(
+                GATE.subprocess,
+                "run",
+                side_effect=GATE.subprocess.TimeoutExpired("worker", 600),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "timed out"):
+                    GATE.run_worker(root, root, root / "timeout")
+            self.assertIn("timed out", (root / "timeout/worker.log").read_text())
+
+    def test_worker_cannot_reuse_a_stale_inventory_after_empty_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "inventory.json").write_text('[{"name": "stale"}]')
+            completed = mock.Mock(returncode=0, stdout="", stderr="")
+            with (
+                mock.patch.object(GATE.subprocess, "run", return_value=completed),
+                self.assertRaises(FileNotFoundError),
+            ):
+                GATE.run_worker(root, root, root, inventory=True)
+
+    def test_first_introduction_compares_all_cases_and_propagates_regression_exit(self):
+        for head_duration, expected_exit in ((100, 0), (105, 1)):
+            calls = []
+
+            def worker(suite, package, output, inventory=False):
+                calls.append((suite, package, inventory))
+                if inventory:
+                    row = report()["results"][0]
+                    return [
+                        {key: row[key] for key in ("name", "cpp_target", "workload")}
+                    ]
+                return report(
+                    head_duration if package.parent.name == "head-build" else 100
+                )
+
+            with tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                argv = [
+                    "--base-root",
+                    str(root / "base-build"),
+                    "--head-root",
+                    str(root / "head-build"),
+                    "--base-source",
+                    str(root / "base-source"),
+                    "--head-source",
+                    str(root / "head-source"),
+                    "--output-dir",
+                    str(root / "results"),
+                ]
+                with (
+                    mock.patch.object(GATE, "build_configuration", return_value={}),
+                    mock.patch.object(GATE, "source_sha", return_value="commit"),
+                    mock.patch.object(GATE, "run_worker", side_effect=worker),
+                    contextlib.redirect_stdout(io.StringIO()),
+                    contextlib.redirect_stderr(io.StringIO()),
+                ):
+                    self.assertEqual(GATE.main(argv), expected_exit)
+                result = json.loads((root / "results/results.json").read_text())
+                self.assertEqual(
+                    result["status"], "passed" if expected_exit == 0 else "failed"
+                )
+                self.assertFalse(result["baseline_has_suite"])
+                self.assertEqual(len(result["comparisons"]), 1)
+                self.assertEqual(len(result["raw_samples_ns"]["base"]["case"]), 20)
+                self.assertEqual(
+                    len(calls), 41
+                )  # one inventory plus 20 base/head pairs
+                self.assertTrue(
+                    all(
+                        call[0] == root / "head-source/dal-python/benchmarks"
+                        for call in calls
+                    )
+                )
+
+    def test_invalid_cli_sampling_and_thresholds_are_rejected(self):
+        required = [
+            "--base-root",
+            "base",
+            "--head-root",
+            "head",
+            "--base-source",
+            "source",
+            "--output-dir",
+            "output",
+        ]
+        for extra in (
+            ["--samples", "9"],
+            ["--confirmation-rounds", "1"],
+            ["--threshold-percent", "nan"],
+            ["--threshold-percent", "-1"],
+        ):
+            with (
+                contextlib.redirect_stderr(io.StringIO()),
+                self.assertRaises(SystemExit) as error,
+            ):
+                GATE.arguments(required + extra)
+            self.assertEqual(error.exception.code, 2)
+
+    def test_build_contract_rejects_debug_or_wrong_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / "CMakeCache.txt"
+            path.write_text(
+                f"CMAKE_BUILD_TYPE:STRING=Release\nDAL_BUILD_PYTHON:BOOL=ON\nCMAKE_HOME_DIRECTORY:INTERNAL={root}\n"
+            )
+            GATE.build_configuration(root, root)
+            with self.assertRaisesRegex(ValueError, "build/source mismatch"):
+                GATE.build_configuration(root, root / "different")
+            path.write_text(path.read_text().replace("Release", "Debug"))
+            with self.assertRaisesRegex(ValueError, "Release"):
+                GATE.build_configuration(root, root)
+
+    def test_linux_required_benchmark_job_runs_python_gate_with_native_policy(self):
+        workflow = (SCRIPTS.parent / "workflows/cmake-linux.yml").read_text()
+        job = workflow.split("  benchmark:\n", 1)[1].split("  linux-gate:\n", 1)[0]
+        self.assertIn("check_python_benchmark_regressions.py", job)
+        self.assertEqual(job.count("-DDAL_BUILD_PYTHON=ON"), 2)
+        self.assertEqual(job.count('-DPython3_EXECUTABLE="$(command -v python3)"'), 2)
+        gate = job.split("- name: Compare base and head Python performance", 1)[
+            1
+        ].split("- name:", 1)[0]
+        for flag in (
+            "--samples 10",
+            "--confirmation-rounds 2",
+            "--threshold-percent 4",
+            "--output-dir benchmark-results/python-paired",
+        ):
+            self.assertIn(flag, gate)
+        self.assertNotIn("continue-on-error", gate)
+        self.assertIn("- benchmark", workflow.split("  linux-gate:\n", 1)[1])
+        self.assertIn(
+            "if: always()", job.split("- name: Upload benchmark evidence", 1)[1]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_python_syntax.py
+++ b/.github/scripts/tests/test_python_syntax.py
@@ -22,6 +22,7 @@ class PythonSyntaxTest(unittest.TestCase):
         self.assertIn("dal-python/tests/test_date.py", paths)
         self.assertIn("dal-python/scripts/smoke_installed_wheel.py", paths)
         self.assertIn("dal-python/examples/005.yield_curve_jacobian.py", paths)
+        self.assertIn("dal-python/benchmarks/dal_benchmarks/runner.py", paths)
         self.assertEqual(CHECK_SYNTAX.syntax_errors(CHECK_SYNTAX.python_paths()), [])
 
     def test_main_runs_only_under_the_grammar_floor(self):

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -549,6 +549,16 @@ jobs:
           sudo apt install -y gcc-14 g++-14 make cmake time \
             libc++-dev autotools-dev autoconf libtool
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # @v10.0.1
+
+      - name: Set up benchmark Python
+        run: |
+          export VIRTUAL_ENV="$PWD/dal-python/.venv"
+          uv venv "$VIRTUAL_ENV" --python 3.13
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          uv pip install pytest numpy
+
       - name: Capture benchmark environment
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
@@ -578,11 +588,13 @@ jobs:
           cmake -S . -B build/benchmark-head \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
-            -DDAL_BUILD_PUBLIC=OFF \
+            -DDAL_BUILD_PUBLIC=ON \
+            -DDAL_PUBLIC_BUILD_TESTS=OFF \
             -DDAL_CPP_BUILD_TESTS=OFF \
             -DDAL_CPP_BUILD_EXAMPLES=OFF \
             -DDAL_CPP_BUILD_BENCHMARKS=ON \
-            -DDAL_BUILD_PYTHON=OFF \
+            -DDAL_BUILD_PYTHON=ON \
+            -DPython3_EXECUTABLE="$(command -v python3)" \
             -DDAL_USE_XAD_AAD=OFF \
             -DDAL_USE_CODIPACK_AAD=OFF \
             -DDAL_USE_ADEPT_AAD=OFF \
@@ -597,16 +609,30 @@ jobs:
           cmake -S benchmark-base -B benchmark-base/build/benchmark-base \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
-            -DDAL_BUILD_PUBLIC=OFF \
+            -DDAL_BUILD_PUBLIC=ON \
+            -DDAL_PUBLIC_BUILD_TESTS=OFF \
             -DDAL_CPP_BUILD_TESTS=OFF \
             -DDAL_CPP_BUILD_EXAMPLES=OFF \
             -DDAL_CPP_BUILD_BENCHMARKS=ON \
-            -DDAL_BUILD_PYTHON=OFF \
+            -DDAL_BUILD_PYTHON=ON \
+            -DPython3_EXECUTABLE="$(command -v python3)" \
             -DDAL_USE_XAD_AAD=OFF \
             -DDAL_USE_CODIPACK_AAD=OFF \
             -DDAL_USE_ADEPT_AAD=OFF \
             -DDAL_ENABLE_NATIVE_ARCH=ON
           cmake --build benchmark-base/build/benchmark-base --parallel
+
+      - name: Verify Python workloads on both native builds
+        id: python-workloads
+        env:
+          DAL_NUM_THREADS: 4
+        run: |
+          for build_root in "$GITHUB_WORKSPACE/benchmark-base/build/benchmark-base" "$GITHUB_WORKSPACE/build/benchmark-head"; do
+            (
+              cd "$build_root/dal-python"
+              PYTHONPATH="$build_root/dal-python" python3 -m pytest "$GITHUB_WORKSPACE/dal-python/tests" -q
+            )
+          done
 
       - name: Run head benchmarks
         env:
@@ -649,7 +675,24 @@ jobs:
 
           exit "$benchmark_failure"
 
+      - name: Compare base and head Python performance
+        if: ${{ !cancelled() && steps.python-workloads.outcome == 'success' }}
+        env:
+          DAL_NUM_THREADS: 4
+        run: |
+          python3 .github/scripts/check_python_benchmark_regressions.py \
+            --base-source benchmark-base \
+            --head-source . \
+            --base-root benchmark-base/build/benchmark-base \
+            --head-root build/benchmark-head \
+            --output-dir benchmark-results/python-paired \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            --samples 10 \
+            --confirmation-rounds 2 \
+            --threshold-percent 4
+
       - name: Compare base and head performance
+        if: ${{ !cancelled() && steps.python-workloads.outcome == 'success' }}
         env:
           DAL_NUM_THREADS: 4
         run: |

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -429,6 +429,27 @@ Tests are located in `tests/` and cover:
 - Resettable/MTM XCCY construction with immutable fixing snapshots
 - Joint domestic/foreign/basis XCCY calibration, including matrix and named-range contracts
 
+## Performance Benchmarks
+
+The [Python benchmark suite](benchmarks/README.md) provides 70 public-interface
+workloads mapped to the C++ benchmark inventory: RNG, script construction and MC,
+single-curve and XCCY calibration, node risk, and quote-risk provenance/aggregation.
+It records raw samples, workload sizes, native-module identity, and a Markdown summary.
+
+From `dal-python/`, using a current installed wheel or editable build:
+
+```bash
+python benchmarks/run_benchmarks.py --smoke
+python benchmarks/run_benchmarks.py --samples 10 --warmups 2
+python benchmarks/run_benchmarks.py --group rate_risk_perf --filter generic
+```
+
+The normal pytest suite checks every workload at smoke scale without a speed
+threshold. Linux CI also gates all 70 full-scale cases against independent base/head
+builds, using two rounds of ten interleaved processes and a strict 4% threshold in
+both rounds. The coverage map explicitly records unbound C++ kernels and fixture
+differences; Python timings include binding and result-conversion costs.
+
 ## Project Structure
 
 ```
@@ -441,6 +462,7 @@ dal-python/
 ├── run_tests.sh            # Standalone binding test helpers (POSIX and PowerShell)
 ├── run_tests.ps1
 ├── examples/               # Numbered end-to-end Python examples
+├── benchmarks/             # Public-interface performance runner and C++ coverage map
 ├── scripts/                # Release verification and installed-wheel smoke helpers
 ├── src/
 │   ├── bindings/

--- a/dal-python/benchmarks/README.md
+++ b/dal-python/benchmarks/README.md
@@ -53,15 +53,15 @@ are errors, never silently skipped workloads.
 
 ## Workload alignment
 
-| Native target | Python cases | Full workload and timing boundary |
-|---|---:|---|
-| `rng_perf` | 4 | 100,000 paths × 10 dimensions; Sobol normal fast, normal precise with polish, uniform, and MRG32 normal; fresh generator and output matrix each invocation |
-| `script_perf` | 1 | Same three-year weekly barrier event table; `Product_New` + `Product_DebugJson`, including frontend construction, indexing and JSON serialization |
-| `script_mc_perf` | 8 | Vanilla: 200,000 double / 20,000 AAD paths; weekly barrier: 100,000 / 10,000; tree and compiled evaluators; product/model creation and preprocessing included |
-| `curve_calibration_perf` | 21 | Same 23 annual swaps and 24 future knots; PWC, PWL, LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED × ANALYTIC/BUMPED × diagnostics/solve-only, plus LOG_LINEAR APPROXIMATE |
-| `xccy_perf` | 8 | Joint/staged × ANALYTIC/BUMPED × diagnostics/solve-only; adapted square fixture with five quotes per calibrated block |
-| `rate_risk_perf` | 19 | 120-IRS batch and 240 single-component calls; five-year OIS daily compounding; 24-XCCY × five-component batch; nine single/joint/staged quote portfolios; six generic-joint portfolios |
-| `quote_risk_perf` | 9 | Single, joint XCCY and staged provenance at N=8/16; additional generic joint provenance at total N=5/10/16 |
+| Native target            | Python cases | Full workload and timing boundary                                                                                                                                                      |
+|--------------------------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rng_perf`               | 4            | 100,000 paths × 10 dimensions; Sobol normal fast, normal precise with polish, uniform, and MRG32 normal; fresh generator and output matrix each invocation                             |
+| `script_perf`            | 1            | Same three-year weekly barrier event table; `Product_New` + `Product_DebugJson`, including frontend construction, indexing and JSON serialization                                      |
+| `script_mc_perf`         | 8            | Vanilla: 200,000 double / 20,000 AAD paths; weekly barrier: 100,000 / 10,000; tree and compiled evaluators; product/model creation and preprocessing included                          |
+| `curve_calibration_perf` | 21           | Same 23 annual swaps and 24 future knots; PWC, PWL, LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED × ANALYTIC/BUMPED × diagnostics/solve-only, plus LOG_LINEAR APPROXIMATE                       |
+| `xccy_perf`              | 8            | Joint/staged × ANALYTIC/BUMPED × diagnostics/solve-only; adapted square fixture with five quotes per calibrated block                                                                  |
+| `rate_risk_perf`         | 19           | 120-IRS batch and 240 single-component calls; five-year OIS daily compounding; 24-XCCY × five-component batch; nine single/joint/staged quote portfolios; six generic-joint portfolios |
+| `quote_risk_perf`        | 9            | Single, joint XCCY and staged provenance at N=8/16; additional generic joint provenance at total N=5/10/16                                                                             |
 
 All these target mappings are marked `partial`: the timed boundary is the Python
 interface, and some native-only subcases remain inaccessible. This is not a claim
@@ -91,10 +91,10 @@ are not exposed by Python and are not measured.
 Native targets without direct Python kernel timing are listed individually by
 `--coverage` and in every report:
 
-| Coverage | Native targets |
-|---|---|
+| Coverage                          | Native targets                                                                                                                             |
+|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | Indirect through another workload | `tape_perf`, `jacobian_perf`, `interp_perf`, `krylov_perf`, `specialfunctions_perf`, `ycinstrument_perf`, `threadpool_perf`, `stacks_perf` |
-| No corresponding bound operation | `matrix_perf`, `pde_perf`, `banded_perf`, `cholesky_perf`, `black_perf`, `iv_brent_perf` |
+| No corresponding bound operation  | `matrix_perf`, `pde_perf`, `banded_perf`, `cholesky_perf`, `black_perf`, `iv_brent_perf`                                                   |
 
 Additional gaps within covered families include isolated script preprocessing and
 parsing, direct BrownianBridge/IRN RNG fills, XCCY precompute/price/reset-aware and

--- a/dal-python/benchmarks/README.md
+++ b/dal-python/benchmarks/README.md
@@ -1,0 +1,203 @@
+# DAL Python interface benchmarks
+
+This suite runs 70 workloads through `import dal`, with a coverage entry for every
+target in [the C++ benchmark inventory](../../dal-cpp/benchmarks/CMakeLists.txt).
+It requires a current DAL Python build and Python 3.9–3.13. The runner uses the
+standard library; pytest is needed only for its correctness tests.
+
+## Running
+
+With a current wheel or editable installation, run from `dal-python/`:
+
+```bash
+python benchmarks/run_benchmarks.py --coverage
+python benchmarks/run_benchmarks.py --list
+python benchmarks/run_benchmarks.py --smoke --output-dir ../benchmark-results/python-smoke
+python benchmarks/run_benchmarks.py --samples 10 --warmups 2 --output-dir ../benchmark-results/python
+python benchmarks/run_benchmarks.py --group script_mc_perf --group curve_calibration_perf
+python benchmarks/run_benchmarks.py --group rate_risk_perf --filter generic
+```
+
+`--coverage` does not import DAL. `--list` lists selected case names and exact
+workloads using the active DAL environment. Unknown groups, empty selections and
+invalid sample counts fail. A group with only indirect/unavailable coverage cannot
+be selected for timing.
+
+For a Linux workspace build, configure from the repository root using the same
+Python interpreter for CMake and execution:
+
+```bash
+cmake --preset=Release-linux -S . -B build/Release-linux \
+  -DDAL_BUILD_PYTHON=ON -DPython3_EXECUTABLE="$(command -v python3)"
+cmake --build build/Release-linux --target _dal --parallel 4
+cd dal-python
+DAL_NUM_THREADS=4 PYTHONPATH=../build/Release-linux/dal-python \
+  python3 -m pytest tests -q
+DAL_NUM_THREADS=4 PYTHONPATH=../build/Release-linux/dal-python \
+  python3 benchmarks/run_benchmarks.py --output-dir ../benchmark-results/python
+```
+
+In PowerShell, select the corresponding build-tree package before running:
+
+```powershell
+cd dal-python
+$env:PYTHONPATH = (Resolve-Path ../build/Release-windows/dal-python).Path
+$env:DAL_NUM_THREADS = "4"
+python benchmarks/run_benchmarks.py --smoke
+```
+
+Run pytest from `dal-python/` to avoid an old installed `dal/` directory at the
+repository root shadowing the selected build. Verify `environment.native_module`
+in the JSON report. An older published wheel may lack required APIs; missing APIs
+are errors, never silently skipped workloads.
+
+## Workload alignment
+
+| Native target | Python cases | Full workload and timing boundary |
+|---|---:|---|
+| `rng_perf` | 4 | 100,000 paths × 10 dimensions; Sobol normal fast, normal precise with polish, uniform, and MRG32 normal; fresh generator and output matrix each invocation |
+| `script_perf` | 1 | Same three-year weekly barrier event table; `Product_New` + `Product_DebugJson`, including frontend construction, indexing and JSON serialization |
+| `script_mc_perf` | 8 | Vanilla: 200,000 double / 20,000 AAD paths; weekly barrier: 100,000 / 10,000; tree and compiled evaluators; product/model creation and preprocessing included |
+| `curve_calibration_perf` | 21 | Same 23 annual swaps and 24 future knots; PWC, PWL, LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED × ANALYTIC/BUMPED × diagnostics/solve-only, plus LOG_LINEAR APPROXIMATE |
+| `xccy_perf` | 8 | Joint/staged × ANALYTIC/BUMPED × diagnostics/solve-only; adapted square fixture with five quotes per calibrated block |
+| `rate_risk_perf` | 19 | 120-IRS batch and 240 single-component calls; five-year OIS daily compounding; 24-XCCY × five-component batch; nine single/joint/staged quote portfolios; six generic-joint portfolios |
+| `quote_risk_perf` | 9 | Single, joint XCCY and staged provenance at N=8/16; additional generic joint provenance at total N=5/10/16 |
+
+All these target mappings are marked `partial`: the timed boundary is the Python
+interface, and some native-only subcases remain inaccessible. This is not a claim
+of full native case parity.
+
+`Product_New` only stores events; the timed `Product_DebugJson` call is needed to
+execute the native preprocessor/parser. Its indexing and serialization cost is
+also included. Python's MRG32 constructor fixes `precise=true`, while the native
+RNG benchmark selects `precise=false`; this policy difference is recorded rather
+than treated as equivalent timing. Sobol precision/polish flags match the native cases.
+
+The single-curve quote portfolios retain the native N=2/5/16 and 1/120-trade
+shapes. Joint XCCY uses five calibrated blocks (domestic discount/forward, foreign
+discount/forward, basis), with N=2 or 10 quotes per block and 1/24 trades. Staged
+basis portfolios use N=2/5/16 and 1/24 trades. XCCY fixtures use explicit flat
+domestic/foreign curves and a deterministic basis quote ladder; the native fixture
+generates quotes from sloped curves. XCCY node timing uses the joint calibration
+fixture. These are related workloads, not identical native input sets.
+
+Generic joint portfolios use the native three-layered-curve fixture with total
+quote widths N=5/10/16 and 100/1,000 IRS. Flat-curve calibration quotes are derived
+analytically in Python. Every third position receives fixed on 250,000 notional;
+the others pay fixed on 1,000,000. The third curve is a structural-zero trade
+dependency. The internal joint-node reference and native preparation/tape counters
+are not exposed by Python and are not measured.
+
+Native targets without direct Python kernel timing are listed individually by
+`--coverage` and in every report:
+
+| Coverage | Native targets |
+|---|---|
+| Indirect through another workload | `tape_perf`, `jacobian_perf`, `interp_perf`, `krylov_perf`, `specialfunctions_perf`, `ycinstrument_perf`, `threadpool_perf`, `stacks_perf` |
+| No corresponding bound operation | `matrix_perf`, `pde_perf`, `banded_perf`, `cholesky_perf`, `black_perf`, `iv_brent_perf` |
+
+Additional gaps within covered families include isolated script preprocessing and
+parsing, direct BrownianBridge/IRN RNG fills, XCCY precompute/price/reset-aware and
+approximate calibration cases, and internal quote-state probes. Matrix storage
+conversion and MC call pricing are not substitutes for native matrix arithmetic
+or analytic Black/IV kernels.
+
+## Measurement and correctness
+
+Fixture creation, calibration of risk markets, reference results, and validation
+run outside timing. Risk aggregation reuses immutable provenance and markets;
+provenance construction has separate cases. Each case performs an untimed checked
+call, then warmups, then measured calls. Validation after every call checks output
+shapes, finite results, calibration residuals, matrix-retention policy, tree/compiled
+PV and Greek agreement, batch/single node-risk agreement, provenance availability,
+passive/quote-risk PV agreement and DV01 units. Vanilla MC also checks an independent
+Black-Scholes formula. Unavailable or ineligible results fail the run.
+
+`perf_counter_ns` measures one complete public workload per sample. Python argument
+and return conversion are included; inspecting results and destroying the previous
+result are excluded. GC remains enabled. No native executable is launched or
+timed by this runner. Native initialization occurs before measurements.
+
+Full mode defaults to ten samples and two warmups. Smoke mode uses one sample,
+zero warmups, 1,024 RNG paths, 2,048 MC paths and at most two portfolio trades;
+calibration widths remain intact. Workload metadata records actual sizes, even
+when a case's stable name contains its full-profile trade count. Smoke timings
+must not be compared with full timings. `DAL_NUM_THREADS` defaults to 4 when
+unset and must be set before DAL is imported.
+
+Outputs are `results.json` (schema `dal.python-benchmarks/1`) and `summary.md`.
+They retain every raw nanosecond sample, minimum/median/maximum, failures, profile,
+coverage, Python/platform/CPU identity, thread settings, native-module path and
+SHA-256, suite source hashes, checkout SHA/status, and discoverable CMake flags.
+The checkout SHA does not prove an installed wheel's source revision. Interrupted
+runs retain `status: running`; failed cases have no successful timing row and the
+runner exits nonzero. Reusing an output directory replaces its previous report.
+
+Standalone runner measurements are informational. Python and C++ results have
+different boundaries and must not be divided into a claimed language overhead
+ratio. The Python CI gate below compares Python base/head runs separately from
+the native nine-target gate. For manual comparisons,
+retain separate output directories, use equivalent Release builds and workloads,
+record both module hashes, fix thread settings, and interleave repeated processes
+on the same quiet machine. Shared-host/WSL noise and a single timing run cannot
+establish a regression.
+
+The normal Python pytest suite executes every smoke workload and verifies the
+runner's failure handling and the complete CMake target mapping. Adding a native
+target without a documented coverage entry fails that inventory check. The
+repository's Python 3.9 syntax gate includes benchmark sources.
+
+## CI regression gate
+
+The Linux `Benchmarks` job builds both the PR base (or pre-push commit on `master`)
+and the tested revision as independent Release builds with Python bindings enabled.
+Both use the same CPython 3.13 interpreter, compiler, AAD backend, native architecture
+flags and `DAL_NUM_THREADS=4`. The job verifies the head Python correctness suite
+against both modules before measuring performance.
+
+The [paired Python gate](../../.github/scripts/check_python_benchmark_regressions.py)
+runs the complete head workload suite on **both** native modules. Each fresh process
+checks its package and native-extension paths before execution, performs one checked
+preflight call and two warmups per case, and records one full-scale sample. Base/head
+order alternates on every process pair. Two confirmation rounds each contain ten
+pairs: 20 processes per side, with 20 samples for every case on each side. A case
+fails only when its head minimum exceeds its base minimum by strictly more than
+4% in both rounds. Exactly +4% passes.
+
+The same head test code and workload metadata must be used for both sides, including
+when the base predates this benchmark suite. This first introduction still measures
+and gates all 70 cases against the base library; it is not an unmeasured adoption
+pass. When a base suite exists, its inventory is also checked: removing or renaming
+a case fails. New cases must run against both libraries. A missing base API,
+incorrect/ineligible result, unexpected package path, changed binary or suite hash,
+different workload/configuration, timeout, or incomplete sample set fails the gate.
+There is no smoke-mode or case-filter option in the gate.
+
+To reproduce it after creating two independent, equivalently configured workspace
+Release builds with `DAL_BUILD_PYTHON=ON` and the same `Python3_EXECUTABLE`, run from
+the head source checkout:
+
+```bash
+DAL_NUM_THREADS=4 python3 .github/scripts/check_python_benchmark_regressions.py \
+  --base-source /path/to/base-source \
+  --head-source . \
+  --base-root /path/to/base-build \
+  --head-root /path/to/head-build \
+  --output-dir benchmark-results/python-paired \
+  --samples 10 --confirmation-rounds 2 --threshold-percent 4
+```
+
+The build-root arguments identify the CMake workspace roots, whose Python packages
+are under `dal-python/`; do not pass installed/staged packages. The gate validates
+Release configuration, matching compiler/options, and each build's source directory.
+Source commit IDs, build configuration, native module paths/hashes, suite hashes,
+raw timings, per-round minima and deltas are retained in
+`results.json` (`dal.python-performance-gate/1`). Every worker has a `raw/NN-side/`
+directory containing its normal runner reports and captured output. Errors still
+produce a failing gate report; interrupted runs retain `status: running`.
+
+The job appends the comparison to the GitHub Actions summary and uploads all Python
+evidence inside the existing `benchmark-linux-*` artifact for 30 days, including on
+failure. Python and native comparison steps can both report failures, and either
+failure blocks the existing `Linux CI gate`. Windows continues to run the Python
+correctness/smoke workloads through pytest; the paired performance gate is Linux-only.

--- a/dal-python/benchmarks/dal_benchmarks/__init__.py
+++ b/dal-python/benchmarks/dal_benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in benchmarks of the public DAL Python interface."""

--- a/dal-python/benchmarks/dal_benchmarks/calibration.py
+++ b/dal-python/benchmarks/dal_benchmarks/calibration.py
@@ -1,0 +1,128 @@
+"""Public-interface curve fixtures; no imports from the unit-test suite."""
+
+import math
+
+import dal
+
+from .harness import Workload, require
+
+
+def leg(months=12, unadjusted=True):
+    value = dal.RateLegConvention_New(
+        dal.PeriodLength_New(f"{months}M"), dal.DayBasis_New("ACT_365F")
+    )
+    value.payment_lag = 0
+    if unadjusted:
+        value.business_day_convention = dal.BizDayConvention_.UNADJUSTED
+        value.payment_convention = dal.BizDayConvention_.UNADJUSTED
+    return value
+
+
+def index(projected=False, months=3, unadjusted=True):
+    value = dal.RateIndexConvention_New(
+        dal.PeriodLength_New(f"{months}M"),
+        dal.DayBasis_New("ACT_365F"),
+        dal.CollateralType_OIS(),
+        projected,
+    )
+    value.fixing_lag = 0
+    value.spot_lag = 0
+    if unadjusted:
+        value.business_day_convention = dal.BizDayConvention_.UNADJUSTED
+    return value
+
+
+def single_spec(representation, approximate=False):
+    """The 23 swaps and 24 future knots of curve_calibration_perf."""
+    today = dal.Date_(2022, 1, 1)
+    builder = dal.CurveCalibrationSpecBuilder_()
+    builder.today_ = today
+    builder.ccy_ = dal.String_("USD")
+    builder.curveName_ = dal.String_("curve_calibration_perf")
+    builder.targetCollateral_ = dal.CollateralType_OIS()
+    builder.calibrateDiscountCurve_ = True
+    builder.liborBasis_ = dal.DayBasis_New("ACT_365F")
+    builder.tolerance_ = 1e-10
+    builder.fitTolerance_ = 1e-8
+    builder.initialGuess_ = 0.03
+    builder.smoothingWeight_ = 1.0
+    builder.knot_policy = dal.CurveKnotPolicy.INPUT
+    builder.solveMode_ = (
+        dal.CurveSolveMode.APPROXIMATE if approximate else dal.CurveSolveMode.EXACT
+    )
+    if representation in ("PWC", "PWL"):
+        builder.parameterization_ = (
+            dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
+            if representation == "PWC"
+            else dal.CurveParameterization.PIECEWISE_LINEAR_FWD
+        )
+        builder.knotDates_ = [dal.Date_(2022 + y, 7, 1) for y in range(23)] + [
+            dal.Date_(2045, 1, 1)
+        ]
+    else:
+        builder.parameterization_ = dal.CurveParameterization.LOG_DISCOUNT
+        builder.logDfScheme_ = getattr(dal.LogDfScheme, representation)
+        builder.knotDates_ = [dal.Date_(2022 + y, 1, 1) for y in range(25)]
+    builder.instruments_ = [
+        dal.Swap_New(
+            today,
+            today,
+            dal.Date_(2022 + y, 1, 1),
+            (1.0 + 2.5 * (y - 1) / 22) / 100,
+            leg(),
+            index(months=12),
+            leg(),
+        )
+        for y in range(1, 24)
+    ]
+    return builder.Build()
+
+
+def calibration_options(mode, diagnostics=True, kind="single"):
+    constructors = {
+        "single": dal.CurveCalibrationOptions_,
+        "staged": dal.CrossCurrencyCalibrationOptions_,
+        "joint": dal.JointXccyCalibrationOptions_,
+    }
+    options = constructors[kind]()
+    options.jacobian_mode = getattr(dal.CurveJacobianMode, mode)
+    options.compute_eff_jacobian_inverse = diagnostics
+    options.compute_forward_jacobian = diagnostics
+    return options
+
+
+def check_single(result, count, diagnostics, approximate=False, mode="ANALYTIC"):
+    diagnostic = result.diagnostics_
+    require(len(diagnostic.modelRates_) == count, "calibration residual width changed")
+    require(
+        all(math.isfinite(value) for value in diagnostic.modelRates_),
+        "nonfinite model rate",
+    )
+    require(math.isfinite(diagnostic.maxAbsResidual_), "nonfinite calibration residual")
+    if not approximate:
+        require(
+            diagnostic.maxAbsResidual_ < 1e-7, "exact calibration residual too large"
+        )
+    require(
+        diagnostic.jacobian_.rows()
+        == (count if diagnostics and mode == "ANALYTIC" and not approximate else 0),
+        "forward Jacobian retention changed",
+    )
+    if diagnostics and not approximate:
+        require(
+            diagnostic.effJacobianInverse_.cols() == count,
+            "inverse quote width changed",
+        )
+    else:
+        require(
+            diagnostic.effJacobianInverse_.rows() == 0, "solve-only retained an inverse"
+        )
+
+
+def prepare_calibration(representation, mode, diagnostics, approximate=False):
+    spec = single_spec(representation, approximate)
+    options = calibration_options(mode, diagnostics)
+    return Workload(
+        lambda: dal.CalibrateSingleCurve(spec, options),
+        lambda result: check_single(result, 23, diagnostics, approximate, mode),
+    )

--- a/dal-python/benchmarks/dal_benchmarks/cases.py
+++ b/dal-python/benchmarks/dal_benchmarks/cases.py
@@ -249,7 +249,7 @@ def _node_cases(add, smoke, risk, xccy):
     )
 
 
-def _quote_cases(add, smoke, risk, xccy):
+def _provenance_cases(add, risk, xccy):
     for kind in ("single", "joint", "staged"):
         for width in (8, 16):
             factory = (
@@ -267,6 +267,10 @@ def _quote_cases(add, smoke, risk, xccy):
                 },
                 partial(risk.prepare_quote, factory, True),
             )
+
+
+def _quote_cases(add, smoke, risk, xccy):
+    _provenance_cases(add, risk, xccy)
     portfolio_shapes = [
         ("single", 2, "ANALYTIC", 1),
         ("joint", 2, "ANALYTIC", 1),

--- a/dal-python/benchmarks/dal_benchmarks/cases.py
+++ b/dal-python/benchmarks/dal_benchmarks/cases.py
@@ -1,0 +1,327 @@
+"""Explicit mapping of every native target to the callable Python surface."""
+
+from functools import partial
+
+from .harness import Case
+
+
+# 'partial' means reachable public workloads, never native-kernel timing parity.
+CPP_COVERAGE = {
+    "rng_perf": {
+        "status": "partial",
+        "detail": "100K x 10D Sobol fast/precise/uniform and MRG32 normal; public matrix allocation included. MRG32 is fixed to precise=true in Python versus false in C++. BrownianBridge and IRN have no direct binding.",
+    },
+    "script_perf": {
+        "status": "partial",
+        "detail": "Same three-year weekly barrier events; Product_New + Product_DebugJson times frontend construction with indexing/JSON output. Product_New alone only stores events. Parser/preprocessor stages are not separately bound.",
+    },
+    "script_mc_perf": {
+        "status": "partial",
+        "detail": "All eight vanilla/barrier x double/AAD x tree/compiled cases; native path counts, dates and model. Includes public result conversion.",
+    },
+    "curve_calibration_perf": {
+        "status": "partial",
+        "detail": "All 21 cases: five representations x analytic/bumped x diagnostics/solve, plus approximate. Same 23 swaps/24 future knots.",
+    },
+    "xccy_perf": {
+        "status": "partial",
+        "detail": "Joint/staged analytic/bumped x diagnostics/solve using five quotes per block. Adapted square quote ladder; native 15-instrument/reset-aware/approximate and precompute pricing cases are not reproduced.",
+    },
+    "rate_risk_perf": {
+        "status": "partial",
+        "detail": "120-IRS batch/single, 5Y daily OIS, 24-XCCY batch, single/joint/staged quote portfolios and layered generic joint N=5/10/16 x 100/1000 IRS. XCCY market ladder adapted; internal counters and joint-node reference are unbound.",
+    },
+    "quote_risk_perf": {
+        "status": "partial",
+        "detail": "Single, joint XCCY and staged provenance at N=8/16; joint XCCY has five parameter blocks. Adds generic joint N=5/10/16. Internal component state probe is unbound.",
+    },
+    "matrix_perf": {
+        "status": "unavailable",
+        "detail": "Python exposes matrix storage/conversion, not Multiply/MultiplyLeft kernels.",
+    },
+    "tape_perf": {
+        "status": "indirect",
+        "detail": "Tape clear/rewind/propagation APIs are unbound; AAD MC and rate risk exercise them indirectly.",
+    },
+    "jacobian_perf": {
+        "status": "indirect",
+        "detail": "Synthetic AAD sweep/harvesting APIs are unbound; calibration covers real Jacobians.",
+    },
+    "pde_perf": {
+        "status": "unavailable",
+        "detail": "ThetaScheme and PDE grid/rollback APIs are unbound.",
+    },
+    "interp_perf": {
+        "status": "indirect",
+        "detail": "Cubic interpolation microkernel is unbound; LOG_CUBIC_NATURAL calibration exercises interpolation.",
+    },
+    "krylov_perf": {
+        "status": "indirect",
+        "detail": "Conjugate-gradient solver is unbound; approximate calibration exercises it indirectly.",
+    },
+    "banded_perf": {
+        "status": "unavailable",
+        "detail": "Banded matrix-vector kernel is unbound.",
+    },
+    "cholesky_perf": {
+        "status": "unavailable",
+        "detail": "Cholesky decomposition API is unbound.",
+    },
+    "specialfunctions_perf": {
+        "status": "indirect",
+        "detail": "Special-function APIs are unbound; normal RNG exercises inverse-normal functions.",
+    },
+    "black_perf": {
+        "status": "unavailable",
+        "detail": "Analytic Black/Bachelier pricing and Greek APIs are unbound; MC is a different algorithm.",
+    },
+    "iv_brent_perf": {
+        "status": "unavailable",
+        "detail": "Implied-volatility and Brent solver APIs are unbound.",
+    },
+    "ycinstrument_perf": {
+        "status": "indirect",
+        "detail": "Instrument factories are bound, but isolated Precompute/operator() is not. Calibration exercises instrument pricing.",
+    },
+    "threadpool_perf": {
+        "status": "indirect",
+        "detail": "Thread-pool scheduling API is unbound; MC uses the native pool.",
+    },
+    "stacks_perf": {
+        "status": "indirect",
+        "detail": "Block-list/stack primitives are unbound; native AAD workloads use them internally.",
+    },
+}
+
+
+def build_cases(smoke=False):
+    # --coverage reads the mapping without importing the native extension.
+    from . import calibration, risk, simulation, xccy
+
+    cases = []
+
+    def add(name, target, workload, prepare):
+        cases.append(
+            Case(
+                name,
+                target,
+                dict(workload, profile="smoke" if smoke else "full"),
+                prepare,
+            )
+        )
+
+    _simulation_cases(add, smoke, simulation)
+    _calibration_cases(add, calibration)
+    _xccy_cases(add, xccy)
+    _node_cases(add, smoke, risk, xccy)
+    _quote_cases(add, smoke, risk, xccy)
+    _generic_cases(add, smoke, risk)
+    return cases
+
+
+def _simulation_cases(add, smoke, simulation):
+    paths = 1024 if smoke else 100_000
+    for kind in (
+        "sobol_normal_fast",
+        "sobol_normal_precise",
+        "sobol_uniform",
+        "mrg32_normal",
+    ):
+        add(
+            f"rng.{kind}",
+            "rng_perf",
+            {
+                "paths": paths,
+                "dimensions": 10,
+                "boundary": "generator creation + matrix fill",
+                "precise": kind in ("sobol_normal_precise", "mrg32_normal"),
+                "polish": kind in ("sobol_normal_precise", "mrg32_normal"),
+            },
+            partial(simulation.prepare_rng, kind, paths),
+        )
+    add(
+        "script.construct_and_parse",
+        "script_perf",
+        {
+            "years": 3,
+            "frequency": "1W",
+            "constructions": 1,
+            "boundary": "event storage + native frontend + variable indexing + JSON serialization",
+        },
+        simulation.prepare_script,
+    )
+    for kind, double_paths, aad_paths in (
+        ("vanilla", 200_000, 20_000),
+        ("barrier", 100_000, 10_000),
+    ):
+        for aad in (False, True):
+            for compiled in (False, True):
+                paths = 2048 if smoke else aad_paths if aad else double_paths
+                name = f"mc.{kind}.{'aad' if aad else 'double'}.{'compiled' if compiled else 'tree'}"
+                add(
+                    name,
+                    "script_mc_perf",
+                    {
+                        "paths": paths,
+                        "aad": aad,
+                        "compiled": compiled,
+                        "boundary": "product + model + preprocessing + simulation + result conversion",
+                    },
+                    partial(simulation.prepare_mc, kind, aad, compiled, paths),
+                )
+
+
+def _calibration_cases(add, calibration):
+    for representation in ("PWC", "PWL", "LOG_LINEAR", "LOG_CUBIC_NATURAL", "MIXED"):
+        for mode in ("ANALYTIC", "BUMPED"):
+            for diagnostic in (True, False):
+                add(
+                    f"calibration.{representation}.{mode}.{'diagnostics' if diagnostic else 'solve'}",
+                    "curve_calibration_perf",
+                    {
+                        "swaps": 23,
+                        "future_knots": 24,
+                        "representation": representation,
+                        "jacobian": mode,
+                        "diagnostics": diagnostic,
+                    },
+                    partial(
+                        calibration.prepare_calibration,
+                        representation,
+                        mode,
+                        diagnostic,
+                    ),
+                )
+    add(
+        "calibration.LOG_LINEAR.APPROXIMATE",
+        "curve_calibration_perf",
+        {
+            "swaps": 23,
+            "future_knots": 24,
+            "representation": "LOG_LINEAR",
+            "solve_mode": "APPROXIMATE",
+        },
+        partial(calibration.prepare_calibration, "LOG_LINEAR", "ANALYTIC", True, True),
+    )
+
+
+def _xccy_cases(add, xccy):
+    for kind in ("joint", "staged"):
+        for mode in ("ANALYTIC", "BUMPED"):
+            for diagnostic in (True, False):
+                add(
+                    f"xccy.{kind}.{mode}.{'diagnostics' if diagnostic else 'solve'}",
+                    "xccy_perf",
+                    {
+                        "quotes_per_block": 5,
+                        "blocks": 5 if kind == "joint" else 1,
+                        "jacobian": mode,
+                        "diagnostics": diagnostic,
+                        "fixture": "adapted square quote ladder",
+                    },
+                    partial(xccy.prepare_calibration, kind, mode, diagnostic),
+                )
+
+
+def _node_cases(add, smoke, risk, xccy):
+    count = 2 if smoke else 120
+    for operation in ("batch", "single", "ois"):
+        add(
+            f"nodes.{operation}",
+            "rate_risk_perf",
+            {
+                "trades": 1 if operation == "ois" else count,
+                "components": 1 if operation == "ois" else 2,
+                "years": 5 if operation == "ois" else 10,
+            },
+            partial(risk.prepare_nodes, count, operation),
+        )
+    count = 2 if smoke else 24
+    add(
+        "nodes.xccy",
+        "rate_risk_perf",
+        {
+            "trades": count,
+            "components": 5,
+            "fixture": "adapted joint calibration market",
+        },
+        partial(xccy.prepare_nodes, count),
+    )
+
+
+def _quote_cases(add, smoke, risk, xccy):
+    for kind in ("single", "joint", "staged"):
+        for width in (8, 16):
+            factory = (
+                partial(risk.single_fixture, width, 1, "ANALYTIC")
+                if kind == "single"
+                else partial(xccy.fixture, kind, width, 1, "ANALYTIC")
+            )
+            add(
+                f"provenance.{kind}.n{width}",
+                "quote_risk_perf",
+                {
+                    "quotes_per_block": width,
+                    "blocks": 5 if kind == "joint" else 1,
+                    "boundary": "provenance construction only",
+                },
+                partial(risk.prepare_quote, factory, True),
+            )
+    portfolio_shapes = [
+        ("single", 2, "ANALYTIC", 1),
+        ("joint", 2, "ANALYTIC", 1),
+        ("staged", 2, "ANALYTIC", 1),
+        ("single", 5, "ANALYTIC", 120),
+        ("single", 16, "BUMPED", 120),
+        ("joint", 10, "ANALYTIC", 24),
+        ("joint", 10, "BUMPED", 24),
+        ("staged", 16, "ANALYTIC", 24),
+        ("staged", 5, "BUMPED", 24),
+    ]
+    for kind, width, mode, full_count in portfolio_shapes:
+        count = min(full_count, 2) if smoke else full_count
+        factory = (
+            partial(risk.single_fixture, width, count, mode)
+            if kind == "single"
+            else partial(xccy.fixture, kind, width, count, mode)
+        )
+        add(
+            f"quotes.{kind}.n{width}.{mode}.t{full_count}",
+            "rate_risk_perf",
+            {
+                "quotes_per_block": width,
+                "blocks": 5 if kind == "joint" else 1,
+                "trades": count,
+                "jacobian": mode,
+                "boundary": "aggregation only; calibration and provenance excluded",
+            },
+            partial(risk.prepare_quote, factory),
+        )
+
+
+def _generic_cases(add, smoke, risk):
+    for width in (5, 10, 16):
+        factory = partial(risk.generic_fixture, width, 1)
+        add(
+            f"provenance.generic.n{width}",
+            "quote_risk_perf",
+            {"quotes": width, "blocks": 3, "layered": True},
+            partial(risk.prepare_quote, factory, True),
+        )
+        for full_count in (100, 1000):
+            count = 2 if smoke else full_count
+            add(
+                f"quotes.generic.n{width}.t{full_count}",
+                "rate_risk_perf",
+                {
+                    "quotes": width,
+                    "blocks": 3,
+                    "trades": count,
+                    "layered": True,
+                    "fixture": "native flat curve quotes derived analytically; third block is a structural zero",
+                    "boundary": "aggregation only; calibration and provenance excluded",
+                },
+                partial(
+                    risk.prepare_quote, partial(risk.generic_fixture, width, count)
+                ),
+            )

--- a/dal-python/benchmarks/dal_benchmarks/harness.py
+++ b/dal-python/benchmarks/dal_benchmarks/harness.py
@@ -1,0 +1,73 @@
+"""Timing boundary and serializable evidence, independent of DAL imports."""
+
+from dataclasses import dataclass
+import statistics
+import time
+from typing import Any, Callable
+
+
+@dataclass
+class Workload:
+    run: Callable[[], Any]
+    validate: Callable[[Any], None]
+
+
+@dataclass
+class Case:
+    name: str
+    cpp_target: str
+    workload: dict
+    prepare: Callable[[], Workload]
+
+    def description(self):
+        return {
+            "name": self.name,
+            "cpp_target": self.cpp_target,
+            "workload": self.workload,
+        }
+
+
+def require(condition, message):
+    # Keep validation active under python -O too.
+    if not condition:
+        raise ValueError(message)
+
+
+def measure(case, *, samples=10, warmups=2, clock=time.perf_counter_ns):
+    require(
+        samples > 0 and warmups >= 0, "samples must be positive and warmups nonnegative"
+    )
+    work = case.prepare()
+    work.validate(work.run())
+    for _ in range(warmups):
+        work.validate(work.run())
+    durations = []
+    for _ in range(samples):
+        start = clock()
+        value = work.run()
+        elapsed = clock() - start
+        work.validate(value)
+        require(elapsed > 0, "nonpositive benchmark duration")
+        durations.append(elapsed)
+        # Destruction of the prior result must not leak into the next sample.
+        del value
+    return dict(
+        case.description(),
+        samples_ns=durations,
+        min_ns=min(durations),
+        median_ns=statistics.median(durations),
+        max_ns=max(durations),
+        status="passed",
+    )
+
+
+def select_cases(cases, groups, name_filter):
+    unknown = set(groups) - {case.cpp_target for case in cases}
+    require(not unknown, f"Unknown or unavailable benchmark groups: {sorted(unknown)}")
+    selected = [
+        case
+        for case in cases
+        if (not groups or case.cpp_target in groups) and name_filter in case.name
+    ]
+    require(bool(selected), "No benchmark cases selected")
+    return selected

--- a/dal-python/benchmarks/dal_benchmarks/risk.py
+++ b/dal-python/benchmarks/dal_benchmarks/risk.py
@@ -46,6 +46,28 @@ def deposit(today, maturity, name, key="discount"):
     )
 
 
+def irs_terms(ordinal, discount, forward, generic):
+    identity = dal.FixingIdentity_()
+    identity.index_name = "USD-LIBOR" if generic else "USD-SOFR"
+    identity.fixing_hour = 11
+    identity.fixing_minute = 0
+    # The public trade validator requires positive notionals. Represent the native
+    # fixture's short positions by reversing payer direction with the same magnitude.
+    notional = (250_000 if ordinal % 3 == 0 else 1_000_000) if generic else 1_000_000
+    pay_fixed = ordinal % 3 != 0 if generic else ordinal % 2 == 0
+    return dal.FixedFloatTradeTerms_(
+        notional=notional,
+        contract_rate=0.03,
+        pay_fixed=pay_fixed,
+        fixed_leg=leg(6 if generic else 12, unadjusted=generic),
+        float_leg=leg(3 if generic else 12, unadjusted=generic),
+        float_index=index(projected=generic, unadjusted=generic),
+        fixing_identity=identity,
+        forecast_component_key=forward,
+        discount_component_key=discount,
+    )
+
+
 def irs(
     today,
     start,
@@ -57,25 +79,7 @@ def irs(
     ois=False,
     generic=False,
 ):
-    identity = dal.FixingIdentity_()
-    identity.index_name = "USD-LIBOR" if generic else "USD-SOFR"
-    identity.fixing_hour = 11
-    identity.fixing_minute = 0
-    # The public trade validator requires positive notionals. Represent the native
-    # fixture's short positions by reversing payer direction with the same magnitude.
-    notional = (250_000 if ordinal % 3 == 0 else 1_000_000) if generic else 1_000_000
-    pay_fixed = ordinal % 3 != 0 if generic else ordinal % 2 == 0
-    terms = dal.FixedFloatTradeTerms_(
-        notional=notional,
-        contract_rate=0.03,
-        pay_fixed=pay_fixed,
-        fixed_leg=leg(6 if generic else 12, unadjusted=generic),
-        float_leg=leg(3 if generic else 12, unadjusted=generic),
-        float_index=index(projected=generic, unadjusted=generic),
-        fixing_identity=identity,
-        forecast_component_key=forward,
-        discount_component_key=discount,
-    )
+    terms = irs_terms(ordinal, discount, forward, generic)
     return dal.RateTradeDefinition_(
         instrument_id=f"irs-{ordinal}",
         instrument_type=dal.RateInstrumentType.OIS
@@ -161,6 +165,36 @@ def flat_swap_quote(today, years, months, forward):
     return floating / annuity
 
 
+def generic_instrument(today, block, months, ordinal):
+    maturity = dal.Date_(2026 + ordinal, 1, 2)
+    if block == 0:
+        years = (maturity - today) / 365
+        quote = math.expm1(0.02 * years) / years
+        return dal.Deposit_New(today, today, maturity, quote, index())
+    quote = flat_swap_quote(today, ordinal + 1, months, 0.034 + 0.004 * (block - 1))
+    return dal.Swap_New(
+        today, today, maturity, quote, leg(6), index(True, months), leg(months)
+    )
+
+
+def generic_declaration(today, width, block):
+    size = width // 3 + (block < width % 3)
+    declaration = dal.JointCurveDeclaration_()
+    declaration.curve_name = "repeated_name"
+    declaration.parameterization = dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
+    declaration.calibrate_discount_curve = block == 0
+    declaration.target_collateral = dal.CollateralType_OIS()
+    months = 6 if block == 2 else 3
+    if block:
+        declaration.target_tenor = dal.PeriodLength_New(f"{months}M")
+    declaration.base_layered_over_discount = block != 0
+    declaration.knot_dates = [dal.Date_(2025 + i, 7, 2) for i in range(size)]
+    declaration.instruments = [
+        generic_instrument(today, block, months, i) for i in range(size)
+    ]
+    return declaration
+
+
 def generic_fixture(width, count, mode="ANALYTIC"):
     """Three layered flat PWC curves and quotes from jointquoteriskfixtures.hpp."""
     today = dal.Date_(2025, 1, 2)
@@ -168,44 +202,7 @@ def generic_fixture(width, count, mode="ANALYTIC"):
     spec.today, spec.ccy = today, "USD"
     spec.tolerance, spec.fit_tolerance, spec.initial_guess = 1e-11, 1e-9, 0.025
     spec.max_evaluations, spec.max_restarts = 1000, 100
-    curves = []
-    for block in range(3):
-        size = width // 3 + (block < width % 3)
-        declaration = dal.JointCurveDeclaration_()
-        declaration.curve_name = "repeated_name"
-        declaration.parameterization = dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
-        declaration.calibrate_discount_curve = block == 0
-        declaration.target_collateral = dal.CollateralType_OIS()
-        months = 6 if block == 2 else 3
-        if block:
-            declaration.target_tenor = dal.PeriodLength_New(f"{months}M")
-        declaration.base_layered_over_discount = block != 0
-        declaration.knot_dates = [dal.Date_(2025 + i, 7, 2) for i in range(size)]
-        instruments = []
-        for i in range(size):
-            maturity = dal.Date_(2026 + i, 1, 2)
-            years = (maturity - today) / 365
-            quote = (
-                math.expm1(0.02 * years) / years
-                if block == 0
-                else flat_swap_quote(today, i + 1, months, 0.034 + 0.004 * (block - 1))
-            )
-            instruments.append(
-                dal.Deposit_New(today, today, maturity, quote, index())
-                if block == 0
-                else dal.Swap_New(
-                    today,
-                    today,
-                    maturity,
-                    quote,
-                    leg(6),
-                    index(True, months),
-                    leg(months),
-                )
-            )
-        declaration.instruments = instruments
-        curves.append(declaration)
-    spec.curves = curves
+    spec.curves = [generic_declaration(today, width, block) for block in range(3)]
     options = dal.JointMultiCurveCalibrationOptions_()
     options.compute_eff_jacobian_inverse = True
     options.jacobian_mode = getattr(dal.CurveJacobianMode, mode)
@@ -303,7 +300,7 @@ def prepare_quote(fixture_factory, provenance_only=False):
     )
 
 
-def prepare_nodes(count, operation):
+def node_fixture(count, operation):
     today, start = dal.Date_(2026, 1, 15), dal.Date_(2026, 4, 15)
     knots = [dal.Date_(2026, 7, 15)] + [
         dal.Date_(year, 1, 15) for year in range(2027, 2034)
@@ -319,6 +316,11 @@ def prepare_nodes(count, operation):
         irs(today, start, maturity, i, ois=ois) for i in range(1 if ois else count)
     ]
     keys = ["forecast"] if ois else ["forecast", "discount"]
+    return market, trades, keys
+
+
+def prepare_nodes(count, operation):
+    market, trades, keys = node_fixture(count, operation)
     expected = [
         dal.RateTradeNodeSensitivities(trade=trade, market=market, component_key=key)
         for trade in trades

--- a/dal-python/benchmarks/dal_benchmarks/risk.py
+++ b/dal-python/benchmarks/dal_benchmarks/risk.py
@@ -1,0 +1,357 @@
+"""Steady-state rate-risk fixtures and validation outside the timed region."""
+
+from dataclasses import dataclass
+import math
+
+import dal
+
+from .calibration import calibration_options, index, leg
+from .harness import Workload, require
+
+
+@dataclass
+class RiskFixture:
+    market: object
+    trades: list
+    build_provenance: object
+    quotes: int
+
+
+def rate_market(today, components, xccy=None, hour=9, minute=0):
+    return dal.RatePricingMarket_(
+        valuation_time=dal.DateTime_(today, hour, minute),
+        result_currency="USD",
+        curve_components=components,
+        xccy_market=xccy,
+        fixings=dal.MarketFixingSnapshot_New({}),
+    )
+
+
+def deposit(today, maturity, name, key="discount"):
+    terms = dal.DepositTradeTerms_(
+        notional=1_000_000,
+        contract_rate=0.02,
+        lend=True,
+        index=index(months=6),
+        discount_component_key=key,
+    )
+    return dal.RateTradeDefinition_(
+        instrument_id=name,
+        instrument_type=dal.RateInstrumentType.DEPOSIT,
+        trade_date=today,
+        start_date=today,
+        maturity_date=maturity,
+        currency="USD",
+        terms=terms,
+    )
+
+
+def irs(
+    today,
+    start,
+    maturity,
+    ordinal,
+    *,
+    discount="discount",
+    forward="forecast",
+    ois=False,
+    generic=False,
+):
+    identity = dal.FixingIdentity_()
+    identity.index_name = "USD-LIBOR" if generic else "USD-SOFR"
+    identity.fixing_hour = 11
+    identity.fixing_minute = 0
+    # The public trade validator requires positive notionals. Represent the native
+    # fixture's short positions by reversing payer direction with the same magnitude.
+    notional = (250_000 if ordinal % 3 == 0 else 1_000_000) if generic else 1_000_000
+    pay_fixed = ordinal % 3 != 0 if generic else ordinal % 2 == 0
+    terms = dal.FixedFloatTradeTerms_(
+        notional=notional,
+        contract_rate=0.03,
+        pay_fixed=pay_fixed,
+        fixed_leg=leg(6 if generic else 12, unadjusted=generic),
+        float_leg=leg(3 if generic else 12, unadjusted=generic),
+        float_index=index(projected=generic, unadjusted=generic),
+        fixing_identity=identity,
+        forecast_component_key=forward,
+        discount_component_key=discount,
+    )
+    return dal.RateTradeDefinition_(
+        instrument_id=f"irs-{ordinal}",
+        instrument_type=dal.RateInstrumentType.OIS
+        if ois
+        else dal.RateInstrumentType.IRS,
+        trade_date=today,
+        start_date=start,
+        maturity_date=maturity,
+        currency="USD",
+        terms=dal.OisTradeTerms_(value=terms)
+        if ois
+        else dal.IrsTradeTerms_(value=terms),
+    )
+
+
+def single_fixture(width, count, mode):
+    today = dal.Date_(2025, 1, 2)
+    knots = [
+        dal.Date_(2025 + (i + 1) // 2, 7 if i % 2 == 0 else 1, 2) for i in range(width)
+    ]
+    # Generate deposit quotes from the native fixture's piecewise constant forwards.
+    forwards = [0.02 + 0.0005 * i for i in range(width)]
+    integral, previous, quotes = 0.0, today, []
+    for i, maturity in enumerate(knots):
+        integral += forwards[max(0, i - 1)] * (maturity - previous) / 365
+        quotes.append(math.expm1(integral) / ((maturity - today) / 365))
+        previous = maturity
+    builder = dal.CurveCalibrationSpecBuilder_()
+    builder.today_, builder.ccy_, builder.curveName_ = (
+        today,
+        dal.String_("USD"),
+        dal.String_("single_quote_bench"),
+    )
+    builder.parameterization_ = dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
+    builder.knot_policy = dal.CurveKnotPolicy.INPUT
+    builder.tolerance_, builder.initialGuess_ = 1e-10, 0.02
+    builder.knotDates_ = knots
+    builder.instruments_ = [
+        dal.Deposit_New(today, today, maturity, quote, index(months=6))
+        for maturity, quote in zip(knots, quotes)
+    ]
+    spec = builder.Build()
+    options = calibration_options(mode)
+    options.compute_forward_jacobian = False
+    result = dal.CalibrateSingleCurve(spec, options)
+    market = rate_market(today, {"discount": result.curve_})
+    config = dal.RateQuoteRiskProvenanceConfig_(
+        calibration_id="single-quote-bench",
+        component_key_by_parameter_block={"single_quote_bench": "discount"},
+    )
+
+    def build():
+        return dal.BuildSingleCurveQuoteRiskProvenance(
+            spec=spec,
+            result=result,
+            options=options,
+            bound_market=market,
+            config=config,
+        )
+
+    return RiskFixture(
+        market,
+        [deposit(today, knots[-1], f"deposit-{i}") for i in range(count)],
+        build,
+        width,
+    )
+
+
+def flat_swap_quote(today, years, months, forward):
+    """Independent par quote for the native generic fixture's flat 2% discount curve."""
+
+    def coupons(frequency):
+        previous = today
+        for month in range(frequency, 12 * years + 1, frequency):
+            end = dal.Date_(2025 + month // 12, 1 + month % 12, 2)
+            yield (end - previous) / 365, math.exp(-0.02 * (end - today) / 365)
+            previous = end
+
+    floating = sum(
+        math.expm1(forward * accrual) * df for accrual, df in coupons(months)
+    )
+    annuity = sum(accrual * df for accrual, df in coupons(6))
+    return floating / annuity
+
+
+def generic_fixture(width, count, mode="ANALYTIC"):
+    """Three layered flat PWC curves and quotes from jointquoteriskfixtures.hpp."""
+    today = dal.Date_(2025, 1, 2)
+    spec = dal.JointMultiCurveCalibrationSpec_()
+    spec.today, spec.ccy = today, "USD"
+    spec.tolerance, spec.fit_tolerance, spec.initial_guess = 1e-11, 1e-9, 0.025
+    spec.max_evaluations, spec.max_restarts = 1000, 100
+    curves = []
+    for block in range(3):
+        size = width // 3 + (block < width % 3)
+        declaration = dal.JointCurveDeclaration_()
+        declaration.curve_name = "repeated_name"
+        declaration.parameterization = dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
+        declaration.calibrate_discount_curve = block == 0
+        declaration.target_collateral = dal.CollateralType_OIS()
+        months = 6 if block == 2 else 3
+        if block:
+            declaration.target_tenor = dal.PeriodLength_New(f"{months}M")
+        declaration.base_layered_over_discount = block != 0
+        declaration.knot_dates = [dal.Date_(2025 + i, 7, 2) for i in range(size)]
+        instruments = []
+        for i in range(size):
+            maturity = dal.Date_(2026 + i, 1, 2)
+            years = (maturity - today) / 365
+            quote = (
+                math.expm1(0.02 * years) / years
+                if block == 0
+                else flat_swap_quote(today, i + 1, months, 0.034 + 0.004 * (block - 1))
+            )
+            instruments.append(
+                dal.Deposit_New(today, today, maturity, quote, index())
+                if block == 0
+                else dal.Swap_New(
+                    today,
+                    today,
+                    maturity,
+                    quote,
+                    leg(6),
+                    index(True, months),
+                    leg(months),
+                )
+            )
+        declaration.instruments = instruments
+        curves.append(declaration)
+    spec.curves = curves
+    options = dal.JointMultiCurveCalibrationOptions_()
+    options.compute_eff_jacobian_inverse = True
+    options.jacobian_mode = getattr(dal.CurveJacobianMode, mode)
+    result = dal.CalibrateJointMultiCurveBundle(spec, options)
+    require(result.converged, "generic joint calibration did not converge")
+    forwards = {str(key): value for key, value in result.forward_curves.items()}
+    market = rate_market(
+        today,
+        {
+            "curve:0": next(iter(result.discount_curves.values())),
+            "curve:1": forwards[str(dal.PeriodLength_New("3M"))],
+            "curve:2": forwards[str(dal.PeriodLength_New("6M"))],
+        },
+        hour=0,
+    )
+    config = dal.RateQuoteRiskProvenanceConfig_(
+        calibration_id="generic-joint",
+        component_key_by_parameter_block={f"curve:{i}": f"curve:{i}" for i in range(3)},
+    )
+
+    def build():
+        return dal.BuildJointMultiCurveQuoteRiskProvenance(
+            spec=spec,
+            result=result,
+            options=options,
+            bound_market=market,
+            config=config,
+        )
+
+    maturity = dal.Date_(2026 + (width // 3 + (1 < width % 3)) - 1, 1, 2)
+    trades = [
+        irs(
+            today,
+            today,
+            maturity,
+            i,
+            discount="curve:0",
+            forward="curve:1",
+            generic=True,
+        )
+        for i in range(count)
+    ]
+    return RiskFixture(market, trades, build, width)
+
+
+def check_provenance(value, width):
+    require(value.available, f"unavailable provenance: {value.reason}")
+    require(len(value.axis.quotes) == width, "provenance quote count changed")
+    require(
+        bool(value.axis.fingerprint) and bool(value.state.fingerprint),
+        "missing provenance fingerprint",
+    )
+    require(value.effective_inverse.Cols() == width, "effective inverse width changed")
+
+
+def check_quote_risk(value, fixture, expected_pvs):
+    require(not value.provenance_failures, "quote risk provenance failed")
+    require(len(value.buckets) == fixture.quotes, "quote bucket count changed")
+    require(
+        len(value.meta) == len(fixture.trades)
+        and all(row.eligible for row in value.meta),
+        "ineligible quote-risk trade",
+    )
+    for row, pv in zip(value.meta, expected_pvs):
+        require(
+            math.isclose(row.pv, pv, rel_tol=1e-10, abs_tol=1e-8),
+            "quote-risk PV differs from passive pricing",
+        )
+    for bucket in value.buckets:
+        require(
+            math.isfinite(bucket.d_pv_d_decimal_quote) and math.isfinite(bucket.dv01),
+            "nonfinite quote risk",
+        )
+        require(bucket.dv01 == bucket.d_pv_d_decimal_quote * 1e-4, "DV01 units changed")
+
+
+def prepare_quote(fixture_factory, provenance_only=False):
+    fixture = fixture_factory()
+    if provenance_only:
+        return Workload(
+            fixture.build_provenance,
+            lambda result: check_provenance(result, fixture.quotes),
+        )
+    provenance = fixture.build_provenance()
+    check_provenance(provenance, fixture.quotes)
+    priced = dal.PriceRateTrades(trades=fixture.trades, market=fixture.market)
+    require(all(row.succeeded for row in priced), "passive pricing failed")
+    pvs = [row.pv for row in priced]
+    # Calibration and provenance construction remain entirely outside the timer.
+    return Workload(
+        lambda: dal.AggregateRatePortfolioQuoteRisk(
+            trades=fixture.trades, market=fixture.market, provenances=[provenance]
+        ),
+        lambda value: check_quote_risk(value, fixture, pvs),
+    )
+
+
+def prepare_nodes(count, operation):
+    today, start = dal.Date_(2026, 1, 15), dal.Date_(2026, 4, 15)
+    knots = [dal.Date_(2026, 7, 15)] + [
+        dal.Date_(year, 1, 15) for year in range(2027, 2034)
+    ]
+    components = {
+        key: dal.DiscountPWC_New(key, "USD", knots, [rate] * 8)
+        for key, rate in (("discount", 0.03), ("forecast", 0.035))
+    }
+    market = rate_market(today, components, hour=10, minute=30)
+    ois = operation == "ois"
+    maturity = dal.Date_(2031 if ois else 2036, 4, 15)
+    trades = [
+        irs(today, start, maturity, i, ois=ois) for i in range(1 if ois else count)
+    ]
+    keys = ["forecast"] if ois else ["forecast", "discount"]
+    expected = [
+        dal.RateTradeNodeSensitivities(trade=trade, market=market, component_key=key)
+        for trade in trades
+        for key in keys
+    ]
+    require(all(row.eligible for row in expected), "node-risk reference ineligible")
+
+    def run():
+        if operation in ("single", "ois"):
+            return [
+                dal.RateTradeNodeSensitivities(
+                    trade=trade, market=market, component_key=key
+                )
+                for trade in trades
+                for key in keys
+            ]
+        return dal.RateTradeNodeSensitivitiesBatch(
+            trades=trades, market=market, component_keys=keys
+        )
+
+    def validate(value):
+        rows = [cell.result for cell in value] if operation == "batch" else value
+        require(len(rows) == len(expected), "node-risk cell count changed")
+        for row, reference in zip(rows, expected):
+            require(
+                row.eligible
+                and math.isfinite(row.pv)
+                and all(math.isfinite(x) for x in row.gradient),
+                "node-risk cell failed",
+            )
+            require(
+                row.gradient == reference.gradient and row.pv == reference.pv,
+                "batch/single node risk differs",
+            )
+
+    return Workload(run, validate)

--- a/dal-python/benchmarks/dal_benchmarks/runner.py
+++ b/dal-python/benchmarks/dal_benchmarks/runner.py
@@ -1,0 +1,264 @@
+"""Command-line runner: retain all samples, failures and environment provenance."""
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import time
+
+from .cases import CPP_COVERAGE, build_cases
+from .harness import measure, select_cases
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def git_value(root, *args):
+    try:
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def environment():
+    import dal
+
+    root = Path(__file__).resolve().parents[3]
+    native = Path(dal._dal.__file__).resolve()
+    cache = next(
+        (
+            parent / "CMakeCache.txt"
+            for parent in native.parents
+            if (parent / "CMakeCache.txt").is_file()
+        ),
+        None,
+    )
+    cmake = {}
+    if cache:
+        for line in cache.read_text(encoding="utf-8").splitlines():
+            if line.startswith(
+                (
+                    "CMAKE_BUILD_TYPE:",
+                    "CMAKE_CXX_COMPILER:",
+                    "CMAKE_CXX_FLAGS",
+                    "DAL_USE_",
+                    "DAL_ENABLE_NATIVE_ARCH:",
+                )
+            ):
+                key, value = line.split("=", 1)
+                cmake[key] = value
+    cpu = platform.processor()
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.is_file():
+        cpu = next(
+            (
+                line.split(":", 1)[1].strip()
+                for line in cpuinfo.read_text().splitlines()
+                if line.startswith("model name")
+            ),
+            cpu,
+        )
+    sources = {
+        path.name: sha256(path) for path in sorted(Path(__file__).parent.glob("*.py"))
+    }
+    return {
+        "utc": datetime.now(timezone.utc).isoformat(),
+        "python": sys.version,
+        "executable": sys.executable,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu": cpu,
+        "cpu_count": os.cpu_count(),
+        "dal_version": dal.__version__,
+        "dal_package": str(Path(dal.__file__).resolve()),
+        "native_module": str(native),
+        "native_sha256": sha256(native),
+        "cmake_cache": str(cache) if cache else None,
+        "cmake": cmake,
+        "source_head": git_value(root, "rev-parse", "HEAD"),
+        "source_status": git_value(root, "status", "--porcelain"),
+        "suite_sha256": sources,
+        "thread_environment": {
+            key: os.environ.get(key)
+            for key in (
+                "DAL_NUM_THREADS",
+                "OMP_NUM_THREADS",
+                "OPENBLAS_NUM_THREADS",
+                "MKL_NUM_THREADS",
+            )
+        },
+        "clock": vars(time.get_clock_info("perf_counter")),
+        "provenance_note": "Source HEAD describes this checkout; native SHA256 identifies the loaded binary. An installed wheel may come from a different revision.",
+    }
+
+
+def write_report(output, report):
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "results.json").write_text(
+        json.dumps(report, indent=2, allow_nan=False) + "\n", encoding="utf-8"
+    )
+    lines = [
+        "# DAL Python interface benchmarks",
+        "",
+        f"Profile: {report['profile']}; status: {report['status']}.",
+        "",
+        "Informational in-process timings, including Python/native conversion. No C++ speed ratio or regression verdict is inferred.",
+        "",
+        f"Samples per case: {report['samples']}; warmups: {report['warmups']}; reduction: minimum (median also shown).",
+        "",
+    ]
+    environment_data = report["environment"]
+    for key in (
+        "source_head",
+        "dal_version",
+        "native_module",
+        "native_sha256",
+        "platform",
+        "cpu",
+    ):
+        if key in environment_data:
+            lines.append(f"- {key}: `{environment_data[key]}`")
+    lines += [
+        "",
+        "| Case | C++ target | Min (ms) | Median (ms) | Status |",
+        "|---|---|---:|---:|---|",
+    ]
+    for row in report["results"]:
+        if row["status"] == "passed":
+            lines.append(
+                f"| {row['name']} | {row['cpp_target']} | {row['min_ns'] / 1e6:.6f} | {row['median_ns'] / 1e6:.6f} | passed |"
+            )
+        else:
+            error = row["error"].replace("\n", " ").replace("|", "\\|")
+            lines.append(
+                f"| {row['name']} | {row['cpp_target']} | — | — | FAILED: {error} |"
+            )
+    lines += [
+        "",
+        "## Native coverage",
+        "",
+        "| Target | Coverage | Boundary / gap |",
+        "|---|---|---|",
+    ]
+    for target, entry in CPP_COVERAGE.items():
+        lines.append(f"| {target} | {entry['status']} | {entry['detail']} |")
+    lines += [
+        "",
+        "Raw samples, exact workloads, loaded module hash and environment are in `results.json`.",
+        "",
+    ]
+    (output / "summary.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def parser():
+    value = argparse.ArgumentParser(description=__doc__)
+    value.add_argument(
+        "--smoke",
+        action="store_true",
+        help="reduce paths and portfolio sizes; use only for correctness/smoke checks",
+    )
+    value.add_argument(
+        "--samples",
+        type=int,
+        help="measured invocations per case (default: 10 full, 1 smoke)",
+    )
+    value.add_argument(
+        "--warmups",
+        type=int,
+        help="untimed warmup invocations (default: 2 full, 0 smoke)",
+    )
+    value.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        help="C++ target, repeatable; e.g. rate_risk_perf",
+    )
+    value.add_argument("--filter", default="", help="case-name substring")
+    value.add_argument(
+        "--list", action="store_true", help="list the selected case names and workloads"
+    )
+    value.add_argument(
+        "--coverage",
+        action="store_true",
+        help="print all native targets and Python coverage; no DAL import needed",
+    )
+    value.add_argument(
+        "--output-dir", type=Path, default=Path("benchmark-results/python")
+    )
+    return value
+
+
+def main(argv=None):
+    cli = parser()
+    args = cli.parse_args(argv)
+    if args.coverage:
+        print(json.dumps(CPP_COVERAGE, indent=2))
+        return 0
+    samples = args.samples if args.samples is not None else (1 if args.smoke else 10)
+    warmups = args.warmups if args.warmups is not None else (0 if args.smoke else 2)
+    if samples <= 0 or warmups < 0:
+        cli.error("--samples must be positive and --warmups nonnegative")
+    # Must precede the first DAL import, where the native pool is initialized.
+    os.environ.setdefault("DAL_NUM_THREADS", "4")
+    try:
+        cases = select_cases(build_cases(args.smoke), args.group, args.filter)
+    except ValueError as error:
+        cli.error(str(error))
+    if args.list:
+        for case in cases:
+            print(json.dumps(case.description(), sort_keys=True))
+        return 0
+    report = {
+        "schema": "dal.python-benchmarks/1",
+        "profile": "smoke" if args.smoke else "full",
+        "samples": samples,
+        "warmups": warmups,
+        "environment": environment(),
+        "coverage": CPP_COVERAGE,
+        "status": "running",
+        "results": [],
+    }
+    # Invalidate any older success report before running the first workload.
+    write_report(args.output_dir, report)
+    import dal
+
+    original_date = dal.EvaluationDate_Get()
+    try:
+        for case in cases:
+            try:
+                result = measure(case, samples=samples, warmups=warmups)
+                print(f"{case.name}: {result['min_ns'] / 1e6:.6f} ms (min)", flush=True)
+            except Exception as error:
+                result = dict(
+                    case.description(),
+                    status="failed",
+                    error=f"{type(error).__name__}: {error}",
+                )
+                print(f"{case.name}: FAILED: {error}", file=sys.stderr, flush=True)
+            report["results"].append(result)
+            write_report(args.output_dir, report)
+    finally:
+        dal.EvaluationDate_Set(original_date)
+    report["status"] = (
+        "passed"
+        if all(row["status"] == "passed" for row in report["results"])
+        else "failed"
+    )
+    write_report(args.output_dir, report)
+    return 0 if report["status"] == "passed" else 1

--- a/dal-python/benchmarks/dal_benchmarks/runner.py
+++ b/dal-python/benchmarks/dal_benchmarks/runner.py
@@ -7,7 +7,8 @@ import json
 import os
 from pathlib import Path
 import platform
-import subprocess
+import shutil
+import subprocess  # nosec B404
 import sys
 import time
 
@@ -24,9 +25,17 @@ def sha256(path):
 
 
 def git_value(root, *args):
+    if args not in (("rev-parse", "HEAD"), ("status", "--porcelain")):
+        raise ValueError("unsupported Git metadata query")
+    executable = shutil.which("git")
+    if executable is None:
+        return None
     try:
-        return subprocess.run(
-            ["git", "-C", str(root), *args],
+        # Resolve the fixed tool, allow only the two read-only queries above, and
+        # pass the checkout path literally without shell expansion.
+        return subprocess.run(  # nosec B603  # nosemgrep
+            [str(Path(executable).resolve()), "-C", str(root), *args],
+            shell=False,
             check=True,
             capture_output=True,
             text=True,
@@ -36,11 +45,7 @@ def git_value(root, *args):
         return None
 
 
-def environment():
-    import dal
-
-    root = Path(__file__).resolve().parents[3]
-    native = Path(dal._dal.__file__).resolve()
+def cmake_environment(native):
     cache = next(
         (
             parent / "CMakeCache.txt"
@@ -63,6 +68,10 @@ def environment():
             ):
                 key, value = line.split("=", 1)
                 cmake[key] = value
+    return str(cache) if cache else None, cmake
+
+
+def cpu_model():
     cpu = platform.processor()
     cpuinfo = Path("/proc/cpuinfo")
     if cpuinfo.is_file():
@@ -74,6 +83,15 @@ def environment():
             ),
             cpu,
         )
+    return cpu
+
+
+def environment():
+    import dal
+
+    root = Path(__file__).resolve().parents[3]
+    native = Path(dal._dal.__file__).resolve()
+    cache, cmake = cmake_environment(native)
     sources = {
         path.name: sha256(path) for path in sorted(Path(__file__).parent.glob("*.py"))
     }
@@ -83,13 +101,13 @@ def environment():
         "executable": sys.executable,
         "platform": platform.platform(),
         "machine": platform.machine(),
-        "cpu": cpu,
+        "cpu": cpu_model(),
         "cpu_count": os.cpu_count(),
         "dal_version": dal.__version__,
         "dal_package": str(Path(dal.__file__).resolve()),
         "native_module": str(native),
         "native_sha256": sha256(native),
-        "cmake_cache": str(cache) if cache else None,
+        "cmake_cache": cache,
         "cmake": cmake,
         "source_head": git_value(root, "rev-parse", "HEAD"),
         "source_status": git_value(root, "status", "--porcelain"),
@@ -204,31 +222,40 @@ def parser():
     return value
 
 
-def main(argv=None):
+def arguments(argv):
     cli = parser()
     args = cli.parse_args(argv)
-    if args.coverage:
-        print(json.dumps(CPP_COVERAGE, indent=2))
-        return 0
-    samples = args.samples if args.samples is not None else (1 if args.smoke else 10)
-    warmups = args.warmups if args.warmups is not None else (0 if args.smoke else 2)
-    if samples <= 0 or warmups < 0:
+    if args.samples is None:
+        args.samples = 1 if args.smoke else 10
+    if args.warmups is None:
+        args.warmups = 0 if args.smoke else 2
+    if args.samples <= 0 or args.warmups < 0:
         cli.error("--samples must be positive and --warmups nonnegative")
-    # Must precede the first DAL import, where the native pool is initialized.
-    os.environ.setdefault("DAL_NUM_THREADS", "4")
+    return cli, args
+
+
+def run_case(case, samples, warmups):
     try:
-        cases = select_cases(build_cases(args.smoke), args.group, args.filter)
-    except ValueError as error:
-        cli.error(str(error))
-    if args.list:
-        for case in cases:
-            print(json.dumps(case.description(), sort_keys=True))
-        return 0
+        result = measure(case, samples=samples, warmups=warmups)
+        print(f"{case.name}: {result['min_ns'] / 1e6:.6f} ms (min)", flush=True)
+        return result
+    except Exception as error:
+        print(f"{case.name}: FAILED: {error}", file=sys.stderr, flush=True)
+        return dict(
+            case.description(),
+            status="failed",
+            error=f"{type(error).__name__}: {error}",
+        )
+
+
+def run_cases(cases, args):
+    import dal
+
     report = {
         "schema": "dal.python-benchmarks/1",
         "profile": "smoke" if args.smoke else "full",
-        "samples": samples,
-        "warmups": warmups,
+        "samples": args.samples,
+        "warmups": args.warmups,
         "environment": environment(),
         "coverage": CPP_COVERAGE,
         "status": "running",
@@ -236,22 +263,10 @@ def main(argv=None):
     }
     # Invalidate any older success report before running the first workload.
     write_report(args.output_dir, report)
-    import dal
-
     original_date = dal.EvaluationDate_Get()
     try:
         for case in cases:
-            try:
-                result = measure(case, samples=samples, warmups=warmups)
-                print(f"{case.name}: {result['min_ns'] / 1e6:.6f} ms (min)", flush=True)
-            except Exception as error:
-                result = dict(
-                    case.description(),
-                    status="failed",
-                    error=f"{type(error).__name__}: {error}",
-                )
-                print(f"{case.name}: FAILED: {error}", file=sys.stderr, flush=True)
-            report["results"].append(result)
+            report["results"].append(run_case(case, args.samples, args.warmups))
             write_report(args.output_dir, report)
     finally:
         dal.EvaluationDate_Set(original_date)
@@ -262,3 +277,21 @@ def main(argv=None):
     )
     write_report(args.output_dir, report)
     return 0 if report["status"] == "passed" else 1
+
+
+def main(argv=None):
+    cli, args = arguments(argv)
+    if args.coverage:
+        print(json.dumps(CPP_COVERAGE, indent=2))
+        return 0
+    # Must precede the first DAL import, where the native pool is initialized.
+    os.environ.setdefault("DAL_NUM_THREADS", "4")
+    try:
+        cases = select_cases(build_cases(args.smoke), args.group, args.filter)
+    except ValueError as error:
+        cli.error(str(error))
+    if args.list:
+        for case in cases:
+            print(json.dumps(case.description(), sort_keys=True))
+        return 0
+    return run_cases(cases, args)

--- a/dal-python/benchmarks/dal_benchmarks/simulation.py
+++ b/dal-python/benchmarks/dal_benchmarks/simulation.py
@@ -1,0 +1,144 @@
+"""RNG and script workloads matching the native benchmark inputs."""
+
+import json
+import math
+
+import dal
+
+from .harness import Workload, require
+
+
+def prepare_rng(kind, paths):
+    def run():
+        if kind == "mrg32_normal":
+            return dal.PseudoRSG_Get_Normal(dal.PseudoRSG_New(1024, 10), paths)
+        precise = kind == "sobol_normal_precise"
+        generator = dal.SobolRSG_New(0, 10, precise=precise, polish=precise)
+        fill = (
+            dal.SobolRSG_Get_Uniform
+            if kind == "sobol_uniform"
+            else dal.SobolRSG_Get_Normal
+        )
+        return fill(generator, paths)
+
+    # Reinitializing on every call matches rng_perf and makes each sample identical.
+    reference = run()
+    expected = [reference(i, j) for i in (0, paths // 2, paths - 1) for j in (0, 9)]
+
+    def validate(value):
+        require((value.Rows(), value.Cols()) == (paths, 10), "RNG shape changed")
+        actual = [value(i, j) for i in (0, paths // 2, paths - 1) for j in (0, 9)]
+        require(
+            actual == expected and all(math.isfinite(x) for x in actual),
+            "RNG is not finite/repeatable",
+        )
+        if kind == "sobol_uniform":
+            require(all(0 <= x <= 1 for x in actual), "uniform RNG outside [0, 1]")
+
+    return Workload(run, validate)
+
+
+def script_inputs(kind):
+    if kind == "construct":
+        dal.EvaluationDate_Set(dal.Date_(2022, 9, 25))
+        return (
+            [
+                "BARRIER",
+                "STRIKE",
+                dal.Date_(2022, 9, 25),
+                "START: 2022-09-25\nEND: 2025-09-25\nFREQ: 1W",
+                dal.Date_(2025, 9, 25),
+            ],
+            [
+                "150.00",
+                "120.00",
+                "alive = 1",
+                "IF spot() > BARRIER:0.1 THEN alive = 0 END",
+                "IF spot() > BARRIER:0.1 THEN alive = 0 END uoc pays alive * MAX(spot() - STRIKE, 0.0)",
+            ],
+        )
+    dal.EvaluationDate_Set(dal.Date_(2024, 1, 1))
+    if kind == "vanilla":
+        return ["STRIKE", dal.Date_(2025, 1, 1)], [
+            "100.0",
+            "call pays MAX(spot() - STRIKE, 0.0)",
+        ]
+    return (
+        [
+            "STRIKE",
+            "BARRIER",
+            dal.Date_(2024, 1, 1),
+            "START: 2024-01-01 END: 2025-01-01 FREQ: 1W",
+            dal.Date_(2025, 1, 1),
+        ],
+        [
+            "100.0",
+            "150.0",
+            "alive = 1",
+            "if spot() >= BARRIER:0.1 then alive = 0 end",
+            "uoc pays alive * MAX(spot() - STRIKE, 0.0)",
+        ],
+    )
+
+
+def prepare_script():
+    dates, events = script_inputs("construct")
+    expected = json.loads(dal.Product_DebugJson(dal.Product_New(dates, events)))
+    return Workload(
+        # Product_New only stores event data. The dump call is what actually
+        # constructs ScriptProduct_ and executes the native frontend.
+        lambda: dal.Product_DebugJson(dal.Product_New(dates, events)),
+        lambda result: require(json.loads(result) == expected, "script AST changed"),
+    )
+
+
+def prepare_mc(kind, aad, compiled, paths):
+    dates, events = script_inputs(kind)
+
+    def run(use_compiled=compiled):
+        # Like script_mc_perf, product/model construction and preprocessing are timed.
+        return dal.MonteCarlo_Value(
+            dal.Product_New(dates, events),
+            dal.BSModelData_New(100, 0.2, 0.05, 0.02),
+            paths,
+            "sobol",
+            False,
+            aad,
+            0.01,
+            use_compiled,
+        )
+
+    reference = run(not compiled)
+
+    def validate(result):
+        require(
+            result.keys() == reference.keys() and "PV" in result,
+            "MC result keys changed",
+        )
+        require(
+            all(
+                math.isfinite(v)
+                and math.isclose(v, reference[k], rel_tol=1e-10, abs_tol=1e-9)
+                for k, v in result.items()
+            ),
+            "tree/compiled MC results disagree",
+        )
+        require(result["PV"] > 0, "MC payoff missing")
+        if aad:
+            require(any(k.startswith("d_") for k in result), "AAD Greeks missing")
+        if kind == "vanilla":
+            years = (dal.Date_(2025, 1, 1) - dal.Date_(2024, 1, 1)) / 365
+            d1 = (0.05 - 0.02 + 0.5 * 0.2**2) * math.sqrt(years) / 0.2
+            d2 = d1 - 0.2 * math.sqrt(years)
+
+            def cdf(x):
+                return (1 + math.erf(x / math.sqrt(2))) / 2
+
+            price = 100 * (
+                math.exp(-0.02 * years) * cdf(d1) - math.exp(-0.05 * years) * cdf(d2)
+            )
+            require(
+                abs(result["PV"] - price) < 0.4, "MC differs from Black-Scholes oracle"
+            )
+
+    return Workload(run, validate)

--- a/dal-python/benchmarks/dal_benchmarks/xccy.py
+++ b/dal-python/benchmarks/dal_benchmarks/xccy.py
@@ -1,0 +1,255 @@
+"""Joint and staged XCCY calibration, provenance and aggregation workloads."""
+
+import math
+
+import dal
+
+from .calibration import calibration_options, index, leg
+from .harness import Workload, require
+from .risk import RiskFixture, rate_market
+
+
+def config():
+    convention = dal.CrossCurrencyConvention_()
+    convention.initial_notional_exchange = True
+    convention.final_notional_exchange = True
+    convention.spread_on_foreign_leg = True
+    convention.domestic_index = index(True)
+    convention.foreign_index = index(True)
+    convention.domestic_leg = leg(3)
+    convention.foreign_leg = leg(3)
+    value = dal.CrossCurrencySwapConfig_()
+    value.pair = dal.CurrencyPair_New("USD", "EUR")
+    value.domestic_notional, value.foreign_notional = 110.0, 100.0
+    value.convention = convention
+    value.notional_mode = dal.XccyNotionalMode.FIXED
+    return value
+
+
+def trade(today, maturity, ordinal, trade_config):
+    terms = dal.XccyTradeTerms_(
+        position_count=10_000.0,
+        contract_spread=0.0015,
+        spread_on_foreign_leg=True,
+        receive_non_spread_pay_spread=True,
+        config=trade_config,
+    )
+    return dal.RateTradeDefinition_(
+        instrument_id=f"xccy-{ordinal}",
+        instrument_type=dal.RateInstrumentType.XCCY,
+        trade_date=today,
+        start_date=today,
+        maturity_date=maturity,
+        currency="USD",
+        terms=terms,
+    )
+
+
+def currency_spec(today, ccy, width):
+    declarations = []
+    for projected in (False, True):
+        declaration = dal.JointCurveDeclaration_()
+        declaration.curve_name = f"{ccy}_{'3m' if projected else 'ois'}"
+        declaration.parameterization = dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
+        declaration.calibrate_discount_curve = not projected
+        declaration.target_collateral = dal.CollateralType_OIS()
+        declaration.target_tenor = dal.PeriodLength_New("3M")
+        declaration.knot_dates = [dal.Date_(2025 + i, 7, 16) for i in range(width)]
+        rate = (0.015 if ccy == "USD" else 0.01) + (0.009 if projected else 0)
+        declaration.instruments = [
+            dal.Deposit_New(
+                today,
+                today,
+                dal.Date_(2026 + i, 1, 16),
+                math.expm1(rate * ((dal.Date_(2026 + i, 1, 16) - today) / 365))
+                / ((dal.Date_(2026 + i, 1, 16) - today) / 365),
+                index(projected),
+            )
+            for i in range(width)
+        ]
+        declarations.append(declaration)
+    value = dal.JointCurrencyCurveSpec_()
+    value.ccy = dal.Ccy_(ccy)
+    value.libor_basis = dal.DayBasis_New("ACT_365F")
+    value.curves = declarations
+    return value
+
+
+def fixed_block(ccy, width):
+    knots = [dal.Date_(2026 + i, 1, 16) for i in range(width)]
+    discount = dal.DiscountPWC_New(
+        f"{ccy}_ois", ccy, knots, [0.015 if ccy == "USD" else 0.01] * width
+    )
+    forward = dal.DiscountPWC_New(
+        f"{ccy}_3m", ccy, knots, [0.024 if ccy == "USD" else 0.019] * width
+    )
+    return dal.CurveBlock_New(
+        ccy,
+        ccy,
+        {dal.CollateralType_OIS(): discount},
+        {dal.PeriodLength_New("3M"): forward},
+        dal.DayBasis_New("ACT_365F"),
+    )
+
+
+def spec_for(kind, width):
+    today = dal.Date_(2025, 1, 16)
+    trade_config = config()
+    knots = [dal.Date_(2026 + i, 1, 16) for i in range(width)]
+    instruments = [
+        dal.CrossCurrencySwap_New(
+            today, today, dal.Date_(2026 + i, 7, 16), 0.001 + 0.0001 * i, trade_config
+        )
+        for i in range(width)
+    ]
+    if kind == "joint":
+        basis = dal.XccyBasisCurveDeclaration_()
+        basis.curve_name, basis.knot_dates, basis.instruments = (
+            "usd_eur_basis",
+            knots,
+            instruments,
+        )
+        basis.parameterization = dal.CurveParameterization.PIECEWISE_CONSTANT_FWD
+        builder = dal.JointXccyCalibrationSpecBuilder_()
+        builder.valuation_time = dal.DateTime_(today, 9, 0)
+        builder.pair = trade_config.pair
+        builder.collateral_currency = dal.Ccy_("USD")
+        builder.fx_spot = 1.10
+        builder.domestic = currency_spec(today, "USD", width)
+        builder.foreign = currency_spec(today, "EUR", width)
+        builder.basis = basis
+        builder.fixings = dal.MarketFixingSnapshot_New({})
+        builder.solver_options.initial_guess = 0.005
+        builder.solver_options.tolerance = 1e-10
+        builder.solver_options.max_evaluations = 1000
+    else:
+        builder = dal.CrossCurrencyCalibrationSpecBuilder_()
+        builder.today = today
+        builder.valuation_time = dal.DateTime_(today, 9, 0)
+        builder.basis_pair = trade_config.pair
+        builder.collateral_currency = dal.Ccy_("USD")
+        builder.domestic_curve_block, builder.foreign_curve_block = (
+            fixed_block("USD", width),
+            fixed_block("EUR", width),
+        )
+        builder.fx_spot, builder.initial_guess, builder.tolerance = 1.10, 0.001, 1e-10
+        builder.fixings = dal.MarketFixingSnapshot_New({})
+        builder.knot_dates, builder.instruments = knots, instruments
+    return builder.Build()
+
+
+def calibrator(kind):
+    return dal.CalibrateJointXccyMarket if kind == "joint" else dal.CalibrateXccyMarket
+
+
+def check_calibration(value, kind, width, diagnostics, mode):
+    if kind == "joint":
+        require(value.converged, "joint XCCY calibration did not converge")
+        residuals, matrix = value.residuals, value.jacobian_at_solution
+        require(len(residuals) == 5 * width, "joint XCCY residual count changed")
+    else:
+        residuals, matrix = value.diagnostics.residuals, value.diagnostics.jacobian
+        require(len(residuals) == width, "staged XCCY residual count changed")
+    require(
+        all(math.isfinite(r) and abs(r) < 1e-7 for r in residuals),
+        "XCCY residual too large",
+    )
+    require(
+        matrix.rows() == (len(residuals) if diagnostics and mode == "ANALYTIC" else 0),
+        "XCCY Jacobian retention changed",
+    )
+
+
+def prepare_calibration(kind, mode, diagnostics, width=5):
+    spec = spec_for(kind, width)
+    options = calibration_options(mode, diagnostics, kind)
+    return Workload(
+        lambda: calibrator(kind)(spec, options),
+        lambda value: check_calibration(value, kind, width, diagnostics, mode),
+    )
+
+
+def fixture(kind, width, count, mode):
+    today = dal.Date_(2025, 1, 16)
+    spec = spec_for(kind, width)
+    options = calibration_options(mode, kind=kind)
+    options.compute_forward_jacobian = False
+    result = calibrator(kind)(spec, options)
+    if kind == "joint":
+        blocks = (result.domestic_curve_block, result.foreign_curve_block)
+        curves = []
+        for block in blocks:
+            curves.extend(
+                (
+                    next(iter(block.discount_curves.values())),
+                    next(iter(block.forward_curves.values())),
+                )
+            )
+        curves.append(result.basis_curve)
+        bindings = {
+            entry.name: f"component-{i}"
+            for i, entry in enumerate(result.parameter_ranges)
+        }
+        require(len(bindings) == len(curves), "joint XCCY parameter blocks changed")
+        components = {f"component-{i}": curve for i, curve in enumerate(curves)}
+        xccy_market = dal.CrossCurrencyMarket_New(
+            domestic_block=blocks[0],
+            foreign_block=blocks[1],
+            fx_spot=1.10,
+            valuation_time=dal.DateTime_(today, 9, 0),
+            collateral_currency="USD",
+            fixings=result.fixings,
+            basis_curve=result.basis_curve,
+        )
+        build_function = dal.BuildJointXccyQuoteRiskProvenance
+    else:
+        components = {"basis": result.basis_curve}
+        bindings = {"basis:xccy_basis_USD": "basis"}
+        xccy_market = result.market
+        build_function = dal.BuildStagedXccyBasisQuoteRiskProvenance
+    market = rate_market(today, components, xccy_market)
+    provenance_config = dal.RateQuoteRiskProvenanceConfig_(
+        calibration_id=f"{kind}-quote-bench", component_key_by_parameter_block=bindings
+    )
+
+    def build():
+        return build_function(
+            spec=spec,
+            result=result,
+            options=options,
+            bound_market=market,
+            config=provenance_config,
+        )
+
+    maturity = dal.Date_(2025 + width, 1 if kind == "joint" else 7, 16)
+    trades = [trade(today, maturity, i, config()) for i in range(count)]
+    return RiskFixture(market, trades, build, width * (5 if kind == "joint" else 1))
+
+
+def prepare_nodes(count):
+    data = fixture("joint", 5, count, "ANALYTIC")
+    keys = [f"component-{i}" for i in range(5)]
+    expected = [
+        dal.RateTradeNodeSensitivities(trade=t, market=data.market, component_key=k)
+        for t in data.trades
+        for k in keys
+    ]
+
+    def validate(value):
+        require(len(value) == 5 * count, "XCCY node cell count changed")
+        for cell, reference in zip(value, expected):
+            require(
+                cell.result.eligible and reference.eligible, "XCCY node cell ineligible"
+            )
+            require(
+                cell.result.gradient == reference.gradient
+                and math.isfinite(cell.result.pv),
+                "XCCY batch/single disagreement",
+            )
+
+    return Workload(
+        lambda: dal.RateTradeNodeSensitivitiesBatch(
+            trades=data.trades, market=data.market, component_keys=keys
+        ),
+        validate,
+    )

--- a/dal-python/benchmarks/run_benchmarks.py
+++ b/dal-python/benchmarks/run_benchmarks.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Run from any directory with a current DAL wheel or explicit build PYTHONPATH."""
+
+from dal_benchmarks.runner import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dal-python/tests/test_benchmarks.py
+++ b/dal-python/tests/test_benchmarks.py
@@ -1,0 +1,204 @@
+"""Correctness and evidence contracts for the opt-in performance suite."""
+
+import json
+from pathlib import Path
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "benchmarks"))
+
+from dal_benchmarks.harness import Case, Workload, measure, select_cases
+from dal_benchmarks.cases import CPP_COVERAGE, build_cases
+
+
+def test_measure_keeps_setup_and_validation_outside_timing():
+    events = []
+
+    def prepare():
+        events.append("prepare")
+        return Workload(
+            lambda: events.append("run") or 7, lambda value: events.append("validate")
+        )
+
+    ticks = iter((10, 20, 30, 60))
+
+    def clock():
+        events.append("clock")
+        return next(ticks)
+
+    case = Case("example", "rng_perf", {"paths": 10}, prepare)
+    result = measure(case, samples=2, warmups=1, clock=clock)
+    assert result["samples_ns"] == [10, 30]
+    assert result["min_ns"] == 10
+    assert result["median_ns"] == 20
+    assert events == [
+        "prepare",
+        "run",
+        "validate",
+        "run",
+        "validate",
+        "clock",
+        "run",
+        "clock",
+        "validate",
+        "clock",
+        "run",
+        "clock",
+        "validate",
+    ]
+
+
+def test_invalid_results_cannot_be_reported_as_timings():
+    def reject(value):
+        raise ValueError("incorrect output")
+
+    case = Case("bad", "rng_perf", {}, lambda: Workload(lambda: 0, reject))
+    with pytest.raises(ValueError, match="incorrect output"):
+        measure(case, samples=1, warmups=0)
+
+
+def test_invalid_measured_sample_cannot_follow_a_passing_preflight():
+    outputs = iter([7, 0])
+
+    def validate(value):
+        if value != 7:
+            raise ValueError("measured output changed")
+
+    case = Case(
+        "bad_sample", "rng_perf", {}, lambda: Workload(lambda: next(outputs), validate)
+    )
+    with pytest.raises(ValueError, match="measured output changed"):
+        measure(case, samples=1, warmups=0)
+
+
+def test_script_frontend_runs_inside_timing(monkeypatch):
+    import dal
+    from dal_benchmarks.simulation import prepare_script
+
+    events = []
+    original = dal.Product_DebugJson
+
+    def dump(product):
+        events.append("parse")
+        return original(product)
+
+    def clock():
+        events.append("clock")
+        return len(events)
+
+    monkeypatch.setattr(dal, "Product_DebugJson", dump)
+    case = Case("frontend", "script_perf", {}, prepare_script)
+    measure(case, samples=1, warmups=0, clock=clock)
+    assert events[-3:] == ["clock", "parse", "clock"]
+
+
+def test_selection_rejects_empty_or_unknown_groups():
+    case = Case("rng.normal", "rng_perf", {}, lambda: None)
+    assert select_cases([case], ["rng_perf"], "normal") == [case]
+    with pytest.raises(ValueError, match="Unknown"):
+        select_cases([case], ["typo"], "")
+    with pytest.raises(ValueError, match="No benchmark"):
+        select_cases([case], [], "missing")
+
+
+def test_cpp_target_inventory_has_no_unexplained_gaps():
+    root = Path(__file__).resolve().parents[2]
+    cmake = (root / "dal-cpp/benchmarks/CMakeLists.txt").read_text()
+    targets = set(re.findall(r"\b\w+_perf\b", cmake))
+    assert set(CPP_COVERAGE) == targets
+    cases = build_cases(smoke=True)
+    assert len({case.name for case in cases}) == len(cases)
+    covered = {case.cpp_target for case in cases}
+    assert covered == {
+        name for name, entry in CPP_COVERAGE.items() if entry["status"] == "partial"
+    }
+    assert all(entry["detail"] for entry in CPP_COVERAGE.values())
+    json.dumps([case.description() for case in cases], allow_nan=False)
+
+
+@pytest.mark.parametrize("case", build_cases(smoke=True), ids=lambda case: case.name)
+def test_smoke_workload_validates_through_python_api(case):
+    # This verifies real native results without introducing timing thresholds in CI.
+    result = measure(case, samples=1, warmups=0)
+    assert result["min_ns"] > 0
+
+
+def test_runner_retains_failures_and_restores_evaluation_date(tmp_path, monkeypatch):
+    import dal
+    from dal_benchmarks import runner
+
+    original = dal.EvaluationDate_Get()
+
+    def prepare():
+        dal.EvaluationDate_Set(dal.Date_(2030, 1, 1))
+        raise ValueError("invalid fixture")
+
+    monkeypatch.setattr(
+        runner, "build_cases", lambda smoke: [Case("bad", "rng_perf", {}, prepare)]
+    )
+    monkeypatch.setattr(runner, "environment", lambda: {})
+    assert runner.main(["--smoke", "--output-dir", str(tmp_path)]) == 1
+    report = json.loads((tmp_path / "results.json").read_text())
+    assert report["status"] == "failed"
+    assert "invalid fixture" in report["results"][0]["error"]
+    assert "samples_ns" not in report["results"][0]
+    assert dal.EvaluationDate_Get() == original
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--samples", "0"],
+        ["--warmups", "-1"],
+        ["--filter", "does-not-exist"],
+        ["--group", "typo"],
+    ],
+)
+def test_runner_rejects_invalid_requests(arguments):
+    from dal_benchmarks.runner import main
+
+    with pytest.raises(SystemExit) as caught:
+        main(arguments)
+    assert caught.value.code == 2
+
+
+def test_report_round_trip_preserves_raw_samples_and_binary_provenance(tmp_path):
+    from dal_benchmarks.runner import main
+
+    assert (
+        main(
+            [
+                "--smoke",
+                "--filter",
+                "sobol_uniform",
+                "--samples",
+                "2",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+    report = json.loads((tmp_path / "results.json").read_text())
+    assert report["status"] == "passed"
+    assert len(report["results"]) == 1
+    assert len(report["results"][0]["samples_ns"]) == 2
+    assert report["results"][0]["workload"]["paths"] == 1024
+    assert Path(report["environment"]["native_module"]).is_file()
+    assert len(report["environment"]["native_sha256"]) == 64
+    assert set(report["coverage"]) == set(CPP_COVERAGE)
+
+
+def test_full_profile_preserves_native_path_and_portfolio_sizes():
+    cases = {case.name: case.workload for case in build_cases()}
+    assert cases["rng.sobol_normal_fast"]["paths"] == 100_000
+    assert cases["mc.vanilla.double.tree"]["paths"] == 200_000
+    assert cases["mc.barrier.aad.compiled"]["paths"] == 10_000
+    assert cases["calibration.PWC.BUMPED.diagnostics"]["swaps"] == 23
+    assert cases["nodes.batch"]["trades"] == 120
+    assert cases["nodes.xccy"]["trades"] == 24
+    for width in (5, 10, 16):
+        assert cases[f"quotes.generic.n{width}.t1000"]["trades"] == 1000
+        assert cases[f"quotes.generic.n{width}.t1000"]["quotes"] == width

--- a/dal-python/tests/test_benchmarks.py
+++ b/dal-python/tests/test_benchmarks.py
@@ -202,3 +202,37 @@ def test_full_profile_preserves_native_path_and_portfolio_sizes():
     for width in (5, 10, 16):
         assert cases[f"quotes.generic.n{width}.t1000"]["trades"] == 1000
         assert cases[f"quotes.generic.n{width}.t1000"]["quotes"] == width
+
+
+def test_metadata_git_command_rejects_non_metadata_arguments(tmp_path, monkeypatch):
+    from dal_benchmarks import runner
+
+    def unexpected(*args, **kwargs):
+        pytest.fail("unapproved Git operation reached subprocess")
+
+    monkeypatch.setattr(runner.subprocess, "run", unexpected)
+    with pytest.raises(ValueError, match="metadata"):
+        runner.git_value(tmp_path, "config", "user.name", "changed")
+
+
+def test_metadata_git_uses_resolved_tool_and_literal_arguments(tmp_path, monkeypatch):
+    from dal_benchmarks import runner
+    from types import SimpleNamespace
+
+    executable = str(tmp_path / "tools/git")
+    monkeypatch.setattr(runner.shutil, "which", lambda name: executable)
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="commit\n")
+
+    monkeypatch.setattr(runner.subprocess, "run", run)
+    root = tmp_path / "repo with spaces; literal"
+    assert runner.git_value(root, "rev-parse", "HEAD") == "commit"
+    command, options = calls[0]
+    assert command == [executable, "-C", str(root), "rev-parse", "HEAD"]
+    assert options["shell"] is False
+    monkeypatch.setattr(runner.shutil, "which", lambda name: None)
+    assert runner.git_value(root, "status", "--porcelain") is None
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

- Add 70 Python public-interface benchmark cases for RNG, script construction/MC, curve and XCCY calibration, node risk, and quote-risk provenance/aggregation. Map all 21 C++ benchmark targets, documenting partial coverage, unbound kernels, and fixture differences.
- Add a required Python performance comparison to the existing Linux benchmark job. Independent base/head Release builds run the same full head workload suite, including when the baseline predates the suite. Each case uses two rounds of ten interleaved process samples per side; regression requires a strictly greater than 4% slowdown in both rounds using the best sample from each round.
- Fail the gate on correctness errors, removed cases, incomplete results, unexpected imports, or incompatible builds/workloads. Retain module/source identities, raw timings, logs, and summaries in the existing 30-day benchmark artifact. Windows runs the correctness/smoke tests; paired timing is Linux-only.

## Test plan

- [x] Run the complete Python suite against each of two independent Release builds: 372 passed per build. After review fixes, recheck the publication clone: 374 passed, including two Git metadata command-safety tests.
- [x] Run all 70 full-scale workloads with ten samples each: 700 timing samples passed validation.
- [x] Exercise the complete paired gate against independently built copies of baseline `1abb3d4b`, including a base checkout without the new suite: 70 cases and 2,800 timing samples passed. This is a same-native-revision control validating the gate, not a claimed performance improvement.
- [x] Run CI-script unit tests: 159 tests, 153 passed and 6 platform-specific skips; cover the strict 4% boundary, confirmation rounds, removed/new coverage, worker failures, stale output, and build/workload identity checks.
- [x] Pass CPython 3.9 syntax checks (52 files), Ruff checks/formatting, documentation checks (50 Markdown files), workflow YAML/shell validation, and staged patch whitespace checks.
- [x] Address Codacy complexity/security findings; pass Lizard with maximum complexity 8 and Bandit. Re-run all 70 full-scale workloads after refactoring and verify unchanged case inventory and workload parameters. Align the README tables requested in review.
- [x] Complete remote CI for `74cbe444`: 46 successful checks and one expected PyPI-publish skip; Codacy reports zero issues and the review thread is resolved. [Linux CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34508736888), [Windows CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34508736950), [wheel CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34508736958).
- [x] Verify the uploaded Linux benchmark artifact: all 70 Python cases and 2,800 raw samples pass the two-round 4% gate; the existing nine-target C++ gate also passes. The tested merge-ref tree matches the PR head and benchmark source hashes match the reviewed files.
