### PR TITLE
perf: add AAD node risk to Python performance gates

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -687,6 +687,7 @@ jobs:
         env:
           DAL_NUM_THREADS: 4
         run: |
+          # The full inventory includes 32/256-IRS native AAD node-DV01 workloads.
           python3 .github/scripts/check_python_benchmark_regressions.py \
             --base-source benchmark-base \
             --head-source . \
@@ -705,7 +706,7 @@ jobs:
           uv pip install --require-hashes \
             -r dal-python/benchmarks/requirements-comparisons.txt
 
-      - name: Compare Python performance with QuantLib and rateslib
+      - name: Compare Python pricing and AAD risk with QuantLib and rateslib
         if: ${{ !cancelled() && steps.python-comparison-dependencies.outcome == 'success' }}
         env:
           DAL_NUM_THREADS: 4

--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -431,7 +431,7 @@ Tests are located in `tests/` and cover:
 
 ## Performance Benchmarks
 
-The [Python benchmark suite](benchmarks/README.md) provides 70 public-interface
+The [Python benchmark suite](benchmarks/README.md) provides 72 public-interface
 workloads mapped to the C++ benchmark inventory: RNG, script construction and MC,
 single-curve and XCCY calibration, node risk, and quote-risk provenance/aggregation.
 It records raw samples, workload sizes, native-module identity, and a Markdown summary.
@@ -445,16 +445,17 @@ python benchmarks/run_benchmarks.py --group rate_risk_perf --filter generic
 ```
 
 The normal pytest suite checks every workload at smoke scale without a speed
-threshold. Linux CI also gates all 70 full-scale cases against independent base/head
+threshold. Linux CI also gates all 72 full-scale cases against independent base/head
 builds, using two rounds of ten interleaved processes and a strict 4% threshold in
 both rounds. The coverage map explicitly records unbound C++ kernels and fixture
 differences; Python timings include binding and result-conversion costs.
 
-The Linux gate also requires five common workloads to run against DAL,
+The Linux gate also requires seven common workloads to run against DAL,
 QuantLib-Python and rateslib with matching numerical results. Its report shows
-discount-query, IRS pricing and parallel zero-curve DV01 timings and relative
-speeds. Third-party dependencies are pinned separately for benchmarks; they are
-not DAL runtime dependencies. See the
+discount-query, IRS pricing, parallel zero-curve DV01 and full node DV01 timings.
+Node risk uses DAL reverse AAD, rateslib forward AD and QuantLib finite differences,
+with each algorithm identified in the evidence. Third-party dependencies are pinned
+separately for benchmarks; they are not DAL runtime dependencies. See the
 [comparison methodology and commands](benchmarks/README.md#third-party-comparison).
 
 ## Project Structure

--- a/dal-python/benchmarks/README.md
+++ b/dal-python/benchmarks/README.md
@@ -1,6 +1,6 @@
 # DAL Python interface benchmarks
 
-This suite runs 70 workloads through `import dal`, with a coverage entry for every
+This suite runs 72 workloads through `import dal`, with a coverage entry for every
 target in [the C++ benchmark inventory](../../dal-cpp/benchmarks/CMakeLists.txt).
 It requires a current DAL Python build and Python 3.9–3.13. The runner uses the
 standard library; pytest is needed only for its correctness tests.
@@ -53,15 +53,15 @@ are errors, never silently skipped workloads.
 
 ## Workload alignment
 
-| Native target            | Python cases | Full workload and timing boundary                                                                                                                                                      |
-|--------------------------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `rng_perf`               | 4            | 100,000 paths × 10 dimensions; Sobol normal fast, normal precise with polish, uniform, and MRG32 normal; fresh generator and output matrix each invocation                             |
-| `script_perf`            | 1            | Same three-year weekly barrier event table; `Product_New` + `Product_DebugJson`, including frontend construction, indexing and JSON serialization                                      |
-| `script_mc_perf`         | 8            | Vanilla: 200,000 double / 20,000 AAD paths; weekly barrier: 100,000 / 10,000; tree and compiled evaluators; product/model creation and preprocessing included                          |
-| `curve_calibration_perf` | 21           | Same 23 annual swaps and 24 future knots; PWC, PWL, LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED × ANALYTIC/BUMPED × diagnostics/solve-only, plus LOG_LINEAR APPROXIMATE                       |
-| `xccy_perf`              | 8            | Joint/staged × ANALYTIC/BUMPED × diagnostics/solve-only; adapted square fixture with five quotes per calibrated block                                                                  |
-| `rate_risk_perf`         | 19           | 120-IRS batch and 240 single-component calls; five-year OIS daily compounding; 24-XCCY × five-component batch; nine single/joint/staged quote portfolios; six generic-joint portfolios |
-| `quote_risk_perf`        | 9            | Single, joint XCCY and staged provenance at N=8/16; additional generic joint provenance at total N=5/10/16                                                                             |
+| Native target            | Python cases | Full workload and timing boundary                                                                                                                                |
+|--------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rng_perf`               | 4            | 100,000 paths × 10 dimensions; Sobol normal fast, normal precise with polish, uniform, and MRG32 normal; fresh generator and output matrix each invocation       |
+| `script_perf`            | 1            | Same three-year weekly barrier event table; `Product_New` + `Product_DebugJson`, including frontend construction, indexing and JSON serialization                |
+| `script_mc_perf`         | 8            | Vanilla: 200,000 double / 20,000 AAD paths; weekly barrier: 100,000 / 10,000; tree and compiled evaluators; product/model creation and preprocessing included    |
+| `curve_calibration_perf` | 21           | Same 23 annual swaps and 24 future knots; PWC, PWL, LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED × ANALYTIC/BUMPED × diagnostics/solve-only, plus LOG_LINEAR APPROXIMATE |
+| `xccy_perf`              | 8            | Joint/staged × ANALYTIC/BUMPED × diagnostics/solve-only; adapted square fixture with five quotes per calibrated block                                            |
+| `rate_risk_perf`         | 21           | 120-IRS batch and 240 single-component calls; five-year OIS; 24-XCCY batch; nine quote portfolios; six generic-joint portfolios; 32/256-IRS AAD node DV01        |
+| `quote_risk_perf`        | 9            | Single, joint XCCY and staged provenance at N=8/16; additional generic joint provenance at total N=5/10/16                                                       |
 
 All these target mappings are marked `partial`: the timed boundary is the Python
 interface, and some native-only subcases remain inaccessible. This is not a claim
