### PR TITLE
perf: expand Python option and curve calibration benchmarks

### DIFF
--- a/dal-python/README.md
+++ b/dal-python/README.md
@@ -431,9 +431,9 @@ Tests are located in `tests/` and cover:
 
 ## Performance Benchmarks
 
-The [Python benchmark suite](benchmarks/README.md) provides 72 public-interface
+The [Python benchmark suite](benchmarks/README.md) provides 90 public-interface
 workloads mapped to the C++ benchmark inventory: RNG, script construction and MC,
-single-curve and XCCY calibration, node risk, and quote-risk provenance/aggregation.
+single/multi-curve and XCCY calibration, node risk, and quote-risk provenance/aggregation.
 It records raw samples, workload sizes, native-module identity, and a Markdown summary.
 
 From `dal-python/`, using a current installed wheel or editable build:
@@ -445,14 +445,17 @@ python benchmarks/run_benchmarks.py --group rate_risk_perf --filter generic
 ```
 
 The normal pytest suite checks every workload at smoke scale without a speed
-threshold. Linux CI also gates all 72 full-scale cases against independent base/head
+threshold. Linux CI also gates all 90 full-scale cases against independent base/head
 builds, using two rounds of ten interleaved processes and a strict 4% threshold in
 both rounds. The coverage map explicitly records unbound C++ kernels and fixture
 differences; Python timings include binding and result-conversion costs.
 
-The Linux gate also requires seven common workloads to run against DAL,
-QuantLib-Python and rateslib with matching numerical results. Its report shows
-discount-query, IRS pricing, parallel zero-curve DV01 and full node DV01 timings.
+The Linux gate also checks 31 comparison workloads against DAL,
+QuantLib-Python and rateslib with independent numerical oracles. Its report covers
+discount queries, IRS PV and DV01, Monte Carlo vanilla/barrier prices and
+Delta/Vega/Rho, plus single, staged/joint multi-curve and XCCY calibration.
+Rateslib equity MC and QuantLib simultaneous joint calibration are explicitly
+unsupported; every other case must complete successfully.
 Node risk uses DAL reverse AAD, rateslib forward AD and QuantLib finite differences,
 with each algorithm identified in the evidence. Third-party dependencies are pinned
 separately for benchmarks; they are not DAL runtime dependencies. See the

--- a/dal-python/benchmarks/README.md
+++ b/dal-python/benchmarks/README.md
@@ -1,9 +1,10 @@
 # DAL Python interface benchmarks
 
-This suite runs 72 workloads through `import dal`, with a coverage entry for every
+This suite runs 90 workloads through `import dal`, with a coverage entry for every
 target in [the C++ benchmark inventory](../../dal-cpp/benchmarks/CMakeLists.txt).
 It requires a current DAL Python build and Python 3.9–3.13. The runner uses the
-standard library; pytest is needed only for its correctness tests.
+standard library and NumPy for the independent barrier-option integration oracle;
+pytest is needed only for its correctness tests.
 
 ## Running
 
@@ -57,9 +58,9 @@ are errors, never silently skipped workloads.
 |--------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `rng_perf`               | 4            | 100,000 paths × 10 dimensions; Sobol normal fast, normal precise with polish, uniform, and MRG32 normal; fresh generator and output matrix each invocation       |
 | `script_perf`            | 1            | Same three-year weekly barrier event table; `Product_New` + `Product_DebugJson`, including frontend construction, indexing and JSON serialization                |
-| `script_mc_perf`         | 8            | Vanilla: 200,000 double / 20,000 AAD paths; weekly barrier: 100,000 / 10,000; tree and compiled evaluators; product/model creation and preprocessing included    |
-| `curve_calibration_perf` | 21           | Same 23 annual swaps and 24 future knots; PWC, PWL, LOG_LINEAR, LOG_CUBIC_NATURAL, MIXED × ANALYTIC/BUMPED × diagnostics/solve-only, plus LOG_LINEAR APPROXIMATE |
-| `xccy_perf`              | 8            | Joint/staged × ANALYTIC/BUMPED × diagnostics/solve-only; adapted square fixture with five quotes per calibrated block                                            |
+| `script_mc_perf`         | 16           | Eight native-aligned tree/compiled double/AAD cases plus eight comparable vanilla/barrier MC price and Greek cases at 16,384/65,536 paths                         |
+| `curve_calibration_perf` | 27           | 21 native-aligned representation/Jacobian/diagnostic cases plus single, staged multi-curve and joint multi-curve comparisons at 5/15 quotes per block           |
+| `xccy_perf`              | 12           | Eight native-aligned joint/staged/Jacobian/diagnostic cases plus staged and joint XCCY comparisons at 5/15 quotes per block                                       |
 | `rate_risk_perf`         | 21           | 120-IRS batch and 240 single-component calls; five-year OIS; 24-XCCY batch; nine quote portfolios; six generic-joint portfolios; 32/256-IRS AAD node DV01        |
 | `quote_risk_perf`        | 9            | Single, joint XCCY and staged provenance at N=8/16; additional generic joint provenance at total N=5/10/16                                                       |
 
@@ -121,8 +122,9 @@ or analytic Black/IV kernels.
 
 ## Measurement and correctness
 
-Fixture creation, calibration of risk markets, reference results, and validation
-run outside timing. Risk aggregation reuses immutable provenance and markets;
+Raw fixture data, calibration of risk markets, reference results, and validation
+run outside timing. Fresh MC product/model construction and calibration solves
+are inside their respective workloads. Risk aggregation reuses immutable provenance and markets;
 provenance construction has separate cases. Each case performs an untimed checked
 call, then warmups, then measured calls. Validation after every call checks output
 shapes, finite results, calibration residuals, matrix-retention policy, tree/compiled
@@ -138,7 +140,9 @@ timed by this runner. Native initialization occurs before measurements.
 Full mode defaults to ten samples and two warmups. Smoke mode uses one sample,
 zero warmups, 1,024 RNG paths, 2,048 MC paths, four comparable AAD-risk trades,
 and at most two trades in the other portfolio cases; calibration widths remain
-intact. Workload metadata records actual sizes, even
+intact for the original calibration cases. The additional comparable MC cases use
+4,096 paths in smoke mode, and comparable calibrations use two quotes per block.
+Workload metadata records actual sizes, even
 when a case's stable name contains its full-profile trade count. Smoke timings
 must not be compared with full timings. `DAL_NUM_THREADS` defaults to 4 when
 unset and must be set before DAL is imported.
@@ -196,7 +200,7 @@ recorded CI interpreter, platform and native CPU flags; they are diagnostic buil
 outputs, not portable distribution wheels.
 
 The same head benchmark code and workload metadata must be used for both sides,
-including when the base predates this benchmark suite. All 72 cases are measured
+including when the base predates this benchmark suite. All 90 cases are measured
 and gated against the base library. When a base suite exists, its inventory is
 also checked: removing or renaming a case fails. New cases must run against both
 libraries. A missing base API,
@@ -235,9 +239,12 @@ correctness/smoke workloads through pytest; the paired performance gate is Linux
 
 ## Third-party comparison
 
-The Linux `Benchmarks` job also runs thirteen common workloads against DAL,
-QuantLib-Python and rateslib. All three backends must execute every case and pass
-an independent cashflow oracle. Missing dependencies, incorrect results, incomplete
+The Linux `Benchmarks` job also runs 31 workloads against DAL,
+QuantLib-Python and rateslib. Every supported backend/case pair must execute and pass
+its independent oracle. Only declared unsupported capabilities are reported as
+`unsupported` with a reason and no timings: rateslib equity MC, and QuantLib
+simultaneous joint calibration. This gives 31 DAL, 27 QuantLib and 23 rateslib
+measured cases. Missing dependencies, incorrect results, incomplete
 reports, changed workloads/binaries or process timeouts fail the job and therefore
 the existing `Linux CI gate`. Relative speed is reported without an absolute
 competitor speed threshold; the separate base/head gate still enforces the 4% DAL
@@ -265,13 +272,15 @@ python dal-python/benchmarks/run_comparisons.py \
 ```
 
 The output directory must be new, so an old successful report cannot satisfy a
-failed run. `--smoke` uses four queries/trades and one process per backend for
+failed run. `--smoke` uses four queries/trades, 4,096 MC paths, two calibration
+quotes per block and one process per backend for
 local correctness checks; CI always uses full sizes and at least two rounds of ten
 fresh processes per backend. Backend order rotates for each sample and reverses
 on the second round. Each process performs a checked preflight, two warmups, then
 one measured invocation per case. Imports, fixture construction, reference values,
 validation and returned-float-list destruction are outside timing. Instrument
-construction/destruction is timed in the explicit cold cases. GC stays enabled, DAL uses
+construction/destruction is timed in the explicit cold cases, MC option cases and
+calibration cases. GC stays enabled, DAL uses
 four threads, and OMP/OpenBLAS/MKL use one thread.
 
 | Case                | Full workload                                                   |
@@ -302,7 +311,7 @@ Update cases represent two portfolio valuations; divide by two only when
 reporting an explicitly labelled cost per valuation. All new cases check their
 complete returned vectors against the independent oracle on every invocation.
 
-All cases use valuation date 2025-01-15, USD, ACT/365F, annual fixed and IBOR legs,
+The thirteen discount/IRS cases use valuation date 2025-01-15, USD, ACT/365F, annual fixed and IBOR legs,
 unadjusted dates, no holidays, zero fixing/payment lag, and the same discount and
 forecast curve. Trades start in 2026, mature over 2028–2045, and alternate payer
 and receiver directions with varying positive notionals and coupons. The common
@@ -335,11 +344,80 @@ rateslib active pricing and gradient extraction, QuantLib relinking and repricin
 and bucket conversion are timed. Numeric oracle validation runs outside timing;
 shape, eligibility and AD-type guards during conversion reject unsupported results.
 Every invocation recalculates risk. The base/head 4% gate measures these DAL AAD
-workloads too. No third-party coverage is claimed for calibration, MC, XCCY,
-or other unmatched operations.
+workloads too.
 
