### PR TITLE
fix: restore joint quote risk through base curves (DAL-193)

### DIFF
--- a/.codex/artifacts/reviews/dal-193/implementation.md
+++ b/.codex/artifacts/reviews/dal-193/implementation.md
@@ -12,6 +12,7 @@ B1 now propagates joint quote risk through the actual consumed curve/base graph,
 - Initial verified code head: `9a847361081ebd3b5450cb9273a1c7597f369e10`.
 - First draft head: `fb01602a99dbe694ad68b1ea9eaf97d072eb4fd4`, adding this record only.
 - The CI repair below updates the same draft PR; its exact published head and single post-push CI snapshot are recorded in the follow-up evidence archive and Multica handoff comment.
+- The subsequent review repair and master integration are separate commits, mapped below. The final record-only head and its single CI snapshot are included in the review-repair handoff.
 
 Controlling inputs were the approved B1 specification, API note, and `Proceed with caveats` critique attached to DAL-193. Their attachment IDs are respectively `01a08bfd-6b19-74bf-afcf-6a80c73d5dd4`, `01a08c0e-1962-74dc-98bf-c139a7159b26`, and `01a08c1b-9290-7c4b-a8e5-68b2e4b777f8`. Q1 and B2 remain excluded.
 
@@ -194,6 +195,54 @@ build/Release-linux/dal-cpp/dal_cpp_tests \
 - The static comparison confirms that all original assertion expressions and test case names remain; only the helper failure-propagation assertion was added. Patch whitespace checks passed. No threshold, gate configuration, public contract, numeric assertion, or excluded Q1/B2 scope changed.
 
 Per the explicit follow-up instruction, this turn runs directed build/regression/static checks only. The initial 1552-test full native validation, Python/public/Excel results, independent oracle files, generated-source/docs/helper checks, and nine-target performance evidence above remain reusable prior-head evidence, not new-head full-suite claims. Actual MSVC builds, Windows Benchmarks, hosted Codacy, wheels, the full backend matrix, and final-head complete local/CI acceptance remain for the subsequent pipeline. One CI snapshot will be read after pushing this repair; this implementation phase does not wait for CI completion or merge.