@@ -87,6 +87,13 @@ analytically in Python. Every third position receives fixed on 250,000 notional;
 the others pay fixed on 1,000,000. The third curve is a structural-zero trade
 dependency. The internal joint-node reference and native preparation/tape counters
 are not exposed by Python and are not measured.
+
+`nodes.aad_dv01.t32` and `nodes.aad_dv01.t256` reuse the third-party comparison's
+single-curve IRS portfolios. Each native `RateTradeNodeSensitivitiesBatch` invocation
+records and propagates reverse AAD, then returns all 21 non-anchor node derivatives
+per trade. Conversion to zero-rate DV01 is included in timing. These two cases need
+only DAL and the standard library; third-party packages are not needed by the
+base/head gate. Their shared adapter and oracle files are included in suite hashes.
 
 Native targets without direct Python kernel timing are listed individually by
 `--coverage` and in every report:
@@ -119,8 +126,9 @@ result are excluded. GC remains enabled. No native executable is launched or
 timed by this runner. Native initialization occurs before measurements.
 
 Full mode defaults to ten samples and two warmups. Smoke mode uses one sample,
-zero warmups, 1,024 RNG paths, 2,048 MC paths and at most two portfolio trades;
-calibration widths remain intact. Workload metadata records actual sizes, even
+zero warmups, 1,024 RNG paths, 2,048 MC paths, four comparable AAD-risk trades,
+and at most two trades in the other portfolio cases; calibration widths remain
+intact. Workload metadata records actual sizes, even
 when a case's stable name contains its full-profile trade count. Smoke timings
 must not be compared with full timings. `DAL_NUM_THREADS` defaults to 4 when
 unset and must be set before DAL is imported.
@@ -152,8 +160,9 @@ repository's Python 3.9 syntax gate includes benchmark sources.
 The Linux `Benchmarks` job builds both the PR base (or pre-push commit on `master`)
 and the tested revision as independent Release builds with Python bindings enabled.
 Both use the same CPython 3.13 interpreter, compiler, AAD backend, native architecture
-flags and `DAL_NUM_THREADS=4`. The job verifies the head Python correctness suite
-against both modules before measuring performance.
+flags and `DAL_NUM_THREADS=4`. The job verifies each revision's correctness tests
+against its own native module, then the shared head benchmark workloads against
+both modules before measuring performance.
 
 The [paired Python gate](../../.github/scripts/check_python_benchmark_regressions.py)
 runs the complete head workload suite on **both** native modules. Each fresh process
@@ -164,11 +173,11 @@ pairs: 20 processes per side, with 20 samples for every case on each side. A cas
 fails only when its head minimum exceeds its base minimum by strictly more than
 4% in both rounds. Exactly +4% passes.
 
-The same head test code and workload metadata must be used for both sides, including
-when the base predates this benchmark suite. This first introduction still measures
-and gates all 70 cases against the base library; it is not an unmeasured adoption
-pass. When a base suite exists, its inventory is also checked: removing or renaming
-a case fails. New cases must run against both libraries. A missing base API,
+The same head benchmark code and workload metadata must be used for both sides,
+including when the base predates this benchmark suite. All 72 cases are measured
+and gated against the base library. When a base suite exists, its inventory is
+also checked: removing or renaming a case fails. New cases must run against both
+libraries. A missing base API,
 incorrect/ineligible result, unexpected package path, changed binary or suite hash,
 different workload/configuration, timeout, or incomplete sample set fails the gate.
 There is no smoke-mode or case-filter option in the gate.
@@ -204,7 +213,7 @@ correctness/smoke workloads through pytest; the paired performance gate is Linux
 
 ## Third-party comparison
 
-The Linux `Benchmarks` job also runs the same five common workloads against DAL,
+The Linux `Benchmarks` job also runs the same seven common workloads against DAL,
 QuantLib-Python and rateslib. All three backends must execute every case and pass
 an independent cashflow oracle. Missing dependencies, incorrect results, incomplete
 reports, changed workloads/binaries or process timeouts fail the job and therefore
@@ -242,39 +251,63 @@ one measured invocation per case. Imports, fixture construction, reference value
 validation and result destruction are outside timing. GC stays enabled, DAL uses
 four threads, and OMP/OpenBLAS/MKL use one thread.
 
-| Case               | Full workload                                                    |
-| ------------------ | ---------------------------------------------------------------- |
-| `discount_queries` | 4,096 distinct, permuted dates on a 22-node log-linear DF curve  |
-| `irs_pv_32`        | Price 32 forward-starting IRS, returning one PV per trade        |
-| `irs_pv_256`       | Price 256 forward-starting IRS, returning one PV per trade       |
-| `irs_dv01_32`      | Reprice 32 IRS on two prepared parallel-shifted zero curves      |
-| `irs_dv01_256`     | Reprice 256 IRS on two prepared parallel-shifted zero curves     |
+| Case                | Full workload                                                   |
+|---------------------|-----------------------------------------------------------------|
+| `discount_queries`  | 4,096 distinct, permuted dates on a 22-node log-linear DF curve |
+| `irs_pv_32`         | Price 32 forward-starting IRS, returning one PV per trade       |
+| `irs_pv_256`        | Price 256 forward-starting IRS, returning one PV per trade      |
+| `irs_dv01_32`       | Reprice 32 IRS on two prepared parallel-shifted zero curves     |
+| `irs_dv01_256`      | Reprice 256 IRS on two prepared parallel-shifted zero curves    |
+| `irs_node_dv01_32`  | Compute 21 zero-rate node DV01 buckets for each of 32 IRS       |
+| `irs_node_dv01_256` | Compute 21 zero-rate node DV01 buckets for each of 256 IRS      |
 
 All cases use valuation date 2025-01-15, USD, ACT/365F, annual fixed and IBOR legs,
 unadjusted dates, no holidays, zero fixing/payment lag, and the same discount and
 forecast curve. Trades start in 2026, mature over 2028–2045, and alternate payer
 and receiver directions with varying positive notionals and coupons. The common
 oracle independently computes the fixed coupon annuity and telescoping floating
-leg from log-linear discount factors. Query tolerance is 2e-12 absolute; PV/DV01
-tolerance is 2e-7 USD absolute, both with 1e-10 relative tolerance.
+leg from log-linear discount factors. Query tolerance is 2e-12 absolute; PV/parallel
+DV01 tolerance is 2e-7 USD absolute; node DV01 tolerance is 2e-6 USD/bp absolute
+to accommodate finite-difference truncation and cancellation. All use 1e-10 relative
+tolerance. The node oracle differentiates those cashflows analytically, including
+interpolation weights; tests also check off-node dates against independent bumps.
 