-DAL uses `PriceRateTrades` batches; QuantLib and rateslib price instrument lists.
-All adapters return floats in input order, including conversion cost. QuantLib's
+### Monte Carlo options
+
+Eight `mc_{vanilla,barrier}_{price,greeks}_{16384,65536}` cases use native DAL and
+QuantLib Monte Carlo engines under Black-Scholes. Spot and strike are 100,
+volatility is 20%, the continuous rate is 3%, and dividend yield is 1%. Valuation
+is 2025-01-15 and maturity is 364 days later, with ACT/365F time. The up-and-out call
+has barrier 130, zero rebate and exactly 52 weekly observations including maturity.
+QuantLib's [`MCBarrierEngine`](https://github.com/lballabio/QuantLib/blob/master/ql/pricingengines/barrier/mcbarrierengine.hpp)
+uses `isBiased=True` to select discrete monitoring; its default continuous-barrier
+correction would price a different payoff.
+
+Both use Sobol with no Brownian bridge or antithetics. DAL restarts at initial
+point 0; QuantLib uses fixed seed 42, since seed 0 can randomize high-dimensional
+direction initialization. Streams need not coincide between libraries. Product,
+model and engine construction, preprocessing, simulation and conversion are timed
+on every invocation, preventing cached NPV or reuse of a completed simulation.
+
+Greek cases return `[PV, Delta, Vega, Rho]`, with sensitivities per unit spot,
+decimal volatility and decimal rate. DAL vanilla uses reverse AAD. QuantLib
+vanilla and both discrete-barrier engines use central differences with common
+random numbers, with bumps of 1 spot unit, 0.01 volatility and 0.01 rate. The
+barrier reference uses the same finite bumps. Hard barrier indicators are not
+treated as having a valid naive pathwise derivative. Gamma and Theta are not
+included in these first-order Greek workloads; the original DAL smoothed-AAD
+barrier cases remain separate.
+
+An analytic Black-Scholes oracle checks vanilla results. The discrete-barrier
+oracle integrates Gaussian log-price transitions at every observation and handles
+the final truncated call expectation analytically. Its 256/384-point convergence
+is tested independently of either MC implementation. At 16,384 paths, absolute
+`[PV, Delta, Vega, Rho]` tolerances are `[0.08, 0.01, 0.5, 0.5]` for vanilla and
+`[0.25, 0.05, 3, 4]` for the barrier, scaled by `sqrt(16384 / paths)`. These are
+explicit MC accuracy bounds, not deterministic equality or equal-error-cost
+comparisons. Full output widths, finite values and each Greek are checked. The
+JSON conventions and workload records retain path counts, bumps and methods.
+
+### Curve calibration
+
+Ten `calibration_{single,multi_staged,multi_joint,xccy_staged,xccy_joint}_{5,15}`
+cases calibrate non-flat markets at 5 or 15 annual quotes per block. Each curve has
+annual log-linear DF pillars and a fixed unit anchor. Synthetic quotes come from
+independent scalar annual IRS and fixed-notional USD/EUR XCCY cashflows, with
+ACT/365F, no holidays or adjustments, and zero fixing/payment/settlement lag.
+Each library constructs fresh instruments and initial curves, solves, and returns
+every solved annual node and midpoint DF inside timing. Raw quotes and the oracle
+are outside timing. The DF tolerance is 2e-8 absolute plus 1e-10 relative; a solver
+success flag alone cannot pass the comparison.
+
+- `single` solves a USD discount curve from annual fixed/float swaps.
+- `multi_staged` solves USD discount then forward curves, using the solved
+  discount curve in the second stage. DAL calls its public single-curve solver
+  twice with optional Jacobian/inverse retention disabled.
+- `multi_joint` solves both USD curves simultaneously, using DAL's joint API or
+  rateslib's AD [`Solver`](https://rateslib.com/py/en/latest/c_solver.html).
+- `xccy_staged` solves EUR discounting under USD collateral against fixed USD/EUR
+  domestic discount and forecast curves. XCCY swaps exchange both principals and
+  carry spread on the EUR leg, with USD per EUR spot 1.10. DAL's basis DF is
+  converted as `EUR domestic DF / basis DF` before comparison. Its piecewise
+  constant forward intervals reproduce the common log-linear DF curve exactly.
+- `xccy_joint` solves all five discount/forecast/cross-currency blocks together
+  using DAL's joint XCCY solver and rateslib's Solver/FXForwards/XCS APIs.
+
+QuantLib uses fresh log-linear discount bootstraps and constant-notional XCCY basis
+rate helpers for supported staged cases. Its Python API has no matching
+simultaneous joint solver, so those four rows are explicitly unsupported. DAL's
+optional final Jacobian and inverse retention is disabled; rateslib retains its
+public solver AD state and status output. These comparisons include differences
+between the available numerical methods. Supported solver failures remain errors.
+
+For the thirteen discount/IRS cases, DAL uses `PriceRateTrades` batches; QuantLib
+and rateslib price instrument lists. All adapters return floats in input order,
+including conversion cost. QuantLib's
 `recalculate()` forces every NPV invocation to run its pricing engine. Rateslib's
 public `curve_caching` setting is disabled, so discount queries measure interpolation
 rather than cached date lookups, and `ad=0` selects passive pricing outside the
@@ -351,10 +429,11 @@ case explicitly measures invalidation and fresh pricing. These are comparisons
 of the available Python APIs, not isolated
 identical native kernels.
 
-`results.json` (`dal.python-comparisons/2`) retains raw timings, minimum and median,
+`results.json` (`dal.python-comparisons/3`) retains raw timings, minimum and median,
 per-round ratios, conventions and provenance. Each process also retains its checked
 output values, package versions, module paths/hashes, source and dependency-lock
 hashes, DAL build flags, CPU/Python/thread settings and log. `summary.md` and the
 Actions summary show per-round minima and `third_party / DAL` ratios (>1 means DAL
-took less time). Both successful and failed evidence is uploaded in the existing
+took less time); unsupported cells show `N/A` and have no ratio or timing sample.
+Both successful and failed evidence is uploaded in the existing
 `benchmark-linux-*` artifact under `python-third-party/`.