+
+## Review repair of `908b2f0`
+
+Controlling review: attachment `01a08c86-2f03-78ab-9865-a9a71d42869f`, verdict `Request Changes` on `908b2f0ce8f7de7f04091563f6720feb76d572fd`. The tester had completed full native validation and both oracle audits on that head (attachment `01a08c7a-d5e2-77ff-a8b9-46341edd4cc2`); those results did not cover the mixed-source counterexample or the A3/F05 combinations. This follow-up addresses the three findings locally and awaits independent tester/reviewer acceptance.
+
+### P1: mixed v1/joint source order
+
+The new `TestXccyProvenanceOrderPreservesStandaloneAndJointResults` was first built and run with unchanged `908b2f0` production code. RED: one expected failure, with v1 ineligible and `AAD_EVALUATION_FAILED` for `[joint, single]`; `[single, joint]` and each independent source were successful. The test compares every meta field, every bucket field and numerical value, PV totals, and the single passive-pricing count against separate calls.
+
+The minimal fix keys XCCY hoists by both trade identity and coordinate mode, using two private maps. Standalone preparation and joint lazy/historical preparation remain separate; passive pricing stays shared per trade. GREEN: the same regression and three adjacent historical/standalone XCCY controls passed. No test assertion was weakened.
+
+### P2: A3/S03 native-coordinate oracle
+
+Two new tests rebuild `PWLF extra -> ZeroRate -> LogDF -> PWC middle -> H0/H1`, with historical knots and fixed extra-layer parameters. Both PWC/PWLF calibrated layouts and layered/unlayered forward declarations are covered, giving eight topology configurations. For every consumed native coordinate, the test clones passive curves, applies only that coordinate's native `ApplyDX` shift, rebuilds the full dependent chain, and compares the central PV difference with `JointNodeSensitivitiesBatch` using an absolute `1e-3` derivative tolerance. It performs no recalibration or quote-Jacobian projection in this oracle.
+
+The checks also compare all unchanged native parameters, assert the target forward's original base handle remains fixed when its own parameters are shifted, require active/passive PV agreement within `1e-8`, verify native widths, and verify the unused H1 slice and original five quote buckets in the H0-only topology. The four extra-layer representations are exact builtin types; their own parameters and geometry are reconstructed from unchanged fixture values. Both tests passed.
+
+### P2: F05 preparation failures
+
+The necessary private seam runs only after a joint preparation cache miss, inside the existing exception/failure-cache boundary. It throws for selected exact PWC intermediate handles; it does not reuse the early sweep or opaque-graph seams.
+
+The new test covers 12 contexts: H0-only failure, H1-only failure, and simultaneous failures, each with two deterministic relative-address orders and two extra-key orders. An owning array permits reversing which independent base path occupies the lower address, verified with `std::less`; this is not an allocator-order assumption. Bound keys deliberately have reverse lexical order (`z-discount`, `a-forward`). Each individual path is exercised before the dual-failure case. Single failures produce the corresponding complete G(K0)/G(K1); simultaneous failures always produce G(K0).
+
+For each context the test checks no failed-trade buckets, complete failure metadata, retained passive PV, and exact healthy-trade buckets. A repeated failed trade in the same aggregation triggers the failed-preparation cache: the affected preparation hook is attempted only once. H1-only failure proves an earlier H0 sweep occurred and was discarded. Healthy contributions and their sweeps remain intact; a later call without the seam reproduces the original successful result. All contexts passed.
+
+### Commit mapping and integration
+
+- P1 RED test: `78ed201d1dd839096ec45ae9ae5e6ef4c210a344`.
+- P1 minimum production fix / focused GREEN: `e356c0d784e6df03b8c317192ffe09702fef2cf5`.
+- A3/S03 direct tests / GREEN: `786bef6922eda84084400ae6c133859bbd973030`.
+- F05 private seam and direct tests / GREEN: `342dfa860ad1f9c8d0743393e1af199f04c419bf`.
+- Separate master merge: `603a2195700dae86386f7b02729d95c7338d2f1d`, parents `342dfa860ad1f9c8d0743393e1af199f04c419bf` and `3ee049462612611cf9b6563e69bf1ecc8bc68db9` (#345). The merge had no conflicts and did not change the repair's three C++ files.
+- The following delivery commit updates this record only. Its full head is recorded in the attachment manifest and issue comment.
+
+The self-authored source scope is the B1 hoist cache, its private preparation seam, and `dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp`. The separate merge imports #345's Python benchmarks and paired CI comparison unchanged. Linux Benchmarks now includes `check_python_benchmark_regressions.py` with 10 samples, two confirmation rounds, and the unchanged 4% threshold. No gate, public signature, numerical/compatibility contract, or Q1/B2 exclusion was changed.
+
+Integrated directed verification on `603a2195700dae86386f7b02729d95c7338d2f1d`:
+
+```bash
+cmake --build build/Release-linux --target dal_cpp_tests --parallel 4
+build/Release-linux/dal-cpp/dal_cpp_tests \
+  --gtest_filter='JointQuoteRiskTest.*:RateCashflowPricingTest.*:QuoteRiskAggregationTest.*' \
+  --gtest_output=xml:build/dal193-review-regressions.xml
+```
+
+Result: **148/148 passed** (36 joint, 87 pricing, 25 quote aggregation). Both affected C++ translation units passed GCC warning checks with the existing CI exclusions and Clang delayed-template syntax checks. Lizard reports all newly added functions/tests at complexity 6 or less; the existing `HoistXccy` remains 8 and `PreparationFor` remains at its pre-repair value of 9. Patch checks pass.
+
+As instructed, no full local suite, Python runtime suite, or paired performance gate was rerun in this turn. Prior complete results remain attributed to their prior heads. Final-head complete local/CI validation, the newly integrated Python paired gate, independent review, documentation, and approval/branch-protection acceptance remain required. The follow-up evidence archive contains the RED/GREEN logs, integrated XML and compiler/static evidence, separate repair/integration deltas, commit mapping, and exactly one post-push CI snapshot. DAL-193 stays `in_progress`; PR #346 remains unmerged.
 
 ## Handoff
 

--- a/.codex/artifacts/reviews/dal-193/implementation.md
+++ b/.codex/artifacts/reviews/dal-193/implementation.md
@@ -9,8 +9,9 @@ B1 now propagates joint quote risk through the actual consumed curve/base graph,
 - RED: `a4bd9a41445e9d9ef22f2131d3022893a4f59a62`.
 - Initial GREEN: `060a411734fb5925e3dad685e4c1154ead5f480d`.
 - Source protection and surface verification: `129a69f8c1ad95a98543c5a7d86f0494d73f503a`.
-- Verified code head: `9a847361081ebd3b5450cb9273a1c7597f369e10`.
-- The delivery commit adds this record only; the exact published head is recorded on the draft PR and its Multica handoff comment.
+- Initial verified code head: `9a847361081ebd3b5450cb9273a1c7597f369e10`.
+- First draft head: `fb01602a99dbe694ad68b1ea9eaf97d072eb4fd4`, adding this record only.
+- The CI repair below updates the same draft PR; its exact published head and single post-push CI snapshot are recorded in the follow-up evidence archive and Multica handoff comment.
 
 Controlling inputs were the approved B1 specification, API note, and `Proceed with caveats` critique attached to DAL-193. Their attachment IDs are respectively `01a08bfd-6b19-74bf-afcf-6a80c73d5dd4`, `01a08c0e-1962-74dc-98bf-c139a7159b26`, and `01a08c1b-9290-7c4b-a8e5-68b2e4b777f8`. Q1 and B2 remain excluded.
 
@@ -55,7 +56,7 @@ For the original `curve:0:1` bucket, baseline returned `31228.07347268159` versu
 
 An additional RED case showed one attempted pricing call through a cyclic source reachable only through the unregistered XCCY path. After the protection change the attempted-call count is zero, with one `INVALID` provenance failure, no trade meta, no buckets, and no sweep. Its RED/GREEN logs are included.
 
-## Local validation
+## Initial local validation
 
 ```bash
 NUM_CORES=4 ADDITIONAL_CMAKE_FLAGS='-DDAL_BUILD_EXCEL_PORTABLE_TESTS=ON' bash ./build_linux.sh --python 3.12
@@ -156,8 +157,46 @@ The benchmark's previous exact preparation count of three included the unused re
 
 The comparable benchmark portfolios already have complete economically relevant base paths on baseline. The old B1 missing-path calculation was not used as an equivalent-work performance baseline. The changed hot path maps to the existing `rate_risk_perf` target; no new benchmark target is introduced.
 
+## CI repair of the first draft
+
+The orchestrator returned `fb01602a99dbe694ad68b1ea9eaf97d072eb4fd4` to implementation for MSVC compilation and three new Codacy complexity findings. This follow-up changes only `dal-cpp/dal/curve/ratecashflowpricing.cpp`, `dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp`, and this record.
+
+The downloaded failed `build (msvc, xad)` log from run `34507960051`, job `102974740264`, confirms C2065 on `typeid(curve)` inside the generic visitor and the following C2338 uniform-return diagnostic from `std::visit`. The log identifies MSVC 14.51.36231. The triggering comment reports the same compile failure in all three Windows builds and Windows Benchmarks; compilation failed before benchmark measurements.
+
+`IsExactJointCurve` now evaluates dynamic RTTI outside the generic lambda, captures the resulting `std::type_info` reference explicitly, and declares the visitor return type as `bool`. Each non-monostate alternative still compares that dynamic RTTI with its exact static curve type; opaque and derived curves keep the approved rejection behavior.
+
+The complexity repair extracts the consumed path preparation and XCCY preparation loops into private helpers. A consumed path stops at the addressed target; a constant XCCY root stops at itself, preserving the previous preparation set, order, cache reuse, and failure handling. The oracle test moves only its per-bucket recalibration assertions into a helper and calls it through `ASSERT_NO_FATAL_FAILURE`, preserving fail-fast propagation. All original assertions, tolerances, test cases, and mode/layout/layer/alias combinations remain present.
+
+Lizard 1.23.0 reproduces the three Codacy counts before repair and reports the following after repair, using the unchanged limit of 8:
+
+| Function                                                       | Before | After |
+|----------------------------------------------------------------|--------|-------|
+| `JointPreparations`                                            | 9      | 6     |
+| `HoistXccy`                                                    | 10     | 8     |
+| `TestUnregisteredXccyOracleAcrossModesLayoutsLayersAndAliases` | 10     | 6     |
+| `PrepareJointPath`                                             | new    | 5     |
+| `PrepareXccyConsumedCurves`                                    | new    | 3     |
+| `AssertXccyOracleBuckets`                                      | new    | 5     |
+
+The RED evidence for this repair is the actual published-head MSVC failure and the reproduced static threshold violations. The native GCC baseline already passed all 32 joint tests. The minimum portability change then passed a targeted native build and the same 32 tests before the complexity extraction; no artificial behavioral failure was introduced for this compiler-only repair.
+
+Final directed verification:
+
+```bash
+cmake --build build/Release-linux --target dal_cpp_tests --parallel 4
+build/Release-linux/dal-cpp/dal_cpp_tests \
+  --gtest_filter='JointQuoteRiskTest.*:RateCashflowPricingTest.*:QuoteRiskAggregationTest.*'
+```
+
+- Native Release target build passed; the final directed regression filter passed **144/144** tests (32 joint, 87 pricing, 25 quote aggregation), including exact-type C1–C4, historical knots, aliases/preparation counts, invalid source protection, tape rollback, and standalone XCCY behavior.
+- Both changed C++ translation units passed GCC `-Wall -Wextra -Wpedantic -Werror` syntax checks with exactly the repository CI's existing warning-category exclusions.
+- The production translation unit also passed Clang 21 syntax validation with `-fdelayed-template-parsing -fms-extensions`. This uses Linux headers and is supplementary portability evidence; it is not a real MSVC build result.
+- The static comparison confirms that all original assertion expressions and test case names remain; only the helper failure-propagation assertion was added. Patch whitespace checks passed. No threshold, gate configuration, public contract, numeric assertion, or excluded Q1/B2 scope changed.
+
+Per the explicit follow-up instruction, this turn runs directed build/regression/static checks only. The initial 1552-test full native validation, Python/public/Excel results, independent oracle files, generated-source/docs/helper checks, and nine-target performance evidence above remain reusable prior-head evidence, not new-head full-suite claims. Actual MSVC builds, Windows Benchmarks, hosted Codacy, wheels, the full backend matrix, and final-head complete local/CI acceptance remain for the subsequent pipeline. One CI snapshot will be read after pushing this repair; this implementation phase does not wait for CI completion or merge.
+
 ## Handoff
 
-The evidence archive contains RED/GREEN and full-test logs, the baseline C1–C4 characterization source, both final oracle CSVs and validators/manifests, generated/docs/helper/warning results, and complete benchmark environment/raw/summary results. Source changes are committed; generated logs and the earlier investigation materials are excluded from Git.
+The initial evidence archive contains RED/GREEN and full-test logs, the baseline C1–C4 characterization source, both final oracle CSVs and validators/manifests, generated/docs/helper/warning results, and complete benchmark environment/raw/summary results. The CI repair archive adds the actual MSVC failure log, directed build/regression/static evidence, the source delta, and a single post-push CI snapshot. Source changes are committed; generated logs and the earlier investigation materials are excluded from Git.
 
 Local verification covers native AADet on Linux/WSL2 and portable Excel. Windows XLL and the alternative AAD backend CI matrix have not been run locally. The orchestrator will arrange tester → reviewer → doc-writer and the final published-head CI/merge acceptance. Documentation review should explicitly preserve the C1/C3 compatibility qualification and the restriction to actual consumed exact builtin graphs.

--- a/.codex/artifacts/reviews/dal-193/implementation.md
+++ b/.codex/artifacts/reviews/dal-193/implementation.md
@@ -1,0 +1,163 @@
+# DAL-193 B1 implementation
+
+B1 now propagates joint quote risk through the actual consumed curve/base graph, including unregistered XCCY forecast roots. This record covers implementation and local verification; the orchestrator owns the subsequent tester, reviewer, doc-writer, and final CI/merge stages. DAL-193 remains `in_progress`.
+
+## Revisions and approved scope
+
+- Baseline: `1abb3d4b45222f3ce825bec8249f6da938f58104` (master / #344).
+- Branch: `agent/dal-implementer/9c96ec6e82b7`.
+- RED: `a4bd9a41445e9d9ef22f2131d3022893a4f59a62`.
+- Initial GREEN: `060a411734fb5925e3dad685e4c1154ead5f480d`.
+- Source protection and surface verification: `129a69f8c1ad95a98543c5a7d86f0494d73f503a`.
+- Verified code head: `9a847361081ebd3b5450cb9273a1c7597f369e10`.
+- The delivery commit adds this record only; the exact published head is recorded on the draft PR and its Multica handoff comment.
+
+Controlling inputs were the approved B1 specification, API note, and `Proceed with caveats` critique attached to DAL-193. Their attachment IDs are respectively `01a08bfd-6b19-74bf-afcf-6a80c73d5dd4`, `01a08c0e-1962-74dc-98bf-c139a7159b26`, and `01a08c1b-9290-7c4b-a8e5-68b2e4b777f8`. Q1 and B2 remain excluded.
+
+## Implementation
+
+The only production source changes are in `dal-cpp/dal/curve/ratecashflowpricing.cpp` and its private `ratecashflowpricing_internal.hpp`.
+
+- Joint consumption uses a per-trade closure of actual selected roots and base handles. Path-local identity checks distinguish cycles from shared bases. Exact PWC, PWLF, LogDF, and ZeroRate types are supported; an unknown necessary node makes every potentially affected bound block incomplete.
+- Preparation includes consumed paths to the target and the constant roots needed by the XCCY typed view. Intermediate parameters remain constant; the target's own base remains passive in that target's sweep. Aliases do not create extra preparations or sweeps. Unused registered descendants do not enter preparation.
+- Joint forward preparation selects an auxiliary anchor before the earliest knot when needed. Rebuilding retains the original PWC/PWLF knots and left/right values, including historical knots; standalone preparation is unchanged.
+- Existing family, routing, root-classification, passive-validation, and expired-XCCY gates retain their order. New unknown-graph failures use `AAD_EVALUATION_FAILED`, wrapped by `QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE` at the aggregate boundary.
+- The aggregate validates a completed native slice against the bound block width and finite-value requirements before copying it. A failed block discards the whole local trade/provenance gradient. A successfully obtained passive PV is still counted once, and healthy sibling trades continue.
+- Invalid v2 sources are checked against actual XCCY root/base paths before passive pricing, even when no provenance remains active. This closes the independently reproduced unsafe unregistered-path evaluation. Pure v1 malformed sources still raise their existing call-level exception; only v2 produces the `INVALID` source marker.
+- Two private test hooks distinguish an exception while recorded AAD nodes are live from failures after a completed sweep but before aggregate slice acceptance. The pre-existing early forced-failure hook and its token are retained.
+
+No public signature, result field, token, constructor default, provenance factory validation, or fingerprint encoding changed. The implementation deliberately changes joint eligibility for some custom curve inputs, as detailed below.
+
+## C1–C4 compatibility evidence
+
+All four old-behavior characterizations passed against the unmodified baseline before their assertions were changed for the approved contract. The exact characterization source and log accompany this record.
+
+| Case                                               | Observed baseline behavior                                                                                            | Implemented joint behavior                                                                                           |
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| C1: builtin EUR forecast with opaque unit leaf     | Factory/aggregate accepted; PV and all five registered-control risks were identical to the equivalent builtin market. | Factory still accepts; one incomplete meta at the first declared bound key, original reason `AAD_EVALUATION_FAILED`. |
+| C2: opaque forwarding layer hiding H0              | Factory/aggregate accepted, but the tested quote derivative omitted more than one million units of base response.     | Incomplete meta at the first declared bound key; no partial direct risk.                                             |
+| C3: empty PWC-derived EUR forecast                 | Factory/aggregate accepted; PV and all five risks equaled the builtin control.                                        | Exact-type joint gate rejects the necessary derived node with `AAD_EVALUATION_FAILED`.                               |
+| C4: Future consuming only an opaque root hiding H0 | Eligible structural zero with five zero buckets.                                                                      | Original root representation gate now runs; incomplete meta with `CURVE_REPRESENTATION_NOT_AAD_ENABLED`.             |
+
+C1 and C3 are intentional restrictions of previously numerically correct custom inputs. Compatibility must not be described as merely rejecting previously incorrect inputs. Likewise, prior success of arbitrary non-default `B_` template instances is not established: linking and serialization constraints apply, as the critique notes. The new exact-type graph gate does not add support for those instances.
+
+## RED and GREEN evidence
+
+The RED commit contains five normal CMake-discovered tests: the original unregistered-XCCY defect and C1–C4's approved outcomes. Against baseline, all five failed for the expected reasons. The initial GREEN passed all 22 then-current `JointQuoteRiskTest` cases.
+
+```bash
+cmake --build build/Release-linux --target dal_cpp_tests --parallel 4
+build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='JointQuoteRiskTest.TestUnregisteredXccyBaseMatchesFullRecalibration:JointQuoteRiskTest.TestOpaque*Closed:JointQuoteRiskTest.TestDerivedBuiltinFailsClosed:JointQuoteRiskTest.TestOpaqueOnlyRootKeepsRepresentationGate'
+build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='JointQuoteRiskTest.*'
+```
+
+For the original `curve:0:1` bucket, baseline returned `31228.07347268159` versus full recalibration `-1663168.021141246` dPV/dDecimalQuote. The repaired result is `-1663168.021048957`; DV01 is `-166.3168021048957`. The ±1 bp recalibration oracle is `-166.31680834041799`. Passive EUR PV remains `-31068.298577158537`.
+
+An additional RED case showed one attempted pricing call through a cyclic source reachable only through the unregistered XCCY path. After the protection change the attempted-call count is zero, with one `INVALID` provenance failure, no trade meta, no buckets, and no sweep. Its RED/GREEN logs are included.
+
+## Local validation
+
+```bash
+NUM_CORES=4 ADDITIONAL_CMAKE_FLAGS='-DDAL_BUILD_EXCEL_PORTABLE_TESTS=ON' bash ./build_linux.sh --python 3.12
+cmake --build build/Release-linux --target dal_check_generated --parallel 4
+python3 .github/scripts/check_docs.py
+python3 -m unittest discover -s .github/scripts/tests -v
+```
+
+- Full build/install/CTest: **1552/1552 passed**, including **291 Python tests**, core/public C++, and portable Excel.
+- Generated-source check passed without drift; documentation checks passed for 51 Markdown files.
+- CI helper suite: 146 tests, successful with 6 environment-dependent skips.
+- Changed production translation unit passed `-Wall -Wextra -Wpedantic -Werror` syntax validation using the repository's existing warning-category exclusions. This is a translation-unit check, not a separate full warning-clean build.
+- The original oracle validator accepted **992 buckets across 96 fixtures** at the verified code head. The independent B1 validator accepted **80/80** raw observation rows across analytic/bumped, PWC/PWLF, layered/unlayered, and registered/unregistered controls; derivative, ±1 bp DV01, unit identity, and registration/PV invariance all pass.
+- Additional tests cover mixed unregistered LogDF/ZeroRate/PWLF chains, historical PWC/PWLF knots, single-currency base-only consumption, standalone fixed-base behavior, aliases, unused descendants, reversed trade order and separate closures, declaration-order failure keys, stale sources, family/root/fixing/expiry gates, and healthy siblings.
+- Real completed second-block exception/NaN/width failures discard the first block's slice. A separate exception with live recorded nodes proves tape rewind; the same provenance then produces the original B1 result. Concurrent successful callers retain independent tapes.
+- Public C++ and ordinary Python constructors both execute B1 against recalibration. A test-only native Python extension injects the custom opaque fixture; it is not installed or exported by the production package. Python metadata and the portable Excel ten-column failure spill preserve existing fields, positions, and unavailable/INCOMPLETE tokens.
+
+The Python finite-difference fixture uses tighter solve/fit tolerances than the existing cross-language fixture so its strict absolute derivative assertion is reproducible. The existing golden-reference fixture and assertions were retained.
+
+## Performance validation
+
+Baseline and head use detached `dal193-perf/base-source` / `head-source` checkouts and separate `base-build` / `head-build` directories. Both use identical pinned dependencies, GCC 15.2.0, CMake 4.2.3, Unix Makefiles, Release static native AADet, native CPU tuning, and `DAL_NUM_THREADS=4` on the same i9-13900HX WSL2 host. WSL timing can be noisy; the repository's paired minimum reduction is used.
+
+```bash
+DAL_NUM_THREADS=4 python3 .github/scripts/check_benchmark_regressions.py \
+  --base-root ../dal193-perf/base-build --head-root ../dal193-perf/head-build \
+  --output-dir ../dal193-perf/paired-final --samples 10 \
+  --confirmation-rounds 2 --threshold-percent 4
+```
+
+Final verdict: **no regression under the repository gate**. All **9 targets / 51 cases** passed, with 20 process samples per side. Every raw process output, per-case minimum, both round deltas, and gate decision is retained in `paired-final/results.json` and `paired-final/summary.md` in the evidence archive. An isolated round above 4% is not a failure under the required two-round rule.
+
+### Paired benchmark results
+
+2 independent rounds of 10 interleaved process-level samples; failure requires every round to exceed +4.00%.
+
+| Benchmark      | Case                                                       | Base min      | Head min      | Change | Round changes  | Result |
+|----------------|------------------------------------------------------------|---------------|---------------|--------|----------------|--------|
+| tape_perf      | Clear + re-record (100K nodes)                             | 0.900797 ms   | 0.906077 ms   | +0.59% | +2.80%, -0.64% | pass   |
+| tape_perf      | PropagateToStart (100K nodes)                              | 0.424813 ms   | 0.431848 ms   | +1.66% | +1.66%, +1.99% | pass   |
+| tape_perf      | PropagateToStart multi-mode (100K nodes, 10 results)       | 0.556076 ms   | 0.553092 ms   | -0.54% | -0.72%, +1.07% | pass   |
+| tape_perf      | Rewind + re-record (100K nodes)                            | 0.582877 ms   | 0.583456 ms   | +0.10% | +0.10%, +0.63% | pass   |
+| tape_perf      | ZeroAdjoints sweep (100K nodes)                            | 0.118066 ms   | 0.120115 ms   | +1.74% | +1.74%, -0.03% | pass   |
+| jacobian_perf  | AnalyticJacobian dense harvest (24 x 23)                   | 0.006381 ms   | 0.006209 ms   | -2.70% | -0.75%, -2.70% | pass   |
+| jacobian_perf  | AnalyticJacobian row-width harvest (24 x 23)               | 0.006197 ms   | 0.006225 ms   | +0.45% | -2.64%, +0.45% | pass   |
+| pde_perf       | ThetaScheme rollback (200x200 CN)                          | 0.184057 ms   | 0.192450 ms   | +4.56% | +4.56%, +2.03% | pass   |
+| pde_perf       | ThetaScheme rollback (200x200 implicit)                    | 0.184228 ms   | 0.187336 ms   | +1.69% | +1.69%, +1.79% | pass   |
+| pde_perf       | ThetaScheme rollback (200x2000 explicit)                   | 0.767762 ms   | 0.772620 ms   | +0.63% | +2.26%, -0.87% | pass   |
+| rng_perf       | BrownianBridge FillNormal (100K x 10D)                     | 7.036000 ms   | 7.152000 ms   | +1.65% | +0.77%, +1.65% | pass   |
+| rng_perf       | MRG32k3a FillNormal (100K x 10D)                           | 18.920000 ms  | 18.638000 ms  | -1.49% | +2.78%, -1.49% | pass   |
+| rng_perf       | ShuffledIRN FillNormal (100K x 10D)                        | 10.911000 ms  | 10.962000 ms  | +0.47% | +0.10%, +0.47% | pass   |
+| rng_perf       | Sobol FillNormal fast (100K x 10D)                         | 4.485000 ms   | 4.406000 ms   | -1.76% | +0.44%, -1.76% | pass   |
+| rng_perf       | Sobol FillNormal precise opt-in (100K x 10D)               | 37.453000 ms  | 37.481000 ms  | +0.07% | -0.56%, +0.07% | pass   |
+| rng_perf       | Sobol FillUniform (100K x 10D)                             | 0.990695 ms   | 1.024000 ms   | +3.36% | -0.38%, +3.36% | pass   |
+| interp_perf    | Cubic interp (50 knots, 10K queries)                       | 0.050187 ms   | 0.050353 ms   | +0.33% | +3.54%, +0.33% | pass   |
+| interp_perf    | Inlined linear LV-style (1e5 paths x 200 steps, 200 knots) | 100.583000 ms | 100.274000 ms | -0.31% | +0.49%, -0.31% | pass   |
+| interp_perf    | Linear interp (50 knots, 10K queries)                      | 0.042217 ms   | 0.042410 ms   | +0.46% | +3.26%, +0.16% | pass   |
+| krylov_perf    | BCGSolve (500x500 tridiag)                                 | 0.017723 ms   | 0.017755 ms   | +0.18% | -0.12%, +0.42% | pass   |
+| krylov_perf    | CGSolve (500x500 tridiag)                                  | 0.014535 ms   | 0.014500 ms   | -0.24% | -0.33%, -0.03% | pass   |
+| banded_perf    | TriDecomp MultiplyLeft (10K)                               | 0.004224 ms   | 0.004221 ms   | -0.07% | -0.07%, -0.07% | pass   |
+| banded_perf    | TriDiagonal Decompose (10K)                                | 0.075419 ms   | 0.075270 ms   | -0.20% | +0.04%, -0.20% | pass   |
+| banded_perf    | TriDiagonal MultiplyLeft (10K)                             | 0.004203 ms   | 0.004204 ms   | +0.02% | +0.02%, -0.05% | pass   |
+| cholesky_perf  | CholeskyDecompose (200x200)                                | 0.356988 ms   | 0.354999 ms   | -0.56% | +0.01%, -0.65% | pass   |
+| cholesky_perf  | CholeskyDecompose+Multiply (200x200)                       | 0.359896 ms   | 0.359680 ms   | -0.06% | -0.11%, -0.06% | pass   |
+| rate_risk_perf | Quote risk aggregate (joint XCCY)                          | 0.222103 ms   | 0.220635 ms   | -0.66% | -0.18%, -0.85% | pass   |
+| rate_risk_perf | Quote risk aggregate (single curve)                        | 0.008200 ms   | 0.008274 ms   | +0.90% | +0.90%, +0.89% | pass   |
+| rate_risk_perf | Quote risk aggregate (staged XCCY basis)                   | 0.064616 ms   | 0.064170 ms   | -0.69% | -1.01%, -0.54% | pass   |
+| rate_risk_perf | Quote risk generic joint (100 IRS x N=10)                  | 2.426000 ms   | 2.389000 ms   | -1.53% | -1.65%, -1.20% | pass   |
+| rate_risk_perf | Quote risk generic joint (100 IRS x N=16)                  | 3.989000 ms   | 3.960000 ms   | -0.73% | -1.35%, -0.55% | pass   |
+| rate_risk_perf | Quote risk generic joint (100 IRS x N=5)                   | 1.633000 ms   | 1.649000 ms   | +0.98% | +1.29%, +0.49% | pass   |
+| rate_risk_perf | Quote risk generic joint (1000 IRS x N=10)                 | 24.288000 ms  | 23.839000 ms  | -1.85% | -2.15%, -1.85% | pass   |
+| rate_risk_perf | Quote risk generic joint (1000 IRS x N=16)                 | 40.115000 ms  | 39.806000 ms  | -0.77% | -0.58%, -1.10% | pass   |
+| rate_risk_perf | Quote risk generic joint (1000 IRS x N=5)                  | 16.329000 ms  | 16.265000 ms  | -0.39% | -0.39%, -1.15% | pass   |
+| rate_risk_perf | Quote risk generic joint node reference (100 IRS x N=10)   | 2.364000 ms   | 2.340000 ms   | -1.02% | -1.02%, -1.26% | pass   |
+| rate_risk_perf | Quote risk generic joint node reference (100 IRS x N=16)   | 3.950000 ms   | 3.909000 ms   | -1.04% | -0.86%, -1.14% | pass   |
+| rate_risk_perf | Quote risk generic joint node reference (100 IRS x N=5)    | 1.574000 ms   | 1.589000 ms   | +0.95% | +0.95%, +0.06% | pass   |
+| rate_risk_perf | Quote risk generic joint node reference (1000 IRS x N=10)  | 23.757000 ms  | 23.618000 ms  | -0.59% | -0.56%, -0.59% | pass   |
+| rate_risk_perf | Quote risk generic joint node reference (1000 IRS x N=16)  | 40.076000 ms  | 39.557000 ms  | -1.30% | -1.53%, -1.23% | pass   |
+| rate_risk_perf | Quote risk generic joint node reference (1000 IRS x N=5)   | 16.100000 ms  | 16.069000 ms  | -0.19% | -0.21%, -0.19% | pass   |
+| rate_risk_perf | Quote risk portfolio joint ANALYTIC (24 XCCY x N=10/block) | 5.107000 ms   | 5.082000 ms   | -0.49% | -0.88%, -0.49% | pass   |
+| rate_risk_perf | Quote risk portfolio joint BUMPED (24 XCCY x N=10/block)   | 5.115000 ms   | 5.084000 ms   | -0.61% | -0.25%, -0.74% | pass   |
+| rate_risk_perf | Quote risk portfolio single ANALYTIC (120 deposits x N=5)  | 0.117801 ms   | 0.118710 ms   | +0.77% | +0.31%, +0.96% | pass   |
+| rate_risk_perf | Quote risk portfolio single BUMPED (120 deposits x N=16)   | 0.165294 ms   | 0.167775 ms   | +1.50% | +1.27%, +1.52% | pass   |
+| rate_risk_perf | Quote risk portfolio staged ANALYTIC (24 XCCY x N=16)      | 4.258000 ms   | 4.218000 ms   | -0.94% | -1.01%, -0.94% | pass   |
+| rate_risk_perf | Quote risk portfolio staged BUMPED (24 XCCY x N=5)         | 1.494000 ms   | 1.480000 ms   | -0.94% | -1.20%, -0.40% | pass   |
+| rate_risk_perf | Rate OIS daily compounding sweep (5Y quarterly x daily)    | 0.247663 ms   | 0.247254 ms   | -0.17% | -0.29%, +2.45% | pass   |
+| rate_risk_perf | Rate XCCY batch serial (24 XCCY x 5 components)            | 0.853243 ms   | 0.847706 ms   | -0.65% | -0.67%, -0.59% | pass   |
+| rate_risk_perf | Rate batch serial (120 IRS x 2 components)                 | 3.254000 ms   | 3.230000 ms   | -0.74% | -0.71%, -1.19% | pass   |
+| rate_risk_perf | Rate single-trade sweeps (240 IRS calls)                   | 4.307000 ms   | 4.274000 ms   | -0.77% | -0.77%, -1.29% | pass   |
+
+Head Sobol precise opt-in / fast ratio: 8.51x (limit 10.00x).
+
+All performance acceptance checks passed.
+
+The head `rate_risk_perf` smoke run passed the separate generic-joint aggregate-versus-complete-native-reference 20% ceiling for N=5/10/16 and 100/1000 IRS. Observed overheads were respectively 3.953%/0.851%, 1.302%/0.710%, and 1.868%/-1.562%, with zero recalibrations, one provenance preparation, two consumed native preparations, and 200/2000 sweeps.
+
+The benchmark's previous exact preparation count of three included the unused registered third forward curve. Its assertion now requires exactly two, matching the approved consumed-only preparation rule and a dedicated unit test. Numerical reference, workload, widths, quote transform, sweep bound, and timing thresholds are retained. The initial measurement stopped at that stale count assertion; its logs are retained separately and do not constitute the final performance verdict.
+
+The comparable benchmark portfolios already have complete economically relevant base paths on baseline. The old B1 missing-path calculation was not used as an equivalent-work performance baseline. The changed hot path maps to the existing `rate_risk_perf` target; no new benchmark target is introduced.
+
+## Handoff
+
+The evidence archive contains RED/GREEN and full-test logs, the baseline C1–C4 characterization source, both final oracle CSVs and validators/manifests, generated/docs/helper/warning results, and complete benchmark environment/raw/summary results. Source changes are committed; generated logs and the earlier investigation materials are excluded from Git.
+
+Local verification covers native AADet on Linux/WSL2 and portable Excel. Windows XLL and the alternative AAD backend CI matrix have not been run locally. The orchestrator will arrange tester → reviewer → doc-writer and the final published-head CI/merge acceptance. Documentation review should explicitly preserve the C1/C3 compatibility qualification and the restriction to actual consumed exact builtin graphs.

--- a/.github/scripts/tests/test_python_benchmark_regressions.py
+++ b/.github/scripts/tests/test_python_benchmark_regressions.py
@@ -5,9 +5,12 @@ import contextlib
 import importlib.util
 import io
 import json
+import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from unittest import mock
 
@@ -48,6 +51,53 @@ def report(duration=100):
 
 
 class PythonBenchmarkRegressionTest(unittest.TestCase):
+    @unittest.skipIf(sys.platform == "win32", "Linux workflow requires bash")
+    def test_workload_verification_matches_regressions_to_each_native_revision(self):
+        workflow = (SCRIPTS.parent / "workflows/cmake-linux.yml").read_text()
+        step = workflow.split(
+            "- name: Verify Python workloads on both native builds", 1
+        )[1].split("      - name:", 1)[0]
+        script = textwrap.dedent(step.split("        run: |\n", 1)[1])
+        # Model a new regression that must fail on the old native library.
+        python_stub = """
+python3() {
+  printf '%s|%s|%s\\n' "$PWD" "$PYTHONPATH" "$3"
+  if [[ "$PWD" == "$GITHUB_WORKSPACE/benchmark-base/"* && "$3" == "$GITHUB_WORKSPACE/dal-python/tests" ]]; then
+    return 17
+  fi
+}
+"""
+        with tempfile.TemporaryDirectory(prefix="dal revisions ") as directory:
+            root = Path(directory).resolve()
+            base = root / "benchmark-base/build/benchmark-base/dal-python"
+            head = root / "build/benchmark-head/dal-python"
+            for package in (base, head):
+                package.mkdir(parents=True)
+            result = subprocess.run(
+                ["bash", "-e", "-c", python_stub + script],
+                cwd=root,
+                env={**os.environ, "GITHUB_WORKSPACE": str(root)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            calls = [line.split("|") for line in result.stdout.splitlines()]
+            shared = root / "dal-python/tests/test_benchmarks.py"
+            expected = (
+                (base, root / "benchmark-base/dal-python/tests"),
+                (base, shared),
+                (head, root / "dal-python/tests"),
+                (head, shared),
+            )
+            self.assertEqual(
+                calls,
+                [
+                    [str(package), str(package), str(tests)]
+                    for package, tests in expected
+                ],
+            )
+
     def test_threshold_requires_two_independent_best_of_ten_failures(self):
         base = [report()] * 20
         head = [report(105)] * 20

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -627,12 +627,19 @@ jobs:
         env:
           DAL_NUM_THREADS: 4
         run: |
-          for build_root in "$GITHUB_WORKSPACE/benchmark-base/build/benchmark-base" "$GITHUB_WORKSPACE/build/benchmark-head"; do
+          verify_python_build() {
+            local source_root="$1"
+            local build_root="$2"
             (
               cd "$build_root/dal-python"
-              PYTHONPATH="$build_root/dal-python" python3 -m pytest "$GITHUB_WORKSPACE/dal-python/tests" -q
+              # A new bug regression can intentionally fail on the base revision.
+              PYTHONPATH="$build_root/dal-python" python3 -m pytest "$source_root/dal-python/tests" -q
+              # Both native revisions must still satisfy the same head workloads.
+              PYTHONPATH="$build_root/dal-python" python3 -m pytest "$GITHUB_WORKSPACE/dal-python/tests/test_benchmarks.py" -q
             )
-          done
+          }
+          verify_python_build "$GITHUB_WORKSPACE/benchmark-base" "$GITHUB_WORKSPACE/benchmark-base/build/benchmark-base"
+          verify_python_build "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/build/benchmark-head"
 
       - name: Run head benchmarks
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Each entry is a short bullet under a dated heading, in the form:
 
 Only add a heading when a qualifying change ships. Do not create empty future headings.
 
+## 2026-09-11
+
+- **Joint quote-risk base graphs and eligibility** — joint risk follows actual
+  consumed base paths, including unregistered XCCY forecast curves, with
+  historical native coordinates preserved. Necessary nodes must be exact
+  builtin curve types. This intentionally makes opaque unit-discount leaves
+  and builtin subclasses ineligible even when their previous numerical results
+  were correct; standalone node risk and v1 quote-risk semantics are unchanged.
+  See the [graph contract](docs/methodology/generic_joint_quote_risk.md#aggregation-and-failures).
+
 ## 2026-09-08
 
 - **Generic joint quote-space DV01** — exact same-currency joint calibration can

--- a/dal-cpp/benchmarks/rate_risk_perf/genericjointbenchmarks.cpp
+++ b/dal-cpp/benchmarks/rate_risk_perf/genericjointbenchmarks.cpp
@@ -94,7 +94,7 @@ namespace Dal::RateRiskPerf {
             const int sweeps = after.sweeps_ - before.sweeps_;
             REQUIRE(calibrations == 0 && preparations == (reference ? 0 : 1),
                     "Joint benchmark recalibration or provenance preparation count drifted");
-            REQUIRE(nodes == 3 && sweeps == 2 * trades, "Joint benchmark prepared or swept an unexpected number of native blocks");
+            REQUIRE(nodes == 2 && sweeps == 2 * trades, "Joint benchmark prepared an unused block or swept an unexpected number of native blocks");
             if (sample < 0)
                 return;
             if (const char* path = std::getenv("DAL_JOINT_QUOTE_RISK_BENCHMARK_FILE")) {

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -703,6 +703,46 @@ namespace Dal {
         using JointNodePreparations_ = std::map<const DiscountCurve_*, const NodeSensitivityPreparation_*>;
         using ActiveCurveMap_ = std::map<const DiscountCurve_*, std::shared_ptr<Tape::DiscountCurve_<AAD::Number_>>>;
 
+        bool IsExactJointCurve(const DiscountCurve_& curve) {
+            return std::visit(
+                [&](const auto& typed) {
+                    if constexpr (std::is_same_v<std::decay_t<decltype(typed)>, std::monostate>)
+                        return false;
+                    else
+                        return typeid(curve) == typeid(std::remove_pointer_t<std::decay_t<decltype(typed)>>);
+                },
+                RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(curve));
+        }
+
+        struct JointCurveClosure_ {
+            bool complete_ = true;
+            Vector_<const DiscountCurve_*> roots_;
+            std::map<const DiscountCurve_*, const DiscountCurve_*> bases_;
+        };
+
+        JointCurveClosure_ BuildJointCurveClosure(const Vector_<const DiscountCurve_*>& roots) {
+            JointCurveClosure_ result;
+            result.roots_ = roots;
+            for (const auto* root : roots) {
+                std::set<const DiscountCurve_*> path;
+                const auto* curve = root;
+                if (!curve)
+                    result.complete_ = false;
+                while (curve) {
+                    if (!path.insert(curve).second || !IsExactJointCurve(*curve)) {
+                        result.complete_ = false;
+                        break;
+                    }
+                    if (result.bases_.count(curve))
+                        break;
+                    const auto* base = RateCashflowPricingInternal::NodeSensitivityBase(*curve);
+                    result.bases_.emplace(curve, base);
+                    curve = base;
+                }
+            }
+            return result;
+        }
+
         bool CurveDependsOn(const DiscountCurve_* curve, const DiscountCurve_* target) {
             std::set<const DiscountCurve_*> visited;
             while (curve) {
@@ -832,14 +872,21 @@ namespace Dal {
                 return SweepSingleCurrency(trade, componentKey, jointCoordinates);
             }
 
-            bool ConsumesComponent(const Vector_<String_>& dependencies, const String_& key, bool jointCoordinates) {
-                if (std::find(dependencies.begin(), dependencies.end(), key) != dependencies.end())
-                    return true;
+            bool ConsumesComponent(const RateTradeDefinition_& trade,
+                                   const Vector_<String_>& dependencies,
+                                   const String_& key,
+                                   bool jointCoordinates) {
                 if (!jointCoordinates)
-                    return false;
-                const auto& related = JointDependencyKeys(key);
-                return std::any_of(dependencies.begin(), dependencies.end(),
-                                   [&](const String_& dependency) { return std::find(related.begin(), related.end(), dependency) != related.end(); });
+                    return std::find(dependencies.begin(), dependencies.end(), key) != dependencies.end();
+                const auto target = market_.curveComponents_.find(key);
+                if (target == market_.curveComponents_.end() || !target->second)
+                    return true;
+                if (std::holds_alternative<XccyTradeTerms_>(trade.terms_) && trade.maturityDate_ < market_.valuationTime_.Date()) {
+                    const auto& roots = HoistXccy(trade, std::get<XccyTradeTerms_>(trade.terms_), true).consumed_.curves_;
+                    return std::any_of(roots.begin(), roots.end(), [&](const auto* root) { return CurveDependsOn(root, target->second.get()); });
+                }
+                const auto& closure = JointClosureFor(trade);
+                return !closure.complete_ || closure.bases_.count(target->second.get());
             }
 
             const RatePricingTradeResult_& PassivePrice(const RateTradeDefinition_& trade) {
@@ -860,43 +907,37 @@ namespace Dal {
             }
 
         private:
-            const Vector_<String_>& JointDependencyKeys(const String_& key) {
-                const auto found = jointDependencies_.find(key);
-                if (found != jointDependencies_.end())
+            const JointCurveClosure_& JointClosureFor(const RateTradeDefinition_& trade) {
+                const auto found = jointClosures_.find(&trade);
+                if (found != jointClosures_.end())
                     return found->second;
-                Vector_<String_> result;
-                const auto target = market_.curveComponents_.find(key);
-                if (target != market_.curveComponents_.end() && target->second)
-                    for (const auto& [candidate, curve] : market_.curveComponents_)
-                        if (CurveDependsOn(curve.get(), target->second.get()))
-                            result.push_back(candidate);
-                return jointDependencies_.emplace(key, std::move(result)).first->second;
-            }
-
-            bool PrepareJointChain(const String_& key, const DiscountCurve_* curve) {
-                auto& result = jointPreparations_.at(key);
-                const auto* target = market_.curveComponents_.at(key).get();
-                while (curve && !result.count(curve)) {
-                    const auto* preparation = PreparationFor(curve, RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*curve));
-                    if (!preparation) {
-                        result.clear();
-                        return false;
+                Vector_<const DiscountCurve_*> roots;
+                if (const auto* terms = std::get_if<XccyTradeTerms_>(&trade.terms_))
+                    roots = HoistXccy(trade, *terms, true).consumed_.curves_;
+                else
+                    for (const auto& key : DependencyKeysFor(trade)) {
+                        const auto component = market_.curveComponents_.find(key);
+                        roots.push_back(component == market_.curveComponents_.end() ? nullptr : component->second.get());
                     }
-                    result.emplace(curve, preparation);
-                    curve = curve == target ? nullptr : preparation->passiveBase_.get();
-                }
-                return true;
+                return jointClosures_.emplace(&trade, BuildJointCurveClosure(roots)).first->second;
             }
 
-            const JointNodePreparations_* JointPreparationsForKey(const String_& key) {
-                const auto found = jointPreparations_.find(key);
-                if (found != jointPreparations_.end())
-                    return found->second.empty() ? nullptr : &found->second;
-                auto& result = jointPreparations_[key];
-                for (const auto& dependency : JointDependencyKeys(key))
-                    if (!PrepareJointChain(key, market_.curveComponents_.at(dependency).get()))
-                        return nullptr;
-                return result.empty() ? nullptr : &result;
+            JointNodePreparations_ JointPreparations(const JointCurveClosure_& closure, const DiscountCurve_* target, bool xccy) {
+                JointNodePreparations_ result;
+                for (const auto* root : closure.roots_) {
+                    const bool depends = CurveDependsOn(root, target);
+                    if (!xccy && !depends)
+                        continue;
+                    for (const auto* curve = root; curve && !result.count(curve); curve = closure.bases_.at(curve)) {
+                        const auto* preparation = PreparationFor(curve, RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*curve), true);
+                        if (!preparation)
+                            return {};
+                        result.emplace(curve, preparation);
+                        if (!depends || curve == target)
+                            break;
+                    }
+                }
+                return result;
             }
 
             struct ComponentGate_ {
@@ -922,18 +963,31 @@ namespace Dal {
             }
 
             const NodeSensitivityPreparation_* PreparationFor(const DiscountCurve_* curve,
-                                                              const RateCashflowPricingInternal::NodeSensitivityCurve_& classification) {
-                if (preparationFailures_.count(curve))
+                                                              const RateCashflowPricingInternal::NodeSensitivityCurve_& classification,
+                                                              bool jointCoordinates = false) {
+                auto& preparations = jointCoordinates ? jointPrepared_ : prepared_;
+                auto& failures = jointCoordinates ? jointPreparationFailures_ : preparationFailures_;
+                if (failures.count(curve))
                     return nullptr;
-                const auto found = prepared_.find(curve);
-                if (found != prepared_.end())
+                const auto found = preparations.find(curve);
+                if (found != preparations.end())
                     return &found->second;
                 try {
-                    NodeSensitivityPreparation_ preparation = PrepareNodeSensitivityCurve(classification, market_.valuationTime_.Date());
+                    Date_ anchor = market_.valuationTime_.Date();
+                    if (jointCoordinates)
+                        std::visit(
+                            [&](const auto& typed) {
+                                using curve_t = std::decay_t<decltype(typed)>;
+                                if constexpr (std::is_same_v<curve_t, const Tape::DiscountPWC_<double>*> ||
+                                              std::is_same_v<curve_t, const Tape::DiscountPWLF_<double>*>)
+                                    anchor = std::min(anchor, typed->KnotDates().front().AddDays(-1));
+                            },
+                            classification);
+                    NodeSensitivityPreparation_ preparation = PrepareNodeSensitivityCurve(classification, anchor);
                     ++RateCashflowPricingInternal::g_nodeSensitivityPreparationCount;
-                    return &prepared_.emplace(curve, std::move(preparation)).first->second;
+                    return &preparations.emplace(curve, std::move(preparation)).first->second;
                 } catch (const std::exception&) {
-                    preparationFailures_.insert(curve);
+                    failures.insert(curve);
                     return nullptr;
                 }
             }
@@ -957,21 +1011,23 @@ namespace Dal {
                 return {};
             }
 
-            bool NeedsJointSweep(const String_& key, bool jointCoordinates) { return jointCoordinates && JointDependencyKeys(key).size() > 1; }
-
             RateTradeNodeSensitivityResult_
             SweepJoint(const RateTradeDefinition_& trade, const String_& key, const XccyNodeSensitivityHoist_* hoist = nullptr) {
-                const auto* preparations = JointPreparationsForKey(key);
-                if (!preparations)
+                const auto& closure = JointClosureFor(trade);
+                if (!closure.complete_)
                     return RateCashflowPricingInternal::NodeSensitivityFailure("AAD_EVALUATION_FAILED");
-                return RunJointNodeSensitivityStage(trade, market_, market_.curveComponents_.at(key).get(), *preparations, hoist);
+                const auto* target = market_.curveComponents_.at(key).get();
+                const auto preparations = JointPreparations(closure, target, hoist != nullptr);
+                if (!preparations.count(target))
+                    return RateCashflowPricingInternal::NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+                return RunJointNodeSensitivityStage(trade, market_, target, preparations, hoist);
             }
 
             RateTradeNodeSensitivityResult_
             SweepSingleCurrency(const RateTradeDefinition_& trade, const String_& componentKey, bool jointCoordinates) {
                 using namespace RateCashflowPricingInternal;
                 const Vector_<String_>& dependencyKeys = DependencyKeysFor(trade);
-                if (!ConsumesComponent(dependencyKeys, componentKey, jointCoordinates))
+                if (!ConsumesComponent(trade, dependencyKeys, componentKey, jointCoordinates))
                     return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
 
                 // Availability and representation are gated for every component the trade depends
@@ -981,19 +1037,20 @@ namespace Dal {
                     return NodeSensitivityFailure(dependencyFailure);
                 if (!PassiveOk(trade))
                     return NodeSensitivityFailure("TRADE_VALIDATION_FAILED");
+                if (jointCoordinates)
+                    return SweepJoint(trade, componentKey);
                 const NodeSensitivityPreparation_* target = PreparationForKey(componentKey);
                 if (!target)
                     return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
-                if (NeedsJointSweep(componentKey, jointCoordinates))
-                    return SweepJoint(trade, componentKey);
                 return RunSingleNodeSensitivityStage(trade, market_, componentKey, *target);
             }
 
-            const XccyNodeSensitivityHoist_& HoistXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms) {
+            const XccyNodeSensitivityHoist_& HoistXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, bool jointCoordinates = false) {
                 const auto found = xccyHoists_.find(&trade);
                 if (found != xccyHoists_.end())
                     return found->second;
                 XccyNodeSensitivityHoist_ hoist;
+                hoist.expired_ = trade.maturityDate_ < market_.valuationTime_.Date();
                 hoist.consumed_ = ResolveXccyConsumedCurves(terms, market_);
                 hoist.dependencyKeys_ = DependencyKeysForConsumedCurves(hoist.consumed_.curves_, market_);
                 // Classification walk over the consumed curves only — unused in-block members are
@@ -1008,7 +1065,7 @@ namespace Dal {
                     }
                     hoist.classified_[curve] = classification;
                 }
-                if (!hoist.classificationFailureCurve_) {
+                if (!hoist.classificationFailureCurve_ && (!jointCoordinates || hoist.expired_)) {
                     for (const auto& [curve, classification] : hoist.classified_) {
                         if (const NodeSensitivityPreparation_* preparation = PreparationFor(curve, classification))
                             hoist.prepared_[curve] = *preparation;
@@ -1024,7 +1081,6 @@ namespace Dal {
                 } catch (const std::exception&) {
                     hoist.plan_.reset();
                 }
-                hoist.expired_ = trade.maturityDate_ < market_.valuationTime_.Date();
                 return xccyHoists_.emplace(&trade, std::move(hoist)).first->second;
             }
 
@@ -1041,10 +1097,10 @@ namespace Dal {
             RateTradeNodeSensitivityResult_
             SweepXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, const String_& componentKey, bool jointCoordinates) {
                 using namespace RateCashflowPricingInternal;
-                const XccyNodeSensitivityHoist_& hoist = HoistXccy(trade, terms);
+                const XccyNodeSensitivityHoist_& hoist = HoistXccy(trade, terms, jointCoordinates);
                 if (!hoist.consumed_.resolved_)
                     return UnresolvedXccyFailure(trade);
-                if (!ConsumesComponent(hoist.dependencyKeys_, componentKey, jointCoordinates))
+                if (!ConsumesComponent(trade, hoist.dependencyKeys_, componentKey, jointCoordinates))
                     return NodeSensitivityFailure("TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
                 REQUIRE(market_.xccyMarket_, "XCCY node sensitivity requires an immutable cross-currency market");
                 const DiscountCurve_* targetCurve = market_.curveComponents_.at(componentKey).get();
@@ -1053,10 +1109,15 @@ namespace Dal {
                                                                                                    : "AAD_EVALUATION_FAILED");
                 if (!PassiveOk(trade))
                     return NodeSensitivityFailure("TRADE_VALIDATION_FAILED");
+                if (jointCoordinates && !hoist.expired_)
+                    return hoist.plan_ ? SweepJoint(trade, componentKey, &hoist) : NodeSensitivityFailure("AAD_EVALUATION_FAILED");
                 if (!XccyPreparationReady(hoist))
                     return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
-                if (NeedsJointSweep(componentKey, jointCoordinates))
-                    return SweepJoint(trade, componentKey, &hoist);
+                if (jointCoordinates && !hoist.prepared_.count(targetCurve)) {
+                    const auto* target = PreparationForKey(componentKey);
+                    return target ? RateTradeNodeSensitivityResult_{true, 0.0, Vector_<>(target->expectedParameterCount_, 0.0), String_()}
+                                  : NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+                }
                 return RunXccyNodeSensitivityStage(terms, market_, targetCurve, hoist);
             }
 
@@ -1074,8 +1135,9 @@ namespace Dal {
             std::map<const RateTradeDefinition_*, RatePricingTradeResult_> passivePrices_;
             std::map<const RateTradeDefinition_*, Vector_<String_>> dependencyKeys_;
             std::map<const RateTradeDefinition_*, XccyNodeSensitivityHoist_> xccyHoists_;
-            std::map<String_, Vector_<String_>> jointDependencies_;
-            std::map<String_, JointNodePreparations_> jointPreparations_;
+            std::map<const RateTradeDefinition_*, JointCurveClosure_> jointClosures_;
+            std::map<const DiscountCurve_*, NodeSensitivityPreparation_> jointPrepared_;
+            std::set<const DiscountCurve_*> jointPreparationFailures_;
         };
     } // namespace
 
@@ -1491,7 +1553,7 @@ namespace Dal {
             bool structuralZero = true;
             const bool jointCoordinates = item.provenance_->Kind() == "JOINT_MULTI_CURVE";
             for (const auto& block : item.blocks_) {
-                const bool consumesComponent = sweeper->ConsumesComponent(passive.dependencyComponentKeys_, block.componentKey_, jointCoordinates);
+                const bool consumesComponent = sweeper->ConsumesComponent(trade, passive.dependencyComponentKeys_, block.componentKey_, jointCoordinates);
                 if (dependencyPlanAvailable && !consumesComponent)
                     continue;
                 structuralZero = false;
@@ -1512,7 +1574,10 @@ namespace Dal {
                     AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, false, false, block.componentKey_, cell.reason_, result);
                     return;
                 }
-                REQUIRE(static_cast<int>(cell.gradient_.size()) == block.parameterCount_, "QUOTE_RISK_GRADIENT_WIDTH_MISMATCH");
+                if (static_cast<int>(cell.gradient_.size()) != block.parameterCount_) {
+                    AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, false, false, block.componentKey_, "AAD_EVALUATION_FAILED", result);
+                    return;
+                }
                 std::copy(cell.gradient_.begin(), cell.gradient_.end(), gradient.begin() + block.offset_);
             }
             AddQuoteRiskGradient(item.index_, actualPvCcy.String(), gradient, gradientSums);

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -6,6 +6,7 @@
 #include <dal/platform/strict.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <optional>
 #include <set>
@@ -1070,8 +1071,9 @@ namespace Dal {
 
             const XccyNodeSensitivityHoist_&
             HoistXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, bool jointCoordinates = false) {
-                const auto found = xccyHoists_.find(&trade);
-                if (found != xccyHoists_.end())
+                auto& hoists = xccyHoists_[jointCoordinates];
+                const auto found = hoists.find(&trade);
+                if (found != hoists.end())
                     return found->second;
                 XccyNodeSensitivityHoist_ hoist;
                 hoist.expired_ = trade.maturityDate_ < market_.valuationTime_.Date();
@@ -1096,7 +1098,7 @@ namespace Dal {
                 } catch (const std::exception&) {
                     hoist.plan_.reset();
                 }
-                return xccyHoists_.emplace(&trade, std::move(hoist)).first->second;
+                return hoists.emplace(&trade, std::move(hoist)).first->second;
             }
 
             RateTradeNodeSensitivityResult_ UnresolvedXccyFailure(const RateTradeDefinition_& trade) {
@@ -1149,7 +1151,8 @@ namespace Dal {
             std::set<const DiscountCurve_*> preparationFailures_;
             std::map<const RateTradeDefinition_*, RatePricingTradeResult_> passivePrices_;
             std::map<const RateTradeDefinition_*, Vector_<String_>> dependencyKeys_;
-            std::map<const RateTradeDefinition_*, XccyNodeSensitivityHoist_> xccyHoists_;
+            // Joint and standalone coordinates require different hoist preparation.
+            std::array<std::map<const RateTradeDefinition_*, XccyNodeSensitivityHoist_>, 2> xccyHoists_;
             std::map<const RateTradeDefinition_*, JointCurveClosure_> jointClosures_;
             std::map<const DiscountCurve_*, NodeSensitivityPreparation_> jointPrepared_;
             std::set<const DiscountCurve_*> jointPreparationFailures_;

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <set>
 #include <type_traits>
+#include <typeinfo>
 
 #include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveparameterization.hpp>
@@ -704,12 +705,13 @@ namespace Dal {
         using ActiveCurveMap_ = std::map<const DiscountCurve_*, std::shared_ptr<Tape::DiscountCurve_<AAD::Number_>>>;
 
         bool IsExactJointCurve(const DiscountCurve_& curve) {
+            const std::type_info& actualType = typeid(curve);
             return std::visit(
-                [&](const auto& typed) {
+                [&actualType](const auto& typed) -> bool {
                     if constexpr (std::is_same_v<std::decay_t<decltype(typed)>, std::monostate>)
                         return false;
                     else
-                        return typeid(curve) == typeid(std::remove_pointer_t<std::decay_t<decltype(typed)>>);
+                        return actualType == typeid(std::remove_pointer_t<std::decay_t<decltype(typed)>>);
                 },
                 RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(curve));
         }
@@ -922,20 +924,29 @@ namespace Dal {
                 return jointClosures_.emplace(&trade, BuildJointCurveClosure(roots)).first->second;
             }
 
+            bool PrepareJointPath(const JointCurveClosure_& closure,
+                                  const DiscountCurve_* root,
+                                  const DiscountCurve_* target,
+                                  JointNodePreparations_* preparations) {
+                for (const auto* curve = root; curve && !preparations->count(curve); curve = closure.bases_.at(curve)) {
+                    const auto* preparation = PreparationFor(curve, RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*curve), true);
+                    if (!preparation)
+                        return false;
+                    preparations->emplace(curve, preparation);
+                    if (curve == target)
+                        break;
+                }
+                return true;
+            }
+
             JointNodePreparations_ JointPreparations(const JointCurveClosure_& closure, const DiscountCurve_* target, bool xccy) {
                 JointNodePreparations_ result;
                 for (const auto* root : closure.roots_) {
                     const bool depends = CurveDependsOn(root, target);
                     if (!xccy && !depends)
                         continue;
-                    for (const auto* curve = root; curve && !result.count(curve); curve = closure.bases_.at(curve)) {
-                        const auto* preparation = PreparationFor(curve, RateCashflowPricingInternal::ClassifyNodeSensitivityCurve(*curve), true);
-                        if (!preparation)
-                            return {};
-                        result.emplace(curve, preparation);
-                        if (!depends || curve == target)
-                            break;
-                    }
+                    if (!PrepareJointPath(closure, root, depends ? target : root, &result))
+                        return {};
                 }
                 return result;
             }
@@ -1045,6 +1056,18 @@ namespace Dal {
                 return RunSingleNodeSensitivityStage(trade, market_, componentKey, *target);
             }
 
+            void PrepareXccyConsumedCurves(XccyNodeSensitivityHoist_* hoist) {
+                for (const auto& [curve, classification] : hoist->classified_) {
+                    if (const NodeSensitivityPreparation_* preparation = PreparationFor(curve, classification))
+                        hoist->prepared_[curve] = *preparation;
+                    else {
+                        hoist->preparationOk_ = false;
+                        break;
+                    }
+                }
+                hoist->preparationAttempted_ = true;
+            }
+
             const XccyNodeSensitivityHoist_&
             HoistXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, bool jointCoordinates = false) {
                 const auto found = xccyHoists_.find(&trade);
@@ -1066,17 +1089,8 @@ namespace Dal {
                     }
                     hoist.classified_[curve] = classification;
                 }
-                if (!hoist.classificationFailureCurve_ && (!jointCoordinates || hoist.expired_)) {
-                    for (const auto& [curve, classification] : hoist.classified_) {
-                        if (const NodeSensitivityPreparation_* preparation = PreparationFor(curve, classification))
-                            hoist.prepared_[curve] = *preparation;
-                        else {
-                            hoist.preparationOk_ = false;
-                            break;
-                        }
-                    }
-                    hoist.preparationAttempted_ = true;
-                }
+                if (!hoist.classificationFailureCurve_ && (!jointCoordinates || hoist.expired_))
+                    PrepareXccyConsumedCurves(&hoist);
                 try {
                     hoist.plan_ = BuildXccyCashflowPlan(trade.startDate_, trade.maturityDate_, terms.config_);
                 } catch (const std::exception&) {

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -813,6 +813,8 @@ namespace Dal {
                 for (const auto& [curve, preparation] : preparations)
                     BuildJointActiveCurve(curve, target, parameters, preparations, &active);
                 AAD::Number_ pv = PriceJointActive(trade, market, active, xccyHoist);
+                if (const auto hook = g_jointNodeSensitivityRecordedPvHook.load(std::memory_order_relaxed))
+                    hook(target);
                 AAD::Adjoint(pv) = 1.0;
                 AAD::PropagateToStart(*AAD::Tape());
                 NodeSensitivityCandidate_ candidate;

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -872,10 +872,8 @@ namespace Dal {
                 return SweepSingleCurrency(trade, componentKey, jointCoordinates);
             }
 
-            bool ConsumesComponent(const RateTradeDefinition_& trade,
-                                   const Vector_<String_>& dependencies,
-                                   const String_& key,
-                                   bool jointCoordinates) {
+            bool
+            ConsumesComponent(const RateTradeDefinition_& trade, const Vector_<String_>& dependencies, const String_& key, bool jointCoordinates) {
                 if (!jointCoordinates)
                     return std::find(dependencies.begin(), dependencies.end(), key) != dependencies.end();
                 const auto target = market_.curveComponents_.find(key);
@@ -1045,7 +1043,8 @@ namespace Dal {
                 return RunSingleNodeSensitivityStage(trade, market_, componentKey, *target);
             }
 
-            const XccyNodeSensitivityHoist_& HoistXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, bool jointCoordinates = false) {
+            const XccyNodeSensitivityHoist_&
+            HoistXccy(const RateTradeDefinition_& trade, const XccyTradeTerms_& terms, bool jointCoordinates = false) {
                 const auto found = xccyHoists_.find(&trade);
                 if (found != xccyHoists_.end())
                     return found->second;
@@ -1539,6 +1538,22 @@ namespace Dal {
 
         bool UsablePassivePrice(const RatePricingTradeResult_& passive) { return passive.succeeded_ && std::isfinite(passive.pv_); }
 
+        RateTradeNodeSensitivityResult_
+        QuoteRiskSweep(const RateTradeDefinition_& trade, const String_& key, int width, bool jointCoordinates, NodeSensitivitySweeper_* sweeper) {
+            using namespace RateCashflowPricingInternal;
+            try {
+                auto cell = sweeper->Sweep(trade, key, jointCoordinates);
+                if (!cell.eligible_)
+                    return cell;
+                if (jointCoordinates)
+                    if (const auto hook = g_quoteRiskRecordedSweepHook.load(std::memory_order_relaxed))
+                        hook(key, &cell);
+                return FinalizeNodeSensitivityCandidate({cell.pv_, std::move(cell.gradient_)}, width);
+            } catch (const std::exception&) {
+                return NodeSensitivityFailure("AAD_EVALUATION_FAILED");
+            }
+        }
+
         void ProcessQuoteRiskTradeProvenance(const RateTradeDefinition_& trade,
                                              const RatePricingTradeResult_& passive,
                                              const PreparedQuoteRiskProvenance_& item,
@@ -1553,7 +1568,8 @@ namespace Dal {
             bool structuralZero = true;
             const bool jointCoordinates = item.provenance_->Kind() == "JOINT_MULTI_CURVE";
             for (const auto& block : item.blocks_) {
-                const bool consumesComponent = sweeper->ConsumesComponent(trade, passive.dependencyComponentKeys_, block.componentKey_, jointCoordinates);
+                const bool consumesComponent =
+                    sweeper->ConsumesComponent(trade, passive.dependencyComponentKeys_, block.componentKey_, jointCoordinates);
                 if (dependencyPlanAvailable && !consumesComponent)
                     continue;
                 structuralZero = false;
@@ -1569,13 +1585,9 @@ namespace Dal {
                                         failed.reason_.empty() ? String_("TRADE_VALIDATION_FAILED") : failed.reason_, result);
                     return;
                 }
-                const auto cell = sweeper->Sweep(trade, block.componentKey_, jointCoordinates);
+                const auto cell = QuoteRiskSweep(trade, block.componentKey_, block.parameterCount_, jointCoordinates, sweeper);
                 if (!cell.eligible_) {
                     AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, false, false, block.componentKey_, cell.reason_, result);
-                    return;
-                }
-                if (static_cast<int>(cell.gradient_.size()) != block.parameterCount_) {
-                    AppendQuoteRiskMeta(trade, item, actualPvCcy, passive.pv_, false, false, block.componentKey_, "AAD_EVALUATION_FAILED", result);
                     return;
                 }
                 std::copy(cell.gradient_.begin(), cell.gradient_.end(), gradient.begin() + block.offset_);
@@ -1622,6 +1634,17 @@ namespace Dal {
                 for (const auto& key : invalid.dependencyComponentKeys_)
                     if (ConsumesInvalidCurve(key, market, invalidKeys))
                         return invalid;
+                if (const auto* terms = std::get_if<XccyTradeTerms_>(&trade.terms_)) {
+                    const auto consumed = ResolveXccyConsumedCurves(*terms, market);
+                    const auto closure = BuildJointCurveClosure(consumed.curves_);
+                    if (!closure.complete_)
+                        return invalid;
+                    for (const auto& key : invalidKeys) {
+                        const auto found = market.curveComponents_.find(key);
+                        if (found != market.curveComponents_.end() && closure.bases_.count(found->second.get()))
+                            return invalid;
+                    }
+                }
             } catch (const std::exception&) {
                 return invalid;
             }

--- a/dal-cpp/dal/curve/ratecashflowpricing.cpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing.cpp
@@ -985,6 +985,7 @@ namespace Dal {
                 if (found != preparations.end())
                     return &found->second;
                 try {
+                    RateCashflowPricingInternal::ObserveJointPreparationAttempt(curve, jointCoordinates);
                     Date_ anchor = market_.valuationTime_.Date();
                     if (jointCoordinates)
                         std::visit(

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -84,6 +84,16 @@ namespace Dal::RateCashflowPricingInternal {
     // Test-only fault injection while the joint sweep still owns its recorded tape.
     inline std::atomic<void (*)(const DiscountCurve_*)> g_jointNodeSensitivityRecordedPvHook{nullptr};
 
+    // Test-only preparation fault, invoked only on a joint preparation cache miss.
+    inline std::atomic<void (*)(const DiscountCurve_*)> g_jointNodeSensitivityPreparationHook{nullptr};
+
+    inline void ObserveJointPreparationAttempt(const DiscountCurve_* curve, bool jointCoordinates) {
+        if (!jointCoordinates)
+            return;
+        if (const auto hook = g_jointNodeSensitivityPreparationHook.load(std::memory_order_relaxed))
+            hook(curve);
+    }
+
     using NodeSensitivityCurve_ = std::variant<std::monostate,
                                                const Tape::DiscountPWC_<double>*,
                                                const Tape::DiscountPWLF_<double>*,

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -81,6 +81,9 @@ namespace Dal::RateCashflowPricingInternal {
     using QuoteRiskRecordedSweepHook_ = void (*)(const String_&, RateTradeNodeSensitivityResult_*);
     inline std::atomic<QuoteRiskRecordedSweepHook_> g_quoteRiskRecordedSweepHook{nullptr};
 
+    // Test-only fault injection while the joint sweep still owns its recorded tape.
+    inline std::atomic<void (*)(const DiscountCurve_*)> g_jointNodeSensitivityRecordedPvHook{nullptr};
+
     using NodeSensitivityCurve_ = std::variant<std::monostate,
                                                const Tape::DiscountPWC_<double>*,
                                                const Tape::DiscountPWLF_<double>*,

--- a/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
+++ b/dal-cpp/dal/curve/ratecashflowpricing_internal.hpp
@@ -77,6 +77,10 @@ namespace Dal::RateCashflowPricingInternal {
     // Test-only fault seam for proving quote-risk sibling-gradient atomicity.
     inline std::atomic<const String_*> g_quoteRiskForcedSweepFailureComponent{nullptr};
 
+    // Test-only fault injection after a real sweep, before the aggregate accepts its slice.
+    using QuoteRiskRecordedSweepHook_ = void (*)(const String_&, RateTradeNodeSensitivityResult_*);
+    inline std::atomic<QuoteRiskRecordedSweepHook_> g_quoteRiskRecordedSweepHook{nullptr};
+
     using NodeSensitivityCurve_ = std::variant<std::monostate,
                                                const Tape::DiscountPWC_<double>*,
                                                const Tape::DiscountPWLF_<double>*,

--- a/dal-cpp/tests/curve/jointquoteriskopaque.hpp
+++ b/dal-cpp/tests/curve/jointquoteriskopaque.hpp
@@ -1,0 +1,40 @@
+//
+// Created by dal-implementer on 2026/9/11.
+//
+
+#pragma once
+
+#include <dal/curve/discount.hpp>
+#include <dal/storage/archive.hpp>
+
+namespace JointXccyQuoteRiskFixtures {
+    using namespace Dal;
+
+    class OpaqueCurve_ : public DiscountCurve_ {
+        Handle_<DiscountCurve_> inner_;
+
+    public:
+        explicit OpaqueCurve_(const Handle_<DiscountCurve_>& inner = {}, const String_& currency = "USD")
+            : DiscountCurve_("opaque", currency), inner_(inner) {}
+        double operator()(const Date_& from, const Date_& to) const override { return inner_ ? (*inner_)(from, to) : 1.0; }
+        void Poll(Vector_<const YCComponent_*>* all) const override {
+            all->push_back(this);
+            if (inner_)
+                inner_->Poll(all);
+        }
+        void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>* all) const override {
+            if (inner_)
+                inner_->Poll(all);
+        }
+        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_&, const YCComponent_::substitutions_t& changes) const override {
+            const auto found = changes.find(inner_.get());
+            return std::make_unique<OpaqueCurve_>(found == changes.end() ? inner_ : handle_cast<DiscountCurve_>(found->second), ccy_.String());
+        }
+        void Write(Archive::Store_& dst) const override {
+            dst.SetType("OpaqueCurve_JointQuoteRiskTestOnly");
+            if (inner_)
+                Archive::Utils::Set(dst, "inner", inner_);
+            dst.Done();
+        }
+    };
+} // namespace JointXccyQuoteRiskFixtures

--- a/dal-cpp/tests/curve/jointxccyquoteriskfixtures.hpp
+++ b/dal-cpp/tests/curve/jointxccyquoteriskfixtures.hpp
@@ -23,12 +23,13 @@ namespace JointXccyQuoteRiskFixtures {
     }
 
     inline Dal::Handle_<Dal::DiscountCurve_> Flat(const Dal::JointMultiCurveCalibrationSpec_& spec,
-                                                 const Dal::String_& name,
-                                                 const Dal::String_& currency,
-                                                 double rate,
-                                                 const Dal::Handle_<Dal::DiscountCurve_>& base = {}) {
+                                                  const Dal::String_& name,
+                                                  const Dal::String_& currency,
+                                                  double rate,
+                                                  const Dal::Handle_<Dal::DiscountCurve_>& base = {}) {
         return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC(
-            name, currency, Dal::PiecewiseConstant_(spec.curves_.front().knotDates_, Dal::Vector_<>(spec.curves_.front().knotDates_.size(), rate)), base));
+            name, currency, Dal::PiecewiseConstant_(spec.curves_.front().knotDates_, Dal::Vector_<>(spec.curves_.front().knotDates_.size(), rate)),
+            base));
     }
 
     inline Dal::RatePricingMarket_ Market(const Dal::JointMultiCurveCalibrationSpec_& spec,

--- a/dal-cpp/tests/curve/jointxccyquoteriskfixtures.hpp
+++ b/dal-cpp/tests/curve/jointxccyquoteriskfixtures.hpp
@@ -1,0 +1,97 @@
+//
+// Created by dal-implementer on 2026/9/11.
+//
+
+#pragma once
+
+#include <functional>
+
+#include <dal/curve/piecewiseconstant.hpp>
+#include <dal/curve/xccycalibration.hpp>
+#include <dal/curve/ycconst.hpp>
+
+#include "jointquoteriskfixtures.hpp"
+
+namespace JointXccyQuoteRiskFixtures {
+    using CurveTransform_ = std::function<Dal::Handle_<Dal::DiscountCurve_>(const Dal::Handle_<Dal::DiscountCurve_>&)>;
+
+    inline Dal::JointMultiCurveCalibrationOptions_ Options(Dal::CurveJacobianMode_ mode = Dal::CurveJacobianMode_::Value_::ANALYTIC) {
+        Dal::JointMultiCurveCalibrationOptions_ result;
+        result.computeEffJacobianInverse_ = true;
+        result.jacobianMode_ = mode;
+        return result;
+    }
+
+    inline Dal::Handle_<Dal::DiscountCurve_> Flat(const Dal::JointMultiCurveCalibrationSpec_& spec,
+                                                 const Dal::String_& name,
+                                                 const Dal::String_& currency,
+                                                 double rate,
+                                                 const Dal::Handle_<Dal::DiscountCurve_>& base = {}) {
+        return Dal::Handle_<Dal::DiscountCurve_>(Dal::NewDiscountPWC(
+            name, currency, Dal::PiecewiseConstant_(spec.curves_.front().knotDates_, Dal::Vector_<>(spec.curves_.front().knotDates_.size(), rate)), base));
+    }
+
+    inline Dal::RatePricingMarket_ Market(const Dal::JointMultiCurveCalibrationSpec_& spec,
+                                          const Dal::JointMultiCurveCalibrationResult_& calibrated,
+                                          bool registerExtraForward = false,
+                                          const CurveTransform_& transformBase = {},
+                                          const CurveTransform_& transformEuro = {}) {
+        using namespace Dal;
+        auto result = JointQuoteRiskFixtures::Market(spec, calibrated);
+        const auto euroDiscount = Flat(spec, "eur-ois", "EUR", 0.017);
+        const auto euroForward = transformEuro ? transformEuro(Flat(spec, "eur-3m", "EUR", 0.019)) : Flat(spec, "eur-3m", "EUR", 0.019);
+        const auto basis = Flat(spec, "eur-usd-basis", "EUR", 0.001);
+        const auto base = calibrated.discountCurves_.at(CollateralType_("OIS"));
+        const auto extraForward = transformBase ? transformBase(base) : Flat(spec, "usd-6m", "USD", 0.015, base);
+        result.curveComponents_["eur-discount"] = euroDiscount;
+        result.curveComponents_["eur-forward"] = euroForward;
+        result.curveComponents_["basis"] = basis;
+        if (registerExtraForward)
+            result.curveComponents_["usd-6m"] = extraForward;
+        const Handle_<CurveBlock_> domestic(
+            new CurveBlock_("EUR", "EUR", {{CollateralType_("OIS"), euroDiscount}}, {{PeriodLength_("3M"), euroForward}}, DayBasis::Act365F()));
+        auto forwards = calibrated.forwardCurves_;
+        forwards[PeriodLength_("6M")] = extraForward;
+        const Handle_<CurveBlock_> foreign(new CurveBlock_("USD", "USD", calibrated.discountCurves_, forwards, spec.liborBasis_));
+        auto xccy = std::make_shared<CrossCurrencyMarket_>(domestic, foreign, 0.9, result.valuationTime_, Ccy_("EUR"), result.fixings_);
+        xccy->SetBasisCurve(basis);
+        result.xccyMarket_ = xccy;
+        return result;
+    }
+
+    inline Dal::RateTradeDefinition_ Trade(const Dal::JointMultiCurveCalibrationSpec_& spec) {
+        using namespace Dal;
+        XccyTradeTerms_ terms;
+        terms.positionCount_ = 1.0;
+        terms.contractSpread_ = 0.0015;
+        terms.spreadOnForeignLeg_ = true;
+        terms.receiveNonSpreadPaySpread_ = true;
+        terms.config_.pair_ = CurrencyPair_(Ccy_("EUR"), Ccy_("USD"));
+        terms.config_.domesticNotional_ = 900000.0;
+        terms.config_.foreignNotional_ = 1000000.0;
+        terms.config_.convention_.domesticLeg_ = JointQuoteRiskFixtures::Leg(3);
+        terms.config_.convention_.foreignLeg_ = JointQuoteRiskFixtures::Leg(6);
+        terms.config_.convention_.domesticIndex_ = JointQuoteRiskFixtures::Index(1);
+        terms.config_.convention_.foreignIndex_ = JointQuoteRiskFixtures::Index(2);
+        terms.config_.domesticRateFixing_ = {"EUR-3M", 11, 0};
+        terms.config_.foreignRateFixing_ = {"USD-6M", 11, 0};
+        return {"euro-xccy", RateInstrumentType_::Value_::XCCY, spec.today_, spec.today_, Date::AddMonths(spec.today_, 24), Ccy_("EUR"), terms};
+    }
+
+    inline double Reprice(const Dal::JointMultiCurveCalibrationSpec_& spec,
+                          const Dal::JointMultiCurveCalibrationOptions_& options,
+                          int block,
+                          int ordinal,
+                          double bump,
+                          const CurveTransform_& transformBase = {}) {
+        auto shifted = spec;
+        const auto& instrument = spec.curves_[block].instruments_[ordinal];
+        shifted.curves_[block].instruments_[ordinal] =
+            JointQuoteRiskFixtures::Instrument(spec.today_, instrument->TimeSpan().second, block, instrument->MarketRate() + bump);
+        const auto solved = Dal::CalibrateJointMultiCurve(shifted, options);
+        REQUIRE(solved.converged_, "Joint quote oracle calibration failed");
+        const auto pv = Dal::PriceRateTrade(Trade(spec), Market(shifted, solved, false, transformBase));
+        REQUIRE(pv.succeeded_ && std::isfinite(pv.pv_), "Joint quote oracle repricing failed: " + pv.error_);
+        return pv.pv_;
+    }
+} // namespace JointXccyQuoteRiskFixtures

--- a/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
@@ -1,0 +1,140 @@
+//
+// Created by dal-implementer on 2026/9/11.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/curve/ratecashflowpricing_internal.hpp>
+#include <dal/storage/archive.hpp>
+
+#include "jointxccyquoteriskfixtures.hpp"
+
+using namespace Dal;
+using namespace JointXccyQuoteRiskFixtures;
+
+namespace {
+    class OpaqueCurve_ : public DiscountCurve_ {
+        Handle_<DiscountCurve_> inner_;
+
+    public:
+        explicit OpaqueCurve_(const Handle_<DiscountCurve_>& inner = {}) : DiscountCurve_("opaque", "USD"), inner_(inner) {}
+        double operator()(const Date_& from, const Date_& to) const override { return inner_ ? (*inner_)(from, to) : 1.0; }
+        void Poll(Vector_<const YCComponent_*>* all) const override {
+            all->push_back(this);
+            if (inner_)
+                inner_->Poll(all);
+        }
+        void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>* all) const override {
+            if (inner_)
+                inner_->Poll(all);
+        }
+        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_&, const YCComponent_::substitutions_t& changes) const override {
+            const auto found = changes.find(inner_.get());
+            return std::make_unique<OpaqueCurve_>(found == changes.end() ? inner_ : handle_cast<DiscountCurve_>(found->second));
+        }
+        void Write(Archive::Store_& dst) const override {
+            dst.SetType("OpaqueCurve_JointQuoteRiskTestOnly");
+            if (inner_)
+                Archive::Utils::Set(dst, "inner", inner_);
+            dst.Done();
+        }
+    };
+
+    class TaggedPwc_ : public Tape::DiscountPWC_<double> {
+    public:
+        explicit TaggedPwc_(const Tape::DiscountPWC_<double>& curve)
+            : Tape::DiscountPWC_<double>(curve.Name(), curve.ccy_.String(), curve.KnotDates(), curve.FRight(), curve.Base()) {}
+    };
+
+    RatePortfolioQuoteRisk_ Risk(const JointMultiCurveCalibrationSpec_& spec,
+                                 const JointMultiCurveCalibrationResult_& calibrated,
+                                 const RatePricingMarket_& market,
+                                 const Vector_<RateTradeDefinition_>& trades) {
+        const auto provenance = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(2));
+        REQUIRE(provenance.Available(), provenance.Reason());
+        return AggregateRatePortfolioQuoteRisk(trades, market, {provenance});
+    }
+
+    RateTradeDefinition_ Future(const JointMultiCurveCalibrationSpec_& spec, const String_& key) {
+        FutureTradeTerms_ terms;
+        terms.contractCount_ = 1.0;
+        terms.referencePrice_ = 100.0;
+        terms.contractValuePerPricePoint_ = 1.0;
+        terms.long_ = true;
+        terms.index_ = JointQuoteRiskFixtures::Index(1);
+        terms.fixingIdentity_ = {"USD-3M", 11, 0};
+        terms.forecastComponentKey_ = key;
+        return {"future", RateInstrumentType_::Value_::FUTURE, spec.today_, spec.today_, Date::AddMonths(spec.today_, 3), Ccy_("USD"), terms};
+    }
+
+    void AssertIncomplete(const RatePortfolioQuoteRisk_& risk,
+                          const RateTradeDefinition_& trade,
+                          const RatePricingMarket_& market,
+                          const String_& reason = "AAD_EVALUATION_FAILED",
+                          const String_& key = "curve:0") {
+        ASSERT_TRUE(risk.provenanceFailures_.empty());
+        ASSERT_TRUE(risk.buckets_.empty());
+        ASSERT_EQ(risk.meta_.size(), 1);
+        const auto& meta = risk.meta_[0];
+        ASSERT_FALSE(meta.eligible_);
+        ASSERT_FALSE(meta.structuralZero_);
+        ASSERT_EQ(meta.reason_, "QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE");
+        ASSERT_EQ(meta.originalNodeRiskReason_, reason);
+        ASSERT_EQ(meta.failingComponentKey_, key);
+        ASSERT_EQ(meta.instrumentId_, trade.instrumentId_);
+        ASSERT_EQ(meta.calibrationId_, "generic-joint");
+        const auto passive = PriceRateTrade(trade, market);
+        ASSERT_DOUBLE_EQ(meta.pv_, passive.succeeded_ ? passive.pv_ : 0.0);
+    }
+} // namespace
+
+TEST(JointQuoteRiskTest, TestUnregisteredXccyBaseMatchesFullRecalibration) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = Market(spec, calibrated);
+    const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
+    ASSERT_EQ(risk.meta_.size(), 1);
+    ASSERT_TRUE(risk.meta_[0].eligible_);
+    ASSERT_EQ(risk.buckets_.size(), 5);
+    const double derivative = (Reprice(spec, Options(), 0, 1, 1.0e-6) - Reprice(spec, Options(), 0, 1, -1.0e-6)) / 2.0e-6;
+    ASSERT_NEAR(risk.buckets_[1].dPvDDecimalQuote_, derivative, 1.0e-3);
+}
+
+TEST(JointQuoteRiskTest, TestOpaqueLeafFailsClosed) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = Market(spec, calibrated, true, {}, [&](const auto&) {
+        return Flat(spec, "eur-3m", "EUR", 0.019, Handle_<DiscountCurve_>(new OpaqueCurve_()));
+    });
+    const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
+    AssertIncomplete(risk, Trade(spec), market);
+}
+
+TEST(JointQuoteRiskTest, TestOpaqueForwardingFailsClosed) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = Market(spec, calibrated, true, [&](const auto& base) {
+        return Flat(spec, "usd-6m", "USD", 0.015, Handle_<DiscountCurve_>(new OpaqueCurve_(base)));
+    });
+    const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
+    AssertIncomplete(risk, Trade(spec), market);
+}
+
+TEST(JointQuoteRiskTest, TestDerivedBuiltinFailsClosed) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = Market(spec, calibrated, true, {}, [](const auto& root) {
+        return Handle_<DiscountCurve_>(new TaggedPwc_(dynamic_cast<const Tape::DiscountPWC_<double>&>(*root)));
+    });
+    const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
+    AssertIncomplete(risk, Trade(spec), market);
+}
+
+TEST(JointQuoteRiskTest, TestOpaqueOnlyRootKeepsRepresentationGate) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    auto market = JointQuoteRiskFixtures::Market(spec, calibrated);
+    market.curveComponents_["opaque-forecast"] = Handle_<DiscountCurve_>(new OpaqueCurve_(market.curveComponents_.at("curve:0")));
+    const auto risk = Risk(spec, calibrated, market, {Future(spec, "opaque-forecast")});
+    AssertIncomplete(risk, Future(spec, "opaque-forecast"), market, "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+}

--- a/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
@@ -4,41 +4,20 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <future>
+#include <limits>
+
 #include <dal/curve/ratecashflowpricing_internal.hpp>
 #include <dal/storage/archive.hpp>
 
+#include "jointquoteriskopaque.hpp"
 #include "jointxccyquoteriskfixtures.hpp"
 
 using namespace Dal;
 using namespace JointXccyQuoteRiskFixtures;
 
 namespace {
-    class OpaqueCurve_ : public DiscountCurve_ {
-        Handle_<DiscountCurve_> inner_;
-
-    public:
-        explicit OpaqueCurve_(const Handle_<DiscountCurve_>& inner = {}) : DiscountCurve_("opaque", "USD"), inner_(inner) {}
-        double operator()(const Date_& from, const Date_& to) const override { return inner_ ? (*inner_)(from, to) : 1.0; }
-        void Poll(Vector_<const YCComponent_*>* all) const override {
-            all->push_back(this);
-            if (inner_)
-                inner_->Poll(all);
-        }
-        void Poll(std::map<const YCComponent_*, Handle_<YCComponent_>>* all) const override {
-            if (inner_)
-                inner_->Poll(all);
-        }
-        [[nodiscard]] std::unique_ptr<YCComponent_> Clone(const String_&, const YCComponent_::substitutions_t& changes) const override {
-            const auto found = changes.find(inner_.get());
-            return std::make_unique<OpaqueCurve_>(found == changes.end() ? inner_ : handle_cast<DiscountCurve_>(found->second));
-        }
-        void Write(Archive::Store_& dst) const override {
-            dst.SetType("OpaqueCurve_JointQuoteRiskTestOnly");
-            if (inner_)
-                Archive::Utils::Set(dst, "inner", inner_);
-            dst.Done();
-        }
-    };
 
     class TaggedPwc_ : public Tape::DiscountPWC_<double> {
     public:
@@ -103,9 +82,8 @@ TEST(JointQuoteRiskTest, TestUnregisteredXccyBaseMatchesFullRecalibration) {
 TEST(JointQuoteRiskTest, TestOpaqueLeafFailsClosed) {
     const auto spec = JointQuoteRiskFixtures::Spec();
     const auto calibrated = CalibrateJointMultiCurve(spec, Options());
-    const auto market = Market(spec, calibrated, true, {}, [&](const auto&) {
-        return Flat(spec, "eur-3m", "EUR", 0.019, Handle_<DiscountCurve_>(new OpaqueCurve_()));
-    });
+    const auto market = Market(spec, calibrated, true, {},
+                               [&](const auto&) { return Flat(spec, "eur-3m", "EUR", 0.019, Handle_<DiscountCurve_>(new OpaqueCurve_())); });
     const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
     AssertIncomplete(risk, Trade(spec), market);
 }
@@ -113,9 +91,8 @@ TEST(JointQuoteRiskTest, TestOpaqueLeafFailsClosed) {
 TEST(JointQuoteRiskTest, TestOpaqueForwardingFailsClosed) {
     const auto spec = JointQuoteRiskFixtures::Spec();
     const auto calibrated = CalibrateJointMultiCurve(spec, Options());
-    const auto market = Market(spec, calibrated, true, [&](const auto& base) {
-        return Flat(spec, "usd-6m", "USD", 0.015, Handle_<DiscountCurve_>(new OpaqueCurve_(base)));
-    });
+    const auto market = Market(spec, calibrated, true,
+                               [&](const auto& base) { return Flat(spec, "usd-6m", "USD", 0.015, Handle_<DiscountCurve_>(new OpaqueCurve_(base))); });
     const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
     AssertIncomplete(risk, Trade(spec), market);
 }
@@ -137,4 +114,311 @@ TEST(JointQuoteRiskTest, TestOpaqueOnlyRootKeepsRepresentationGate) {
     market.curveComponents_["opaque-forecast"] = Handle_<DiscountCurve_>(new OpaqueCurve_(market.curveComponents_.at("curve:0")));
     const auto risk = Risk(spec, calibrated, market, {Future(spec, "opaque-forecast")});
     AssertIncomplete(risk, Future(spec, "opaque-forecast"), market, "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+}
+
+TEST(JointQuoteRiskTest, TestUnregisteredXccyOracleAcrossModesLayoutsLayersAndAliases) {
+    for (bool layered : {false, true})
+        for (auto layout : {CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD})
+            for (auto mode : {CurveJacobianMode_::Value_::ANALYTIC, CurveJacobianMode_::Value_::BUMPED}) {
+                const auto spec = JointQuoteRiskFixtures::Spec(5, 2, layout, layered);
+                const auto options = Options(mode);
+                const auto calibrated = CalibrateJointMultiCurve(spec, options);
+                const auto market = Market(spec, calibrated);
+                auto aliased = market;
+                const auto extra = market.xccyMarket_->ForeignBlock().ForwardCurves().at(PeriodLength_("6M"));
+                aliased.curveComponents_["extra"] = extra;
+                aliased.curveComponents_["extra-alias"] = extra;
+                Vector_<RatePortfolioQuoteRisk_> risks;
+                int preparations = 0, sweeps = 0;
+                for (const auto* routed : {&market, static_cast<const RatePricingMarket_*>(&aliased)}) {
+                    const auto provenance =
+                        BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, options, *routed, JointQuoteRiskFixtures::Config(2));
+                    RateCashflowPricingInternal::g_nodeSensitivityPreparationCount = 0;
+                    RateCashflowPricingInternal::g_nodeSensitivitySweepCount = 0;
+                    RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount = 0;
+                    RateCashflowPricingInternal::g_quoteRiskProvenancePreparationCount = 0;
+                    risks.push_back(AggregateRatePortfolioQuoteRisk({Trade(spec)}, *routed, {provenance}));
+                    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount, 1);
+                    ASSERT_EQ(RateCashflowPricingInternal::g_quoteRiskProvenancePreparationCount, 1);
+                    ASSERT_EQ(risks.back().buckets_.size(), 5);
+                    ASSERT_TRUE(risks.back().meta_[0].eligible_);
+                    ASSERT_EQ(risks.back().meta_[0].actualPvCcy_, Ccy_("EUR"));
+                    if (risks.size() == 1) {
+                        preparations = RateCashflowPricingInternal::g_nodeSensitivityPreparationCount;
+                        sweeps = RateCashflowPricingInternal::g_nodeSensitivitySweepCount;
+                    } else {
+                        ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivityPreparationCount, preparations);
+                        ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivitySweepCount, sweeps);
+                    }
+                }
+                int global = 0;
+                for (int block = 0; block < 2; ++block)
+                    for (int ordinal = 0; ordinal < static_cast<int>(spec.curves_[block].instruments_.size()); ++ordinal, ++global) {
+                        const std::array<double, 5> prices{
+                            risks[0].meta_[0].pv_, Reprice(spec, options, block, ordinal, 1.0e-6), Reprice(spec, options, block, ordinal, -1.0e-6),
+                            Reprice(spec, options, block, ordinal, 1.0e-4), Reprice(spec, options, block, ordinal, -1.0e-4)};
+                        double scale = 1.0;
+                        for (double pv : prices)
+                            scale = std::max(scale, std::abs(pv));
+                        const double derivative = (prices[1] - prices[2]) / 2.0e-6;
+                        const double dv01 = (prices[3] - prices[4]) / 2.0;
+                        for (const auto& risk : risks) {
+                            const auto& bucket = risk.buckets_[global];
+                            ASSERT_LE(std::abs(bucket.dPvDDecimalQuote_ - derivative), 5.0e-6 * std::max(scale, std::abs(derivative)));
+                            ASSERT_LE(std::abs(bucket.dv01_ - dv01), 5.0e-6 * std::max(scale * 1.0e-4, std::abs(dv01)));
+                            ASSERT_LE(std::abs(bucket.dv01_ - 1.0e-4 * bucket.dPvDDecimalQuote_),
+                                      64.0 * std::numeric_limits<double>::epsilon() * std::max(scale * 1.0e-4, std::abs(bucket.dv01_)));
+                        }
+                        ASSERT_DOUBLE_EQ(risks[0].buckets_[global].dPvDDecimalQuote_, risks[1].buckets_[global].dPvDDecimalQuote_);
+                    }
+            }
+}
+
+TEST(JointQuoteRiskTest, TestMixedUnregisteredLayersPreserveHistoricalKnots) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    for (bool historical : {false, true}) {
+        const Vector_<Date_> knots{Date::AddMonths(spec.today_, historical ? -6 : 6), Date::AddMonths(spec.today_, 18)};
+        for (bool mixed : {false, true}) {
+            const CurveTransform_ chain = [&](const auto& base) {
+                Handle_<DiscountCurve_> middle;
+                if (mixed) {
+                    const auto anchor = Date::AddMonths(spec.today_, -12);
+                    const auto log =
+                        Handle_<DiscountCurve_>(NewDiscountLogDF("log-middle", "USD", {anchor, knots[0], knots[1]}, {0.0, -0.001, -0.008},
+                                                                 DayBasis::Act365F(), LogDfScheme_("LOG_LINEAR"), base));
+                    middle = Handle_<DiscountCurve_>(NewDiscountZeroRate("zero-middle", "USD", anchor, knots, {0.004, 0.006}, DayBasis::Act365F(),
+                                                                         LogDfScheme_("LOG_LINEAR"), log));
+                } else
+                    middle = Handle_<DiscountCurve_>(NewDiscountPWC("pwc-middle", "USD", PiecewiseConstant_(knots, {0.003, 0.005}), base));
+                return Handle_<DiscountCurve_>(new Tape::DiscountPWLF_<double>("usd-6m", "USD", knots, {0.009, 0.011}, {0.010, 0.012}, middle));
+            };
+            const auto market = Market(spec, calibrated, false, chain);
+            const auto risk = Risk(spec, calibrated, market, {Trade(spec)});
+            ASSERT_EQ(risk.buckets_.size(), 5);
+            ASSERT_TRUE(risk.meta_[0].eligible_);
+            const double derivative = (Reprice(spec, Options(), 0, 1, 1.0e-6, chain) - Reprice(spec, Options(), 0, 1, -1.0e-6, chain)) / 2.0e-6;
+            ASSERT_NEAR(risk.buckets_[1].dPvDDecimalQuote_, derivative, 1.0e-2);
+        }
+    }
+}
+
+TEST(JointQuoteRiskTest, TestClosuresArePerTradeAndIgnoreUnusedOpaqueDescendants) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    auto market = Market(spec, calibrated);
+    market.curveComponents_["opaque"] = Handle_<DiscountCurve_>(new OpaqueCurve_(market.curveComponents_.at("curve:0")));
+    market.curveComponents_["unused-descendant"] = Flat(spec, "unused", "USD", 0.01, market.curveComponents_.at("opaque"));
+    const auto future = Future(spec, "curve:0");
+    const auto opaque = Future(spec, "opaque");
+    const auto xccy = Trade(spec);
+    const auto expected = Risk(spec, calibrated, market, {future, xccy});
+    for (bool reverse : {false, true}) {
+        Vector_<RateTradeDefinition_> trades{future, xccy, opaque};
+        if (reverse)
+            std::reverse(trades.begin(), trades.end());
+        const auto actual = Risk(spec, calibrated, market, trades);
+        ASSERT_EQ(actual.meta_.size(), 3);
+        ASSERT_EQ(actual.buckets_.size(), expected.buckets_.size());
+        ASSERT_EQ(actual.meta_[reverse ? 0 : 2].originalNodeRiskReason_, "CURVE_REPRESENTATION_NOT_AAD_ENABLED");
+        for (int i = 0; i < static_cast<int>(actual.buckets_.size()); ++i)
+            ASSERT_DOUBLE_EQ(actual.buckets_[i].dPvDDecimalQuote_, expected.buckets_[i].dPvDDecimalQuote_);
+    }
+    const auto clean = Market(spec, calibrated);
+    RateCashflowPricingInternal::g_nodeSensitivityPreparationCount = 0;
+    Risk(spec, calibrated, clean, {future, xccy});
+    const int preparations = RateCashflowPricingInternal::g_nodeSensitivityPreparationCount;
+    RateCashflowPricingInternal::g_nodeSensitivityPreparationCount = 0;
+    Risk(spec, calibrated, market, {future, xccy});
+    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivityPreparationCount, preparations);
+}
+
+TEST(JointQuoteRiskTest, TestSingleCurrencyUnregisteredChainAndStandaloneFixedBase) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    auto market = JointQuoteRiskFixtures::Market(spec, calibrated);
+    market.curveComponents_["spread"] = Flat(spec, "spread", "USD", 0.015, Flat(spec, "middle", "USD", 0.004, market.curveComponents_.at("curve:0")));
+    const auto trade = Future(spec, "spread");
+    const auto joint = Risk(spec, calibrated, market, {trade});
+    ASSERT_TRUE(joint.meta_[0].eligible_);
+    ASSERT_FALSE(joint.meta_[0].structuralZero_);
+    const auto standalone = RateTradeNodeSensitivities(trade, market, "curve:0");
+    ASSERT_FALSE(standalone.eligible_);
+    ASSERT_EQ(standalone.reason_, "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+    const auto active = RateCashflowPricingInternal::JointNodeSensitivitiesBatch({trade}, market, {"curve:0"});
+    ASSERT_EQ(active.size(), 1);
+    ASSERT_TRUE(active[0].result_.eligible_);
+    ASSERT_GT(std::abs(joint.buckets_[0].dPvDDecimalQuote_), 1.0);
+    market.curveComponents_["spread"] = Flat(spec, "spread", "USD", 0.015);
+    RateCashflowPricingInternal::g_nodeSensitivitySweepCount = 0;
+    const auto zero = Risk(spec, calibrated, market, {trade});
+    ASSERT_TRUE(zero.meta_[0].structuralZero_);
+    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivitySweepCount, 0);
+}
+
+TEST(JointQuoteRiskTest, TestInvalidSourceGuardsUnregisteredXccyPathBeforePricing) {
+    struct CyclicPwc_ : TaggedPwc_ {
+        int* calls_;
+        CyclicPwc_(const Tape::DiscountPWC_<double>& curve, int* calls) : TaggedPwc_(curve), calls_(calls) {}
+        void SetBase(const Handle_<DiscountCurve_>& base) { base_ = base; }
+        double operator()(const Date_&, const Date_&) const override {
+            ++*calls_;
+            THROW("Unsafe cyclic path was evaluated");
+        }
+    };
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    auto market = Market(spec, calibrated);
+    auto trade = Trade(spec);
+    std::get<XccyTradeTerms_>(trade.terms_).config_.convention_.foreignIndex_.collateral_ = CollateralType_("GC");
+    const auto rebuild = [&](const Handle_<DiscountCurve_>& base) {
+        auto discounts = market.xccyMarket_->ForeignBlock().DiscountCurves();
+        discounts[CollateralType_("GC")] = Flat(spec, "independent-discount", "USD", 0.02);
+        auto forwards = market.xccyMarket_->ForeignBlock().ForwardCurves();
+        forwards[PeriodLength_("6M")] = Flat(spec, "usd-6m", "USD", 0.015, base);
+        const Handle_<CurveBlock_> foreign(new CurveBlock_("USD", "USD", discounts, forwards, spec.liborBasis_));
+        const auto& domestic = market.xccyMarket_->DomesticBlock();
+        const Handle_<CurveBlock_> domesticHandle(
+            new CurveBlock_("EUR", "EUR", domestic.DiscountCurves(), domestic.ForwardCurves(), DayBasis::Act365F()));
+        auto xccy = std::make_shared<CrossCurrencyMarket_>(domesticHandle, foreign, 0.9, market.valuationTime_, Ccy_("EUR"), market.fixings_);
+        xccy->SetBasisCurve(market.curveComponents_.at("basis"));
+        market.xccyMarket_ = xccy;
+    };
+    rebuild(market.curveComponents_.at("curve:0"));
+    const auto provenance = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(2));
+    int calls = 0;
+    const auto cycle = std::make_shared<CyclicPwc_>(dynamic_cast<const Tape::DiscountPWC_<double>&>(*market.curveComponents_.at("curve:0")), &calls);
+    const Handle_<DiscountCurve_> handle(cycle);
+    cycle->SetBase(handle);
+    struct ClearCycle_ {
+        CyclicPwc_* curve_;
+        ~ClearCycle_() { curve_->SetBase({}); }
+    } clear{cycle.get()};
+    market.curveComponents_["curve:0"] = handle;
+    rebuild(handle);
+    RateCashflowPricingInternal::g_nodeSensitivitySweepCount = 0;
+    const auto risk = AggregateRatePortfolioQuoteRisk({trade}, market, {provenance});
+    ASSERT_EQ(risk.provenanceFailures_.size(), 1);
+    ASSERT_EQ(risk.provenanceFailures_[0].actualStateFingerprint_, "INVALID");
+    ASSERT_EQ(calls, 0);
+    ASSERT_TRUE(risk.meta_.empty());
+    ASSERT_TRUE(risk.buckets_.empty());
+    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivitySweepCount, 0);
+}
+
+namespace {
+    thread_local int recordedFaultKind = 0;
+    thread_local int completedSweeps = 0;
+
+    void FailRecordedSweep(const String_& key, RateTradeNodeSensitivityResult_* cell) {
+        ++completedSweeps;
+        if (key != "curve:1")
+            return;
+        REQUIRE(cell->eligible_ && !cell->gradient_.empty(), "Fault must follow a completed AAD sweep");
+        if (recordedFaultKind == 0)
+            THROW("QUOTE_RISK_CYCLIC_CURVE_GRAPH");
+        if (recordedFaultKind == 1)
+            cell->gradient_[0] = std::numeric_limits<double>::quiet_NaN();
+        else
+            cell->gradient_.push_back(0.0);
+    }
+} // namespace
+
+TEST(JointQuoteRiskTest, TestPostRecordingFailuresDiscardEarlierSlicesAndRestoreTape) {
+    const auto spec = JointQuoteRiskFixtures::Spec(5, 2, CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, true);
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = JointQuoteRiskFixtures::Market(spec, calibrated);
+    const auto trade = JointQuoteRiskFixtures::Irs(spec);
+    const auto healthy = Future(spec, "curve:0");
+    const auto expected = Risk(spec, calibrated, market, {healthy});
+    for (int kind = 0; kind < 3; ++kind) {
+        recordedFaultKind = kind;
+        completedSweeps = 0;
+        struct FaultScope_ {
+            FaultScope_() { RateCashflowPricingInternal::g_quoteRiskRecordedSweepHook = FailRecordedSweep; }
+            ~FaultScope_() { RateCashflowPricingInternal::g_quoteRiskRecordedSweepHook = nullptr; }
+        } fault;
+#if DAL_RATE_RISK_NATIVE_AAD
+        const auto initialSize = AAD::Tape()->nodes_.Size();
+        std::atomic<int> recordedSize{0};
+        RateCashflowPricingInternal::NodeSensitivityTapeSizeObservation_ observation(recordedSize);
+#endif
+        const auto failed = Risk(spec, calibrated, market, {trade});
+        AssertIncomplete(failed, trade, market, "AAD_EVALUATION_FAILED", "curve:1");
+        ASSERT_EQ(completedSweeps, 2);
+        const auto mixed = Risk(spec, calibrated, market, {trade, healthy});
+        ASSERT_EQ(mixed.buckets_.size(), expected.buckets_.size());
+        for (int i = 0; i < static_cast<int>(mixed.buckets_.size()); ++i)
+            ASSERT_DOUBLE_EQ(mixed.buckets_[i].dPvDDecimalQuote_, expected.buckets_[i].dPvDDecimalQuote_);
+        ASSERT_DOUBLE_EQ(mixed.pvByActualPvCcy_.at("USD"), PriceRateTrade(trade, market).pv_ + PriceRateTrade(healthy, market).pv_);
+#if DAL_RATE_RISK_NATIVE_AAD
+        ASSERT_GT(recordedSize.load(), initialSize + 5);
+        ASSERT_EQ(AAD::Tape()->nodes_.Size(), initialSize);
+#endif
+    }
+    const auto expectedHealthy = Risk(spec, calibrated, market, {trade});
+    auto first = std::async(std::launch::async, [&]() { return Risk(spec, calibrated, market, {trade}); });
+    auto second = std::async(std::launch::async, [&]() { return Risk(spec, calibrated, market, {trade}); });
+    for (const auto& result : {first.get(), second.get()}) {
+        ASSERT_TRUE(result.meta_[0].eligible_);
+        for (int i = 0; i < 5; ++i)
+            ASSERT_DOUBLE_EQ(result.buckets_[i].dPvDDecimalQuote_, expectedHealthy.buckets_[i].dPvDDecimalQuote_);
+    }
+}
+
+TEST(JointQuoteRiskTest, TestRootValidationGraphAndExpiryGateOrder) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    for (bool opaqueRoot : {false, true}) {
+        auto market = Market(spec, calibrated, false, {}, [&](const auto&) {
+            const Handle_<DiscountCurve_> opaque(new OpaqueCurve_({}, "EUR"));
+            return opaqueRoot ? opaque : Flat(spec, "eur-3m", "EUR", 0.019, opaque);
+        });
+        auto trade = Trade(spec);
+        auto badFamily = trade;
+        badFamily.instrumentType_ = RateInstrumentType_::Value_::DEPOSIT;
+        AssertIncomplete(Risk(spec, calibrated, market, {badFamily}), badFamily, market, "TRADE_FAMILY_NOT_AAD_ENABLED");
+        market.valuationTime_ = DateTime_(spec.today_, 12, 0);
+        AssertIncomplete(Risk(spec, calibrated, market, {trade}), trade, market, opaqueRoot ? "AAD_EVALUATION_FAILED" : "TRADE_VALIDATION_FAILED");
+        market.valuationTime_ = DateTime_(spec.today_);
+        AssertIncomplete(Risk(spec, calibrated, market, {trade}), trade, market);
+        trade.startDate_ = Date::AddMonths(spec.today_, -24);
+        trade.maturityDate_ = spec.today_.AddDays(-1);
+        const auto expired = Risk(spec, calibrated, market, {trade});
+        if (opaqueRoot)
+            AssertIncomplete(expired, trade, market);
+        else {
+            ASSERT_TRUE(expired.meta_[0].eligible_);
+            ASSERT_DOUBLE_EQ(expired.meta_[0].pv_, 0.0);
+        }
+        market.xccyMarket_.reset();
+        const auto unresolved = Risk(spec, calibrated, market, {trade});
+        ASSERT_TRUE(unresolved.meta_[0].eligible_);
+        ASSERT_TRUE(unresolved.meta_[0].structuralZero_);
+        ASSERT_EQ(RateTradeNodeSensitivities(trade, market, "curve:0").reason_, "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+        trade = Trade(spec);
+        AssertIncomplete(Risk(spec, calibrated, market, {trade}), trade, market, "TRADE_VALIDATION_FAILED");
+    }
+}
+
+TEST(JointQuoteRiskTest, TestUnknownGraphUsesDeclarationOrderAndInactiveSourcesStayInactive) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    auto market = JointQuoteRiskFixtures::Market(spec, calibrated);
+    market.curveComponents_["z-discount"] = market.curveComponents_.at("curve:0");
+    market.curveComponents_["a-forward"] = market.curveComponents_.at("curve:1");
+    market.curveComponents_["opaque"] = Flat(spec, "opaque-root", "USD", 0.0, Handle_<DiscountCurve_>(new OpaqueCurve_()));
+    auto trade = JointQuoteRiskFixtures::Irs(spec);
+    auto& terms = std::get<IrsTradeTerms_>(trade.terms_).value_;
+    terms.discountComponentKey_ = "opaque";
+    terms.forecastComponentKey_ = "a-forward";
+    const RateQuoteRiskProvenanceConfig_ config{"generic-joint", {{"curve:0", "z-discount"}, {"curve:1", "a-forward"}}};
+    const auto provenance = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, config);
+    AssertIncomplete(AggregateRatePortfolioQuoteRisk({trade}, market, {provenance}), trade, market, "AAD_EVALUATION_FAILED", "z-discount");
+    market.valuationTime_ = DateTime_(spec.today_.AddDays(1));
+    RateCashflowPricingInternal::g_nodeSensitivitySweepCount = 0;
+    const auto stale = AggregateRatePortfolioQuoteRisk({trade}, market, {provenance});
+    ASSERT_EQ(stale.provenanceFailures_.size(), 1);
+    ASSERT_TRUE(stale.meta_.empty());
+    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivitySweepCount, 0);
 }

--- a/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
@@ -65,6 +65,31 @@ namespace {
         const auto passive = PriceRateTrade(trade, market);
         ASSERT_DOUBLE_EQ(meta.pv_, passive.succeeded_ ? passive.pv_ : 0.0);
     }
+
+    void AssertXccyOracleBuckets(const JointMultiCurveCalibrationSpec_& spec,
+                                 const JointMultiCurveCalibrationOptions_& options,
+                                 const Vector_<RatePortfolioQuoteRisk_>& risks) {
+        int global = 0;
+        for (int block = 0; block < 2; ++block)
+            for (int ordinal = 0; ordinal < static_cast<int>(spec.curves_[block].instruments_.size()); ++ordinal, ++global) {
+                const std::array<double, 5> prices{
+                    risks[0].meta_[0].pv_, Reprice(spec, options, block, ordinal, 1.0e-6), Reprice(spec, options, block, ordinal, -1.0e-6),
+                    Reprice(spec, options, block, ordinal, 1.0e-4), Reprice(spec, options, block, ordinal, -1.0e-4)};
+                double scale = 1.0;
+                for (double pv : prices)
+                    scale = std::max(scale, std::abs(pv));
+                const double derivative = (prices[1] - prices[2]) / 2.0e-6;
+                const double dv01 = (prices[3] - prices[4]) / 2.0;
+                for (const auto& risk : risks) {
+                    const auto& bucket = risk.buckets_[global];
+                    ASSERT_LE(std::abs(bucket.dPvDDecimalQuote_ - derivative), 5.0e-6 * std::max(scale, std::abs(derivative)));
+                    ASSERT_LE(std::abs(bucket.dv01_ - dv01), 5.0e-6 * std::max(scale * 1.0e-4, std::abs(dv01)));
+                    ASSERT_LE(std::abs(bucket.dv01_ - 1.0e-4 * bucket.dPvDDecimalQuote_),
+                              64.0 * std::numeric_limits<double>::epsilon() * std::max(scale * 1.0e-4, std::abs(bucket.dv01_)));
+                }
+                ASSERT_DOUBLE_EQ(risks[0].buckets_[global].dPvDDecimalQuote_, risks[1].buckets_[global].dPvDDecimalQuote_);
+            }
+    }
 } // namespace
 
 TEST(JointQuoteRiskTest, TestUnregisteredXccyBaseMatchesFullRecalibration) {
@@ -151,26 +176,7 @@ TEST(JointQuoteRiskTest, TestUnregisteredXccyOracleAcrossModesLayoutsLayersAndAl
                         ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivitySweepCount, sweeps);
                     }
                 }
-                int global = 0;
-                for (int block = 0; block < 2; ++block)
-                    for (int ordinal = 0; ordinal < static_cast<int>(spec.curves_[block].instruments_.size()); ++ordinal, ++global) {
-                        const std::array<double, 5> prices{
-                            risks[0].meta_[0].pv_, Reprice(spec, options, block, ordinal, 1.0e-6), Reprice(spec, options, block, ordinal, -1.0e-6),
-                            Reprice(spec, options, block, ordinal, 1.0e-4), Reprice(spec, options, block, ordinal, -1.0e-4)};
-                        double scale = 1.0;
-                        for (double pv : prices)
-                            scale = std::max(scale, std::abs(pv));
-                        const double derivative = (prices[1] - prices[2]) / 2.0e-6;
-                        const double dv01 = (prices[3] - prices[4]) / 2.0;
-                        for (const auto& risk : risks) {
-                            const auto& bucket = risk.buckets_[global];
-                            ASSERT_LE(std::abs(bucket.dPvDDecimalQuote_ - derivative), 5.0e-6 * std::max(scale, std::abs(derivative)));
-                            ASSERT_LE(std::abs(bucket.dv01_ - dv01), 5.0e-6 * std::max(scale * 1.0e-4, std::abs(dv01)));
-                            ASSERT_LE(std::abs(bucket.dv01_ - 1.0e-4 * bucket.dPvDDecimalQuote_),
-                                      64.0 * std::numeric_limits<double>::epsilon() * std::max(scale * 1.0e-4, std::abs(bucket.dv01_)));
-                        }
-                        ASSERT_DOUBLE_EQ(risks[0].buckets_[global].dPvDDecimalQuote_, risks[1].buckets_[global].dPvDDecimalQuote_);
-                    }
+                ASSERT_NO_FATAL_FAILURE(AssertXccyOracleBuckets(spec, options, risks));
             }
 }
 

--- a/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_graph.cpp
@@ -309,6 +309,17 @@ TEST(JointQuoteRiskTest, TestInvalidSourceGuardsUnregisteredXccyPathBeforePricin
 namespace {
     thread_local int recordedFaultKind = 0;
     thread_local int completedSweeps = 0;
+    thread_local const DiscountCurve_* liveFaultTarget = nullptr;
+    thread_local int liveFaultNodes = 0;
+
+    void FailWithLiveTape(const DiscountCurve_* target) {
+        if (target != liveFaultTarget)
+            return;
+#if DAL_RATE_RISK_NATIVE_AAD
+        liveFaultNodes = AAD::Tape()->nodes_.Size();
+#endif
+        THROW("Joint test failure with recorded nodes still live");
+    }
 
     void FailRecordedSweep(const String_& key, RateTradeNodeSensitivityResult_* cell) {
         ++completedSweeps;
@@ -364,6 +375,50 @@ TEST(JointQuoteRiskTest, TestPostRecordingFailuresDiscardEarlierSlicesAndRestore
         for (int i = 0; i < 5; ++i)
             ASSERT_DOUBLE_EQ(result.buckets_[i].dPvDDecimalQuote_, expectedHealthy.buckets_[i].dPvDDecimalQuote_);
     }
+}
+
+TEST(JointQuoteRiskTest, TestLiveRecordingExceptionRewindsBeforeUnregisteredXccyReuse) {
+    const auto spec = JointQuoteRiskFixtures::Spec(5, 2, CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, true);
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = Market(spec, calibrated);
+    const auto provenance = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(2));
+    const auto expected = AggregateRatePortfolioQuoteRisk({Trade(spec)}, market, {provenance});
+#if DAL_RATE_RISK_NATIVE_AAD
+    const auto initialSize = AAD::Tape()->nodes_.Size();
+#endif
+    {
+        liveFaultTarget = market.curveComponents_.at("curve:1").get();
+        liveFaultNodes = 0;
+        struct FaultScope_ {
+            FaultScope_() { RateCashflowPricingInternal::g_jointNodeSensitivityRecordedPvHook = FailWithLiveTape; }
+            ~FaultScope_() { RateCashflowPricingInternal::g_jointNodeSensitivityRecordedPvHook = nullptr; }
+        } fault;
+        const auto trade = JointQuoteRiskFixtures::Irs(spec);
+        const auto failed = AggregateRatePortfolioQuoteRisk({trade}, market, {provenance});
+        AssertIncomplete(failed, trade, market, "AAD_EVALUATION_FAILED", "curve:1");
+#if DAL_RATE_RISK_NATIVE_AAD
+        ASSERT_GT(liveFaultNodes, initialSize + 5);
+        ASSERT_EQ(AAD::Tape()->nodes_.Size(), initialSize);
+#endif
+    }
+    const auto recovered = AggregateRatePortfolioQuoteRisk({Trade(spec)}, market, {provenance});
+    ASSERT_TRUE(recovered.meta_[0].eligible_);
+    for (int i = 0; i < 5; ++i)
+        ASSERT_DOUBLE_EQ(recovered.buckets_[i].dPvDDecimalQuote_, expected.buckets_[i].dPvDDecimalQuote_);
+}
+
+TEST(JointQuoteRiskTest, TestUnusedLayeredBlockIsNeverPrepared) {
+    const auto spec = JointQuoteRiskFixtures::Spec(5, 3, CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, true);
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto market = JointQuoteRiskFixtures::Market(spec, calibrated);
+    const auto provenance = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(3));
+    RateCashflowPricingInternal::g_nodeSensitivityPreparationCount = 0;
+    RateCashflowPricingInternal::g_nodeSensitivitySweepCount = 0;
+    const auto risk = AggregateRatePortfolioQuoteRisk({JointQuoteRiskFixtures::Irs(spec)}, market, {provenance});
+    ASSERT_TRUE(risk.meta_[0].eligible_);
+    ASSERT_EQ(risk.buckets_.size(), 5);
+    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivityPreparationCount, 2);
+    ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivitySweepCount, 2);
 }
 
 TEST(JointQuoteRiskTest, TestRootValidationGraphAndExpiryGateOrder) {

--- a/dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include <dal/curve/ratecashflowpricing_internal.hpp>
 
 #include "jointxccyquoteriskfixtures.hpp"
@@ -82,6 +84,113 @@ namespace {
             ASSERT_NO_FATAL_FAILURE(AssertBucketEqual(*found, bucket));
         }
     }
+
+    Handle_<DiscountCurve_> HistoricalExtraChain(const JointMultiCurveCalibrationSpec_& spec, const Handle_<DiscountCurve_>& base) {
+        const auto anchor = Date::AddMonths(spec.today_, -12);
+        const Vector_<Date_> knots{Date::AddMonths(spec.today_, -6), Date::AddMonths(spec.today_, 18)};
+        const Handle_<DiscountCurve_> pwc(NewDiscountPWC("pwc-middle", "USD", PiecewiseConstant_(knots, {0.003, 0.005}), base));
+        const Handle_<DiscountCurve_> log(NewDiscountLogDF("log-middle", "USD", {anchor, knots[0], knots[1]}, {0.0, -0.001, -0.008},
+                                                         DayBasis::Act365F(), LogDfScheme_("LOG_LINEAR"), pwc));
+        const Handle_<DiscountCurve_> zero(NewDiscountZeroRate("zero-middle", "USD", anchor, knots, {0.004, 0.006}, DayBasis::Act365F(),
+                                                              LogDfScheme_("LOG_LINEAR"), log));
+        return Handle_<DiscountCurve_>(new Tape::DiscountPWLF_<double>("usd-6m", "USD", knots, {0.009, 0.011}, {0.010, 0.012}, zero));
+    }
+
+    RatePricingMarket_ NativeChainMarket(const JointMultiCurveCalibrationSpec_& spec,
+                                         const JointMultiCurveCalibrationResult_& calibrated,
+                                         bool throughForward = true) {
+        return Market(spec, calibrated, false, [&](const auto&) {
+            return HistoricalExtraChain(spec, throughForward ? calibrated.forwardCurves_.at(PeriodLength_("3M"))
+                                                            : calibrated.discountCurves_.at(CollateralType_("OIS")));
+        });
+    }
+
+    Vector_<> NativeForwardParameters(const Handle_<DiscountCurve_>& curve) {
+        if (const auto* pwc = dynamic_cast<const Tape::DiscountPWC_<double>*>(curve.get()))
+            return pwc->FRight();
+        const auto& pwlf = dynamic_cast<const Tape::DiscountPWLF_<double>&>(*curve);
+        const auto left = pwlf.FLeft(), right = pwlf.FRight();
+        Vector_<> result;
+        for (int i = 0; i < static_cast<int>(left.size()); ++i) {
+            result.push_back(left[i]);
+            result.push_back(right[i]);
+        }
+        return result;
+    }
+
+    Handle_<DiscountCurve_> CloneNativeShift(const Handle_<DiscountCurve_>& curve,
+                                            const YCComponent_::substitutions_t& bases,
+                                            int coordinate,
+                                            double shift) {
+        auto clone = curve->Clone(curve->Name(), bases);
+        if (coordinate >= 0) {
+            auto& fit = dynamic_cast<FittableCurve_&>(*clone);
+            Vector_<> dx(fit.NX(), 0.0);
+            dx[coordinate] = shift;
+            fit.ApplyDX(dx.begin(), 1.0);
+        }
+        return handle_cast<DiscountCurve_>(Handle_<YCComponent_>(std::move(clone)));
+    }
+
+    JointMultiCurveCalibrationResult_ NativeBump(const JointMultiCurveCalibrationResult_& calibrated, int block, int coordinate, double shift) {
+        auto result = calibrated;
+        const auto& discount = calibrated.discountCurves_.at(CollateralType_("OIS"));
+        const auto& forward = calibrated.forwardCurves_.at(PeriodLength_("3M"));
+        YCComponent_::substitutions_t bases;
+        if (block == 0) {
+            const auto bumped = CloneNativeShift(discount, {}, coordinate, shift);
+            result.discountCurves_[CollateralType_("OIS")] = bumped;
+            bases.emplace(discount.get(), handle_cast<YCComponent_>(bumped));
+        }
+        result.forwardCurves_[PeriodLength_("3M")] = CloneNativeShift(forward, bases, block == 1 ? coordinate : -1, shift);
+        return result;
+    }
+
+    void AssertNativeBumpState(const RatePricingMarket_& actual, const RatePricingMarket_& original, int block, int coordinate, double shift) {
+        for (int index = 0; index < 2; ++index) {
+            const auto key = JointQuoteRiskFixtures::BlockKey(index);
+            const auto parameters = NativeForwardParameters(actual.curveComponents_.at(key));
+            auto expected = NativeForwardParameters(original.curveComponents_.at(key));
+            if (index == block)
+                expected[coordinate] += shift;
+            ASSERT_EQ(parameters, expected);
+        }
+        if (block == 1) {
+            ASSERT_EQ(actual.curveComponents_.at("curve:0"), original.curveComponents_.at("curve:0"));
+            ASSERT_EQ(RateCashflowPricingInternal::NodeSensitivityBase(*actual.curveComponents_.at("curve:1")),
+                      RateCashflowPricingInternal::NodeSensitivityBase(*original.curveComponents_.at("curve:1")));
+        }
+    }
+
+    void AssertNativeSlice(const JointMultiCurveCalibrationSpec_& spec,
+                           const JointMultiCurveCalibrationResult_& calibrated,
+                           const RatePricingMarket_& market,
+                           int block,
+                           const RateTradeNodeSensitivityCell_& cell,
+                           bool throughForward = true) {
+        const auto key = JointQuoteRiskFixtures::BlockKey(block);
+        const auto passive = PriceRateTrade(Trade(spec), market);
+        ASSERT_TRUE(passive.succeeded_);
+        ASSERT_EQ(cell.componentKey_, key);
+        ASSERT_TRUE(cell.result_.eligible_) << cell.result_.reason_;
+        ASSERT_TRUE(cell.result_.reason_.empty());
+        ASSERT_NEAR(cell.result_.pv_, passive.pv_, 1.0e-8);
+        ASSERT_EQ(cell.result_.gradient_.size(), NativeForwardParameters(market.curveComponents_.at(key)).size());
+        constexpr double bump = 1.0e-6;
+        for (int coordinate = 0; coordinate < static_cast<int>(cell.result_.gradient_.size()); ++coordinate) {
+            SCOPED_TRACE(coordinate);
+            std::array<double, 2> pv;
+            for (int side = 0; side < 2; ++side) {
+                const double shift = side == 0 ? -bump : bump;
+                const auto shifted = NativeChainMarket(spec, NativeBump(calibrated, block, coordinate, shift), throughForward);
+                ASSERT_NO_FATAL_FAILURE(AssertNativeBumpState(shifted, market, block, coordinate, shift));
+                const auto price = PriceRateTrade(Trade(spec), shifted);
+                ASSERT_TRUE(price.succeeded_) << price.error_;
+                pv[side] = price.pv_;
+            }
+            ASSERT_NEAR(cell.result_.gradient_[coordinate], (pv[1] - pv[0]) / (2.0 * bump), 1.0e-3);
+        }
+    }
 } // namespace
 
 TEST(JointQuoteRiskTest, TestXccyProvenanceOrderPreservesStandaloneAndJointResults) {
@@ -119,4 +228,41 @@ TEST(JointQuoteRiskTest, TestXccyProvenanceOrderPreservesStandaloneAndJointResul
         ASSERT_EQ(actual.pvByActualPvCcy_, jointOnly.pvByActualPvCcy_);
         ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount, 1);
     }
+}
+
+TEST(JointQuoteRiskTest, TestHistoricalMixedChainMatchesEveryNativeCoordinate) {
+    for (bool layered : {false, true})
+        for (auto layout : {CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD}) {
+            SCOPED_TRACE(layered);
+            SCOPED_TRACE(CurveParameterization_(layout).String());
+            const auto spec = JointQuoteRiskFixtures::Spec(5, 2, layout, layered);
+            const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+            const auto market = NativeChainMarket(spec, calibrated);
+            const auto cells = RateCashflowPricingInternal::JointNodeSensitivitiesBatch({Trade(spec)}, market, {"curve:0", "curve:1"});
+            ASSERT_EQ(cells.size(), 2);
+            ASSERT_NO_FATAL_FAILURE(AssertNativeSlice(spec, calibrated, market, 0, cells[0]));
+            ASSERT_NO_FATAL_FAILURE(AssertNativeSlice(spec, calibrated, market, 1, cells[1]));
+        }
+}
+
+TEST(JointQuoteRiskTest, TestHistoricalMixedChainConsumesOnlyNativeDiscount) {
+    for (bool layered : {false, true})
+        for (auto layout : {CurveParameterization_::Value_::PIECEWISE_CONSTANT_FWD, CurveParameterization_::Value_::PIECEWISE_LINEAR_FWD}) {
+            SCOPED_TRACE(layered);
+            SCOPED_TRACE(CurveParameterization_(layout).String());
+            const auto spec = JointQuoteRiskFixtures::Spec(5, 2, layout, layered);
+            const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+            const auto market = NativeChainMarket(spec, calibrated, false);
+            const auto cells = RateCashflowPricingInternal::JointNodeSensitivitiesBatch({Trade(spec)}, market, {"curve:0", "curve:1"});
+            ASSERT_EQ(cells.size(), 2);
+            ASSERT_NO_FATAL_FAILURE(AssertNativeSlice(spec, calibrated, market, 0, cells[0], false));
+            ASSERT_FALSE(cells[1].result_.eligible_);
+            ASSERT_EQ(cells[1].result_.reason_, "TRADE_DOES_NOT_DEPEND_ON_COMPONENT");
+            ASSERT_TRUE(cells[1].result_.gradient_.empty());
+            const auto provenance = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(2));
+            const auto risk = AggregateRatePortfolioQuoteRisk({Trade(spec)}, market, {provenance});
+            ASSERT_TRUE(risk.meta_[0].eligible_);
+            ASSERT_FALSE(risk.meta_[0].structuralZero_);
+            ASSERT_EQ(risk.buckets_.size(), 5);
+        }
 }

--- a/dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp
@@ -1,0 +1,122 @@
+//
+// Created by dal-implementer on 2026/9/11.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/curve/ratecashflowpricing_internal.hpp>
+
+#include "jointxccyquoteriskfixtures.hpp"
+
+using namespace Dal;
+using namespace JointXccyQuoteRiskFixtures;
+
+namespace {
+    CurveCalibrationSpec_ EuroSingleSpec(const Date_& today) {
+        CurveCalibrationSpec_ result;
+        result.today_ = today;
+        result.ccy_ = "EUR";
+        result.curveName_ = "eur-single";
+        result.initialGuess_ = 0.02;
+        for (int ordinal = 0; ordinal < 3; ++ordinal) {
+            const auto maturity = Date::AddMonths(today, 12 * (ordinal + 1));
+            result.knotDates_.push_back(maturity);
+            result.instruments_.push_back(Handle_<YCInstrument_>(
+                new Deposit_(today, today, maturity, 0.017 + ordinal * 0.001, JointQuoteRiskFixtures::Index(0))));
+        }
+        return result;
+    }
+
+    RatePricingMarket_ WithEuroDiscount(const RatePricingMarket_& market, const Handle_<DiscountCurve_>& discount) {
+        auto result = market;
+        result.curveComponents_["eur-discount"] = discount;
+        const auto& old = *market.xccyMarket_;
+        const Handle_<CurveBlock_> domestic(new CurveBlock_("EUR", "EUR", {{CollateralType_("OIS"), discount}},
+                                                           old.DomesticBlock().ForwardCurves(), DayBasis::Act365F()));
+        const Handle_<CurveBlock_> foreign(new CurveBlock_("USD", "USD", old.ForeignBlock().DiscountCurves(),
+                                                          old.ForeignBlock().ForwardCurves(), DayBasis::Act365F()));
+        auto xccy = std::make_shared<CrossCurrencyMarket_>(domestic, foreign, old.FxSpot(), result.valuationTime_, Ccy_("EUR"), result.fixings_);
+        xccy->SetBasisCurve(result.curveComponents_.at("basis"));
+        result.xccyMarket_ = xccy;
+        return result;
+    }
+
+    void AssertMetaEqual(const RatePortfolioQuoteRiskMetaEntry_& actual, const RatePortfolioQuoteRiskMetaEntry_& expected) {
+        ASSERT_EQ(actual.instrumentId_, expected.instrumentId_);
+        ASSERT_EQ(actual.calibrationId_, expected.calibrationId_);
+        ASSERT_EQ(actual.eligible_, expected.eligible_) << actual.originalNodeRiskReason_;
+        ASSERT_EQ(actual.structuralZero_, expected.structuralZero_);
+        ASSERT_EQ(actual.reason_, expected.reason_);
+        ASSERT_EQ(actual.failingComponentKey_, expected.failingComponentKey_);
+        ASSERT_EQ(actual.originalNodeRiskReason_, expected.originalNodeRiskReason_);
+        ASSERT_EQ(actual.actualPvCcy_, expected.actualPvCcy_);
+        ASSERT_DOUBLE_EQ(actual.pv_, expected.pv_);
+    }
+
+    void AssertBucketEqual(const RateQuoteRiskBucket_& actual, const RateQuoteRiskBucket_& expected) {
+        ASSERT_EQ(actual.calibrationId_, expected.calibrationId_);
+        ASSERT_EQ(actual.axisFingerprint_, expected.axisFingerprint_);
+        ASSERT_EQ(actual.quoteKey_, expected.quoteKey_);
+        ASSERT_EQ(actual.quoteName_, expected.quoteName_);
+        ASSERT_EQ(actual.residualBlock_, expected.residualBlock_);
+        ASSERT_EQ(actual.quoteOrdinal_, expected.quoteOrdinal_);
+        ASSERT_EQ(actual.actualPvCcy_, expected.actualPvCcy_);
+        ASSERT_DOUBLE_EQ(actual.dPvDDecimalQuote_, expected.dPvDDecimalQuote_);
+        ASSERT_DOUBLE_EQ(actual.dv01_, expected.dv01_);
+    }
+
+    void AssertSourceEqual(const RatePortfolioQuoteRisk_& actual, const RatePortfolioQuoteRisk_& expected) {
+        ASSERT_TRUE(actual.provenanceFailures_.empty());
+        ASSERT_EQ(actual.policy_, expected.policy_);
+        ASSERT_EQ(expected.meta_.size(), 1);
+        const auto meta = std::find_if(actual.meta_.begin(), actual.meta_.end(), [&](const auto& entry) {
+            return entry.calibrationId_ == expected.meta_[0].calibrationId_;
+        });
+        ASSERT_NE(meta, actual.meta_.end());
+        ASSERT_NO_FATAL_FAILURE(AssertMetaEqual(*meta, expected.meta_[0]));
+        for (const auto& bucket : expected.buckets_) {
+            const auto found = std::find_if(actual.buckets_.begin(), actual.buckets_.end(), [&](const auto& entry) {
+                return entry.calibrationId_ == bucket.calibrationId_ && entry.quoteKey_ == bucket.quoteKey_;
+            });
+            ASSERT_NE(found, actual.buckets_.end());
+            ASSERT_NO_FATAL_FAILURE(AssertBucketEqual(*found, bucket));
+        }
+    }
+} // namespace
+
+TEST(JointQuoteRiskTest, TestXccyProvenanceOrderPreservesStandaloneAndJointResults) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    const auto singleSpec = EuroSingleSpec(spec.today_);
+    CurveCalibrationOptions_ singleOptions;
+    singleOptions.computeEffJacobianInverse_ = true;
+    const auto singleResult = CalibrateYieldCurve(singleSpec, singleOptions);
+    const Handle_<DiscountCurve_> euro(std::shared_ptr<const DiscountCurve_>(std::shared_ptr<void>(), singleResult.curve_.get()));
+    const auto market = WithEuroDiscount(Market(spec, calibrated), euro);
+    const auto joint = BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(2));
+    const auto single = BuildSingleCurveQuoteRiskProvenance(singleSpec, singleResult, singleOptions, market,
+                                                           {"eur-single", {{"eur-single", "eur-discount"}}});
+    ASSERT_TRUE(joint.Available());
+    ASSERT_TRUE(single.Available());
+    const Vector_<RateTradeDefinition_> trades{Trade(spec)};
+    const auto jointOnly = AggregateRatePortfolioQuoteRisk(trades, market, {joint});
+    const auto singleOnly = AggregateRatePortfolioQuoteRisk(trades, market, {single});
+    ASSERT_EQ(jointOnly.buckets_.size(), 5);
+    ASSERT_EQ(singleOnly.buckets_.size(), 3);
+    ASSERT_TRUE(jointOnly.meta_[0].eligible_);
+    ASSERT_TRUE(singleOnly.meta_[0].eligible_);
+    ASSERT_EQ(jointOnly.pvByActualPvCcy_, singleOnly.pvByActualPvCcy_);
+    for (bool jointFirst : {false, true}) {
+        SCOPED_TRACE(jointFirst ? "joint, single" : "single, joint");
+        const Vector_<RateQuoteRiskProvenance_> sources = jointFirst ? Vector_<RateQuoteRiskProvenance_>{joint, single}
+                                                                  : Vector_<RateQuoteRiskProvenance_>{single, joint};
+        RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount = 0;
+        const auto actual = AggregateRatePortfolioQuoteRisk(trades, market, sources);
+        ASSERT_EQ(actual.meta_.size(), 2);
+        ASSERT_NO_FATAL_FAILURE(AssertSourceEqual(actual, jointOnly));
+        ASSERT_NO_FATAL_FAILURE(AssertSourceEqual(actual, singleOnly));
+        ASSERT_EQ(actual.buckets_.size(), 8);
+        ASSERT_EQ(actual.pvByActualPvCcy_, jointOnly.pvByActualPvCcy_);
+        ASSERT_EQ(RateCashflowPricingInternal::g_nodeSensitivityPassivePriceCount, 1);
+    }
+}

--- a/dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp
+++ b/dal-cpp/tests/curve/test_joint_quote_risk_preparation.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <optional>
+#include <set>
 
 #include <dal/curve/ratecashflowpricing_internal.hpp>
 
@@ -191,6 +193,138 @@ namespace {
             ASSERT_NEAR(cell.result_.gradient_[coordinate], (pv[1] - pv[0]) / (2.0 * bump), 1.0e-3);
         }
     }
+
+    struct PreparationFailureInput_ {
+        RatePricingMarket_ market_;
+        RateTradeDefinition_ bad_, healthy_;
+        std::optional<RateQuoteRiskProvenance_> provenance_;
+        std::array<Handle_<DiscountCurve_>, 2> middle_;
+    };
+
+    PreparationFailureInput_ PreparationFailureInput(const JointMultiCurveCalibrationSpec_& spec,
+                                                      const JointMultiCurveCalibrationResult_& calibrated,
+                                                      bool reverseAllocation,
+                                                      bool reverseKeys) {
+        PreparationFailureInput_ result;
+        result.market_ = JointQuoteRiskFixtures::Market(spec, calibrated);
+        using Curve_ = Tape::DiscountPWC_<double>;
+        const auto middle = [&](int block) {
+            return Curve_("middle:" + String::FromInt(block), "USD", spec.curves_[block].knotDates_,
+                          Vector_<>(spec.curves_[block].knotDates_.size(), 0.004),
+                          result.market_.curveComponents_.at(JointQuoteRiskFixtures::BlockKey(block)));
+        };
+        // An array makes the relative addresses deterministic while swapping which base owns each position.
+        const std::shared_ptr<std::array<Curve_, 2>> storage(
+            new std::array<Curve_, 2>{middle(reverseAllocation ? 1 : 0), middle(reverseAllocation ? 0 : 1)});
+        const std::array<String_, 2> keys = reverseKeys ? std::array<String_, 2>{"z-extra", "a-extra"}
+                                                       : std::array<String_, 2>{"a-extra", "z-extra"};
+        for (int block = 0; block < 2; ++block) {
+            const int position = reverseAllocation ? 1 - block : block;
+            result.middle_[block] = Handle_<DiscountCurve_>(std::shared_ptr<const DiscountCurve_>(storage, &(*storage)[position]));
+            result.market_.curveComponents_[keys[block]] = Flat(spec, keys[block], "USD", 0.002, result.middle_[block]);
+        }
+        result.market_.curveComponents_["z-discount"] = result.market_.curveComponents_.at("curve:0");
+        result.market_.curveComponents_["a-forward"] = result.market_.curveComponents_.at("curve:1");
+        result.bad_ = JointQuoteRiskFixtures::Irs(spec);
+        auto& terms = std::get<IrsTradeTerms_>(result.bad_.terms_).value_;
+        terms.discountComponentKey_ = keys[0];
+        terms.forecastComponentKey_ = keys[1];
+        result.healthy_ = JointQuoteRiskFixtures::Irs(spec);
+        result.healthy_.instrumentId_ = "healthy";
+        result.provenance_ = BuildJointMultiCurveQuoteRiskProvenance(
+            spec, calibrated, Options(), result.market_, {"generic-joint", {{"curve:0", "z-discount"}, {"curve:1", "a-forward"}}});
+        return result;
+    }
+
+    thread_local std::set<const DiscountCurve_*> preparationFaults;
+    thread_local std::map<const DiscountCurve_*, int> preparationAttempts;
+
+    void FailSelectedPreparation(const DiscountCurve_* curve) {
+        ++preparationAttempts[curve];
+        if (preparationFaults.count(curve))
+            THROW("Test joint native preparation failure");
+    }
+
+    class PreparationFaultScope_ {
+    public:
+        PreparationFaultScope_(const PreparationFailureInput_& input, int mask) {
+            preparationFaults.clear();
+            preparationAttempts.clear();
+            for (int block = 0; block < 2; ++block)
+                if (mask & (1 << block))
+                    preparationFaults.insert(input.middle_[block].get());
+            RateCashflowPricingInternal::g_jointNodeSensitivityPreparationHook = FailSelectedPreparation;
+        }
+        ~PreparationFaultScope_() { RateCashflowPricingInternal::g_jointNodeSensitivityPreparationHook = nullptr; }
+        PreparationFaultScope_(const PreparationFaultScope_&) = delete;
+        PreparationFaultScope_& operator=(const PreparationFaultScope_&) = delete;
+    };
+
+    void AssertPreparationFailure(const RatePortfolioQuoteRiskMetaEntry_& actual,
+                                   const RateTradeDefinition_& trade,
+                                   const RatePricingMarket_& market,
+                                   const String_& key) {
+        const auto passive = PriceRateTrade(trade, market);
+        ASSERT_TRUE(passive.succeeded_);
+        const RatePortfolioQuoteRiskMetaEntry_ expected{trade.instrumentId_, "generic-joint", false, false,
+                                                       "QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE", key, "AAD_EVALUATION_FAILED", Ccy_("USD"),
+                                                       passive.pv_};
+        ASSERT_NO_FATAL_FAILURE(AssertMetaEqual(actual, expected));
+    }
+
+    void AssertBucketsEqual(const RatePortfolioQuoteRisk_& actual, const RatePortfolioQuoteRisk_& expected) {
+        ASSERT_EQ(actual.buckets_.size(), expected.buckets_.size());
+        for (int index = 0; index < static_cast<int>(actual.buckets_.size()); ++index)
+            ASSERT_NO_FATAL_FAILURE(AssertBucketEqual(actual.buckets_[index], expected.buckets_[index]));
+    }
+
+    void AssertPreparationFaultCase(const PreparationFailureInput_& input, int mask) {
+        using namespace RateCashflowPricingInternal;
+        const String_ key = mask == 2 ? "a-forward" : "z-discount";
+        const auto healthyOnly = AggregateRatePortfolioQuoteRisk({input.healthy_}, input.market_, {*input.provenance_});
+        const auto noFault = AggregateRatePortfolioQuoteRisk({input.bad_, input.healthy_}, input.market_, {*input.provenance_});
+        ASSERT_EQ(healthyOnly.meta_.size(), 1);
+        ASSERT_TRUE(healthyOnly.meta_[0].eligible_);
+        ASSERT_EQ(healthyOnly.buckets_.size(), 5);
+        ASSERT_EQ(noFault.meta_.size(), 2);
+        ASSERT_TRUE(noFault.meta_[0].eligible_);
+        ASSERT_TRUE(noFault.meta_[1].eligible_);
+        {
+            PreparationFaultScope_ fault(input, mask);
+            g_nodeSensitivitySweepCount = 0;
+            const auto failed = AggregateRatePortfolioQuoteRisk({input.bad_}, input.market_, {*input.provenance_});
+            ASSERT_TRUE(failed.provenanceFailures_.empty());
+            ASSERT_TRUE(failed.buckets_.empty());
+            ASSERT_EQ(failed.meta_.size(), 1);
+            ASSERT_NO_FATAL_FAILURE(AssertPreparationFailure(failed.meta_[0], input.bad_, input.market_, key));
+            ASSERT_DOUBLE_EQ(failed.pvByActualPvCcy_.at("USD"), failed.meta_[0].pv_);
+            ASSERT_EQ(g_nodeSensitivitySweepCount, mask == 2 ? 1 : 0);
+            preparationAttempts.clear();
+            auto repeated = input.bad_;
+            repeated.instrumentId_ = "repeated-failure";
+            g_nodeSensitivitySweepCount = 0;
+            g_nodeSensitivityPassivePriceCount = 0;
+            const auto mixed = AggregateRatePortfolioQuoteRisk({input.bad_, repeated, input.healthy_}, input.market_, {*input.provenance_});
+            ASSERT_TRUE(mixed.provenanceFailures_.empty());
+            ASSERT_EQ(mixed.meta_.size(), 3);
+            ASSERT_NO_FATAL_FAILURE(AssertPreparationFailure(mixed.meta_[0], input.bad_, input.market_, key));
+            ASSERT_NO_FATAL_FAILURE(AssertPreparationFailure(mixed.meta_[1], repeated, input.market_, key));
+            ASSERT_NO_FATAL_FAILURE(AssertMetaEqual(mixed.meta_[2], healthyOnly.meta_[0]));
+            ASSERT_NO_FATAL_FAILURE(AssertBucketsEqual(mixed, healthyOnly));
+            ASSERT_DOUBLE_EQ(mixed.pvByActualPvCcy_.at("USD"), mixed.meta_[0].pv_ + mixed.meta_[1].pv_ + healthyOnly.meta_[0].pv_);
+            ASSERT_EQ(preparationAttempts[input.middle_[0].get()], 1);
+            ASSERT_EQ(preparationAttempts[input.middle_[1].get()], mask == 2 ? 1 : 0);
+            ASSERT_EQ(g_nodeSensitivitySweepCount, mask == 2 ? 4 : 2);
+            ASSERT_EQ(g_nodeSensitivityPassivePriceCount, 3);
+        }
+        const auto recovered = AggregateRatePortfolioQuoteRisk({input.bad_, input.healthy_}, input.market_, {*input.provenance_});
+        ASSERT_TRUE(recovered.provenanceFailures_.empty());
+        ASSERT_EQ(recovered.meta_.size(), 2);
+        ASSERT_TRUE(recovered.meta_[0].eligible_);
+        ASSERT_TRUE(recovered.meta_[1].eligible_);
+        ASSERT_EQ(recovered.pvByActualPvCcy_, noFault.pvByActualPvCcy_);
+        ASSERT_NO_FATAL_FAILURE(AssertBucketsEqual(recovered, noFault));
+    }
 } // namespace
 
 TEST(JointQuoteRiskTest, TestXccyProvenanceOrderPreservesStandaloneAndJointResults) {
@@ -264,5 +398,23 @@ TEST(JointQuoteRiskTest, TestHistoricalMixedChainConsumesOnlyNativeDiscount) {
             ASSERT_TRUE(risk.meta_[0].eligible_);
             ASSERT_FALSE(risk.meta_[0].structuralZero_);
             ASSERT_EQ(risk.buckets_.size(), 5);
+        }
+}
+
+TEST(JointQuoteRiskTest, TestPreparationFailuresFollowDeclarationOrderAndReuseFailureCache) {
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, Options());
+    for (bool reverseAllocation : {false, true})
+        for (bool reverseKeys : {false, true}) {
+            SCOPED_TRACE(reverseAllocation);
+            SCOPED_TRACE(reverseKeys);
+            const auto input = PreparationFailureInput(spec, calibrated, reverseAllocation, reverseKeys);
+            ASSERT_TRUE(input.provenance_.has_value());
+            ASSERT_TRUE(input.provenance_->Available());
+            ASSERT_EQ(std::less<const DiscountCurve_*>()(input.middle_[0].get(), input.middle_[1].get()), !reverseAllocation);
+            for (int mask : {1, 2, 3}) {
+                SCOPED_TRACE(mask);
+                ASSERT_NO_FATAL_FAILURE(AssertPreparationFaultCase(input, mask));
+            }
         }
 }

--- a/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
+++ b/dal-cpp/tests/curve/test_quoteriskprovenance.cpp
@@ -15,6 +15,8 @@
 #include <string>
 #include <type_traits>
 
+#include "jointquoteriskopaque.hpp"
+#include "jointxccyquoteriskfixtures.hpp"
 #include <dal/curve/calibration_internal.hpp>
 #include <dal/curve/curveblock.hpp>
 #include <dal/curve/piecewiseconstant.hpp>
@@ -1895,4 +1897,30 @@ TEST(QuoteRiskProvenanceTest, TestNonFiniteFixingAndCyclicCurveGraphFailBeforeHa
         first->ClearBase();
         second->ClearBase();
     }
+}
+
+TEST(QuoteRiskAggregationTest, TestMalformedV1SourceKeepsCallLevelException) {
+    using namespace Dal;
+    namespace fixture = JointXccyQuoteRiskFixtures;
+    auto input = MakeSingleInput(CurveJacobianMode_::Value_::ANALYTIC);
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurve(spec, fixture::Options());
+    const auto bound = input.market_.curveComponents_.at("discount");
+    input.market_ = fixture::Market(spec, calibrated, false, {}, [&](const auto&) {
+        return fixture::Flat(spec, "eur-3m", "EUR", 0.019, Handle_<DiscountCurve_>(new fixture::OpaqueCurve_({}, "EUR")));
+    });
+    input.market_.curveComponents_["discount"] = bound;
+    const auto provenance = BuildSingle(input);
+    const auto cyclic = std::make_shared<CyclicDiscountCurve_>("unrelated-invalid");
+    const Handle_<DiscountCurve_> handle(cyclic);
+    cyclic->SetBase(handle);
+    struct ClearCycle_ {
+        CyclicDiscountCurve_* curve_;
+        ~ClearCycle_() { curve_->ClearBase(); }
+    } clear{cyclic.get()};
+    input.market_.curveComponents_["discount"] = handle;
+    const auto trade = fixture::Trade(spec);
+    const auto passive = PriceRateTrade(trade, input.market_);
+    ASSERT_TRUE(passive.succeeded_);
+    ASSERT_THROW(AggregateRatePortfolioQuoteRisk({trade}, input.market_, {provenance}), Exception_);
 }

--- a/dal-excel/tests/test_jointcalibration.cpp
+++ b/dal-excel/tests/test_jointcalibration.cpp
@@ -4,6 +4,56 @@
 
 #include <dal-excel/src/__jointcalibration_test_api.hpp>
 #include <dal-public/tests/jointquoteriskfixture.hpp>
+#include <tests/curve/jointquoteriskopaque.hpp>
+#include <tests/curve/jointxccyquoteriskfixtures.hpp>
+
+TEST(ExcelJointCalibrationTest, TestUnregisteredXccyBaseQuoteRiskSpill) {
+    using namespace Dal;
+    namespace fixture = JointXccyQuoteRiskFixtures;
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto options = fixture::Options();
+    const auto calibrated = CalibrateJointMultiCurveBundle(spec, options);
+    const Handle_<StorableJointMultiCurveCalibrationResult_> bundle(new StorableJointMultiCurveCalibrationResult_(calibrated, spec, options));
+    const auto nativeMarket = fixture::Market(spec, calibrated);
+    const Handle_<StorableRatePricingMarket_> market(new StorableRatePricingMarket_(nativeMarket));
+    const Handle_<StorableRateTradeDefinition_> trade(new StorableRateTradeDefinition_(fixture::Trade(spec)));
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    JointMultiCurveQuoteRiskProvenance_New(bundle, "b1", {"curve:0", "curve:1"}, {"curve:0", "curve:1"}, market, &provenance);
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill({Handle_<Storable_>(trade)}, market, {Handle_<Storable_>(provenance)}, &spill);
+    ASSERT_EQ(spill.Rows(), 5);
+    ASSERT_EQ(spill.Cols(), 10);
+    const double derivative = (fixture::Reprice(spec, options, 0, 1, 1.0e-6) - fixture::Reprice(spec, options, 0, 1, -1.0e-6)) / 2.0e-6;
+    ASSERT_NEAR(Cell::ToDouble(spill(1, 6)), derivative, 1.0e-3);
+    ASSERT_EQ(Cell::ToString(spill(1, 5)), "EUR");
+    ASSERT_EQ(Cell::ToString(spill(1, 8)), "available");
+    ASSERT_TRUE(Cell::IsEmpty(spill(1, 9)));
+}
+
+TEST(ExcelJointCalibrationTest, TestNativeOpaqueJointGraphKeepsFailureSpillShape) {
+    using namespace Dal;
+    namespace fixture = JointXccyQuoteRiskFixtures;
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = CalibrateJointMultiCurveBundle(spec, fixture::Options());
+    const auto nativeMarket = fixture::Market(spec, calibrated, false, {}, [&](const auto&) {
+        return fixture::Flat(spec, "eur-3m", "EUR", 0.019, Handle_<DiscountCurve_>(new fixture::OpaqueCurve_({}, "EUR")));
+    });
+    const Handle_<StorableRatePricingMarket_> market(new StorableRatePricingMarket_(nativeMarket));
+    const Handle_<StorableJointMultiCurveCalibrationResult_> bundle(
+        new StorableJointMultiCurveCalibrationResult_(calibrated, spec, fixture::Options()));
+    const Handle_<StorableRateTradeDefinition_> trade(new StorableRateTradeDefinition_(fixture::Trade(spec)));
+    Handle_<StorableRateQuoteRiskProvenance_> provenance;
+    JointMultiCurveQuoteRiskProvenance_New(bundle, "b1", {"curve:0", "curve:1"}, {"curve:0", "curve:1"}, market, &provenance);
+    Matrix_<Cell_> spill;
+    RatePortfolioQuoteRisk_Spill({Handle_<Storable_>(trade)}, market, {Handle_<Storable_>(provenance)}, &spill);
+    ASSERT_EQ(spill.Rows(), 1);
+    ASSERT_EQ(spill.Cols(), 10);
+    ASSERT_TRUE(Cell::IsEmpty(spill(0, 6)));
+    ASSERT_TRUE(Cell::IsEmpty(spill(0, 7)));
+    ASSERT_EQ(Cell::ToString(spill(0, 8)), "unavailable");
+    ASSERT_EQ(Cell::ToString(spill(0, 3)), "AAD_EVALUATION_FAILED");
+    ASSERT_EQ(Cell::ToString(spill(0, 9)), "QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE");
+}
 
 namespace {
     using namespace Dal;

--- a/dal-excel/tests/test_jointcalibration.cpp
+++ b/dal-excel/tests/test_jointcalibration.cpp
@@ -7,7 +7,7 @@
 #include <tests/curve/jointquoteriskopaque.hpp>
 #include <tests/curve/jointxccyquoteriskfixtures.hpp>
 
-TEST(ExcelJointCalibrationTest, TestUnregisteredXccyBaseQuoteRiskSpill) {
+TEST(JointCalibrationExcelTest, TestUnregisteredXccyBaseQuoteRiskSpill) {
     using namespace Dal;
     namespace fixture = JointXccyQuoteRiskFixtures;
     const auto spec = JointQuoteRiskFixtures::Spec();
@@ -30,7 +30,7 @@ TEST(ExcelJointCalibrationTest, TestUnregisteredXccyBaseQuoteRiskSpill) {
     ASSERT_TRUE(Cell::IsEmpty(spill(1, 9)));
 }
 
-TEST(ExcelJointCalibrationTest, TestNativeOpaqueJointGraphKeepsFailureSpillShape) {
+TEST(JointCalibrationExcelTest, TestNativeOpaqueJointGraphKeepsFailureSpillShape) {
     using namespace Dal;
     namespace fixture = JointXccyQuoteRiskFixtures;
     const auto spec = JointQuoteRiskFixtures::Spec();

--- a/dal-public/tests/test_curvepricing.cpp
+++ b/dal-public/tests/test_curvepricing.cpp
@@ -8,6 +8,21 @@
 
 #include "jointquoteriskfixture.hpp"
 #include <dal-public/src/curvepricing.hpp>
+#include <tests/curve/jointxccyquoteriskfixtures.hpp>
+
+TEST(CurvePricingPublicTest, TestJointUnregisteredXccyBaseRisk) {
+    using namespace JointXccyQuoteRiskFixtures;
+    const auto spec = JointQuoteRiskFixtures::Spec();
+    const auto calibrated = Dal::CalibrateJointMultiCurveBundle(spec, Options());
+    const auto market = Market(spec, calibrated);
+    const auto provenance = Dal::BuildJointMultiCurveQuoteRiskProvenance(spec, calibrated, Options(), market, JointQuoteRiskFixtures::Config(2));
+    const auto risk = Dal::AggregateRatePortfolioQuoteRisk({Trade(spec)}, market, {provenance});
+    ASSERT_EQ(risk.buckets_.size(), 5);
+    ASSERT_TRUE(risk.meta_[0].eligible_);
+    const double derivative = (Reprice(spec, Options(), 0, 1, 1.0e-6) - Reprice(spec, Options(), 0, 1, -1.0e-6)) / 2.0e-6;
+    ASSERT_NEAR(risk.buckets_[1].dPvDDecimalQuote_, derivative, 1.0e-3);
+    ASSERT_EQ(risk.buckets_[1].actualPvCcy_, Dal::Ccy_("EUR"));
+}
 
 TEST(CurvePricingPublicTest, TestGenericJointCrossLanguageReference) {
     const auto spec = JointQuoteRiskPublicFixture::Spec();

--- a/dal-python/CMakeLists.txt
+++ b/dal-python/CMakeLists.txt
@@ -235,6 +235,14 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/dal/
 if(DAL_PYTHON_BUILD_TESTS)
     enable_testing()
 
+    if(NOT DAL_PYTHON_IS_TOPLEVEL)
+        pybind11_add_module(_dal_quote_risk_test tests/native/jointquoterisk.cpp)
+        target_link_libraries(_dal_quote_risk_test PRIVATE ${DAL_PUBLIC_TARGET})
+        add_custom_command(TARGET _dal_quote_risk_test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:_dal_quote_risk_test>" "${CMAKE_CURRENT_BINARY_DIR}/")
+    endif()
+
     file(COPY
         ${CMAKE_CURRENT_SOURCE_DIR}/src/dal/__init__.py
         ${CMAKE_CURRENT_SOURCE_DIR}/src/dal/api.py

--- a/dal-python/tests/native/jointquoterisk.cpp
+++ b/dal-python/tests/native/jointquoterisk.cpp
@@ -1,0 +1,13 @@
+//
+// Created by dal-implementer on 2026/9/11.
+//
+
+#include <pybind11/pybind11.h>
+
+#include <tests/curve/jointquoteriskopaque.hpp>
+
+PYBIND11_MODULE(_dal_quote_risk_test, m) {
+    m.def("opaque_curve", [](const std::shared_ptr<Dal::DiscountCurve_>& inner, const std::string& currency) -> std::shared_ptr<Dal::DiscountCurve_> {
+        return std::make_shared<JointXccyQuoteRiskFixtures::OpaqueCurve_>(Dal::Handle_<Dal::DiscountCurve_>(inner), Dal::String_(currency.c_str()));
+    });
+}

--- a/dal-python/tests/test_joint_quote_risk.py
+++ b/dal-python/tests/test_joint_quote_risk.py
@@ -11,7 +11,7 @@ import pytest
 from test_quote_risk import _run_with_quote_risk_gil_heartbeat
 
 
-def joint_inputs(*, layered=False, mode=None, inverse=True, bump=None):
+def joint_inputs(*, layered=False, mode=None, inverse=True, bump=None, strict=False):
     today = dal.Date_(2025, 1, 2)
     basis = dal.DayBasis_New("ACT_365F")
     collateral = dal.CollateralType_OIS()
@@ -23,6 +23,9 @@ def joint_inputs(*, layered=False, mode=None, inverse=True, bump=None):
     spec.today = today
     spec.ccy = "USD"
     spec.tolerance = 1e-11
+    if strict:
+        spec.tolerance = 1e-13
+        spec.fit_tolerance = 1e-12
     spec.initial_guess = 0.025
     spec.max_evaluations = 1000
     spec.max_restarts = 100
@@ -88,6 +91,102 @@ def provenance_from(inputs):
     return dal.BuildJointMultiCurveQuoteRiskProvenance(
         spec=spec, result=result, options=options, bound_market=market, config=config,
     )
+
+
+def unregistered_xccy_inputs(*, bump=None, register=False, opaque_leaf=None):
+    spec, options, result, market, config, _ = joint_inputs(bump=bump, strict=True)
+    today = spec.today
+    basis = dal.DayBasis_New("ACT_365F")
+    collateral = dal.CollateralType_OIS()
+    components = {"discount": next(iter(result.discount_curves.values())), "forward": next(iter(result.forward_curves.values()))}
+    valuation_time = dal.DateTime_(today, 0, 0)
+    fixings = dal.MarketFixingSnapshot_New({})
+    knots = [dal.Date_(2025, 7, 2), dal.Date_(2026, 7, 2), dal.Date_(2027, 7, 2)]
+
+    def flat(name, currency, rate, base=None):
+        return dal.DiscountPWC_New(name, currency, knots, [rate] * len(knots), base)
+
+    euro_discount = flat("eur-ois", "EUR", 0.017)
+    euro_forward = flat("eur-3m", "EUR", 0.019, opaque_leaf)
+    extra = flat("usd-6m", "USD", 0.015, components["discount"])
+    basis_curve = flat("basis", "EUR", 0.001)
+    domestic = dal.CurveBlock_New(
+        "EUR", "EUR", {collateral: euro_discount}, {dal.PeriodLength_New("3M"): euro_forward}, basis,
+    )
+    forwards = dict(result.forward_curves)
+    forwards[dal.PeriodLength_New("6M")] = extra
+    foreign = dal.CurveBlock_New("USD", "USD", result.discount_curves, forwards, basis)
+    xccy = dal.CrossCurrencyMarket_New(
+        domestic_block=domestic, foreign_block=foreign, fx_spot=0.9,
+        valuation_time=valuation_time, collateral_currency="EUR", fixings=fixings, basis_curve=basis_curve,
+    )
+    if register:
+        components["extra"] = extra
+    market = dal.RatePricingMarket_(
+        valuation_time=valuation_time, result_currency="USD", curve_components=components,
+        fixings=fixings, xccy_market=xccy,
+    )
+    convention = dal.CrossCurrencyConvention_()
+    for side, tenor in (("domestic", "3M"), ("foreign", "6M")):
+        period = dal.PeriodLength_New(tenor)
+        setattr(convention, f"{side}_index", dal.RateIndexConvention_New(period, basis, collateral, True))
+        setattr(convention, f"{side}_leg", dal.RateLegConvention_New(period, basis))
+    xccy_config = dal.CrossCurrencySwapConfig_()
+    xccy_config.pair = dal.CurrencyPair_New("EUR", "USD")
+    xccy_config.domestic_notional = 900_000.0
+    xccy_config.foreign_notional = 1_000_000.0
+    xccy_config.convention = convention
+    for side, name in (("domestic", "EUR-3M"), ("foreign", "USD-6M")):
+        identity = dal.FixingIdentity_()
+        identity.index_name = name
+        identity.fixing_hour = 11
+        identity.fixing_minute = 0
+        setattr(xccy_config, f"{side}_rate_fixing", identity)
+    terms = dal.XccyTradeTerms_(
+        position_count=1.0, contract_spread=0.0015, spread_on_foreign_leg=True,
+        receive_non_spread_pay_spread=True, config=xccy_config,
+    )
+    trade = dal.RateTradeDefinition_(
+        instrument_id="unregistered-xccy", instrument_type=dal.RateInstrumentType.XCCY,
+        trade_date=today, start_date=today, maturity_date=dal.Date_(2027, 1, 2), currency="EUR", terms=terms,
+    )
+    return spec, options, result, market, config, trade
+
+
+def test_unregistered_xccy_base_matches_recalibration_and_registration_control():
+    inputs = unregistered_xccy_inputs()
+    risk = dal.AggregateRatePortfolioQuoteRisk(trades=[inputs[-1]], market=inputs[3], provenances=[provenance_from(inputs)])
+    assert risk.meta[0].eligible and not risk.meta[0].structural_zero  # nosec B101
+    assert len(risk.buckets) == 5  # nosec B101
+    prices = []
+    for bump in (1e-6, -1e-6, 1e-4, -1e-4):
+        shifted = unregistered_xccy_inputs(bump=(0, 1, bump))
+        price = dal.PriceRateTrades(trades=[shifted[-1]], market=shifted[3])[0]
+        assert price.succeeded  # nosec B101
+        prices.append(price.pv)
+    bucket = risk.buckets[1]
+    assert bucket.d_pv_d_decimal_quote == pytest.approx((prices[0] - prices[1]) / 2e-6, abs=1e-3)  # nosec B101
+    assert bucket.dv01 == pytest.approx((prices[2] - prices[3]) / 2.0, abs=1e-5)  # nosec B101
+    assert bucket.actual_pv_ccy == "EUR"  # nosec B101
+    control = unregistered_xccy_inputs(register=True)
+    registered = dal.AggregateRatePortfolioQuoteRisk(trades=[control[-1]], market=control[3], provenances=[provenance_from(control)])
+    assert [b.d_pv_d_decimal_quote for b in registered.buckets] == [b.d_pv_d_decimal_quote for b in risk.buckets]  # nosec B101
+
+
+def test_native_opaque_joint_fixture_projects_existing_failure_metadata():
+    native_fixture = pytest.importorskip("_dal_quote_risk_test")
+    inputs = unregistered_xccy_inputs(opaque_leaf=native_fixture.opaque_curve(None, "EUR"))
+    provenance = provenance_from(inputs)
+    assert provenance.available  # nosec B101
+    risk = dal.AggregateRatePortfolioQuoteRisk(trades=[inputs[-1]], market=inputs[3], provenances=[provenance])
+    assert not risk.buckets  # nosec B101
+    assert len(risk.meta) == 1  # nosec B101
+    meta = risk.meta[0]
+    assert not meta.eligible and not meta.structural_zero  # nosec B101
+    assert meta.reason == "QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE"  # nosec B101
+    assert meta.original_node_risk_reason == "AAD_EVALUATION_FAILED"  # nosec B101
+    assert meta.failing_component_key == "discount"  # nosec B101
+    assert meta.actual_pv_ccy == "EUR" and math.isfinite(meta.pv)  # nosec B101
 
 
 @pytest.mark.parametrize("layered", [False, True])

--- a/docs/methodology/generic_joint_quote_risk.md
+++ b/docs/methodology/generic_joint_quote_risk.md
@@ -104,14 +104,47 @@ rejected before risk sweeps. A malformed live source is a provenance failure;
 trades consuming that source are not priced through it. Other trades and
 independent provenances continue.
 
-For joint native coordinates, a discount node also affects any consumed
-forward curve layered over that discount curve. Standalone node risk keeps its
-fixed-base semantics. A joint PV gradient includes these base paths before the
-complete g-transpose-E transform. Independent single-curve DV01s cannot be
-concatenated to reproduce this coupled response.
+Joint native coordinates follow each trade's actual consumed curve/base graph
+by handle identity. For XCCY trades, the roots are the selected domestic and
+foreign discount and forecast curves plus any basis curve. A selected forecast
+need not have its own key in `market.curveComponents_`: its base path still
+contributes to a bound calibrated component. Unused registered descendants do
+not enter preparation, and aliases do not duplicate a native sweep.
+
+Only the target's native parameters are independent variables in its sweep.
+Intermediate curve parameters stay constant while their base response remains
+active; the target's own base stays passive. Mixed PWC, PWLF, LogDF, and ZeroRate
+layers retain their original geometry, including historical PWC/PWLF knots and
+left/right values. Standalone node risk and v1 quote-risk sources keep their
+fixed-base semantics. Their preparation caches are separate from joint
+preparation, so mixing source kinds does not make results depend on source
+order. Passive pricing is shared once per trade.
+
+A joint PV gradient includes these base paths before the complete
+g-transpose-E transform. Independent single-curve DV01s cannot be concatenated
+to reproduce this coupled response.
+
+For live joint risk, every necessary graph node must be an exact builtin
+`Tape::DiscountPWC_<double>`, `Tape::DiscountPWLF_<double>`,
+`Tape::DiscountLogDF_<double>`, or `Tape::DiscountZeroRate_<double>` instance.
+Opaque nodes and subclasses, including an otherwise unchanged builtin
+subclass or an opaque unit-discount leaf, are outside this eligibility domain.
+Provenance factory acceptance alone does not establish trade-level graph
+eligibility. An incomplete graph cannot establish a structural zero. Existing
+family, routing, root-representation, passive-validation, and expired-XCCY
+gates retain their priority; a subsequent graph or preparation failure reports
+`AAD_EVALUATION_FAILED`.
 
 If one consumed block fails, the whole `(trade, provenance)` gradient is
-discarded. A non-consumed parameter block remains exactly zero without an AAD
+discarded, including slices from earlier successful sweeps. Exceptions,
+non-finite results, and incorrect gradient widths produce one
+`QUOTE_RISK_TRADE_PROVENANCE_INCOMPLETE` metadata entry with the failing bound
+key and original node-risk reason. Bound blocks are processed in declaration
+order. Successfully priced passive PV is retained once, and healthy trades and
+independent provenances continue. Invalid v2 sources are also checked along
+unregistered XCCY root/base paths before passive pricing.
+
+A non-consumed parameter block remains exactly zero without an AAD
 sweep; its quote buckets can still contain coupled risk through E. A trade
 consuming no bound components contributes structural-zero buckets. Numerical
 roundoff in the dense matrix is distinct from structural zeros in the native
@@ -147,6 +180,11 @@ The executable oracle covers 2/3 blocks, N=5/10/16, both modes, all four native
 parameterizations, and layered/unlayered curves (96 configurations, 992 buckets).
 Separate tests cover mixed parameterizations, reversed input order, signed
 positions, full native parameter responses, and source/failure boundaries.
+Unregistered XCCY base paths have full-recalibration and registration-invariance
+controls. Historical mixed chains also have central native-coordinate bump
+oracles that rebuild dependent layers without recalibration or quote mapping.
+Failure tests cover declaration order, preparation-cache reuse, mixed v1/joint
+source order, discarded partial slices, and tape recovery.
 Each original quote is recalibrated and repriced at ±1e-6 and ±1e-4; calibration
 failure, non-finite output, or loss of an eligible trade fails the test.
 

--- a/docs/methodology/rate_node_risk.md
+++ b/docs/methodology/rate_node_risk.md
@@ -56,6 +56,12 @@ XCCY uses uniformly typed market/curve-block views. Consumed curves are
 active-typed, but only the selected component's parameters are registered as
 independent variables. Non-target parameters and FX spot stay constant.
 
+These fixed-base coordinates also serve v1 quote-risk provenance. Generic joint
+quote risk follows consumed base paths in separate joint sweeps, including
+paths through unregistered XCCY forecast roots; it does not change the public
+standalone node-risk coordinates. See the
+[joint graph and eligibility contract](generic_joint_quote_risk.md#aggregation-and-failures).
+
 Each sweep owns its thread's tape through `TapeGuard_`, registers inputs,
 records pricing, seeds the PV adjoint, propagates, and validates the finite
 gradient and its expected width. The guard rewinds on exit, including failure.


### PR DESCRIPTION
## Summary

- Restore joint quote risk through each trade's actual consumed base graph, including unregistered XCCY forecast curves. The regression's EUR bucket now matches full recalibration at approximately -166.32 DV01 instead of +3.12.
- Preserve historical native coordinates and constant intermediate parameters. Keep standalone/v1 and joint preparation separate so mixed provenance order cannot change eligibility or risk, while sharing passive pricing once per trade.
- Isolate opaque/derived graphs, preparation exceptions, non-finite values, and wrong-width slices at the trade/provenance boundary; discard earlier partial gradients, preserve available passive PV, and protect invalid v2 sources before pricing through unregistered paths.
- Document the exact-builtin graph requirement and its compatibility impact: opaque unit-discount leaves and builtin subclasses can become ineligible even when their previous results were numerically correct. Public signatures, result fields, fingerprint formats, and standalone fixed-base coordinates remain unchanged.
- Fix the benchmark CI preflight to run each native revision against its own regression suite. Both builds still validate the same current benchmark workloads and use the unchanged paired performance policy (10 samples, two rounds, 4% threshold).

Closes DAL-193

## Test plan

- [x] Full native Linux Release build/install and CTest on the final source: 1556/1556 passed, including 376 Python tests, public C++, and portable Excel.
- [x] Numerical oracle: 992 buckets across 96 fixtures validated, with source-SHA and evidence-digest manifest.
- [x] Directed regressions included in CTest: unregistered XCCY recalibration and registration invariance, historical mixed-chain native-coordinate bumps, mixed v1/joint source ordering, declaration-order preparation failures and cache reuse, partial-gradient discard, and tape recovery.
- [x] Generated-source drift check, documentation checks for 51 Markdown files, 160 CI helper tests (6 environment-dependent skips), Ruff, complexity checks, and patch whitespace checks.
- [x] Benchmark preflight RED/GREEN: reproduce the new head regression failing on the old native library, verify correct source/build routing with an executable shell regression, and pass the same 85 workload tests against both native libraries.
- [x] Final-head hosted Linux/Windows CI, backend matrix, wheels, Python/native paired performance gates, Codacy, and review audit: 46 checks successful, with only PR-inapplicable PyPI publication skipped. Codacy reports zero issues; no unresolved review threads remain.

Full local native validation and the oracle manifest were captured at `300d5476bc21d077745d66fc8279207f9dc16623`. The subsequent CI-only correction was validated by the helper suite and both native workload runs; native source is unchanged. Hosted checks cover the latest PR head, including Windows/MSVC and alternative AAD backends.

Final hosted head: `0fc009b8f9201c5f7202f0ef0034e40ef5945287`. [Linux CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34518903070), [Windows CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34518903065), and [wheels](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34518903081) all succeeded. The remote oracle artifact was independently revalidated: 992 buckets / 96 fixtures, matching evidence digest, and a CI merge commit with the same file tree as this head.