-DV01 here is `(PV(zero + 1bp) - PV(zero - 1bp)) / 2`, with the same decimal-rate
-shift applied to both discounting and forecasting. It measures finite-difference
-parallel zero-curve risk, **not** calibrated quote-space risk or native AAD. Curve
-construction is excluded. The C++-aligned suite continues to measure DAL's native
-node/quote-risk APIs separately; no third-party coverage is claimed for calibration,
-MC, XCCY, or other unmatched operations.
+Parallel `irs_dv01_*` is `(PV(zero + 1bp) - PV(zero - 1bp)) / 2`, with the same
+decimal-rate shift applied to both discounting and forecasting. It measures finite-difference
+parallel zero-curve risk. Node `irs_node_dv01_*` returns `dPV/dzero_i * 1e-4`
+for each non-anchor curve node, ordered by trade then node date. Both discounting
+and forecasting consume the same active curve, so each bucket includes both effects.
+These are curve-node derivatives, not calibrated quote-space risk.
+
+DAL uses native reverse AAD through `RateTradeNodeSensitivitiesBatch`; log-DF
+gradients are scaled by `-time_i * 1e-4`. Rateslib uses
+[forward AD with Dual numbers](https://rateslib.com/py/en/2.0.x/u_dual.html)
+(`ad=1` and `rateslib.dual.gradient`), scaling DF gradients by
+`-time_i * DF_i * 1e-4`. The pinned QuantLib adapter uses central finite differences
+with a 1e-6 decimal zero-rate step (0.01bp), scaled to USD/bp. It relinks and reprices
+each of the 42 prepared shifted curves. QuantLib's finite-difference reference and
+rateslib's forward AD are explicitly labelled separately from DAL's reverse AAD
+in every raw result and summary; timings compare available algorithms as well as APIs.
+
+Curve/trade construction is excluded. DAL tape recording and reverse propagation,
+rateslib active pricing and gradient extraction, QuantLib relinking and repricing,
+and bucket conversion are timed. Numeric oracle validation runs outside timing;
+shape, eligibility and AD-type guards during conversion reject unsupported results.
+Every invocation recalculates risk. The base/head 4% gate measures these DAL AAD
+workloads too. No third-party coverage is claimed for calibration, MC, XCCY,
+or other unmatched operations.
 
 DAL uses `PriceRateTrades` batches; QuantLib and rateslib price instrument lists.
 All adapters return floats in input order, including conversion cost. QuantLib's
 `recalculate()` forces every NPV invocation to run its pricing engine. Rateslib's
 public `curve_caching` setting is disabled, so discount queries measure interpolation
-rather than cached date lookups, and `ad=0` selects passive pricing. QuantLib keeps
-its constructed schedules/coupons; DAL's public batch call owns its internal
+rather than cached date lookups, and `ad=0` selects passive pricing outside the
+node-risk cases. QuantLib keeps its constructed schedules/coupons; DAL's public batch
+call owns its internal
 preparation. These are comparisons of the available Python APIs, not isolated
 identical native kernels.
 
-`results.json` (`dal.python-comparisons/1`) retains raw timings, minimum and median,
+`results.json` (`dal.python-comparisons/2`) retains raw timings, minimum and median,
 per-round ratios, conventions and provenance. Each process also retains its checked
 output values, package versions, module paths/hashes, source and dependency-lock
 hashes, DAL build flags, CPU/Python/thread settings and log. `summary.md` and the

--- a/dal-python/benchmarks/dal_benchmarks/cases.py
+++ b/dal-python/benchmarks/dal_benchmarks/cases.py
@@ -29,7 +29,7 @@ CPP_COVERAGE = {
     },
     "rate_risk_perf": {
         "status": "partial",
-        "detail": "120-IRS batch/single, 5Y daily OIS, 24-XCCY batch, single/joint/staged quote portfolios and layered generic joint N=5/10/16 x 100/1000 IRS. XCCY market ladder adapted; internal counters and joint-node reference are unbound.",
+        "detail": "120-IRS batch/single, 5Y daily OIS, 24-XCCY batch, quote portfolios, generic joint N=5/10/16 x 100/1000 IRS and 32/256-IRS AAD node DV01. XCCY market ladder adapted; internal counters and joint-node reference are unbound.",
     },
     "quote_risk_perf": {
         "status": "partial",
@@ -114,9 +114,30 @@ def build_cases(smoke=False):
     _calibration_cases(add, calibration)
     _xccy_cases(add, xccy)
     _node_cases(add, smoke, risk, xccy)
+    _aad_comparison_cases(add, smoke)
     _quote_cases(add, smoke, risk, xccy)
     _generic_cases(add, smoke, risk)
     return cases
+
+
+def _aad_comparison_cases(add, smoke):
+    from dal_comparisons.scenarios import cases, RISK_METHODS, NODES
+    from dal_comparisons.suite import prepare
+
+    for case in cases(smoke):
+        if case["operation"] == "node_dv01":
+            size = case["name"].rsplit("_", 1)[1]
+            add(
+                f"nodes.aad_dv01.t{size}",
+                "rate_risk_perf",
+                {
+                    "trades": case["size"],
+                    "nodes": len(NODES) - 1,
+                    "method": RISK_METHODS["dal"],
+                    "risk": "dPV/dzero_i * 1bp",
+                },
+                partial(prepare, "dal", case),
+            )
 
 
 def _simulation_cases(add, smoke, simulation):

--- a/dal-python/benchmarks/dal_benchmarks/runner.py
+++ b/dal-python/benchmarks/dal_benchmarks/runner.py
@@ -92,9 +92,10 @@ def environment():
     root = Path(__file__).resolve().parents[3]
     native = Path(dal._dal.__file__).resolve()
     cache, cmake = cmake_environment(native)
-    sources = {
-        path.name: sha256(path) for path in sorted(Path(__file__).parent.glob("*.py"))
-    }
+    suite = Path(__file__).resolve().parent.parent
+    paths = list((suite / "dal_benchmarks").glob("*.py"))
+    paths += list((suite / "dal_comparisons").glob("*.py"))
+    sources = {str(path.relative_to(suite)): sha256(path) for path in sorted(paths)}
     return {
         "utc": datetime.now(timezone.utc).isoformat(),
         "python": sys.version,

--- a/dal-python/benchmarks/dal_benchmarks/runner.py
+++ b/dal-python/benchmarks/dal_benchmarks/runner.py
@@ -95,7 +95,9 @@ def environment():
     suite = Path(__file__).resolve().parent.parent
     paths = list((suite / "dal_benchmarks").glob("*.py"))
     paths += list((suite / "dal_comparisons").glob("*.py"))
-    sources = {str(path.relative_to(suite)): sha256(path) for path in sorted(paths)}
+    sources = {
+        path.relative_to(suite).as_posix(): sha256(path) for path in sorted(paths)
+    }
     return {
         "utc": datetime.now(timezone.utc).isoformat(),
         "python": sys.version,

--- a/dal-python/benchmarks/dal_comparisons/compare.py
+++ b/dal-python/benchmarks/dal_comparisons/compare.py
@@ -9,7 +9,7 @@ import sys
 
 from dal_benchmarks.harness import require
 from .evidence import ROOT, SCHEMA, check_report, source_hashes, timings, write_json
-from .scenarios import CONVENTIONS, cases
+from .scenarios import CONVENTIONS, cases, method
 from .suite import BACKENDS
 
 
@@ -127,7 +127,10 @@ def aggregate(reports, smoke):
     rows = []
     for case in cases(smoke):
         measurements = {
-            backend: timings(reports[backend], case["name"]) for backend in BACKENDS
+            backend: dict(
+                timings(reports[backend], case["name"]), method=method(backend, case)
+            )
+            for backend in BACKENDS
         }
         dal_time = measurements["dal"]["min_ns"]
         ratios = {
@@ -148,6 +151,12 @@ def summary(report):
         "",
         "Correctness and complete execution are required. Timing ratios are "
         "informational; DAL base/head regression remains a separate 4% gate.",
+        "",
+        "Node DV01: DAL reverse AAD; rateslib forward AD (Dual); "
+        "QuantLib central finite difference (0.01bp step). "
+        "Each returns all 21 non-anchor buckets per trade, in USD/bp. "
+        "Curve construction is excluded; differentiation, conversion and "
+        "QuantLib relinking/repricing are timed.",
         "",
     ]
     if report["status"] != "passed":

--- a/dal-python/benchmarks/dal_comparisons/dal_adapter.py
+++ b/dal-python/benchmarks/dal_comparisons/dal_adapter.py
@@ -2,7 +2,8 @@
 
 import dal
 
-from .scenarios import LOG_DFS, NODES, TIMES, TODAY
+from dal_benchmarks.harness import require
+from .scenarios import BUMP, LOG_DFS, NODES, TIMES, TODAY
 
 
 def date(value):
@@ -74,7 +75,7 @@ def discount_runner(dates):
     return lambda: [source(anchor, value) for value in native_dates]
 
 
-def pricing_runner(portfolio, shift):
+def pricing_inputs(portfolio, shift):
     source = curve(shift)
     market = dal.RatePricingMarket_(
         valuation_time=dal.DateTime_(date(TODAY), 9, 0),
@@ -83,10 +84,40 @@ def pricing_runner(portfolio, shift):
         fixings=dal.MarketFixingSnapshot_New({}),
     )
     native_trades = [swap(value, i) for i, value in enumerate(portfolio)]
+    return native_trades, market
+
+
+def pricing_runner(portfolio, shift):
+    native_trades, market = pricing_inputs(portfolio, shift)
 
     def run():
         rows = dal.PriceRateTrades(trades=native_trades, market=market)
         # Native failures are data; NaN makes the common out-of-timer validator fail.
         return [row.pv if row.succeeded else float("nan") for row in rows]
+
+    return run
+
+
+def node_values(cell, ordinal):
+    require(
+        cell.instrument_id == f"comparison-{ordinal}" and cell.component_key == "curve",
+        "AAD node-risk cell order changed",
+    )
+    row = cell.result
+    require(row.eligible, f"AAD node risk ineligible: {row.reason}")
+    gradient = row.gradient
+    require(len(gradient) == len(TIMES) - 1, "AAD node-risk gradient width mismatch")
+    return [-t * BUMP * value for t, value in zip(TIMES[1:], gradient)]
+
+
+def node_risk_runner(portfolio):
+    native_trades, market = pricing_inputs(portfolio, 0.0)
+
+    def run():
+        cells = dal.RateTradeNodeSensitivitiesBatch(
+            trades=native_trades, market=market, component_keys=["curve"]
+        )
+        require(len(cells) == len(native_trades), "AAD node-risk cell count mismatch")
+        return [value for i, cell in enumerate(cells) for value in node_values(cell, i)]
 
     return run

--- a/dal-python/benchmarks/dal_comparisons/evidence.py
+++ b/dal-python/benchmarks/dal_comparisons/evidence.py
@@ -7,9 +7,9 @@ from pathlib import Path
 import statistics
 
 from dal_benchmarks.harness import require
-from .scenarios import CONVENTIONS, cases, expected, validate
+from .scenarios import CONVENTIONS, cases, expected, method, tolerance, validate
 
-SCHEMA = "dal.python-comparisons/1"
+SCHEMA = "dal.python-comparisons/2"
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -53,14 +53,16 @@ def backend_files(backend):
     return {str(path): sha256(path) for path in paths}
 
 
-def check_row(row, case):
+def check_row(row, case, backend):
     require(row["status"] == "passed", "worker case failed")
     require(row["workload"] == case, "comparison workload changed")
+    require(
+        row.get("method") == method(backend, case), "comparison risk method changed"
+    )
     durations = row["samples_ns"]
     require(len(durations) == 1, "worker must return one sample")
     require(type(durations[0]) is int and durations[0] > 0, "invalid timing sample")
-    tolerance = 2e-12 if case["operation"] == "discount" else 2e-7
-    validate(row["values"], expected(case), abs_tol=tolerance)
+    validate(row["values"], expected(case), abs_tol=tolerance(case))
 
 
 def check_report(report, backend, smoke, hashes):
@@ -79,7 +81,7 @@ def check_report(report, backend, smoke, hashes):
         "missing, duplicate or reordered comparison cases",
     )
     for row, case in zip(report["results"], inventory):
-        check_row(row, case)
+        check_row(row, case, backend)
 
 
 def timings(reports, name):

--- a/dal-python/benchmarks/dal_comparisons/evidence.py
+++ b/dal-python/benchmarks/dal_comparisons/evidence.py
@@ -25,7 +25,7 @@ def source_hashes():
     paths = list((ROOT / "dal_comparisons").glob("*.py"))
     paths += list((ROOT / "dal_benchmarks").glob("*.py"))
     paths += [ROOT / "run_comparisons.py", ROOT / "requirements-comparisons.txt"]
-    return {str(path.relative_to(ROOT)): sha256(path) for path in sorted(paths)}
+    return {path.relative_to(ROOT).as_posix(): sha256(path) for path in sorted(paths)}
 
 
 def package_versions():

--- a/dal-python/benchmarks/dal_comparisons/quantlib_adapter.py
+++ b/dal-python/benchmarks/dal_comparisons/quantlib_adapter.py
@@ -1,18 +1,22 @@
 """QuantLib Python bindings; force fresh NPV calculation on every invocation."""
 
 import QuantLib as ql
+import math
 
-from .scenarios import NODES, TODAY, node_dfs
+from .scenarios import BUMP, NODE_BUMP, NODES, TIMES, TODAY, node_dfs
 
 
 def date(value):
     return ql.Date(value.day, value.month, value.year)
 
 
-def curve(shift):
+def curve(shift, node=None, node_shift=0.0):
+    dfs = node_dfs(shift)
+    if node is not None:
+        dfs[node] *= math.exp(-node_shift * TIMES[node])
     return ql.DiscountCurve(
         [date(value) for value in NODES],
-        node_dfs(shift),
+        dfs,
         ql.Actual365Fixed(),
         ql.NullCalendar(),
     )
@@ -63,16 +67,41 @@ def swap(value, handle):
     return result
 
 
+def prices(swaps):
+    values = []
+    for instrument in swaps:
+        instrument.recalculate()
+        values.append(instrument.NPV())
+    return values
+
+
 def pricing_runner(portfolio, shift):
     ql.Settings.instance().evaluationDate = date(TODAY)
     handle = ql.YieldTermStructureHandle(curve(shift))
     swaps = [swap(value, handle) for value in portfolio]
 
+    return lambda: prices(swaps)
+
+
+def node_risk_runner(portfolio):
+    ql.Settings.instance().evaluationDate = date(TODAY)
+    handle = ql.RelinkableYieldTermStructureHandle(curve(0.0))
+    swaps = [swap(value, handle) for value in portfolio]
+    shifts = [
+        (curve(0.0, i, NODE_BUMP), curve(0.0, i, -NODE_BUMP))
+        for i in range(1, len(NODES))
+    ]
+
     def run():
-        values = []
-        for instrument in swaps:
-            instrument.recalculate()
-            values.append(instrument.NPV())
-        return values
+        buckets = []
+        for up, down in shifts:
+            handle.linkTo(up)
+            high = prices(swaps)
+            handle.linkTo(down)
+            low = prices(swaps)
+            buckets.append(
+                [(a - b) * BUMP / (2 * NODE_BUMP) for a, b in zip(high, low)]
+            )
+        return [value for row in zip(*buckets) for value in row]
 
     return run

--- a/dal-python/benchmarks/dal_comparisons/rateslib_adapter.py
+++ b/dal-python/benchmarks/dal_comparisons/rateslib_adapter.py
@@ -1,18 +1,21 @@
-"""Rateslib passive pricing with the same unadjusted annual IBOR conventions."""
+"""Rateslib passive pricing and forward AD risk for unadjusted annual IRS."""
 
 import rateslib as rl
+from rateslib.dual import gradient
 
-from .scenarios import NODES, node_dfs
+from dal_benchmarks.harness import require
+from .scenarios import BUMP, NODES, TIMES, node_dfs
 
 
-def curve(shift):
+def curve(shift, ad=0):
     # Public configuration: do not compare a date->DF cache hit with interpolation.
     rl.defaults.curve_caching = False
     return rl.Curve(
         nodes=dict(zip(NODES, node_dfs(shift))),
         interpolation="log_linear",
         convention="Act365F",
-        ad=0,
+        id="comparison",
+        ad=ad,
     )
 
 
@@ -46,3 +49,22 @@ def pricing_runner(portfolio, shift):
     source = curve(shift)
     swaps = [swap(value) for value in portfolio]
     return lambda: [float(instrument.npv(curves=source)) for instrument in swaps]
+
+
+def node_risk_runner(portfolio):
+    source = curve(0.0, ad=1)
+    swaps = [swap(value) for value in portfolio]
+    variables = [f"comparison{i}" for i in range(1, len(NODES))]
+    scales = [-t * BUMP * df for t, df in zip(TIMES[1:], node_dfs()[1:])]
+
+    def risk(instrument):
+        value = instrument.npv(curves=source)
+        require(
+            isinstance(value, rl.Dual), "rateslib risk lost automatic differentiation"
+        )
+        return [
+            float(scale * derivative)
+            for scale, derivative in zip(scales, gradient(value, variables))
+        ]
+
+    return lambda: [value for instrument in swaps for value in risk(instrument)]

--- a/dal-python/benchmarks/dal_comparisons/rateslib_adapter.py
+++ b/dal-python/benchmarks/dal_comparisons/rateslib_adapter.py
@@ -62,9 +62,13 @@ def node_risk_runner(portfolio):
         require(
             isinstance(value, rl.Dual), "rateslib risk lost automatic differentiation"
         )
+        derivatives = gradient(value, variables)
+        require(
+            len(derivatives) == len(scales),
+            "rateslib node-risk gradient width mismatch",
+        )
         return [
-            float(scale * derivative)
-            for scale, derivative in zip(scales, gradient(value, variables))
+            float(scale * derivative) for scale, derivative in zip(scales, derivatives)
         ]
 
     return lambda: [value for instrument in swaps for value in risk(instrument)]

--- a/dal-python/benchmarks/dal_comparisons/scenarios.py
+++ b/dal-python/benchmarks/dal_comparisons/scenarios.py
@@ -9,6 +9,12 @@ NODES = [datetime(2025 + year, 1, 15) for year in range(22)]
 TIMES = [(date - TODAY).days / 365 for date in NODES]
 LOG_DFS = [-(0.02 + 0.0005 * i) * t for i, t in enumerate(TIMES)]
 BUMP = 1e-4
+NODE_BUMP = 1e-6
+RISK_METHODS = {
+    "dal": "reverse AAD",
+    "quantlib": "central finite difference",
+    "rateslib": "forward AD (Dual)",
+}
 CONVENTIONS = {
     "valuation_date": TODAY.isoformat(),
     "currency": "USD",
@@ -21,8 +27,12 @@ CONVENTIONS = {
     "discount_and_forecast": "same curve",
     "risk": "(PV(zero + 1bp) - PV(zero - 1bp)) / 2",
     "risk_curve_construction": "excluded; both shifted curves prepared before timing",
+    "node_risk": "dPV/dzero_i * 1bp; 21 non-anchor nodes; trade-major/node-date order",
+    "node_risk_methods": RISK_METHODS,
+    "node_risk_fd_step": NODE_BUMP,
+    "node_risk_construction": "excluded; AD curve or 42 shifted curves prepared before timing",
     "cache_policy": "QuantLib NPV forced recalculation; rateslib curve_caching=False",
-    "output": "one float per query or trade, in input order",
+    "output": "one float per query/trade; node risk: 21 floats per trade, in node-date order",
     "node_dates": [date.isoformat() for date in NODES],
     "node_log_dfs": LOG_DFS,
 }
@@ -30,7 +40,7 @@ CONVENTIONS = {
 
 def cases(smoke=False):
     result = [{"name": "discount_queries", "operation": "discount", "size": 4096}]
-    for operation in ("pv", "dv01"):
+    for operation in ("pv", "dv01", "node_dv01"):
         for size in (32, 256):
             result.append(
                 {
@@ -66,32 +76,68 @@ def node_dfs(shift=0.0):
     return [math.exp(log_df - shift * t) for log_df, t in zip(LOG_DFS, TIMES)]
 
 
-def discount(date, shift=0.0):
+def weights(date):
     t = (date - TODAY).days / 365
     right = max(1, bisect_left(TIMES, t))
     left = right - 1
     weight = (t - TIMES[left]) / (TIMES[right] - TIMES[left])
-    log_df = LOG_DFS[left] + weight * (LOG_DFS[right] - LOG_DFS[left])
+    return ((left, 1 - weight), (right, weight))
+
+
+def discount(date, shift=0.0, log_dfs=LOG_DFS):
+    t = (date - TODAY).days / 365
+    log_df = sum(log_dfs[i] * weight for i, weight in weights(date))
     return math.exp(log_df - shift * t)
 
 
-def pv(trade, shift=0.0):
-    previous, annuity = trade["start"], 0.0
+def cashflows(trade):
+    previous = trade["start"]
+    result = [(previous, 1.0), (trade["end"], -1.0)]
     for year in range(previous.year + 1, trade["end"].year + 1):
-        date = datetime(year, 1, 15)
-        annuity += (date - previous).days / 365 * discount(date, shift)
+        date = datetime(year, previous.month, previous.day)
+        result.append((date, -trade["rate"] * (date - previous).days / 365))
         previous = date
-    floating = discount(trade["start"], shift) - discount(trade["end"], shift)
-    return trade["sign"] * trade["notional"] * (floating - trade["rate"] * annuity)
+    return result
+
+
+def pv(trade, shift=0.0, log_dfs=LOG_DFS):
+    value = sum(
+        amount * discount(date, shift, log_dfs) for date, amount in cashflows(trade)
+    )
+    return trade["sign"] * trade["notional"] * value
+
+
+def node_dv01(trade):
+    result = [0.0] * len(NODES)
+    for date, amount in cashflows(trade):
+        for i, weight in weights(date):
+            result[i] += amount * discount(date) * weight
+    scale = -trade["sign"] * trade["notional"] * BUMP
+    return [scale * t * value for t, value in zip(TIMES[1:], result[1:])]
+
+
+def method(backend, case):
+    if case["operation"] == "node_dv01":
+        return RISK_METHODS[backend]
+    return "central finite difference" if case["operation"] == "dv01" else "passive"
+
+
+def tolerance(case):
+    return {"discount": 2e-12, "node_dv01": 2e-6}.get(case["operation"], 2e-7)
 
 
 def expected(case):
     if case["operation"] == "discount":
         return [discount(date) for date in queries(case["size"])]
-    portfolio = trades(case["size"])
-    if case["operation"] == "pv":
-        return [pv(trade) for trade in portfolio]
-    return [(pv(trade, BUMP) - pv(trade, -BUMP)) / 2 for trade in portfolio]
+    calculators = {
+        "pv": lambda trade: [pv(trade)],
+        "dv01": lambda trade: [(pv(trade, BUMP) - pv(trade, -BUMP)) / 2],
+        "node_dv01": node_dv01,
+    }
+    if case["operation"] not in calculators:
+        raise ValueError(f"unknown comparison operation: {case['operation']}")
+    calculate = calculators[case["operation"]]
+    return [value for trade in trades(case["size"]) for value in calculate(trade)]
 
 
 def validate(values, reference, *, abs_tol=2e-7):

--- a/dal-python/benchmarks/dal_comparisons/suite.py
+++ b/dal-python/benchmarks/dal_comparisons/suite.py
@@ -3,7 +3,7 @@
 from importlib import import_module
 
 from dal_benchmarks.harness import Workload
-from .scenarios import BUMP, expected, queries, trades, validate
+from .scenarios import BUMP, expected, queries, tolerance, trades, validate
 
 BACKENDS = ("dal", "quantlib", "rateslib")
 
@@ -17,12 +17,16 @@ def prepare(backend, case):
         run = adapter.discount_runner(queries(case["size"]))
     elif case["operation"] == "pv":
         run = adapter.pricing_runner(trades(case["size"]), 0.0)
-    else:
+    elif case["operation"] == "dv01":
         up = adapter.pricing_runner(trades(case["size"]), BUMP)
         down = adapter.pricing_runner(trades(case["size"]), -BUMP)
 
         def run():
             return [(a - b) / 2 for a, b in zip(up(), down())]
 
-    tolerance = 2e-12 if case["operation"] == "discount" else 2e-7
-    return Workload(run, lambda result: validate(result, reference, abs_tol=tolerance))
+    else:
+        run = adapter.node_risk_runner(trades(case["size"]))
+
+    return Workload(
+        run, lambda result: validate(result, reference, abs_tol=tolerance(case))
+    )

--- a/dal-python/benchmarks/dal_comparisons/worker.py
+++ b/dal-python/benchmarks/dal_comparisons/worker.py
@@ -7,7 +7,7 @@ import sys
 
 from dal_benchmarks.harness import Case, Workload, measure, require
 from .evidence import SCHEMA, backend_files, package_versions, source_hashes, write_json
-from .scenarios import CONVENTIONS, cases
+from .scenarios import CONVENTIONS, cases, method
 from .suite import prepare
 
 
@@ -41,7 +41,7 @@ def measured_case(backend, case):
     wrapped = Workload(work.run, check)
     definition = Case(case["name"], "third-party", case, lambda: wrapped)
     result = measure(definition, samples=1, warmups=2)
-    return dict(result, values=last)
+    return dict(result, values=last, method=method(backend, case))
 
 
 def run(args):

--- a/dal-python/benchmarks/tests/test_comparisons.py
+++ b/dal-python/benchmarks/tests/test_comparisons.py
@@ -10,7 +10,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from dal_comparisons.scenarios import cases, expected, validate
+from dal_comparisons.scenarios import cases, expected, method, validate
 from dal_comparisons.suite import prepare
 from dal_comparisons import compare
 from dal_comparisons.evidence import SCHEMA, check_report, source_hashes
@@ -35,6 +35,14 @@ def test_payer_receiver_and_central_difference_signs():
     values = expected(case)
     assert values[0] > 0
     assert values[1] < 0
+
+
+def test_node_risk_inventory_and_bucket_width():
+    inventory = {case["name"]: case for case in cases()}
+    for size in (32, 256):
+        case = inventory[f"irs_node_dv01_{size}"]
+        assert case["operation"] == "node_dv01"
+        assert len(expected(case)) == size * 21
 
 
 @pytest.mark.parametrize("bad", [[], [float("nan")], [float("inf")], [1e9]])
@@ -81,6 +89,7 @@ def worker_report(backend="dal", duration=100):
                 status="passed",
                 samples_ns=[duration],
                 values=expected(case),
+                method=method(backend, case),
             )
             for case in cases(smoke=True)
         ],
@@ -104,6 +113,7 @@ def worker_report(backend="dal", duration=100):
         lambda report: report["results"][0].update(samples_ns=[0]),
         lambda report: report["results"][0].update(samples_ns=[100, 100]),
         lambda report: report["results"][0].update(values=[1e9] * 4),
+        lambda report: report["results"][-1].update(method="central finite difference"),
     ],
 )
 def test_invalid_worker_evidence_fails(mutate):
@@ -237,6 +247,11 @@ def test_rotates_processes_and_reports_minimum_without_relative_speed_gate(
     report = json.loads((args.output_dir / "results.json").read_text())
     row = report["rounds"][0]["cases"][0]
     assert row["third_party_over_dal"] == {"quantlib": 0.5, "rateslib": 0.25}
+    risk = report["rounds"][0]["cases"][-1]
+    assert risk["backends"]["dal"]["method"] == "reverse AAD"
+    assert risk["backends"]["rateslib"]["method"] == "forward AD (Dual)"
+    assert risk["backends"]["quantlib"]["method"] == "central finite difference"
+    assert "Node DV01: DAL reverse AAD" in (args.output_dir / "summary.md").read_text()
 
 
 def test_provenance_drift_fails_between_samples(tmp_path, monkeypatch):

--- a/dal-python/benchmarks/tests/test_node_risk.py
+++ b/dal-python/benchmarks/tests/test_node_risk.py
@@ -1,0 +1,149 @@
+"""Check risk units, interpolation, algorithm dispatch and fresh differentiation."""
+
+from datetime import datetime
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dal_comparisons.scenarios import (
+    BUMP,
+    LOG_DFS,
+    NODES,
+    TIMES,
+    node_dv01,
+    pv,
+    trades,
+    validate,
+)
+from dal_comparisons.suite import prepare
+
+
+def off_node_portfolio():
+    portfolio = trades(2)
+    for trade in portfolio:
+        trade["start"] = datetime(2026, 4, 15)
+        trade["end"] = datetime(2045, 4, 15)
+    return portfolio
+
+
+@pytest.mark.parametrize("trade", off_node_portfolio())
+def test_analytic_buckets_match_independent_node_bumps(trade):
+    buckets = node_dv01(trade)
+    step = 1e-6
+    for i in range(1, len(NODES)):
+        up, down = list(LOG_DFS), list(LOG_DFS)
+        up[i] -= TIMES[i] * step
+        down[i] += TIMES[i] * step
+        finite_difference = (
+            (pv(trade, log_dfs=up) - pv(trade, log_dfs=down)) * BUMP / (2 * step)
+        )
+        assert buckets[i - 1] == pytest.approx(finite_difference, abs=2e-6, rel=1e-10)
+    # All bucket exposures sum to parallel first-order zero-curve risk.
+    parallel = (pv(trade, step) - pv(trade, -step)) * BUMP / (2 * step)
+    assert sum(buckets) == pytest.approx(parallel, abs=2e-6, rel=1e-10)
+
+
+@pytest.mark.parametrize("backend", ["dal", "quantlib", "rateslib"])
+def test_off_node_risk_matches_cashflow_derivatives(backend):
+    from importlib import import_module
+
+    portfolio = off_node_portfolio()
+    reference = [value for trade in portfolio for value in node_dv01(trade)]
+    adapter = import_module(f"dal_comparisons.{backend}_adapter")
+    run = adapter.node_risk_runner(portfolio)
+    validate(run(), reference, abs_tol=2e-6)
+    validate(run(), reference, abs_tol=2e-6)
+
+
+def test_dal_calls_native_aad_each_time_without_passive_repricing(monkeypatch):
+    from dal_comparisons import dal_adapter as adapter
+
+    calls = []
+    native = adapter.dal.RateTradeNodeSensitivitiesBatch
+
+    def aad(**kwargs):
+        calls.append(kwargs)
+        return native(**kwargs)
+
+    def passive(**_kwargs):
+        pytest.fail("AAD risk must not fall back to passive repricing")
+
+    monkeypatch.setattr(adapter.dal, "RateTradeNodeSensitivitiesBatch", aad)
+    monkeypatch.setattr(adapter.dal, "PriceRateTrades", passive)
+    work = prepare("dal", {"operation": "node_dv01", "size": 2})
+    for _ in range(3):
+        work.validate(work.run())
+    assert len(calls) == 3
+    assert all(call["component_keys"] == ["curve"] for call in calls)
+
+
+@pytest.mark.parametrize(
+    "fault", ["ineligible", "missing", "short", "reordered", "nonfinite"]
+)
+def test_invalid_aad_cells_fail_instead_of_producing_timings(monkeypatch, fault):
+    from dal_comparisons import dal_adapter as adapter
+
+    native = adapter.dal.RateTradeNodeSensitivitiesBatch
+
+    def broken(**kwargs):
+        cells = native(**kwargs)
+        row = cells[0].result
+        result = SimpleNamespace(
+            eligible=row.eligible, reason="test failure", gradient=row.gradient
+        )
+        if fault == "ineligible":
+            result.eligible = False
+        elif fault == "short":
+            result.gradient.pop()
+        elif fault == "nonfinite":
+            result.gradient[0] = float("nan")
+        cells[0] = SimpleNamespace(
+            instrument_id=cells[0].instrument_id, component_key="curve", result=result
+        )
+        if fault == "missing":
+            cells.pop()
+        if fault == "reordered":
+            cells.reverse()
+        return cells
+
+    monkeypatch.setattr(adapter.dal, "RateTradeNodeSensitivitiesBatch", broken)
+    work = prepare("dal", {"operation": "node_dv01", "size": 2})
+    with pytest.raises(ValueError):
+        work.validate(work.run())
+
+
+def test_rateslib_requires_an_active_dual_result(monkeypatch):
+    from dal_comparisons import rateslib_adapter as adapter
+
+    monkeypatch.setattr(
+        adapter, "swap", lambda _value: SimpleNamespace(npv=lambda **_kwargs: 1.0)
+    )
+    work = prepare("rateslib", {"operation": "node_dv01", "size": 2})
+    with pytest.raises(ValueError, match="lost automatic differentiation"):
+        work.run()
+
+
+def test_quantlib_reprices_all_node_shifts_each_time(monkeypatch):
+    from dal_comparisons import quantlib_adapter as adapter
+
+    prices = adapter.prices
+    calls = []
+
+    def fresh(swaps):
+        calls.append(len(swaps))
+        return prices(swaps)
+
+    monkeypatch.setattr(adapter, "prices", fresh)
+    work = prepare("quantlib", {"operation": "node_dv01", "size": 2})
+    work.validate(work.run())
+    work.validate(work.run())
+    assert calls == [2] * (2 * 21 * 2)
+
+
+def test_unknown_risk_operation_is_rejected():
+    with pytest.raises(ValueError, match="unknown comparison operation"):
+        prepare("dal", {"operation": "typo", "size": 2})

--- a/dal-python/benchmarks/tests/test_node_risk.py
+++ b/dal-python/benchmarks/tests/test_node_risk.py
@@ -127,6 +127,24 @@ def test_rateslib_requires_an_active_dual_result(monkeypatch):
         work.run()
 
 
+@pytest.mark.parametrize("extra", [False, True])
+def test_rateslib_rejects_incorrect_gradient_width_before_conversion(
+    monkeypatch, extra
+):
+    from dal_comparisons import rateslib_adapter as adapter
+
+    original = adapter.gradient
+
+    def incorrect(value, variables):
+        result = list(original(value, variables))
+        return result + [0.0] if extra else result[:-1]
+
+    monkeypatch.setattr(adapter, "gradient", incorrect)
+    work = prepare("rateslib", {"operation": "node_dv01", "size": 2})
+    with pytest.raises(ValueError, match="gradient width mismatch"):
+        work.run()
+
+
 def test_quantlib_reprices_all_node_shifts_each_time(monkeypatch):
     from dal_comparisons import quantlib_adapter as adapter
 

--- a/dal-python/tests/test_benchmarks.py
+++ b/dal-python/tests/test_benchmarks.py
@@ -204,6 +204,43 @@ def test_full_profile_preserves_native_path_and_portfolio_sizes():
         assert cases[f"quotes.generic.n{width}.t1000"]["quotes"] == width
 
 
+def test_comparable_aad_risk_is_in_the_regression_inventory():
+    cases = {case.name: case for case in build_cases()}
+    for size in (32, 256):
+        case = cases[f"nodes.aad_dv01.t{size}"]
+        assert case.cpp_target == "rate_risk_perf"
+        assert case.workload["trades"] == size
+        assert case.workload["nodes"] == 21
+        assert case.workload["method"] == "reverse AAD"
+
+
+def test_aad_gate_needs_no_third_party_packages(monkeypatch):
+    import builtins
+
+    original = builtins.__import__
+
+    def without_third_parties(name, *args, **kwargs):
+        if name.split(".")[0] in {"QuantLib", "rateslib"}:
+            raise ImportError("third-party packages are not installed")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_third_parties)
+    for case in build_cases(smoke=True):
+        if case.name.startswith("nodes.aad_dv01."):
+            work = case.prepare()
+            work.validate(work.run())
+
+
+def test_suite_hashes_cover_shared_aad_implementation():
+    from dal_benchmarks.runner import environment, sha256
+
+    suite = Path(__file__).resolve().parents[1] / "benchmarks"
+    hashes = environment()["suite_sha256"]
+    for name in ("dal_adapter.py", "scenarios.py", "suite.py"):
+        key = f"dal_comparisons/{name}"
+        assert hashes[key] == sha256(suite / key)
+
+
 def test_metadata_git_command_rejects_non_metadata_arguments(tmp_path, monkeypatch):
     from dal_benchmarks import runner
 


### PR DESCRIPTION
## Summary

The Python third-party performance suite only measured finite-difference parallel DV01. Add full curve-node DV01 for 32 and 256 IRS, returning all 21 non-anchor buckets per trade. DAL uses native reverse AAD, rateslib uses forward AD, and QuantLib supplies a central finite-difference reference; reports identify each method and validate the outputs against an independent cashflow derivative oracle.

- Add the same DAL AAD workloads to the base/head regression inventory: 72 full-scale cases, with the existing strict 4% threshold in both best-of-ten confirmation rounds. Third-party comparisons now cover seven cases; relative speed remains informational.
- Include shared AAD sources in provenance hashes with portable relative paths. Require valid eligibility, exact gradient width before conversion, bucket shape/order, active AD results, and method metadata. Cover off-node interpolation, risk units, fresh calculation, invalid results, and operation without third-party dependencies.
- Document the timing boundaries, node-risk algorithms, tolerances, and comparison evidence schema (`dal.python-comparisons/2`).

## Test plan

- [x] Build the Release CPython 3.13 native bindings and quote-risk test helper from the current master-based source.
- [x] Python correctness and comparison tests: 454 passed. CI helper tests: 154 passed, 6 environment skips.
- [x] Hosted paired performance gates: all 72 Python cases (2,880 samples) and all 51 native cases across nine targets passed. Re-evaluated the downloaded raw Python reports using the unchanged 4% threshold and two best-of-ten rounds.
- [x] Hosted third-party comparison: two interleaved rounds of ten fresh processes per backend; 60 worker reports, 420 timings, and 362,880 node-risk values validated against the current source hashes.
- [x] Ruff, complexity, Bandit, Python 3.9 grammar, documentation, and patch-integrity checks.
- [x] Final head `7baf895fd20016c76617e754284576e270ad7104`: 46 successful checks and the expected skipped PyPI publication job. Linux/Windows suites, wheel builds, Codacy (zero annotations), and coverage/Coveralls passed; no unresolved review threads. The CI merge revision has the same source tree as this head.

[Final performance evidence](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34619612620/artifacts/10273068967) retains the raw reports, provenance, and summaries. The [first-attempt evidence](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34619612620/artifacts/10273190324) is also retained: four existing Python cubic-curve cases and native `ZeroAdjoints` initially exceeded the threshold, while both new AAD cases passed. An independent local paired run and one fresh-runner CI retry passed without changing source, sampling, or thresholds; the initial findings did not reproduce.