--- a/dal-python/benchmarks/dal_benchmarks/cases.py
+++ b/dal-python/benchmarks/dal_benchmarks/cases.py
@@ -17,15 +17,15 @@ CPP_COVERAGE = {
     },
     "script_mc_perf": {
         "status": "partial",
-        "detail": "All eight vanilla/barrier x double/AAD x tree/compiled cases; native path counts, dates and model. Includes public result conversion.",
+        "detail": "All eight native vanilla/barrier x double/AAD x tree/compiled cases, plus eight common third-party MC price/Delta/Vega/Rho workloads at 16K/64K paths. Includes public result conversion.",
     },
     "curve_calibration_perf": {
         "status": "partial",
-        "detail": "All 21 cases: five representations x analytic/bumped x diagnostics/solve, plus approximate. Same 23 swaps/24 future knots.",
+        "detail": "All 21 native-aligned cases plus six non-flat single/staged/joint multi-curve calibration comparisons at 5/15 quotes per block.",
     },
     "xccy_perf": {
         "status": "partial",
-        "detail": "Joint/staged analytic/bumped x diagnostics/solve using five quotes per block. Adapted square quote ladder; native 15-instrument/reset-aware/approximate and precompute pricing cases are not reproduced.",
+        "detail": "Joint/staged analytic/bumped x diagnostics/solve plus four non-flat staged/joint XCCY calibration comparisons at 5/15 quotes per block. Native reset-aware/approximate and precompute pricing cases are not reproduced.",
     },
     "rate_risk_perf": {
         "status": "partial",
@@ -117,7 +117,26 @@ def build_cases(smoke=False):
     _aad_comparison_cases(add, smoke)
     _quote_cases(add, smoke, risk, xccy)
     _generic_cases(add, smoke, risk)
+    _expanded_comparison_cases(add, smoke)
     return cases
+
+
+def _expanded_comparison_cases(add, smoke):
+    from dal_comparisons.scenarios import cases
+    from dal_comparisons.suite import prepare
+
+    for case in cases(smoke):
+        if case["operation"].startswith("mc_"):
+            target = "script_mc_perf"
+        elif case["operation"] == "calibration":
+            target = (
+                "xccy_perf"
+                if case["kind"].startswith("xccy_")
+                else "curve_calibration_perf"
+            )
+        else:
+            continue
+        add(f"comparison.{case['name']}", target, case, partial(prepare, "dal", case))
 
 
 def _aad_comparison_cases(add, smoke):

--- a/dal-python/benchmarks/dal_comparisons/calibration_dal.py
+++ b/dal-python/benchmarks/dal_comparisons/calibration_dal.py
@@ -1,0 +1,246 @@
+"""Fresh public DAL single, multi-curve and XCCY calibration solves."""
+
+import math
+
+import dal
+
+from dal_benchmarks.calibration import calibration_options, index, leg
+from dal_benchmarks.harness import require
+from . import calibration_scenarios as inputs
+
+
+def date(value):
+    return dal.Date_(value.year, value.month, value.day)
+
+
+def instruments(key, data):
+    today = data["dates"][0]
+    convention = index(key.endswith("forward"), months=12)
+    return [
+        dal.Swap_New(today, today, maturity, quote, leg(), convention, leg())
+        for maturity, quote in zip(data["dates"][1:], data["quotes"][key])
+    ]
+
+
+def single_curve(key, data, discount=None):
+    builder = dal.CurveCalibrationSpecBuilder_()
+    builder.today_ = data["dates"][0]
+    builder.ccy_, builder.curveName_ = dal.String_(key[:3].upper()), dal.String_(key)
+    builder.targetCollateral_ = dal.CollateralType_OIS()
+    builder.targetTenor_ = dal.PeriodLength_New("12M")
+    builder.calibrateDiscountCurve_ = key.endswith("discount")
+    builder.liborBasis_ = dal.DayBasis_New("ACT_365F")
+    builder.parameterization_ = dal.CurveParameterization.LOG_DISCOUNT
+    builder.logDfScheme_ = dal.LogDfScheme.LOG_LINEAR
+    builder.knot_policy = dal.CurveKnotPolicy.INPUT
+    builder.knotDates_ = data["dates"]
+    builder.instruments_ = instruments(key, data)
+    builder.tolerance_, builder.fitTolerance_, builder.initialGuess_ = (
+        1e-12,
+        1e-10,
+        0.025,
+    )
+    if discount is not None:
+        builder.discountCurves_ = {dal.CollateralType_OIS(): discount}
+    result = dal.CalibrateSingleCurve(
+        builder.Build(), calibration_options("ANALYTIC", False)
+    )
+    require(
+        result.diagnostics_.maxAbsResidual_ < 1e-9,
+        "DAL single calibration did not converge",
+    )
+    return result.curve_
+
+
+def declaration(key, data):
+    result = dal.JointCurveDeclaration_()
+    result.curve_name = key
+    result.calibrate_discount_curve = key.endswith("discount")
+    result.target_collateral = dal.CollateralType_OIS()
+    result.target_tenor = dal.PeriodLength_New("12M")
+    result.parameterization = dal.CurveParameterization.LOG_DISCOUNT
+    result.log_df_scheme = dal.LogDfScheme.LOG_LINEAR
+    result.knot_dates, result.instruments = data["dates"][1:], instruments(key, data)
+    return result
+
+
+def solve_rates(kind, data):
+    if kind == "multi_joint":
+        spec = dal.JointMultiCurveCalibrationSpec_()
+        spec.today, spec.ccy = data["dates"][0], "USD"
+        spec.curves = [declaration(key, data) for key in inputs.KEYS[:2]]
+        spec.tolerance, spec.fit_tolerance, spec.initial_guess = 1e-12, 1e-10, 0.025
+        options = dal.JointMultiCurveCalibrationOptions_()
+        options.compute_jacobian_at_solution = options.compute_eff_jacobian_inverse = (
+            False
+        )
+        result = dal.CalibrateJointMultiCurveBundle(spec, options)
+        require(result.converged, "DAL multi-curve calibration did not converge")
+        return dict(
+            zip(
+                inputs.KEYS,
+                (
+                    next(iter(result.discount_curves.values())),
+                    next(iter(result.forward_curves.values())),
+                ),
+            )
+        )
+    discount = single_curve(inputs.KEYS[0], data)
+    curves = {inputs.KEYS[0]: discount}
+    if kind == "multi_staged":
+        curves[inputs.KEYS[1]] = single_curve(inputs.KEYS[1], data, discount)
+    return curves
+
+
+def xccy_config():
+    convention = dal.CrossCurrencyConvention_()
+    convention.initial_notional_exchange = convention.final_notional_exchange = True
+    convention.spread_on_foreign_leg = True
+    convention.domestic_index, convention.foreign_index = (
+        index(True, months=12),
+        index(True, months=12),
+    )
+    convention.domestic_leg, convention.foreign_leg = leg(), leg()
+    config = dal.CrossCurrencySwapConfig_()
+    config.pair = dal.CurrencyPair_New("USD", "EUR")
+    config.domestic_notional, config.foreign_notional = 1.10, 1.0
+    config.convention = convention
+    config.notional_mode = dal.XccyNotionalMode.FIXED
+    return config
+
+
+def fixed_curves(data):
+    return {
+        key: dal.DiscountLogDF_New(key, key[:3].upper(), data["dates"], values)
+        for key, values in data["log_dfs"].items()
+    }
+
+
+def block(currency, curves):
+    return dal.CurveBlock_New(
+        currency,
+        currency,
+        {dal.CollateralType_OIS(): curves[f"{currency.lower()}_discount"]},
+        {dal.PeriodLength_New("12M"): curves[f"{currency.lower()}_forward"]},
+        dal.DayBasis_New("ACT_365F"),
+    )
+
+
+def staged_xccy(data, config, swaps):
+    curves = fixed_curves(data)
+    builder = dal.CrossCurrencyCalibrationSpecBuilder_()
+    builder.today = data["dates"][0]
+    builder.valuation_time = dal.DateTime_(builder.today, 0)
+    builder.collateral_currency, builder.basis_pair = dal.Ccy_("USD"), config.pair
+    builder.domestic_curve_block, builder.foreign_curve_block = (
+        block("USD", curves),
+        block("EUR", curves),
+    )
+    builder.fx_spot, builder.initial_guess, builder.tolerance = 1.10, -0.003, 1e-12
+    builder.fixings = dal.MarketFixingSnapshot_New({})
+    # PWC knots begin right-hand intervals; the first rate also extends to today.
+    builder.knot_dates = [builder.today.AddDays(1)] + data["dates"][1:-1]
+    builder.instruments = swaps
+    result = dal.CalibrateXccyMarket(
+        builder.Build(), calibration_options("ANALYTIC", False, "staged")
+    )
+    require(
+        result.diagnostics.max_abs_residual < 1e-9,
+        "DAL XCCY calibration did not converge",
+    )
+    return curves, result.basis_curve
+
+
+def currency_spec(currency, data):
+    result = dal.JointCurrencyCurveSpec_()
+    result.ccy, result.libor_basis = dal.Ccy_(currency), dal.DayBasis_New("ACT_365F")
+    result.curves = [
+        declaration(f"{currency.lower()}_{suffix}", data)
+        for suffix in ("discount", "forward")
+    ]
+    return result
+
+
+def joint_xccy(data, config, swaps):
+    basis = dal.XccyBasisCurveDeclaration_()
+    basis.curve_name, basis.knot_dates, basis.instruments = (
+        "basis",
+        data["dates"][1:],
+        swaps,
+    )
+    basis.parameterization, basis.log_df_scheme = (
+        dal.CurveParameterization.LOG_DISCOUNT,
+        dal.LogDfScheme.LOG_LINEAR,
+    )
+    builder = dal.JointXccyCalibrationSpecBuilder_()
+    builder.valuation_time = dal.DateTime_(data["dates"][0], 0)
+    builder.pair, builder.collateral_currency, builder.fx_spot = (
+        config.pair,
+        dal.Ccy_("USD"),
+        1.10,
+    )
+    builder.domestic, builder.foreign = (
+        currency_spec("USD", data),
+        currency_spec("EUR", data),
+    )
+    builder.basis, builder.fixings = basis, dal.MarketFixingSnapshot_New({})
+    builder.solver_options.tolerance, builder.solver_options.fit_tolerance = (
+        1e-12,
+        1e-10,
+    )
+    builder.solver_options.initial_guess, builder.solver_options.max_evaluations = (
+        0.02,
+        1000,
+    )
+    result = dal.CalibrateJointXccyMarket(
+        builder.Build(), calibration_options("ANALYTIC", False, "joint")
+    )
+    require(result.converged, "DAL joint XCCY calibration did not converge")
+    curves = {}
+    for currency, value in (
+        ("usd", result.domestic_curve_block),
+        ("eur", result.foreign_curve_block),
+    ):
+        curves[f"{currency}_discount"] = next(iter(value.discount_curves.values()))
+        curves[f"{currency}_forward"] = next(iter(value.forward_curves.values()))
+    return curves, result.basis_curve
+
+
+def runner(case):
+    nodes = inputs.dates(case["size"])
+    data = {
+        "dates": [date(value) for value in nodes],
+        "quotes": inputs.quotes(case["size"]),
+        "log_dfs": {
+            key: [math.log(inputs.discount(key, d, case["size"])) for d in nodes]
+            for key in inputs.KEYS[:4]
+        },
+    }
+    queries = [date(value) for value in inputs.queries(case["size"])]
+    today = data["dates"][0]
+
+    def run():
+        basis = None
+        if case["kind"].startswith("xccy_"):
+            config = xccy_config()
+            swaps = [
+                dal.CrossCurrencySwap_New(today, today, maturity, quote, config)
+                for maturity, quote in zip(
+                    data["dates"][1:], data["quotes"][inputs.KEYS[4]]
+                )
+            ]
+            solve = staged_xccy if case["kind"] == "xccy_staged" else joint_xccy
+            curves, basis = solve(data, config, swaps)
+        else:
+            curves = solve_rates(case["kind"], data)
+        values = []
+        for key in inputs.curve_keys(case["kind"]):
+            if key == inputs.KEYS[4]:
+                values.extend(
+                    curves[inputs.KEYS[2]](today, d) / basis(today, d) for d in queries
+                )
+            else:
+                values.extend(curves[key](today, d) for d in queries)
+        return values
+
+    return run

--- a/dal-python/benchmarks/dal_comparisons/calibration_quantlib.py
+++ b/dal-python/benchmarks/dal_comparisons/calibration_quantlib.py
@@ -1,0 +1,121 @@
+"""QuantLib log-linear bootstraps with fresh helpers on every valuation."""
+
+import QuantLib as ql
+
+from . import calibration_scenarios as inputs
+
+
+def date(value):
+    return ql.Date(value.day, value.month, value.year)
+
+
+def index(currency, handle=None):
+    return ql.IborIndex(
+        f"calibration-{currency}",
+        ql.Period(12, ql.Months),
+        0,
+        ql.USDCurrency() if currency == "usd" else ql.EURCurrency(),
+        ql.NullCalendar(),
+        ql.Unadjusted,
+        False,
+        ql.Actual365Fixed(),
+        handle if handle is not None else ql.YieldTermStructureHandle(),
+    )
+
+
+def bootstrap(helpers):
+    return ql.PiecewiseLogLinearDiscount(
+        date(inputs.TODAY), helpers, ql.Actual365Fixed(), ql.IterativeBootstrap(1e-12)
+    )
+
+
+def swap_curve(key, quotes, discount=None):
+    handle = (
+        ql.YieldTermStructureHandle(discount)
+        if discount is not None
+        else ql.YieldTermStructureHandle()
+    )
+    ibor = index(key[:3])
+    helpers = [
+        ql.SwapRateHelper(
+            quote,
+            ql.Period(i, ql.Years),
+            ql.NullCalendar(),
+            ql.Annual,
+            ql.Unadjusted,
+            ql.Actual365Fixed(),
+            ibor,
+            ql.QuoteHandle(),
+            ql.Period(0, ql.Days),
+            handle,
+            0,
+        )
+        for i, quote in enumerate(quotes, 1)
+    ]
+    curve = bootstrap(helpers)
+    curve.discount(helpers[-1].latestDate())
+    return curve
+
+
+def xccy_curve(data):
+    curves = {
+        key: ql.DiscountCurve(
+            data["dates"], dfs, ql.Actual365Fixed(), ql.NullCalendar()
+        )
+        for key, dfs in data["dfs"].items()
+    }
+    domestic = index("usd", ql.YieldTermStructureHandle(curves[inputs.KEYS[1]]))
+    foreign = index("eur", ql.YieldTermStructureHandle(curves[inputs.KEYS[3]]))
+    collateral = ql.YieldTermStructureHandle(curves[inputs.KEYS[0]])
+    helpers = [
+        ql.ConstNotionalCrossCurrencyBasisSwapRateHelper(
+            ql.QuoteHandle(ql.SimpleQuote(quote)),
+            ql.Period(i, ql.Years),
+            0,
+            ql.NullCalendar(),
+            ql.Unadjusted,
+            False,
+            domestic,
+            foreign,
+            collateral,
+            True,
+            False,
+            ql.Annual,
+            0,
+            ql.Annual,
+        )
+        for i, quote in enumerate(data["quotes"][inputs.KEYS[4]], 1)
+    ]
+    return {inputs.KEYS[4]: bootstrap(helpers)}
+
+
+def runner(case):
+    ql.Settings.instance().evaluationDate = date(inputs.TODAY)
+    nodes = inputs.dates(case["size"])
+    data = {
+        "quotes": inputs.quotes(case["size"]),
+        "dates": [date(d) for d in nodes],
+        "dfs": {
+            key: [inputs.discount(key, d, case["size"]) for d in nodes]
+            for key in inputs.KEYS[:4]
+        },
+    }
+    queries = [date(d) for d in inputs.queries(case["size"])]
+
+    def run():
+        if case["kind"] == "xccy_staged":
+            curves = xccy_curve(data)
+        else:
+            discount = swap_curve(inputs.KEYS[0], data["quotes"][inputs.KEYS[0]])
+            curves = {inputs.KEYS[0]: discount}
+            if case["kind"] == "multi_staged":
+                curves[inputs.KEYS[1]] = swap_curve(
+                    inputs.KEYS[1], data["quotes"][inputs.KEYS[1]], discount
+                )
+        return [
+            curves[key].discount(d)
+            for key in inputs.curve_keys(case["kind"])
+            for d in queries
+        ]
+
+    return run

--- a/dal-python/benchmarks/dal_comparisons/calibration_rateslib.py
+++ b/dal-python/benchmarks/dal_comparisons/calibration_rateslib.py
@@ -1,0 +1,161 @@
+"""Rateslib fresh AD solvers for the common annual IRS and XCCY markets."""
+
+import math
+
+import rateslib as rl
+
+from dal_benchmarks.harness import require
+from . import calibration_scenarios as inputs
+
+
+def make_curve(key, data, fixed=False):
+    values = (
+        data["dfs"][key]
+        if fixed
+        else [math.exp(-0.025 * (d - inputs.TODAY).days / 365) for d in data["dates"]]
+    )
+    return rl.Curve(
+        nodes=dict(zip(data["dates"], values)),
+        id=key,
+        interpolation="log_linear",
+        convention="Act365F",
+        ad=0 if fixed else 1,
+    )
+
+
+def swap_instruments(key, data, curves):
+    discount = key[:3] + "_discount"
+    return [
+        rl.IRS(
+            effective=inputs.TODAY,
+            termination=maturity,
+            frequency="A",
+            convention="Act365F",
+            modifier="NONE",
+            calendar="all",
+            payment_lag=0,
+            currency=key[:3],
+            leg2_frequency="A",
+            leg2_convention="Act365F",
+            leg2_modifier="NONE",
+            leg2_payment_lag=0,
+            leg2_fixing_method="ibor(0)",
+            leg2_fixing_frequency="A",
+            curves=[curves[key], curves[discount]],
+        )
+        for maturity in data["dates"][1:]
+    ]
+
+
+def fx_forwards(curves):
+    return rl.FXForwards(
+        fx_rates=rl.FXRates({"eurusd": 1.10}, settlement=inputs.TODAY),
+        fx_curves={
+            "usdusd": curves[inputs.KEYS[0]],
+            "eureur": curves[inputs.KEYS[2]],
+            "eurusd": curves[inputs.KEYS[4]],
+        },
+    )
+
+
+def xccy_instruments(data, curves):
+    return [
+        rl.XCS(
+            effective=inputs.TODAY,
+            termination=maturity,
+            frequency="A",
+            convention="Act365F",
+            modifier="NONE",
+            calendar="all",
+            payment_lag=0,
+            payment_lag_exchange=0,
+            currency="usd",
+            pair="eurusd",
+            notional=1.10,
+            leg2_fx_fixings=1.10,
+            fixed=False,
+            mtm=False,
+            float_spread=0.0,
+            fixing_method="ibor(0)",
+            fixing_frequency="A",
+            leg2_frequency="A",
+            leg2_convention="Act365F",
+            leg2_modifier="NONE",
+            leg2_payment_lag=0,
+            leg2_payment_lag_exchange=0,
+            leg2_fixed=False,
+            leg2_mtm=False,
+            leg2_fixing_method="ibor(0)",
+            leg2_fixing_frequency="A",
+            metric="leg2",
+            curves=[
+                curves[inputs.KEYS[1]],
+                curves[inputs.KEYS[0]],
+                curves[inputs.KEYS[3]],
+                curves[inputs.KEYS[4]],
+            ],
+        )
+        for maturity in data["dates"][1:]
+    ]
+
+
+def solve(keys, data, curves, *, previous=(), fx=None):
+    instruments, quotes = [], []
+    for key in keys:
+        is_xccy = key == inputs.KEYS[4]
+        instruments.extend(
+            xccy_instruments(data, curves)
+            if is_xccy
+            else swap_instruments(key, data, curves)
+        )
+        quotes.extend(
+            value * (10000 if is_xccy else 100) for value in data["quotes"][key]
+        )
+    kwargs = {} if fx is None else {"fx": fx}
+    result = rl.Solver(
+        curves=[curves[key] for key in keys],
+        instruments=instruments,
+        s=quotes,
+        pre_solvers=previous,
+        id="-".join(keys),
+        func_tol=1e-20,
+        conv_tol=1e-20,
+        grad_tol=1e-16,
+        max_iter=100,
+        **kwargs,
+    )
+    require(
+        result.result["status"] == "SUCCESS", "rateslib calibration did not converge"
+    )
+    return result
+
+
+def runner(case):
+    rl.defaults.curve_caching = False
+    nodes = inputs.dates(case["size"])
+    data = {
+        "dates": nodes,
+        "quotes": inputs.quotes(case["size"]),
+        "dfs": {
+            key: [inputs.discount(key, d, case["size"]) for d in nodes]
+            for key in inputs.KEYS[:4]
+        },
+    }
+    keys, queries = inputs.curve_keys(case["kind"]), inputs.queries(case["size"])
+
+    def run():
+        if case["kind"] == "xccy_staged":
+            curves = {
+                key: make_curve(key, data, fixed=key not in keys) for key in inputs.KEYS
+            }
+        else:
+            curves = {key: make_curve(key, data) for key in keys}
+        if case["kind"] == "multi_staged":
+            first = solve(keys[:1], data, curves)
+            solve(keys[1:], data, curves, previous=(first,))
+        else:
+            fx = fx_forwards(curves) if case["kind"].startswith("xccy_") else None
+            solve(keys, data, curves, fx=fx)
+        return [float(curves[key][d]) for key in keys for d in queries]
+
+    return run

--- a/dal-python/benchmarks/dal_comparisons/calibration_scenarios.py
+++ b/dal-python/benchmarks/dal_comparisons/calibration_scenarios.py
@@ -1,0 +1,147 @@
+"""Non-flat curve markets with independent cashflow-derived calibration quotes."""
+
+from bisect import bisect_left
+from datetime import datetime, timedelta
+import math
+
+TODAY = datetime(2025, 1, 15)
+KEYS = (
+    "usd_discount",
+    "usd_forward",
+    "eur_discount",
+    "eur_forward",
+    "eur_usd_discount",
+)
+PROFILES = (
+    (0.025, 0.0003),
+    (0.032, 0.0004),
+    (0.018, 0.0002),
+    (0.024, 0.00035),
+    (0.021, 0.00025),
+)
+KINDS = ("single", "multi_staged", "multi_joint", "xccy_staged", "xccy_joint")
+CONVENTIONS = {
+    "valuation_date": TODAY.isoformat(),
+    "instruments": "annual fixed/float IRS; annual fixed-notional USD/EUR XCCY basis swaps with both principal exchanges, spread on EUR leg",
+    "calendar": "unadjusted, no holidays, zero settlement/fixing/payment lags; ACT/365F",
+    "interpolation": "log-linear discount factors, annual pillars, anchor DF=1",
+    "market": "five distinct non-flat curves; quotes derived from independent scalar cashflows",
+    "profiles": {key: list(profile) for key, profile in zip(KEYS, PROFILES)},
+    "multi_staged": "discount calibration followed by forward calibration using the solved discount curve",
+    "multi_joint": "simultaneous discount and forward calibration",
+    "xccy_staged": "calibrate EUR discounting under USD collateral with four fixed domestic curves",
+    "xccy_joint": "simultaneously solve USD/EUR discount+forward and cross-currency discounting: five blocks",
+    "fx": "USD per EUR = 1.10; USD collateral; DAL basis DF = EUR domestic DF / EUR-under-USD DF",
+    "boundary": "fresh instruments, initial curves, solve and full DF conversion; raw quotes and independent oracle excluded; no reuse of calibrated curves",
+    "output": "solved curves in declared order; every annual node then every mid-year DF; fixed input curves excluded",
+    "diagnostics": "DAL optional Jacobian/inverse retention disabled; rateslib solver AD state and QuantLib bootstrap state retained by their public APIs",
+}
+
+
+def cases(smoke=False):
+    return [
+        {
+            "name": f"calibration_{kind}_{size}",
+            "operation": "calibration",
+            "kind": kind,
+            "size": 2 if smoke else size,
+        }
+        for kind in KINDS
+        for size in (5, 15)
+    ]
+
+
+def dates(size):
+    return [datetime(TODAY.year + i, TODAY.month, TODAY.day) for i in range(size + 1)]
+
+
+def queries(size):
+    nodes = dates(size)
+    return nodes[1:] + [
+        left + timedelta(days=(right - left).days // 2)
+        for left, right in zip(nodes, nodes[1:])
+    ]
+
+
+def curve_keys(kind):
+    if kind == "single":
+        return KEYS[:1]
+    if kind.startswith("multi_"):
+        return KEYS[:2]
+    return KEYS[-1:] if kind == "xccy_staged" else KEYS
+
+
+def discount(key, date, size):
+    nodes = dates(size)
+    i = max(1, bisect_left(nodes, date))
+    left, right = nodes[i - 1], nodes[i]
+    fraction = (date - left).days / (right - left).days
+    level, slope = PROFILES[KEYS.index(key)]
+
+    def log_df(ordinal, value):
+        return -(level + slope * ordinal) * (value - TODAY).days / 365
+
+    return math.exp((1 - fraction) * log_df(i - 1, left) + fraction * log_df(i, right))
+
+
+def swap_rate(forecast, discounting, maturity, size):
+    schedule = dates(maturity)
+    annuity, floating = 0.0, 0.0
+    for start, end in zip(schedule, schedule[1:]):
+        df = discount(discounting, end, size)
+        annuity += (end - start).days / 365 * df
+        floating += (
+            discount(forecast, start, size) / discount(forecast, end, size) - 1
+        ) * df
+    return floating / annuity
+
+
+def xccy_rate(maturity, size):
+    schedule = dates(maturity)
+    totals, annuity = [], 0.0
+    for forecast, discounting in ((KEYS[1], KEYS[0]), (KEYS[3], KEYS[4])):
+        value = discount(discounting, schedule[-1], size)
+        for start, end in zip(schedule, schedule[1:]):
+            df = discount(discounting, end, size)
+            value += (
+                discount(forecast, start, size) / discount(forecast, end, size) - 1
+            ) * df
+            if discounting == KEYS[4]:
+                annuity += (end - start).days / 365 * df
+        totals.append(value)
+    return (totals[0] - totals[1]) / annuity
+
+
+def quotes(size):
+    pairs = (
+        (KEYS[0], KEYS[0]),
+        (KEYS[1], KEYS[0]),
+        (KEYS[2], KEYS[2]),
+        (KEYS[3], KEYS[2]),
+    )
+    result = {
+        key: [swap_rate(forecast, disc, y, size) for y in range(1, size + 1)]
+        for key, (forecast, disc) in zip(KEYS, pairs)
+    }
+    result[KEYS[4]] = [xccy_rate(y, size) for y in range(1, size + 1)]
+    return result
+
+
+def expected(case):
+    return [
+        discount(key, date, case["size"])
+        for key in curve_keys(case["kind"])
+        for date in queries(case["size"])
+    ]
+
+
+def method(backend, case):
+    if backend == "quantlib":
+        return "piecewise log-linear discount bootstrap"
+    if backend == "rateslib":
+        return "forward AD solver, " + (
+            "staged" if case["kind"].endswith("staged") else "simultaneous"
+        )
+    return "analytic Jacobian solve, " + (
+        "staged" if case["kind"].endswith("staged") else "simultaneous"
+    )

--- a/dal-python/benchmarks/dal_comparisons/compare.py
+++ b/dal-python/benchmarks/dal_comparisons/compare.py
@@ -9,7 +9,7 @@ import sys
 
 from dal_benchmarks.harness import require
 from .evidence import ROOT, SCHEMA, check_report, source_hashes, timings, write_json
-from .scenarios import CONVENTIONS, cases, method
+from .scenarios import CONVENTIONS, cases, method, unsupported_reason
 from .suite import BACKENDS
 
 
@@ -126,16 +126,22 @@ def collect_round(args, round_index, hashes, identities):
 def aggregate(reports, smoke):
     rows = []
     for case in cases(smoke):
-        measurements = {
-            backend: dict(
-                timings(reports[backend], case["name"]), method=method(backend, case)
+        measurements = {}
+        for backend in BACKENDS:
+            reason = unsupported_reason(backend, case)
+            measurements[backend] = (
+                dict(status="unsupported", reason=reason)
+                if reason
+                else dict(
+                    timings(reports[backend], case["name"]),
+                    method=method(backend, case),
+                )
             )
-            for backend in BACKENDS
-        }
         dal_time = measurements["dal"]["min_ns"]
         ratios = {
             backend: measurements[backend]["min_ns"] / dal_time
             for backend in BACKENDS[1:]
+            if not unsupported_reason(backend, case)
         }
         rows.append(
             {"workload": case, "backends": measurements, "third_party_over_dal": ratios}
@@ -166,6 +172,21 @@ def summary(report):
         "On unchanged markets QuantLib floating coupons may remain cached "
         "even with swap.recalculate(); DAL prepared pricing recomputes rates.",
         "",
+        "MC options: PV, Delta, Vega, Rho; Sobol paths, fixed seeds, identical "
+        "weekly discrete barrier monitoring. DAL vanilla uses reverse AAD; "
+        "other MC Greeks use common-random-number central differences. "
+        "Analytic vanilla and deterministic Gaussian quadrature barrier oracles "
+        "validate every output with explicit MC tolerances.",
+        "",
+        "Calibration: fresh non-flat annual IRS/XCCY markets, log-linear DFs; "
+        "single, staged/joint multi-curve and staged/joint XCCY solves. "
+        "Every solved node and midpoint is checked. Raw quotes and oracles are "
+        "outside timing; instrument construction, solving and DF conversion are timed.",
+        "",
+        "N/A: declared unsupported capabilities only (rateslib equity MC; "
+        "QuantLib simultaneous joint calibration). Missing packages or failed "
+        "supported cases fail the comparison.",
+        "",
     ]
     if report["status"] != "passed":
         lines += [f"Error: {report['error']}", "See the retained worker logs.", ""]
@@ -182,12 +203,18 @@ def summary(report):
         for row in result["cases"]:
             values = row["backends"]
             times = " | ".join(
-                f"{values[backend]['min_ns'] / 1e6:.4f}" for backend in BACKENDS
+                f"{values[backend]['min_ns'] / 1e6:.4f}"
+                if "min_ns" in values[backend]
+                else "N/A"
+                for backend in BACKENDS
             )
             ratios = row["third_party_over_dal"]
+            ratio_text = " | ".join(
+                f"{ratios[backend]:.3f}" if backend in ratios else "N/A"
+                for backend in BACKENDS[1:]
+            )
             lines.append(
-                f"| {index} | {row['workload']['name']} | {times} "
-                f"| {ratios['quantlib']:.3f} | {ratios['rateslib']:.3f} |"
+                f"| {index} | {row['workload']['name']} | {times} | {ratio_text} |"
             )
     return "\n".join(lines) + "\n"
 

--- a/dal-python/benchmarks/dal_comparisons/evidence.py
+++ b/dal-python/benchmarks/dal_comparisons/evidence.py
@@ -7,9 +7,17 @@ from pathlib import Path
 import statistics
 
 from dal_benchmarks.harness import require
-from .scenarios import CONVENTIONS, cases, expected, method, tolerance, validate
+from .scenarios import (
+    CONVENTIONS,
+    cases,
+    expected,
+    method,
+    tolerance,
+    unsupported_reason,
+    validate,
+)
 
-SCHEMA = "dal.python-comparisons/2"
+SCHEMA = "dal.python-comparisons/3"
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -54,6 +62,16 @@ def backend_files(backend):
 
 
 def check_row(row, case, backend):
+    reason = unsupported_reason(backend, case)
+    if reason:
+        require(
+            row
+            == dict(
+                name=case["name"], workload=case, status="unsupported", reason=reason
+            ),
+            "invalid unsupported comparison evidence",
+        )
+        return
     require(row["status"] == "passed", "worker case failed")
     require(row["workload"] == case, "comparison workload changed")
     require(

--- a/dal-python/benchmarks/dal_comparisons/option_dal.py
+++ b/dal-python/benchmarks/dal_comparisons/option_dal.py
@@ -1,0 +1,48 @@
+"""Native DAL scripted Monte Carlo with explicit path and Greek contracts."""
+
+from datetime import timedelta
+
+import dal
+
+from . import option_scenarios as inputs
+
+
+def date(value):
+    return dal.Date_(value.year, value.month, value.day)
+
+
+def runner(case):
+    dal.EvaluationDate_Set(date(inputs.TODAY))
+    dates, events = ["STRIKE"], [str(inputs.STRIKE)]
+    if case["kind"] == "barrier":
+        dates += ["BARRIER", date(inputs.TODAY)]
+        events += [str(inputs.BARRIER), "alive = 1"]
+        for step in range(1, 53):
+            dates.append(date(inputs.TODAY + timedelta(days=7 * step)))
+            events.append("if spot() >= BARRIER then alive = 0 end")
+        events[-1] += " call pays alive * MAX(spot() - STRIKE, 0.0)"
+    else:
+        dates.append(date(inputs.MATURITY))
+        events.append("call pays MAX(spot() - STRIKE, 0.0)")
+
+    def value(spot, vol, rate, aad=False):
+        return dal.MonteCarlo_Value(
+            dal.Product_New(dates, events),
+            dal.BSModelData_New(spot, vol, rate, inputs.DIVIDEND),
+            case["size"],
+            "sobol",
+            False,
+            aad,
+            0.01,
+            True,
+        )
+
+    def run():
+        if case["operation"] == "mc_price":
+            return [value(inputs.SPOT, inputs.VOL, inputs.RATE)["PV"]]
+        if case["kind"] == "vanilla":
+            result = value(inputs.SPOT, inputs.VOL, inputs.RATE, True)
+            return [result[name] for name in ("PV", "d_spot", "d_vol", "d_rate")]
+        return inputs.bumped_values(lambda s, v, r: value(s, v, r)["PV"])
+
+    return run

--- a/dal-python/benchmarks/dal_comparisons/option_quantlib.py
+++ b/dal-python/benchmarks/dal_comparisons/option_quantlib.py
@@ -1,0 +1,43 @@
+"""QuantLib native MC engines; the barrier has discrete weekly monitoring."""
+
+import QuantLib as ql
+
+from . import option_scenarios as inputs
+
+
+def runner(case):
+    today = ql.Date(inputs.TODAY.day, inputs.TODAY.month, inputs.TODAY.year)
+    maturity = today + 364
+    ql.Settings.instance().evaluationDate = today
+    basis, calendar = ql.Actual365Fixed(), ql.NullCalendar()
+
+    def price(spot, vol, rate):
+        process = ql.BlackScholesMertonProcess(
+            ql.QuoteHandle(ql.SimpleQuote(spot)),
+            ql.YieldTermStructureHandle(ql.FlatForward(today, inputs.DIVIDEND, basis)),
+            ql.YieldTermStructureHandle(ql.FlatForward(today, rate, basis)),
+            ql.BlackVolTermStructureHandle(
+                ql.BlackConstantVol(today, calendar, vol, basis)
+            ),
+        )
+        payoff, exercise = (
+            ql.PlainVanillaPayoff(ql.Option.Call, inputs.STRIKE),
+            ql.EuropeanExercise(maturity),
+        )
+        settings = dict(timeSteps=case["steps"], requiredSamples=case["size"], seed=42)
+        if case["kind"] == "barrier":
+            option = ql.BarrierOption(
+                ql.Barrier.UpOut, inputs.BARRIER, 0.0, payoff, exercise
+            )
+            engine = ql.MCBarrierEngine(
+                process, "lowdiscrepancy", isBiased=True, **settings
+            )
+        else:
+            option = ql.VanillaOption(payoff, exercise)
+            engine = ql.MCEuropeanEngine(process, "lowdiscrepancy", **settings)
+        option.setPricingEngine(engine)
+        return option.NPV()
+
+    if case["operation"] == "mc_greeks":
+        return lambda: inputs.bumped_values(price)
+    return lambda: [price(inputs.SPOT, inputs.VOL, inputs.RATE)]

--- a/dal-python/benchmarks/dal_comparisons/option_scenarios.py
+++ b/dal-python/benchmarks/dal_comparisons/option_scenarios.py
@@ -62,7 +62,7 @@ def vanilla(spot=SPOT, vol=VOL, rate=RATE):
 def barrier_price(spot=SPOT, vol=VOL, rate=RATE, steps=52, nodes=256):
     import numpy as np
 
-    low, high = math.log(SPOT) - 10 * VOL * math.sqrt(YEARS), math.log(BARRIER)
+    low, high = math.log(spot) - 10 * vol * math.sqrt(YEARS), math.log(BARRIER)
     points, weights = np.polynomial.legendre.leggauss(nodes)
     points = low + (points + 1) * (high - low) / 2
     weights = weights * (high - low) / 2

--- a/dal-python/benchmarks/dal_comparisons/option_scenarios.py
+++ b/dal-python/benchmarks/dal_comparisons/option_scenarios.py
@@ -1,0 +1,125 @@
+"""Black-Scholes and deterministic integration oracles for Monte Carlo cases."""
+
+from datetime import datetime, timedelta
+from functools import lru_cache
+import math
+
+TODAY = datetime(2025, 1, 15)
+MATURITY = TODAY + timedelta(days=364)
+SPOT, VOL, RATE, DIVIDEND = 100.0, 0.2, 0.03, 0.01
+STRIKE, BARRIER = 100.0, 130.0
+YEARS = 364 / 365
+BUMPS = (1.0, 0.01, 0.01)
+CONVENTIONS = {
+    "model": "Black-Scholes; S=K=100, vol=0.2, r=0.03, q=0.01",
+    "dates": [TODAY.isoformat(), MATURITY.isoformat()],
+    "day_count": "ACT/365F",
+    "barrier": "up-and-out call, H=130, zero rebate; 52 weekly observations including maturity",
+    "sampling": "Sobol: DAL initial point 0, QuantLib seed 42; no Brownian bridge or antithetics; generators restart per valuation",
+    "greeks": "PV, Delta, Vega, Rho; derivatives per unit spot/decimal vol/decimal rate",
+    "bumps": list(BUMPS),
+    "methods": "DAL vanilla: reverse AAD; other Greeks: central differences with common random numbers; barrier reference uses identical finite bumps",
+    "boundary": "fresh product/model/engine construction, preprocessing, simulation and output conversion; oracle excluded",
+    "oracle": "vanilla analytic Black-Scholes; discrete barrier Gaussian transition quadrature; field-specific MC tolerances",
+}
+
+
+def cases(smoke=False):
+    return [
+        {
+            "name": f"mc_{kind}_{operation}_{paths}",
+            "operation": f"mc_{operation}",
+            "kind": kind,
+            "size": 4096 if smoke else paths,
+            "steps": 1 if kind == "vanilla" else 52,
+        }
+        for kind in ("vanilla", "barrier")
+        for operation in ("price", "greeks")
+        for paths in (16384, 65536)
+    ]
+
+
+def cdf(x):
+    return 0.5 * math.erfc(-x / math.sqrt(2))
+
+
+def vanilla(spot=SPOT, vol=VOL, rate=RATE):
+    root = math.sqrt(YEARS)
+    d1 = (math.log(spot / STRIKE) + (rate - DIVIDEND + vol * vol / 2) * YEARS) / (
+        vol * root
+    )
+    d2 = d1 - vol * root
+    df, dividend_df = math.exp(-rate * YEARS), math.exp(-DIVIDEND * YEARS)
+    return [
+        spot * dividend_df * cdf(d1) - STRIKE * df * cdf(d2),
+        dividend_df * cdf(d1),
+        spot * dividend_df * math.exp(-d1 * d1 / 2) * root / math.sqrt(2 * math.pi),
+        STRIKE * YEARS * df * cdf(d2),
+    ]
+
+
+@lru_cache(maxsize=64)
+def barrier_price(spot=SPOT, vol=VOL, rate=RATE, steps=52, nodes=256):
+    import numpy as np
+
+    low, high = math.log(SPOT) - 10 * VOL * math.sqrt(YEARS), math.log(BARRIER)
+    points, weights = np.polynomial.legendre.leggauss(nodes)
+    points = low + (points + 1) * (high - low) / 2
+    weights = weights * (high - low) / 2
+    dt = YEARS / steps
+    drift, deviation = (rate - DIVIDEND - vol * vol / 2) * dt, vol * math.sqrt(dt)
+
+    def transition(starts):
+        z = (points - starts - drift) / deviation
+        return np.exp(-z * z / 2) * weights / (deviation * math.sqrt(2 * math.pi))
+
+    def terminal_value(start):
+        def bounds(strike):
+            d2 = (start - math.log(strike) + drift) / deviation
+            return cdf(d2 + deviation), cdf(d2)
+
+        first, last = bounds(STRIKE), bounds(BARRIER)
+        return math.exp(start + (rate - DIVIDEND) * dt) * (
+            first[0] - last[0]
+        ) - STRIKE * (first[1] - last[1])
+
+    if steps == 1:
+        return terminal_value(math.log(spot)) * math.exp(-rate * YEARS)
+    # Integrate the final payoff analytically so the strike kink cannot pollute quadrature.
+    values = np.array([terminal_value(point) for point in points])
+    matrix = transition(points[:, None])
+    for _ in range(steps - 2):
+        values = matrix @ values
+    return float(transition(math.log(spot)) @ values) * math.exp(-rate * YEARS)
+
+
+def bumped_values(price):
+    values = [price(SPOT, VOL, RATE)]
+    for i, bump in enumerate(BUMPS):
+        up, down = [SPOT, VOL, RATE], [SPOT, VOL, RATE]
+        up[i] += bump
+        down[i] -= bump
+        values.append((price(*up) - price(*down)) / (2 * bump))
+    return values
+
+
+def expected(case):
+    values = vanilla() if case["kind"] == "vanilla" else bumped_values(barrier_price)
+    return values if case["operation"] == "mc_greeks" else values[:1]
+
+
+def tolerance(case):
+    scale = math.sqrt(16384 / case["size"])
+    bounds = (
+        (0.08, 0.01, 0.5, 0.5) if case["kind"] == "vanilla" else (0.25, 0.05, 3.0, 4.0)
+    )
+    values = [value * scale for value in bounds]
+    return values if case["operation"] == "mc_greeks" else values[:1]
+
+
+def method(backend, case):
+    if case["operation"] == "mc_price":
+        return "Sobol Monte Carlo"
+    if backend == "dal" and case["kind"] == "vanilla":
+        return "Sobol Monte Carlo + reverse AAD"
+    return "Sobol Monte Carlo + central differences (common random numbers)"

--- a/dal-python/benchmarks/dal_comparisons/scenarios.py
+++ b/dal-python/benchmarks/dal_comparisons/scenarios.py
@@ -4,6 +4,8 @@ from bisect import bisect_left
 from datetime import datetime, timedelta
 import math
 
+from . import calibration_scenarios, option_scenarios
+
 TODAY = datetime(2025, 1, 15)
 NODES = [datetime(2025 + year, 1, 15) for year in range(22)]
 TIMES = [(date - TODAY).days / 365 for date in NODES]
@@ -41,6 +43,8 @@ CONVENTIONS = {
     "output": "one float per query/trade; node risk: 21 floats per trade, in node-date order",
     "node_dates": [date.isoformat() for date in NODES],
     "node_log_dfs": LOG_DFS,
+    "monte_carlo": option_scenarios.CONVENTIONS,
+    "calibration": calibration_scenarios.CONVENTIONS,
 }
 
 
@@ -63,8 +67,22 @@ def cases(smoke=False):
                 }
             )
     if smoke:
-        return [dict(case, size=4) for case in result]
-    return result
+        result = [dict(case, size=4) for case in result]
+    return result + option_scenarios.cases(smoke) + calibration_scenarios.cases(smoke)
+
+
+def unsupported_reason(backend, case):
+    if backend == "rateslib" and case["operation"].startswith("mc_"):
+        return "rateslib has no equity-option Monte Carlo engine"
+    if (
+        backend == "quantlib"
+        and case["operation"] == "calibration"
+        and case["kind"].endswith("joint")
+    ):
+        return (
+            "QuantLib Python has no matching simultaneous multi-curve calibration API"
+        )
+    return None
 
 
 def queries(size):
@@ -130,24 +148,36 @@ def node_dv01(trade):
 
 
 def method(backend, case):
+    if case["operation"].startswith("mc_"):
+        return option_scenarios.method(backend, case)
+    if case["operation"] == "calibration":
+        return calibration_scenarios.method(backend, case)
     if case["operation"] == "node_dv01":
         return RISK_METHODS[backend]
     return "central finite difference" if case["operation"] == "dv01" else "passive"
 
 
 def tolerance(case):
+    if case["operation"].startswith("mc_"):
+        return option_scenarios.tolerance(case)
+    if case["operation"] == "calibration":
+        return 2e-8
     return {"discount": 2e-12, "node_dv01": 2e-6}.get(case["operation"], 2e-7)
 
 
 def expected(case):
+    if case["operation"].startswith("mc_"):
+        return option_scenarios.expected(case)
+    if case["operation"] == "calibration":
+        return calibration_scenarios.expected(case)
+    return rate_expected(case)
+
+
+def rate_expected(case):
     if case["operation"] == "discount":
         return [discount(date) for date in queries(case["size"])]
     if case["operation"] == "market_update_pv":
-        return [
-            pv(trade, shift)
-            for shift in (BUMP, -BUMP)
-            for trade in trades(case["size"])
-        ]
+        return shifted_prices(case["size"])
     calculators = {
         "pv": lambda trade: [pv(trade)],
         "prepared_pv": lambda trade: [pv(trade)],
@@ -161,12 +191,21 @@ def expected(case):
     return [value for trade in trades(case["size"]) for value in calculate(trade)]
 
 
+def shifted_prices(size):
+    return [pv(trade, shift) for shift in (BUMP, -BUMP) for trade in trades(size)]
+
+
 def validate(values, reference, *, abs_tol=2e-7):
     if len(values) != len(reference):
         raise ValueError("comparison output width mismatch")
-    for i, (value, target) in enumerate(zip(values, reference)):
+    tolerances = (
+        abs_tol if isinstance(abs_tol, (list, tuple)) else [abs_tol] * len(reference)
+    )
+    if len(tolerances) != len(reference):
+        raise ValueError("comparison tolerance width mismatch")
+    for i, (value, target, bound) in enumerate(zip(values, reference, tolerances)):
         if not math.isfinite(value) or not math.isclose(
-            value, target, rel_tol=1e-10, abs_tol=abs_tol
+            value, target, rel_tol=1e-10, abs_tol=bound
         ):
             raise ValueError(
                 f"comparison numerical mismatch at {i}: {value} != {target}"

--- a/dal-python/benchmarks/dal_comparisons/suite.py
+++ b/dal-python/benchmarks/dal_comparisons/suite.py
@@ -3,7 +3,15 @@
 from importlib import import_module
 
 from dal_benchmarks.harness import Workload
-from .scenarios import BUMP, expected, queries, tolerance, trades, validate
+from .scenarios import (
+    BUMP,
+    expected,
+    queries,
+    tolerance,
+    trades,
+    unsupported_reason,
+    validate,
+)
 
 BACKENDS = ("dal", "quantlib", "rateslib")
 
@@ -11,8 +19,23 @@ BACKENDS = ("dal", "quantlib", "rateslib")
 def prepare(backend, case):
     if backend not in BACKENDS:
         raise ValueError(f"unknown comparison backend: {backend}")
-    adapter = import_module(f"dal_comparisons.{backend}_adapter")
+    reason = unsupported_reason(backend, case)
+    if reason:
+        raise ValueError(reason)
     reference = expected(case)
+    if case["operation"].startswith("mc_") or case["operation"] == "calibration":
+        family = "calibration" if case["operation"] == "calibration" else "option"
+        adapter = import_module(f"dal_comparisons.{family}_{backend}")
+        run = adapter.runner(case)
+    else:
+        adapter = import_module(f"dal_comparisons.{backend}_adapter")
+        run = rate_runner(adapter, case)
+    return Workload(
+        run, lambda result: validate(result, reference, abs_tol=tolerance(case))
+    )
+
+
+def rate_runner(adapter, case):
     if case["operation"] == "discount":
         run = adapter.discount_runner(queries(case["size"]))
     elif case["operation"] == "pv":
@@ -34,6 +57,4 @@ def prepare(backend, case):
         }
         run = runners[case["operation"]](trades(case["size"]))
 
-    return Workload(
-        run, lambda result: validate(result, reference, abs_tol=tolerance(case))
-    )
+    return run

--- a/dal-python/benchmarks/dal_comparisons/worker.py
+++ b/dal-python/benchmarks/dal_comparisons/worker.py
@@ -7,7 +7,7 @@ import sys
 
 from dal_benchmarks.harness import Case, Workload, measure, require
 from .evidence import SCHEMA, backend_files, package_versions, source_hashes, write_json
-from .scenarios import CONVENTIONS, cases, method
+from .scenarios import CONVENTIONS, cases, method, unsupported_reason
 from .suite import prepare
 
 
@@ -31,6 +31,11 @@ def load_dal(package):
 
 
 def measured_case(backend, case):
+    reason = unsupported_reason(backend, case)
+    if reason:
+        return dict(
+            name=case["name"], workload=case, status="unsupported", reason=reason
+        )
     work = prepare(backend, case)
     last = []
 

--- a/dal-python/benchmarks/tests/test_comparisons.py
+++ b/dal-python/benchmarks/tests/test_comparisons.py
@@ -10,7 +10,13 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from dal_comparisons.scenarios import cases, expected, method, validate
+from dal_comparisons.scenarios import (
+    cases,
+    expected,
+    method,
+    unsupported_reason,
+    validate,
+)
 from dal_comparisons.suite import prepare
 from dal_comparisons import compare
 from dal_comparisons.evidence import SCHEMA, check_report, source_hashes
@@ -20,6 +26,10 @@ from dal_comparisons.scenarios import CONVENTIONS
 @pytest.mark.parametrize("backend", ["dal", "quantlib", "rateslib"])
 @pytest.mark.parametrize("case", cases(smoke=True), ids=lambda case: case["name"])
 def test_backends_match_independent_cashflows(backend, case):
+    if unsupported_reason(backend, case):
+        with pytest.raises(ValueError, match=unsupported_reason(backend, case)):
+            prepare(backend, case)
+        return
     work = prepare(backend, case)
     first = work.run()
     work.validate(first)
@@ -56,7 +66,7 @@ def test_pricing_modes_preserve_historical_inventory_and_reject_stale_markets():
         "irs_node_dv01_32",
         "irs_node_dv01_256",
     ]
-    assert [case["operation"] for case in inventory[7:]] == [
+    assert [case["operation"] for case in inventory[7:13]] == [
         operation
         for operation in ("prepared_pv", "market_update_pv", "cold_pv")
         for _ in (32, 256)
@@ -90,6 +100,22 @@ def test_smoke_preserves_case_inventory_but_reduces_sizes():
     assert all(math.isfinite(value) for case in smoke for value in expected(case))
 
 
+def worker_row(backend, case, duration):
+    reason = unsupported_reason(backend, case)
+    if reason:
+        return dict(
+            name=case["name"], workload=case, status="unsupported", reason=reason
+        )
+    return dict(
+        name=case["name"],
+        workload=case,
+        status="passed",
+        samples_ns=[duration],
+        values=expected(case),
+        method=method(backend, case),
+    )
+
+
 def worker_report(backend="dal", duration=100):
     return {
         "schema": SCHEMA,
@@ -106,17 +132,7 @@ def worker_report(backend="dal", duration=100):
             "python": "3.13",
             "thread_environment": {},
         },
-        "results": [
-            dict(
-                name=case["name"],
-                workload=case,
-                status="passed",
-                samples_ns=[duration],
-                values=expected(case),
-                method=method(backend, case),
-            )
-            for case in cases(smoke=True)
-        ],
+        "results": [worker_row(backend, case, duration) for case in cases(smoke=True)],
     }
 
 
@@ -276,6 +292,21 @@ def test_rotates_processes_and_reports_minimum_without_relative_speed_gate(
     assert risk["backends"]["rateslib"]["method"] == "forward AD (Dual)"
     assert risk["backends"]["quantlib"]["method"] == "central finite difference"
     assert "Node DV01: DAL reverse AAD" in (args.output_dir / "summary.md").read_text()
+
+
+def test_unsupported_capabilities_have_no_aggregate_timing_or_ratio():
+    reports = {backend: [worker_report(backend)] for backend in compare.BACKENDS}
+    rows = {row["workload"]["name"]: row for row in compare.aggregate(reports, True)}
+    for name, backend in (
+        ("mc_barrier_greeks_65536", "rateslib"),
+        ("calibration_xccy_joint_15", "quantlib"),
+    ):
+        row = rows[name]
+        assert row["backends"][backend] == {
+            "status": "unsupported",
+            "reason": unsupported_reason(backend, row["workload"]),
+        }
+        assert backend not in row["third_party_over_dal"]
 
 
 def test_provenance_drift_fails_between_samples(tmp_path, monkeypatch):

--- a/dal-python/benchmarks/tests/test_expanded_comparisons.py
+++ b/dal-python/benchmarks/tests/test_expanded_comparisons.py
@@ -1,0 +1,177 @@
+"""Option, calibration and explicit capability contracts for comparisons."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dal_comparisons.scenarios import cases, unsupported_reason
+
+
+def test_discrete_barrier_oracle_converges_without_mc_sampling():
+    from dal_comparisons.option_scenarios import barrier_price
+
+    assert barrier_price(nodes=256) == pytest.approx(barrier_price(nodes=384), abs=1e-8)
+
+
+def test_new_families_preserve_historical_inventory_and_cover_both_sizes():
+    inventory = cases()
+    assert len(inventory) == 31
+    assert [case["name"] for case in inventory[:13]][-1] == "irs_cold_pv_256"
+
+
+def test_mc_inventory_covers_both_products_and_operations():
+    inventory = cases()
+    options = [case for case in inventory if case["operation"].startswith("mc_")]
+    assert len(options) == 8
+    assert {case["kind"] for case in options} == {"vanilla", "barrier"}
+    assert {case["operation"] for case in options} == {"mc_price", "mc_greeks"}
+
+
+def test_calibration_inventory_covers_solve_structures_and_sizes():
+    inventory = cases()
+    calibration = [case for case in inventory if case["operation"] == "calibration"]
+    assert {case["kind"] for case in calibration} == {
+        "single",
+        "multi_staged",
+        "multi_joint",
+        "xccy_staged",
+        "xccy_joint",
+    }
+    assert {case["size"] for case in calibration} == {5, 15}
+
+
+def test_only_declared_unsupported_cases_can_be_skipped():
+    from dal_comparisons.scenarios import unsupported_reason
+    from dal_comparisons.worker import measured_case
+    from dal_comparisons.evidence import check_row
+
+    case = next(c for c in cases(True) if c["operation"] == "mc_price")
+    row = measured_case("rateslib", case)
+    assert row["status"] == "unsupported"
+    assert row["reason"] == unsupported_reason("rateslib", case)
+    assert "samples_ns" not in row and "values" not in row
+    check_row(row, case, "rateslib")
+    with pytest.raises(ValueError):
+        check_row(row, case, "dal")
+    row["reason"] = "dependency import failed"
+    with pytest.raises(ValueError):
+        check_row(row, case, "rateslib")
+
+
+@pytest.mark.parametrize(
+    "kind", ["single", "multi_staged", "multi_joint", "xccy_staged", "xccy_joint"]
+)
+def test_dal_calibration_matches_all_independent_nodes_and_midpoints(kind):
+    from dal_comparisons.suite import prepare
+
+    case = {"name": kind, "operation": "calibration", "kind": kind, "size": 2}
+    work = prepare("dal", case)
+    result = work.run()
+    work.validate(result)
+    work.validate(work.run())
+    result[-1] *= 1.001
+    with pytest.raises(ValueError, match="mismatch"):
+        work.validate(result)
+
+
+@pytest.mark.parametrize("backend", ["quantlib", "rateslib"])
+@pytest.mark.parametrize("kind", ["single", "multi_staged", "xccy_staged"])
+def test_third_party_calibration_matches_independent_nonflat_curves(backend, kind):
+    from dal_comparisons.suite import prepare
+
+    work = prepare(
+        backend, {"name": kind, "operation": "calibration", "kind": kind, "size": 2}
+    )
+    work.validate(work.run())
+    work.validate(work.run())
+
+
+@pytest.mark.parametrize(
+    "backend,case",
+    [
+        (backend, case)
+        for case in cases()[13:]
+        for backend in ("dal", "quantlib", "rateslib")
+        if not unsupported_reason(backend, case)
+    ],
+    ids=lambda value: value["name"] if isinstance(value, dict) else value,
+)
+def test_full_option_and_calibration_profiles_validate(backend, case):
+    from dal_comparisons.suite import prepare
+
+    work = prepare(backend, case)
+    work.validate(work.run())
+
+
+@pytest.mark.parametrize("backend", ["dal", "quantlib"])
+def test_mc_greeks_restart_generators_and_reject_bad_components(backend):
+    from dal_comparisons.suite import prepare
+
+    for kind in ("vanilla", "barrier"):
+        case = next(
+            c
+            for c in cases(True)
+            if c.get("kind") == kind and c["operation"] == "mc_greeks"
+        )
+        work = prepare(backend, case)
+        values = work.run()
+        assert work.run() == pytest.approx(values, abs=1e-12, rel=1e-12)
+        for i in range(4):
+            bad = values[:]
+            bad[i] += 1000
+            with pytest.raises(ValueError, match="mismatch"):
+                work.validate(bad)
+
+
+def test_calibration_queries_are_midnight_and_include_all_intervals():
+    from dal_comparisons.calibration_scenarios import dates, queries
+
+    nodes, grid = dates(15), queries(15)
+    assert len(grid) == 30
+    assert all(d.hour == d.minute == d.second == 0 for d in grid)
+    assert all(
+        left < middle < right
+        for left, middle, right in zip(nodes, grid[15:], nodes[1:])
+    )
+
+
+@pytest.mark.parametrize(
+    "backend,module_name,entrypoint",
+    [
+        ("dal", "dal", "CalibrateSingleCurve"),
+        ("quantlib", "QuantLib", "PiecewiseLogLinearDiscount"),
+        ("rateslib", "rateslib", "Solver"),
+    ],
+)
+def test_staged_calibration_solves_fresh_inside_each_run(
+    backend, module_name, entrypoint, monkeypatch
+):
+    import importlib
+    from dal_comparisons.suite import prepare
+
+    module = importlib.import_module(module_name)
+    original = getattr(module, entrypoint)
+    calls = []
+
+    def counted(*args, **kwargs):
+        calls.append(None)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, entrypoint, counted)
+    work = prepare(
+        backend,
+        {
+            "name": "fresh",
+            "operation": "calibration",
+            "kind": "multi_staged",
+            "size": 2,
+        },
+    )
+    assert not calls
+    work.validate(work.run())
+    assert len(calls) == 2
+    work.validate(work.run())
+    assert len(calls) == 4

--- a/dal-python/benchmarks/tests/test_expanded_comparisons.py
+++ b/dal-python/benchmarks/tests/test_expanded_comparisons.py
@@ -10,10 +10,57 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from dal_comparisons.scenarios import cases, unsupported_reason
 
 
-def test_discrete_barrier_oracle_converges_without_mc_sampling():
+@pytest.mark.parametrize(
+    "spot,vol,rate",
+    [
+        (100, 0.2, 0.03),
+        (99, 0.2, 0.03),
+        (101, 0.2, 0.03),
+        (100, 0.19, 0.03),
+        (100, 0.21, 0.03),
+        (100, 0.2, 0.02),
+        (100, 0.2, 0.04),
+    ],
+)
+def test_discrete_barrier_oracle_converges_without_mc_sampling(spot, vol, rate):
     from dal_comparisons.option_scenarios import barrier_price
 
-    assert barrier_price(nodes=256) == pytest.approx(barrier_price(nodes=384), abs=1e-8)
+    assert barrier_price(spot, vol, rate, nodes=256) == pytest.approx(
+        barrier_price(spot, vol, rate, nodes=384), abs=1e-8, rel=0
+    )
+
+
+@pytest.fixture
+def barrier_oracle():
+    from dal_comparisons import option_scenarios
+
+    option_scenarios.barrier_price.cache_clear()
+    yield option_scenarios
+    option_scenarios.barrier_price.cache_clear()
+
+
+def test_barrier_oracle_preserves_price_homogeneity(barrier_oracle, monkeypatch):
+    inputs = barrier_oracle
+    original = inputs.barrier_price(100, 0.2, 0.03)
+    monkeypatch.setattr(inputs, "STRIKE", 1.0)
+    monkeypatch.setattr(inputs, "BARRIER", 1.3)
+    inputs.barrier_price.cache_clear()
+    assert inputs.barrier_price(1.0, 0.2, 0.03) == pytest.approx(
+        original / 100, abs=1e-11, rel=0
+    )
+
+
+@pytest.mark.parametrize("name,value", [("SPOT", 10000), ("VOL", 0.001)])
+def test_explicit_barrier_inputs_do_not_depend_on_defaults(
+    barrier_oracle, monkeypatch, name, value
+):
+    inputs = barrier_oracle
+    original = inputs.barrier_price(80, 0.4, 0.03)
+    monkeypatch.setattr(inputs, name, value)
+    inputs.barrier_price.cache_clear()
+    assert inputs.barrier_price(80, 0.4, 0.03) == pytest.approx(
+        original, abs=1e-11, rel=0
+    )
 
 
 def test_new_families_preserve_historical_inventory_and_cover_both_sizes():

--- a/dal-python/tests/test_benchmarks.py
+++ b/dal-python/tests/test_benchmarks.py
@@ -214,7 +214,7 @@ def test_comparable_aad_risk_is_in_the_regression_inventory():
         assert case.workload["method"] == "reverse AAD"
 
 
-def test_aad_gate_needs_no_third_party_packages(monkeypatch):
+def test_comparison_gate_needs_no_third_party_packages(monkeypatch):
     import builtins
 
     original = builtins.__import__
@@ -226,9 +226,15 @@ def test_aad_gate_needs_no_third_party_packages(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", without_third_parties)
     for case in build_cases(smoke=True):
-        if case.name.startswith("nodes.aad_dv01."):
+        if case.name.startswith(("nodes.aad_dv01.", "comparison.")):
             work = case.prepare()
             work.validate(work.run())
+
+
+def test_mc_and_calibration_comparisons_are_gated_without_removing_cases():
+    inventory = build_cases()
+    assert len(inventory) == 90
+    assert len([c for c in inventory if c.name.startswith("comparison.")]) == 18
 
 
 def test_suite_hashes_cover_shared_aad_implementation():


### PR DESCRIPTION
## Summary

Extend the Python performance gate with Monte Carlo option pricing/Greeks and
curve calibration comparisons against QuantLib-Python and rateslib. Append 18
DAL workloads (72 → 90) and 18 comparison scenarios (13 → 31), preserving existing
case names, order, workloads and the two-round >4% DAL regression rule.

- Vanilla and weekly discrete up-and-out calls: 16,384/65,536 Sobol paths, price
  and `[PV, Delta, Vega, Rho]`. DAL vanilla uses reverse AAD; the other Greek
  comparisons use central differences with common random numbers. Independent
  Black-Scholes and deterministic barrier integration oracles check every output.
  The barrier integration range follows each valuation's spot and volatility;
  tests verify price homogeneity, explicit-parameter independence, and convergence
  at every finite-difference bump with an absolute 1e-8 bound.
- Single curve, staged/joint multi-curve, and staged/joint XCCY calibration:
  5/15 annual quotes per block, non-flat cashflow-derived markets and log-linear
  discount factors. Time fresh instruments/curves, solving and conversion; verify
  every solved node and midpoint against the independent reference curves.
- Explicit capability records: rateslib equity MC and QuantLib simultaneous
  joint calibration show N/A without timings or ratios. All other cases must run;
  missing dependencies, incorrect outputs and incomplete evidence remain fatal.
  This gives 31 timed DAL cases, 27 QuantLib cases and 23 rateslib cases.
- Existing Linux CI enumerates the expanded inventory and uploads the comparison
  evidence. Document timing boundaries, Greek units, MC tolerances and schema
  `dal.python-comparisons/3`; retain benchmark-only dependency pins.

This change covers the benchmark suite, its tests and documentation.
Cross-library algorithms and parallelism differ; MC accuracy bounds do not imply
equal-error costs. Gamma/Theta are outside these first-order Greek workloads.

## Test plan

- [x] Reproduced the barrier oracle defect with three failing property regressions,
  then verified the fix. Full Python/benchmark suite: 622 passed, no skips.
- [x] Quadrature convergence checked at the base case and all six Greek bumps;
  `rel=0` makes the absolute 1e-8 bound effective.
- [x] Ruff check/format, complexity <=8, CPython 3.9 syntax (73 files),
  documentation (51 files) and diff checks passed.
- [x] Baseline/source pairing and full supported MC/calibration output checks
  are covered by the benchmark suite. Native production sources are unchanged,
  so local C++/sanitizer tests were not repeated for the Python oracle correction.
- [x] Exact final-head Linux/Windows CI, wheels, sanitizers and Codacy:
  46 checks passed; only the expected PR-only PyPI publication skip.
- [x] Hosted 90-case Python and 63-case native performance gates against `master`,
  using two rounds of ten samples per side and unchanged >4% thresholds.
- [x] Hosted full 31-scenario third-party comparison: two rounds of ten fresh
  processes for each backend, with complete oracle and provenance checks.

Hosted evidence: [Linux CI and benchmark artifact](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34684186822/artifacts/10295745923),
[Windows CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34684186821).
The checks belong to final head `76a86b1a`; the artifact records GitHub's test
merge `14c59324`, whose tree exactly matches that head and whose parents are
`master` (`e82f9e4c`) and `76a86b1a`. Downloaded reports were revalidated, including
all 60 third-party workers, source hashes, complete samples and output oracles.

Post-merge validation on `d452725e`: [Linux CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34685639667)
passed 18/18 jobs and [Windows CI](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34685639703)
passed 7/7. The merge tree equals the reviewed head tree. The downloaded
[merge-commit benchmark artifact](https://github.com/wegamekinglc/Derivatives-Algorithms-Lib/actions/runs/34685639667/artifacts/10295448716)
again passed all 90 Python and 63 native cases and all 31 third-party scenarios;
all 60 worker reports were revalidated against the source hashes and output
oracles. Windows' 21 benchmark executables and the 96-fixture/992-bucket joint
quote-risk evidence also passed.
