### PR TITLE
feat: add DAL-198 FIX index literal syntax

### DIFF
--- a/.codex/artifacts/reviews/dal-198/documentation.md
+++ b/.codex/artifacts/reviews/dal-198/documentation.md
@@ -2,7 +2,7 @@ DAL-198 F1 documentation handoff, 2026-09-12. This record controls the pending
 independent review; retire it after delivery.
 
 Reconciled documentation against source and tests at
-`cead11e0548d6fbffcb7c44339ccb0e4c505cfbf`, the accepted F1 issue and frontend
+`9e5613fde2c171bf094ad868b5601c0689fb82e1`, the accepted F1 issue and frontend
 design/critique/API boundaries, and the implementation/testing evidence.
 
 Documentation changes are required:
@@ -11,7 +11,8 @@ Documentation changes are required:
   tokenizer and omitted FIX. It now describes positioned `Lex` tokens, the
   legacy string projection, complete index literals, preserved bracket content
   and delivery suffixes, protected macro/placeholder expansion, strict optional
-  fixing dates, reserved FIX names, NodeFix metadata, and source origins.
+  fixing dates, reserved FIX names, NodeFix metadata, and source origins. The
+  atom/precedence table includes `NodeFix_`.
 - The guide explicitly limits FIX to parsing and AST inspection. All product
   execution entries reject it with `PreparationRequired`, including dead
   branches; no fixing lookup, model binding or public named-pricing API is
@@ -27,23 +28,27 @@ Documentation changes are required:
   FIX and requires conflicting variables/definitions to be renamed. It also
   states the execution limit, without claiming the later preparation APIs.
 
-Non-trivial current debug limitation flagged to the orchestrator for review:
-`Debugger_::Visit(NodeFix_)` records a legacy label and structural kind only.
-The legacy text dump retains raw index/date, JSON emits kind `fix` without
-index/date fields, and `TreeInlineLeaf` has no FIX case so the tree omits the
-leaf. The guide states these actual limits. No source repair belongs to this
-documentation stage.
+The reviewer's P2 debug omission is resolved in source at
+`a3a9f9583ee4dcd7fbece0e61b167efa616630c7`. The guide now states the corrected
+behavior: legacy text and ASCII/Unicode trees retain complete FIX identity and
+optional fixing date at narrow/wide widths; product JSON `/1` rejects any FIX
+with `DebugSchemaUnsupported` before writing any output, including past events
+and dead branches. FIX is removed from the published JSON `/1` kind list. No
+`/2` schema or Describe API is documented as available. The existing changelog
+entry remains accurate and needs no additional entry for this scoped repair.
 
 Validation:
 
 - `python3 .github/scripts/check_docs.py`: passed for all Markdown files,
   checking local links, tables, whitespace, final newlines and documentation
   metadata/workflow rules.
-- `git diff --check` and `git diff --cached --check`: passed; staged scope
-  contains only the four published documentation/changelog files above and
-  this active evidence file.
+- `git diff --check` and `git diff --cached --check`: passed; the correction's
+  staged scope contains only `docs/methodology/script_engine.md` and this
+  active evidence file.
 - Reviewed the complete published-document diff against lexer/preprocessor/
   parser/node, indice EQ/FX parsers, event execution guards and debug renderers.
-  Existing focused 241/241 and full Linux 1586/1586 results are owned by the
-  independent tester; no C++ test rerun is needed for these documentation-only
-  edits. The orchestrator records the final documentation commit SHA.
+  Independent tester results on the repaired source are focused 29/29
+  (`ScriptObservationTest.*:*Debug*`) and fresh full Linux 1588/1588, including
+  the FIX debug regressions and exact legacy SPOT snapshots. No C++ test rerun
+  is needed for these documentation-only edits. The orchestrator records the
+  final documentation commit SHA; independent re-review is the next stage.

--- a/.codex/artifacts/reviews/dal-198/documentation.md
+++ b/.codex/artifacts/reviews/dal-198/documentation.md
@@ -1,0 +1,49 @@
+DAL-198 F1 documentation handoff, 2026-09-12. This record controls the pending
+independent review; retire it after delivery.
+
+Reconciled documentation against source and tests at
+`cead11e0548d6fbffcb7c44339ccb0e4c505cfbf`, the accepted F1 issue and frontend
+design/critique/API boundaries, and the implementation/testing evidence.
+
+Documentation changes are required:
+
+- `docs/methodology/script_engine.md` described `Tokenize` as the sole string
+  tokenizer and omitted FIX. It now describes positioned `Lex` tokens, the
+  legacy string projection, complete index literals, preserved bracket content
+  and delivery suffixes, protected macro/placeholder expansion, strict optional
+  fixing dates, reserved FIX names, NodeFix metadata, and source origins.
+- The guide explicitly limits FIX to parsing and AST inspection. All product
+  execution entries reject it with `PreparationRequired`, including dead
+  branches; no fixing lookup, model binding or public named-pricing API is
+  documented as available. Omitted dates remain optional AST metadata.
+- `docs/methodology/index_parsing.md` incorrectly described bare names as
+  matching nothing and parser input as only the remainder. It now describes
+  complete-string parsing, InvalidIndex/UnknownIndex failures, complete EQ/FX
+  validation, bracket content and delivery validation, and the script limit.
+- `docs/README.md` gains a FIX syntax/limit entry under the existing methodology
+  note. No methodology document was added, removed or renamed, so the
+  `CLAUDE.md` methodology list needs no change.
+- `CHANGELOG.md` gains a qualifying entry: the new parse capability reserves
+  FIX and requires conflicting variables/definitions to be renamed. It also
+  states the execution limit, without claiming the later preparation APIs.
+
+Non-trivial current debug limitation flagged to the orchestrator for review:
+`Debugger_::Visit(NodeFix_)` records a legacy label and structural kind only.
+The legacy text dump retains raw index/date, JSON emits kind `fix` without
+index/date fields, and `TreeInlineLeaf` has no FIX case so the tree omits the
+leaf. The guide states these actual limits. No source repair belongs to this
+documentation stage.
+
+Validation:
+
+- `python3 .github/scripts/check_docs.py`: passed for all Markdown files,
+  checking local links, tables, whitespace, final newlines and documentation
+  metadata/workflow rules.
+- `git diff --check` and `git diff --cached --check`: passed; staged scope
+  contains only the four published documentation/changelog files above and
+  this active evidence file.
+- Reviewed the complete published-document diff against lexer/preprocessor/
+  parser/node, indice EQ/FX parsers, event execution guards and debug renderers.
+  Existing focused 241/241 and full Linux 1586/1586 results are owned by the
+  independent tester; no C++ test rerun is needed for these documentation-only
+  edits. The orchestrator records the final documentation commit SHA.

--- a/.codex/artifacts/reviews/dal-198/documentation.md
+++ b/.codex/artifacts/reviews/dal-198/documentation.md
@@ -1,11 +1,11 @@
-DAL-198 F1 documentation handoff, 2026-09-12. This record controls the pending
+DAL-198 F1 documentation handoff, updated 2026-09-13. This record controls the pending
 independent review; retire it after delivery.
 
 Reconciled documentation against source and tests at
-`9e5613fde2c171bf094ad868b5601c0689fb82e1`, the accepted F1 issue and frontend
+`83e7f5a8ae2af3d1bc2930ac07ea9ffdcb0451a3`, the accepted F1 issue and frontend
 design/critique/API boundaries, and the implementation/testing evidence.
 
-Documentation changes are required:
+Published documentation for F1:
 
 - `docs/methodology/script_engine.md` described `Tokenize` as the sole string
   tokenizer and omitted FIX. It now describes positioned `Lex` tokens, the
@@ -37,18 +37,35 @@ and dead branches. FIX is removed from the published JSON `/1` kind list. No
 `/2` schema or Describe API is documented as available. The existing changelog
 entry remains accurate and needs no additional entry for this scoped repair.
 
+CI repair documentation decision, production revision
+`ce158d11115a1c6597540f0fa62eda6e54bcf645`: no further published documentation
+or CHANGELOG edit is required. Read the complete repair diff, direct indice
+and script diagnostic regressions, and current implementation/test evidence.
+The explicit character-predicate bool conversion and direct exception include
+repair compiler/backend portability; tape initialization repairs test setup.
+Extracted scanner, source-origin, equity-validation and fixing-date helpers
+preserve the accepted grammar and documented metadata. Normalizing both DAL
+and standard logic errors retains `InvalidIndex`, the full delivery input and
+script source context, fulfilling the existing validation contract rather
+than adding a capability, algorithm or public surface. Existing FIX reservation,
+protected expansion, strict dates, debug behavior and `PreparationRequired`
+limits remain accurate. No methodology file or index changes are needed.
+
 Validation:
 
 - `python3 .github/scripts/check_docs.py`: passed for all Markdown files,
   checking local links, tables, whitespace, final newlines and documentation
   metadata/workflow rules.
-- `git diff --check` and `git diff --cached --check`: passed; the correction's
-  staged scope contains only `docs/methodology/script_engine.md` and this
-  active evidence file.
+- `git diff --check` and `git diff --cached --check`: passed; this CI repair
+  documentation pass stages only this active evidence file.
 - Reviewed the complete published-document diff against lexer/preprocessor/
   parser/node, indice EQ/FX parsers, event execution guards and debug renderers.
-  Independent tester results on the repaired source are focused 29/29
-  (`ScriptObservationTest.*:*Debug*`) and fresh full Linux 1588/1588, including
-  the FIX debug regressions and exact legacy SPOT snapshots. No C++ test rerun
-  is needed for these documentation-only edits. The orchestrator records the
-  final documentation commit SHA; independent re-review is the next stage.
+  The independent tester's latest results on the CI repair are native Linux
+  1590/1590, Adept 1582/1582 and CoDiPack 1582/1582, with public API and portable
+  Excel tests enabled. Local complexity verification reports 4/4/7/4 for the
+  four flagged functions; new helpers are at most 7. Commands, logs and backend
+  configuration are recorded in `testing.md` alongside this file. Remote
+  Windows/Codacy results remain pending on the pushed repair head; local
+  evidence does not establish those results. No C++ test rerun is needed for
+  this evidence-only edit. The orchestrator records the final documentation
+  commit SHA; independent re-review of that exact head is the next stage.

--- a/.codex/artifacts/reviews/dal-198/documentation.md
+++ b/.codex/artifacts/reviews/dal-198/documentation.md
@@ -2,7 +2,7 @@ DAL-198 F1 documentation handoff, updated 2026-09-13. This record controls the p
 independent review; retire it after delivery.
 
 Reconciled documentation against source and tests at
-`83e7f5a8ae2af3d1bc2930ac07ea9ffdcb0451a3`, the accepted F1 issue and frontend
+`76fed07e9f2f410966270fa49988e849c510c1b3`, the accepted F1 issue and frontend
 design/critique/API boundaries, and the implementation/testing evidence.
 
 Published documentation for F1:
@@ -51,21 +51,38 @@ than adding a capability, algorithm or public surface. Existing FIX reservation,
 protected expansion, strict dates, debug behavior and `PreparationRequired`
 limits remain accurate. No methodology file or index changes are needed.
 
+Performance repair documentation decision, production revision
+`7d79eeb82b99f5a000a239c9477999dd51aa3479`: no further published documentation
+or CHANGELOG edit is required. Read the complete delta from `78e52eba`,
+implementation evidence and independent correctness evidence. Parser metadata
+now records the first FIX diagnostic during node construction, resets per
+Parse, and supplies the product's retained diagnostic without a recursive AST
+scan. The successful preparation check is inline with a separate throwing
+path; text without an opening bracket skips index-range scanning. These
+implementation changes preserve the documented syntax, protected expansion,
+source context, first FIX identity and execution/debug rejection behavior.
+The existing methodology does not promise the removed scan or prescribe the
+guard's code layout. There is no new numerical method, supported pricing
+capability or compatibility change requiring a changelog entry. Independent
+paired performance validation remains pending; this documentation decision
+makes no speedup or benchmark acceptance claim.
+
 Validation:
 
 - `python3 .github/scripts/check_docs.py`: passed for all Markdown files,
   checking local links, tables, whitespace, final newlines and documentation
   metadata/workflow rules.
-- `git diff --check` and `git diff --cached --check`: passed; this CI repair
+- `git diff --check` and `git diff --cached --check`: passed; this performance repair
   documentation pass stages only this active evidence file.
 - Reviewed the complete published-document diff against lexer/preprocessor/
   parser/node, indice EQ/FX parsers, event execution guards and debug renderers.
-  The independent tester's latest results on the CI repair are native Linux
-  1590/1590, Adept 1582/1582 and CoDiPack 1582/1582, with public API and portable
-  Excel tests enabled. Local complexity verification reports 4/4/7/4 for the
-  four flagged functions; new helpers are at most 7. Commands, logs and backend
-  configuration are recorded in `testing.md` alongside this file. Remote
-  Windows/Codacy results remain pending on the pushed repair head; local
-  evidence does not establish those results. No C++ test rerun is needed for
-  this evidence-only edit. The orchestrator records the final documentation
-  commit SHA; independent re-review of that exact head is the next stage.
+  The independent tester's latest results on the performance repair are native
+  Linux 1592/1592, Adept 1584/1584 and CoDiPack 1584/1584, with public API and
+  portable Excel tests enabled. The new tests verify first-FIX origin,
+  parser reuse/reset and product diagnostic retention across later events.
+  Commands, logs and backend configuration are recorded in `testing.md`
+  alongside this file. No heavy tests or benchmarks were run in this
+  documentation pass. Correctness results do not establish performance or
+  remote CI acceptance. The orchestrator records the final documentation
+  commit SHA; independent re-review of that exact head and paired performance
+  validation remain required.

--- a/.codex/artifacts/reviews/dal-198/implementation.md
+++ b/.codex/artifacts/reviews/dal-198/implementation.md
@@ -134,3 +134,52 @@ test binary built successfully with `cmake --build <build-dir> --target dal_cpp_
   No MSVC `cl`/Windows SDK build is available locally; Windows validation remains
   a remote CI requirement. The parent owns independent testing, the documentation
   decision, review, and publication of this scoped correction.
+
+Performance blocker repair, 2026-09-13, from PR #366 head
+`78e52ebac060dca513537b9b719313fa4df4321e`:
+
+- Retained CI RED shows `script.construct_and_parse` at +6.72% / +7.11%
+  against the unchanged +4% two-round gate. Its A/A controls are below 1%.
+  The tree case also failed (+5.15% / +8.00%), but its same-head A/A samples
+  are bimodal, so this repair does not attribute its exact cost to the guard.
+  Inputs: `dal-198-benchmark-failure/python-paired/summary.md` and the
+  independent `dal-198-performance-diagnosis.md`.
+- The parser now records the first FIX diagnostic while constructing its node,
+  resetting this metadata at the start of each Parse. ParseEvents consumes it
+  instead of recursively applying RTTI to every AST node. The product keeps
+  its first recorded diagnostic across later events and ParseEvents calls.
+  The complete NodeFix diagnostic, including raw spelling and source origins,
+  remains the single formatting source.
+- The product's preparation check now has an inline successful path and an
+  out-of-line throwing path. Every existing caller and direct visitor guard
+  remains in place, including past events, dead branches, tree/AAD/fuzzy
+  evaluation, preprocessing, compilation, and legacy JSON rejection.
+- IndexLiteralRanges returns an empty result immediately for text with no
+  opening bracket. Macro-generated literals are still rescanned on subsequent
+  replacements; bracketed text takes the unchanged validation/protection path.
+  No benchmark threshold, inventory, timing boundary, or CI policy changed.
+
+Correctness evidence:
+
+- Added tests for first-FIX diagnostic identity and per-Parse reset across FIX,
+  SPOT, another FIX with different origins, and empty input. A product test
+  preserves the original past/dead FIX through later events and another
+  ParseEvents call, then verifies a separate legacy product remains usable.
+  The test-first build failed on the absent parser metadata getter
+  (`dal-198-perf-red-build.log`); the performance RED above is the behavioral
+  regression motivating this behavior-preserving repair.
+- `cmake --build build/Release-linux --target dal_cpp_tests -j8`: exit 0
+  (`dal-198-perf-green-build.log`).
+- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.TestParserPreparationDiagnosticReset:ScriptObservationTest.TestProductRetainsFirstPreparationDiagnostic'`:
+  2/2 passed (`dal-198-perf-focused-green.log`).
+- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:ScriptLexerTest.*:ScriptPreprocessorTest.*:ScriptTest.*:IndexTest.*:IndexParseTest.*'`:
+  247/247 passed (`dal-198-perf-regression-green.log`).
+- Local Lizard measures ParseFix 8, IndexLiteralRanges 7, ParseEvents 4 and
+  Lex 4; all touched functions meet the limit of 8
+  (`dal-198-perf-complexity.log`). Existing unrelated complexity warnings
+  remain unchanged. Changed test lines are formatted and diff checks pass.
+
+No speedup or final benchmark acceptance is claimed at this handoff. The parent
+coordinates isolated paired performance validation, independent testing and
+review; this implementation stage ran no timing workload concurrently with
+builds and made no publication or platform changes.

--- a/.codex/artifacts/reviews/dal-198/implementation.md
+++ b/.codex/artifacts/reviews/dal-198/implementation.md
@@ -49,3 +49,19 @@ Evidence logs are in the parent workdir under `dal-198-*-build.log` and
 `dal-198-*-tests.log`. Independent full Linux verification and review are owned by
 the following specialist stages. No published docs or changelog were changed;
 dal-doc-writer decides those changes. The orchestrator records the commit/PR SHA.
+
+Independent tester repair: the bracket scanner initially rejected parentheses
+inside an index name even though `Index::Parse("EQ[AAPL(US)]")` preserves that
+identity. Removed only that extra restriction: bracket content reaches indice
+unchanged, while nested brackets and quotes still fail. The tester owns the new
+regressions and confirmed RED in `dal-198-tester-boundary-red.log`.
+
+Tester-collected GREEN after the repair:
+
+- `cmake --build build/Release-linux --target dal_cpp_tests -j8`: exit 0;
+  `dal-198-tester-green-build.log`.
+- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.TestBracketContentsPreserveIndiceIdentity:ScriptObservationTest.TestInvalidSyntax'`:
+  exit 0, both tests passed; `dal-198-tester-boundary-green.log`. These exercise
+  punctuation, commas and unmatched parentheses within names while retaining
+  malformed quote/nested-bracket rejection. No test files belong to this repair
+  commit; the tester continues the independent expanded and full verification.

--- a/.codex/artifacts/reviews/dal-198/implementation.md
+++ b/.codex/artifacts/reviews/dal-198/implementation.md
@@ -86,3 +86,51 @@ branches. No schema /2, new debug API, or I/O was added.
   rendering, rejection before JSON output for past/future/dead-branch uses,
   and existing exact SPOT debug snapshots. The documentation correction belongs
   to dal-doc-writer; the parent coordinates independent retesting/review.
+
+CI/review blocker repair, 2026-09-13, from PR #366 head
+`62b7a7bf694760df54c790560c6b11abb1683c96`:
+
+- Converted the lexer character predicates explicitly with `!= 0`, addressing
+  MSVC C4800 without changing recognized characters. Added the direct exception
+  header dependency to `node.hpp`, which previously relied on incidental AAD
+  backend includes. The CoDiPack compilation failure was reproduced locally
+  before the header repair (`dal-198-codi-red-build.log`).
+- Reproduced both Adept guard-test crashes in separate CTest processes. The
+  evaluator's `Stack_<adept::adouble>` allocates active values at construction;
+  Adept's active constructor dereferences its active stack, while DAL creates
+  that stack lazily in `Tape()`. The tests now call `Clear(*Tape())` before
+  evaluator construction and `NewRecording(*Tape())` before guard evaluation.
+  All rejection assertions and backend coverage remain enabled. Isolated RED
+  and GREEN are in `dal-198-adept-lifecycle-{red,green}.log` (two crashes, then
+  2/2 passes).
+- Added direct indice and script diagnostic regressions. Invalid delivery dates,
+  increments, and integer-overflow input must retain `InvalidIndex` and the full
+  original index; script errors must also retain the source column. Both tests
+  failed before repair and passed after normalizing both DAL `Exception_` and
+  standard `logic_error` through the shared equity diagnostic helper. Logs:
+  `dal-198-ci-diagnostic-{red,green}-{build,tests}.log`.
+- Extracted cohesive index-body/suffix, token, source-origin, equity-validation,
+  and fixing-date helpers without changing the accepted grammar. Local Lizard
+  reproduces the four reported baseline complexities, then measures
+  `IndexLiteralEnd` 18→4, `Lex` 14→4, `ParseFix` 13→7 and `EquityParser` 10→4.
+  Every new helper is at most 7, below the limit of 8. Unrelated existing
+  high-complexity functions and all analysis/CI policies are unchanged. Command:
+  `lizard dal-cpp/dal/script/lexer.cpp dal-cpp/dal/script/parser.cpp dal-cpp/dal/indice/parser/equity.cpp`;
+  logs `dal-198-complexity-{red,green}.log`.
+
+Verification uses the native `build/Release-linux` directory and separate
+`build/dal-198-adept` / `build/dal-198-codi` directories. Backend configuration:
+`cmake --preset=Release-linux -S . -B build/dal-198-adept -DDAL_USE_ADEPT_AAD=ON -DDAL_CPP_BUILD_EXAMPLES=OFF -DDAL_BUILD_PUBLIC=OFF`,
+and the same command with `build/dal-198-codi` and
+`-DDAL_USE_CODIPACK_AAD=ON`. The preset leaves the other AAD flags off. Each core
+test binary built successfully with `cmake --build <build-dir> --target dal_cpp_tests -j4`.
+
+- Native: `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:ScriptLexerTest.*:ScriptPreprocessorTest.*:ScriptTest.*:IndexTest.*:IndexParseTest.*'`:
+  245/245 passed (`dal-198-ci-native-green-tests.log`).
+- Adept and CoDiPack: `ctest --test-dir <build-dir> -R '^(ScriptObservationTest|ScriptLexerTest|ScriptPreprocessorTest|IndexTest|IndexParseTest)\.|^ScriptTest\.TestDebugger' -j4 --output-on-failure`:
+  77/77 passed on each backend (`dal-198-{adept,codi}-focused-green.log`).
+  CTest isolates the two AAD lifecycle regressions from any preceding tape setup.
+- Changed ranges were formatted, and working/cached diff whitespace checks pass.
+  No MSVC `cl`/Windows SDK build is available locally; Windows validation remains
+  a remote CI requirement. The parent owns independent testing, the documentation
+  decision, review, and publication of this scoped correction.

--- a/.codex/artifacts/reviews/dal-198/implementation.md
+++ b/.codex/artifacts/reviews/dal-198/implementation.md
@@ -65,3 +65,24 @@ Tester-collected GREEN after the repair:
   punctuation, commas and unmatched parentheses within names while retaining
   malformed quote/nested-bracket rejection. No test files belong to this repair
   commit; the tester continues the independent expanded and full verification.
+
+Independent reviewer P2 repair: existing human tree rendering had no FIX leaf
+case, and legacy product JSON /1 silently emitted a `kind=fix` node without its
+identity/date. Human text and tree output now retain complete
+`FIX(index[, date])` syntax, including both delivery and fixing dates. The /1
+product JSON entry checks the product's captured FIX presence before writing and
+throws `DebugSchemaUnsupported`, including observations in past events and dead
+branches. No schema /2, new debug API, or I/O was added.
+
+- RED: `dal_cpp_tests --gtest_filter='ScriptObservationTest.TestDebugger*'`
+  failed both new regressions, reproducing the missing tree leaf and successful
+  incomplete /1 JSON; `dal-198-debug-red-tests.log`. The tests were subsequently
+  placed in the file's existing `ScriptTest` suite per repository convention.
+- GREEN: `cmake --build build/Release-linux --target dal_cpp_tests -j8`, followed
+  by `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:*Debug*'`:
+  build exit 0 and 29/29 tests passed; `dal-198-debug-green-build.log` and
+  `dal-198-debug-green-tests.log`. Tests cover nested FIX expressions, explicit
+  and omitted dates, FX/EQ/delivery names, ASCII/Unicode and narrow/wide tree
+  rendering, rejection before JSON output for past/future/dead-branch uses,
+  and existing exact SPOT debug snapshots. The documentation correction belongs
+  to dal-doc-writer; the parent coordinates independent retesting/review.

--- a/.codex/artifacts/reviews/dal-198/implementation.md
+++ b/.codex/artifacts/reviews/dal-198/implementation.md
@@ -1,0 +1,51 @@
+DAL-198 F1 implementation handoff, 2026-09-12. This artifact controls the pending
+tester, documentation and independent reviewer stages; retire it after delivery.
+
+Implemented the accepted F1 frontend scope. `Lex` emits positioned tokens whose
+variant distinguishes `IndexLiteral_`; the existing `Tokenize` string projection
+remains available for schedules and existing callers. The lexer and each macro or
+placeholder replacement pass share the complete index boundary scan. Macro order
+outside literals is unchanged, and newly expanded literals become protected.
+
+`NodeFix_` stores raw spelling, the parsed immutable `Index_` handle, optional daily
+fixing date, and source offset/line/column. Preprocessed source origins also retain
+the table row and expanded event date, including concatenated same-date events.
+FIX only accepts an unquoted index and optional contiguous strict ISO date. FIX
+definitions/variables report `ReservedIdentifier`; old zero-argument SPOT remains.
+Indice rejects unknown/bare/null results, malformed EQ/FX and trailing input, and
+validates EQ delivery increments without dropping empty compound components.
+
+Minimal `event.cpp`/`event.hpp` changes propagate source origins and reject named
+observations before legacy preprocessing, compilation, past evaluation or tree
+evaluation. The product captures the diagnostic before condition folding, so dead
+branches cannot bypass the guard and old SPOT paths avoid per-path AST scans.
+Direct double/AAD, fuzzy, past, compiler and domain visitors reject NodeFix with
+`PreparationRequired`; the debugger has a structural FIX visitor. No fixing I/O,
+binding, observation plan, or public pricing API was added. These remain later
+stages of the accepted design.
+
+Verification:
+
+- Initialized missing checkout submodules with `git submodule update --init --recursive`.
+- Configured `cmake --preset=Release-linux -S . -B build/Release-linux`.
+- Built `cmake --build build/Release-linux --target dal_cpp_tests -j8`.
+- Initial RED: `dal_cpp_tests --gtest_filter='ScriptObservationTest.*:IndexParseTest.TestParseRejectsBareNameAndNullParser:IndexParseTest.TestParseRejectsMalformedAndTrailingInput'`:
+  all seven tests failed for the intended missing behavior. The initial lexer
+  emitted `FX`, FIX parsed as a variable, names were macro-expanded, parenthesized
+  trailing syntax was ignored, FIX was not reserved, and invalid indices survived.
+- Further RED: `ScriptObservationTest.TestScheduleSourceContext` lacked `row=2`;
+  `ScriptObservationTest.TestPreparationRequiredProductEntryPoints` returned the
+  generic compile prerequisite; `IndexTest.TestParserRejectsIncompleteCompoundDelivery`
+  accepted `EQ[IBM]>3M&`. Each passed after its corresponding change.
+- GREEN: `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:IndexParseTest.*:IndexTest.*:ScriptLexerTest.*:ScriptPreprocessorTest.*:ScriptTest.*'`:
+  238 tests passed. This includes strict date and malformed syntax cases, literal
+  identity/raw case/source metadata, macro-generated protection, delivery forms,
+  dead branches with and without domain processing, and tree/compiled/AAD/fuzzy/
+  past preparation guards alongside existing SPOT regressions.
+- Formatted changed C++ ranges with repository clang-format and checked
+  `git diff --check` and `git diff --cached --check` before committing.
+
+Evidence logs are in the parent workdir under `dal-198-*-build.log` and
+`dal-198-*-tests.log`. Independent full Linux verification and review are owned by
+the following specialist stages. No published docs or changelog were changed;
+dal-doc-writer decides those changes. The orchestrator records the commit/PR SHA.

--- a/.codex/artifacts/reviews/dal-198/testing.md
+++ b/.codex/artifacts/reviews/dal-198/testing.md
@@ -1,0 +1,85 @@
+DAL-198 F1 independent tester handoff, 2026-09-12. This record controls the
+pending documentation and reviewer stages; retire it after delivery.
+
+F1 testing passes after the scoped bracket-content repair. Initial implementation
+was `899748dec20034e33a8375697018e8da92565218`; final production revision is
+`23ae973a50335bd32a1d66c311db1e3068242018`, tested with the test changes committed
+alongside this record. The orchestrator records the final delivery/PR SHA.
+
+Running existing tests:
+
+- Read the accepted issue/design, tester contract, run-tests, write-tests,
+  unit-test style, production APIs and nearby tests before verification.
+- Removed the previous root `test_output.txt`, then ran
+  `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1` on the initial
+  implementation. Exit 0; fresh authoritative summary:
+  `100% tests passed, 0 tests failed out of 1583`; CTest time 10.67 seconds.
+  Preserved as `../dal-198-tester-baseline-full-linux.log`.
+
+Authoring tests:
+
+- Added `ScriptObservationTest.TestBracketContentsPreserveIndiceIdentity`.
+  It first proves names are accepted unchanged by `Index::Parse`, then checks
+  FIX inside MAX, explicit fixing date, exact raw spelling, macro protection
+  and schedule-placeholder protection. Cases include dots, slashes, commas,
+  balanced/unbalanced parentheses inside brackets, and compound delivery.
+- Added `TestSameDateSourceOriginsAfterMacroExpansion` to verify the second
+  same-date statement retains its original table row, expanded line/column,
+  offset and event date after a macro produces an index literal.
+- Added `TestNullParserRetainsSourceContext` using a unique registered parser
+  prefix; a null result must throw a script error retaining index and source.
+- Extended existing preparation checks to direct normal/fuzzy domain visitors,
+  product AAD/fuzzy evaluation and fuzzy compilation. Existing tests already
+  cover direct double/AAD/fuzzy/past/compiler visitors, PreProcess with domain
+  processing enabled or skipped, and dead branches on past/future event dates.
+- Moved the new lexer test to the existing `ScriptLexerTest` suite, complying
+  with the repository's one-suite-per-file convention.
+
+Repairing failures:
+
+- The bracket-content test failed before any production repair:
+  `Index::Parse("EQ[AAPL(US)]")` succeeded, while
+  `x = MAX(FIX(EQ[AAPL(US)], 2026-09-11), 0)` threw `InvalidIndex` from
+  `lexer.cpp:35`. The accepted grammar preserves bracket contents and delegates
+  name validation to indice; parentheses were rejected only by the lexer.
+- Narrow RED command:
+  `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter=ScriptObservationTest.TestBracketContentsPreserveIndiceIdentity`.
+  Exit 1, 0/1 passed; `../dal-198-tester-boundary-red.log`.
+- Reported the failure to the orchestrator and implementer. The implementer
+  repaired only the lexer bracket-content rejection and committed its evidence
+  at `23ae973a`; tester made no production edits.
+- Rebuilt with `cmake --build build/Release-linux --target dal_cpp_tests -j8`
+  (exit 0; `../dal-198-tester-green-build.log`), then ran
+  `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.TestBracketContentsPreserveIndiceIdentity:ScriptObservationTest.TestInvalidSyntax'`.
+  Exit 0, 2/2 passed; `../dal-198-tester-boundary-green.log`. Valid bracket
+  punctuation passes while nested brackets, quotes and malformed syntax fail.
+
+Final verification:
+
+- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:IndexParseTest.*:IndexTest.*:ScriptLexerTest.*:ScriptPreprocessorTest.*:ScriptTest.*'`:
+  exit 0, 241 tests from 6 suites passed; `../dal-198-tester-focused.log`.
+  This covers T01/T02, complete EQ/FX/delivery identity, strict ISO fixing
+  dates distinct from delivery, malformed/unknown/null/trailing rejection,
+  FIX reservation, macro-generated literal protection, source context,
+  PreparationRequired and existing SPOT/frontend regressions.
+- Removed `test_output.txt` again, then freshly ran
+  `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1` after all source and
+  test edits. Exit 0; authoritative summary:
+  `100% tests passed, 0 tests failed out of 1586`; CTest time 8.39 seconds.
+  Final log is root `test_output.txt` and `../dal-198-tester-final-full-linux.log`.
+  The script configured, built all enabled targets, installed, and ran CTest.
+- Active configuration: Linux Release, native AADET AAD, public API enabled,
+  portable Excel tests enabled. Benchmarks excluded by the standard workflow.
+- Inspected the production diff: no fixing/history I/O or named numeric
+  placeholder was introduced. Named execution is rejected before evaluation;
+  market preparation/binding and their numerical acceptance belong to later
+  stages. `git diff --check` and the scoped staged whitespace check passed.
+
+Limits: no Windows XLL, Python binding, alternate AAD backend, sanitizer or
+coverage run was performed. An attempted extra PastEvaluator_<AAD::Number_>
+probe did not compile: the existing visitor list registers only the double
+past evaluator and the template constructor is incompatible with Number_.
+That unsupported probe was removed without production changes; the preexisting
+restriction is for the later past-AAD stage. Supported PastEvaluate and direct,
+future and fuzzy AAD rejection paths pass here. No F1 blocker remains; the
+documentation decision and independent code review are still required.

--- a/.codex/artifacts/reviews/dal-198/testing.md
+++ b/.codex/artifacts/reviews/dal-198/testing.md
@@ -1,12 +1,12 @@
-DAL-198 F1 independent tester handoff, 2026-09-12. This record controls the
+DAL-198 F1 independent tester handoff, updated 2026-09-13. This record controls the
 pending documentation and reviewer stages; retire it after delivery.
 
-F1 testing passes after the bracket-content and reviewer-directed debugger
+F1 local testing passes after the bracket-content, debugger and CI blocker
 repairs. Initial implementation was `899748dec20034e33a8375697018e8da92565218`;
 the bracket repair at `23ae973a50335bd32a1d66c311db1e3068242018` was verified
 with tester changes committed at `cead11e0548d6fbffcb7c44339ccb0e4c505cfbf`.
 Latest independently tested production and test revision is
-`a3a9f9583ee4dcd7fbece0e61b167efa616630c7`. The orchestrator records the final
+`ce158d11115a1c6597540f0fa62eda6e54bcf645`. The orchestrator records the final
 delivery/PR SHA.
 
 Running existing tests:
@@ -98,19 +98,80 @@ Independent verification after reviewer P2 debugger repair:
   `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1` on the repaired
   revision. Exit 0; fresh authoritative summary:
   `100% tests passed, 0 tests failed out of 1588`; CTest time 7.70 seconds.
-  Logs: root `test_output.txt` and
-  `../dal-198-tester-debug-full-linux.log`. Configuration remains Linux Release
-  with native AADET AAD, public API and portable Excel tests, benchmarks
+  Preserved log: `../dal-198-tester-debug-full-linux.log`. Configuration remains
+  Linux Release with native AADET AAD, public API and portable Excel tests, benchmarks
   excluded. This full run includes the two debugger regressions added by the
   implementer. Whitespace and scoped staged checks passed.
 - No blocker remains from independent testing. Updated documentation and a
   new independent review of the resulting head are still required.
 
-Limits: no Windows XLL, Python binding, alternate AAD backend, sanitizer or
-coverage run was performed. An attempted extra PastEvaluator_<AAD::Number_>
-probe did not compile: the existing visitor list registers only the double
+Independent verification after CI blocker repair, 2026-09-13:
+
+- Inspected the diff from PR head `62b7a7bf` to `ce158d11` and the implementation
+  remediation evidence. Explicit `!= 0` predicates address the integer-to-bool
+  conversion; `node.hpp` directly includes its exception dependency. The two
+  guard tests initialize Tape before constructing active evaluator stacks and
+  start recording before evaluation, retaining every rejection assertion.
+  The direct delivery-diagnostic test retains `InvalidIndex` and the complete
+  input for DAL exceptions and standard overflow errors. The script diagnostic
+  test also requires source context for malformed dates and increments.
+  Existing tests cover the extracted lexer/parser helpers; no additional tests
+  or production edits were needed in this independent pass.
+- Removed root `test_output.txt`, then ran
+  `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1`.
+  Exit 0: `100% tests passed, 0 tests failed out of 1590`;
+  CTest time 10.40 seconds. Logs: root `test_output.txt` and
+  `../dal-198-tester-ci-native-full.log`. This includes configure, all-target
+  build, install and full nonbenchmark CTest with native AADET, public API,
+  portable Excel tests and examples enabled.
+- Initial `cmake --build build/dal-198-adept -j4` and
+  `cmake --build build/dal-198-codi -j4` both exited 2 because the inherited
+  core-only caches disabled the public library while enabling portable Excel
+  tests. The Excel compile could not find `dal-public/src/curvepricing.hpp`.
+  Initial failure logs are `../dal-198-tester-ci-{adept,codi}-build.log`.
+  Enabled the required dependency, keeping all tests enabled, with:
+  `cmake --preset=Release-linux -S . -B build/dal-198-adept -DDAL_USE_ADEPT_AAD=ON -DDAL_BUILD_PUBLIC=ON -DDAL_CPP_BUILD_EXAMPLES=OFF`
+  and
+  `cmake --preset=Release-linux -S . -B build/dal-198-codi -DDAL_USE_CODIPACK_AAD=ON -DDAL_BUILD_PUBLIC=ON -DDAL_CPP_BUILD_EXAMPLES=OFF`.
+  Both configure commands exited 0; logs
+  `../dal-198-tester-ci-{adept,codi}-configure.log`.
+- Re-ran `cmake --build build/dal-198-adept -j4` and
+  `cmake --build build/dal-198-codi -j4`: both exited 0, including public API,
+  portable Excel and allocation-test targets. Logs:
+  `../dal-198-tester-ci-{adept,codi}-full-build.log`.
+- `ctest --test-dir build/dal-198-adept --output-on-failure --parallel 4 -LE benchmark`:
+  exit 0, `100% tests passed, 0 tests failed out of 1582`, 17.25 seconds.
+  `ctest --test-dir build/dal-198-codi --output-on-failure --parallel 4 -LE benchmark`:
+  exit 0, `100% tests passed, 0 tests failed out of 1582`, 17.63 seconds.
+  Logs: `../dal-198-tester-ci-{adept,codi}-full-tests.log`.
+  CTest ran each case in its own process: both formerly crashing guard tests
+  and both delivery-diagnostic regressions individually passed on each backend.
+- Final caches confirm exactly one alternate backend enabled in each separate
+  directory; native flags remain all off. All three use Linux Release/GCC
+  15.2.0 with public API and portable Excel tests enabled. Alternate examples
+  remain off; Python and benchmarks are off throughout. CTest discovery differs
+  by nine native-only cases and one backend-only case on each alternate build,
+  giving the eight-test count difference; no tests or policy were suppressed.
+  Discovery evidence: `../dal-198-tester-ci-discovery.log`.
+- Independently ran
+  `lizard dal-cpp/dal/script/lexer.cpp dal-cpp/dal/script/parser.cpp dal-cpp/dal/indice/parser/equity.cpp`:
+  the four reported functions are now CC 4/4/7/4; every new helper is at most 7.
+  The full command exits 1 for unchanged `ParseVarConstFunc` CC 16; a separate
+  Lizard API assertion covering the 14 affected/new functions exits 0 with all
+  below the limit of 8. Logs: `../dal-198-tester-ci-complexity.log` and
+  `../dal-198-tester-ci-complexity-scope.log`. This is local analysis evidence;
+  remote Codacy and Windows CI results still require the new pushed head.
+- Working and scoped staged whitespace checks pass. Local verification is
+  complete; documentation decision, independent review and remote checks remain
+  with the orchestrator's delivery route.
+
+Limits: no local MSVC/Windows XLL, Python binding, XAD backend, sanitizer or
+coverage run was performed. Adept and CoDiPack full configured suites are now
+verified above, superseding the earlier alternate-backend coverage limitation.
+An attempted extra PastEvaluator_<AAD::Number_> probe did not compile: the
+existing visitor list registers only the double
 past evaluator and the template constructor is incompatible with Number_.
 That unsupported probe was removed without production changes; the preexisting
 restriction is for the later past-AAD stage. Supported PastEvaluate and direct,
-future and fuzzy AAD rejection paths pass here. No F1 blocker remains; the
-documentation decision and independent code review are still required.
+future and fuzzy AAD rejection paths pass here. No local testing blocker remains;
+the documentation decision, independent review and remote checks are still required.

--- a/.codex/artifacts/reviews/dal-198/testing.md
+++ b/.codex/artifacts/reviews/dal-198/testing.md
@@ -1,12 +1,12 @@
 DAL-198 F1 independent tester handoff, updated 2026-09-13. This record controls the
 pending documentation and reviewer stages; retire it after delivery.
 
-F1 local testing passes after the bracket-content, debugger and CI blocker
+F1 local testing passes after the bracket-content, debugger, CI and performance
 repairs. Initial implementation was `899748dec20034e33a8375697018e8da92565218`;
 the bracket repair at `23ae973a50335bd32a1d66c311db1e3068242018` was verified
 with tester changes committed at `cead11e0548d6fbffcb7c44339ccb0e4c505cfbf`.
 Latest independently tested production and test revision is
-`ce158d11115a1c6597540f0fa62eda6e54bcf645`. The orchestrator records the final
+`7d79eeb82b99f5a000a239c9477999dd51aa3479`. The orchestrator records the final
 delivery/PR SHA.
 
 Running existing tests:
@@ -120,7 +120,7 @@ Independent verification after CI blocker repair, 2026-09-13:
 - Removed root `test_output.txt`, then ran
   `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1`.
   Exit 0: `100% tests passed, 0 tests failed out of 1590`;
-  CTest time 10.40 seconds. Logs: root `test_output.txt` and
+  CTest time 10.40 seconds. Preserved log:
   `../dal-198-tester-ci-native-full.log`. This includes configure, all-target
   build, install and full nonbenchmark CTest with native AADET, public API,
   portable Excel tests and examples enabled.
@@ -164,6 +164,47 @@ Independent verification after CI blocker repair, 2026-09-13:
 - Working and scoped staged whitespace checks pass. Local verification is
   complete; documentation decision, independent review and remote checks remain
   with the orchestrator's delivery route.
+
+Independent correctness verification after performance repair, 2026-09-13:
+
+- Inspected the complete diff from `78e52eba` to the clean implementation head
+  `7d79eeb82b99f5a000a239c9477999dd51aa3479`, current APIs, implementation
+  evidence and relevant tests. Parser-owned diagnostic state resets at each
+  Parse and is copied into the product before parser reuse. Existing product
+  and visitor guards remain in place. The no-opening-bracket shortcut leaves
+  macro-generated literals protected by subsequent replacement scans.
+- Existing new tests cover first-FIX raw spelling/source, per-Parse reset across
+  FIX/SPOT/FIX/empty input, and retaining the first past/dead-branch observation
+  across later events and another ParseEvents call. Existing tests cover
+  macro expansion, full identity, source origins, direct and product execution
+  guards, PreProcess with domain processing enabled/skipped, and legacy debug
+  rejection. No material missing coverage, test edits or production repairs
+  were identified during this pass.
+- Removed root `test_output.txt`, then ran
+  `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1`.
+  Exit 0: `100% tests passed, 0 tests failed out of 1592`;
+  CTest time 17.08 seconds. Logs: root `test_output.txt` and
+  `../dal-198-tester-perf-native-full.log`. The native workflow configured,
+  built all enabled targets, installed and ran the complete nonbenchmark suite.
+- `cmake --build build/dal-198-adept -j4` and
+  `cmake --build build/dal-198-codi -j4` both exited 0, rebuilding all configured
+  targets. Logs: `../dal-198-tester-perf-{adept,codi}-build.log`.
+- `ctest --test-dir build/dal-198-adept --output-on-failure --parallel 4 -LE benchmark`:
+  exit 0, `100% tests passed, 0 tests failed out of 1584`, 15.69 seconds.
+  `ctest --test-dir build/dal-198-codi --output-on-failure --parallel 4 -LE benchmark`:
+  exit 0, `100% tests passed, 0 tests failed out of 1584`, 16.46 seconds.
+  Logs: `../dal-198-tester-perf-{adept,codi}-full-tests.log`.
+  Both new tests and all preparation-guard cases passed independently in CTest
+  processes on each of the three backends.
+- Caches retain the previous Linux Release/GCC 15.2.0 configuration: native
+  AADET with examples on; separate Adept and CoDiPack directories with examples
+  off; public API and portable Excel tests on in all three. No backend flags,
+  test exclusions or policy were changed. Working/staged whitespace checks pass.
+- All foreground builds and tests completed before notifying the orchestrator
+  that CPU work was finished. This pass ran no timing workload; the reported
+  CTest durations are correctness-run metadata under concurrent workloads and
+  establish no speedup or benchmark acceptance. Paired performance validation,
+  documentation decision, independent review and publication remain separate.
 
 Limits: no local MSVC/Windows XLL, Python binding, XAD backend, sanitizer or
 coverage run was performed. Adept and CoDiPack full configured suites are now

--- a/.codex/artifacts/reviews/dal-198/testing.md
+++ b/.codex/artifacts/reviews/dal-198/testing.md
@@ -1,10 +1,13 @@
 DAL-198 F1 independent tester handoff, 2026-09-12. This record controls the
 pending documentation and reviewer stages; retire it after delivery.
 
-F1 testing passes after the scoped bracket-content repair. Initial implementation
-was `899748dec20034e33a8375697018e8da92565218`; final production revision is
-`23ae973a50335bd32a1d66c311db1e3068242018`, tested with the test changes committed
-alongside this record. The orchestrator records the final delivery/PR SHA.
+F1 testing passes after the bracket-content and reviewer-directed debugger
+repairs. Initial implementation was `899748dec20034e33a8375697018e8da92565218`;
+the bracket repair at `23ae973a50335bd32a1d66c311db1e3068242018` was verified
+with tester changes committed at `cead11e0548d6fbffcb7c44339ccb0e4c505cfbf`.
+Latest independently tested production and test revision is
+`a3a9f9583ee4dcd7fbece0e61b167efa616630c7`. The orchestrator records the final
+delivery/PR SHA.
 
 Running existing tests:
 
@@ -54,7 +57,7 @@ Repairing failures:
   Exit 0, 2/2 passed; `../dal-198-tester-boundary-green.log`. Valid bracket
   punctuation passes while nested brackets, quotes and malformed syntax fail.
 
-Final verification:
+Verification before debugger review:
 
 - `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:IndexParseTest.*:IndexTest.*:ScriptLexerTest.*:ScriptPreprocessorTest.*:ScriptTest.*'`:
   exit 0, 241 tests from 6 suites passed; `../dal-198-tester-focused.log`.
@@ -66,7 +69,7 @@ Final verification:
   `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1` after all source and
   test edits. Exit 0; authoritative summary:
   `100% tests passed, 0 tests failed out of 1586`; CTest time 8.39 seconds.
-  Final log is root `test_output.txt` and `../dal-198-tester-final-full-linux.log`.
+  Preserved log: `../dal-198-tester-final-full-linux.log`.
   The script configured, built all enabled targets, installed, and ran CTest.
 - Active configuration: Linux Release, native AADET AAD, public API enabled,
   portable Excel tests enabled. Benchmarks excluded by the standard workflow.
@@ -74,6 +77,34 @@ Final verification:
   placeholder was introduced. Named execution is rejected before evaluation;
   market preparation/binding and their numerical acceptance belong to later
   stages. `git diff --check` and the scoped staged whitespace check passed.
+
+Independent verification after reviewer P2 debugger repair:
+
+- Read `../dal-198-review.md`, the repair diff at
+  `a3a9f9583ee4dcd7fbece0e61b167efa616630c7`, implementation evidence and
+  existing debugger tests. The repair preserves FIX as a complete tree leaf and
+  rejects legacy product JSON /1 before writing anything. No production edits
+  or additional tests were necessary in this verification pass.
+- `./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='ScriptObservationTest.*:*Debug*'`:
+  exit 0; 29 tests from 2 suites passed. Fresh log:
+  `../dal-198-tester-debug-focused.log`.
+- The new tree regression checks nested expressions, raw index spelling,
+  explicit/omitted fixing dates, EQ/FX and both EQ delivery forms with ASCII
+  and Unicode at narrow/wide widths. Human text output also retains FIX.
+  The JSON regression checks `DebugSchemaUnsupported`, the /1 schema name
+  and zero output bytes for past/future events and dead branches. Existing
+  exact SPOT tree, text and JSON snapshots still pass.
+- Removed root `test_output.txt` before rerunning
+  `NUM_CORES=8 bash ./build_linux.sh > test_output.txt 2>&1` on the repaired
+  revision. Exit 0; fresh authoritative summary:
+  `100% tests passed, 0 tests failed out of 1588`; CTest time 7.70 seconds.
+  Logs: root `test_output.txt` and
+  `../dal-198-tester-debug-full-linux.log`. Configuration remains Linux Release
+  with native AADET AAD, public API and portable Excel tests, benchmarks
+  excluded. This full run includes the two debugger regressions added by the
+  implementer. Whitespace and scoped staged checks passed.
+- No blocker remains from independent testing. Updated documentation and a
+  new independent review of the resulting head are still required.
 
 Limits: no Windows XLL, Python binding, alternate AAD backend, sanitizer or
 coverage run was performed. An attempted extra PastEvaluator_<AAD::Number_>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Only add a heading when a qualifying change ships. Do not create empty future he
 
 ## 2026-09-12
 
+- **Script FIX syntax** — added parsing for unquoted `FIX(index[,date])`,
+  preserving complete EQ/FX names, delivery suffixes, and source context through
+  macro and schedule expansion. **Breaking:** `FIX` is reserved; existing
+  variables or definitions with that name must be renamed. Named execution
+  currently raises `PreparationRequired`; no fixing lookup or named-pricing
+  API is available. See the [syntax and execution limit](docs/methodology/script_engine.md#named-fixing-syntax).
+
 - **Prepared rate-trade pricing** — C++ and Python can retain immutable IRS/OIS/basis
   coupon geometry across PV and AAD node-risk calls while evaluating current
   markets and fixings on every call. Third-party performance comparisons include

--- a/dal-cpp/dal/indice/indexparse.cpp
+++ b/dal-cpp/dal/indice/indexparse.cpp
@@ -23,7 +23,7 @@ namespace Dal {
                 return ParseSuperShot(name);
             const String_ ac = name.substr(0, stop);
             auto pp = TheIndexParsers().find(ac);
-            REQUIRE(pp != TheIndexParsers().end(), "no parser for '" + name + "'");
+            REQUIRE(pp != TheIndexParsers().end(), "UnknownIndex: no parser for '" + name + "'");
             return (*pp->second)(name);
         }
 
@@ -33,7 +33,9 @@ namespace Dal {
     std::unique_ptr<Index_> Index::Parse(const String_& name) {
         if (auto test = ParseComposite(name))
             return test;
-        return ParseSingle(name);
+        auto result = ParseSingle(name);
+        REQUIRE(result != nullptr, "InvalidIndex: no index parsed from '" + name + "'");
+        return result;
     }
 
     std::mutex TheParserMutex;

--- a/dal-cpp/dal/indice/parser/equity.cpp
+++ b/dal-cpp/dal/indice/parser/equity.cpp
@@ -11,33 +11,49 @@
 #include <dal/time/dateutils.hpp>
 
 namespace Dal::Index {
+    namespace {
+        size_t EquityNameEnd(const String_& name) {
+            const auto stop = name.find(']');
+            REQUIRE(name.substr(0, 3) == "EQ[" && stop != String_::npos && stop > 3, "equity index must contain a nonempty EQ[name]");
+            REQUIRE(name.substr(3, stop - 3).find_first_of("[]\"'\r\n") == String_::npos && name.find(']', stop + 1) == String_::npos,
+                    "malformed equity index brackets or name");
+            return stop;
+        }
+
+        void ValidateDeliveryIncrement(const String_& increment) {
+            REQUIRE(!increment.empty() && increment.front() != '&' && increment.back() != '&' && increment.find("&&") == String_::npos,
+                    "equity delivery increment contains an empty component");
+            REQUIRE(!Date::ParseIncrement(increment).IsEmpty(), "invalid equity delivery increment");
+        }
+
+        [[noreturn]] void InvalidEquity(const String_& name, const std::exception& error) {
+            THROW("InvalidIndex: " + name + "; " + String_(error.what()));
+        }
+    } // namespace
+
     std::unique_ptr<Index_> EquityParser(const String_& name) try {
         NOTICE(name);
-        const auto eq_stop = name.find(']');
-        REQUIRE(name.substr(0, 3) == "EQ[" && eq_stop != String_::npos && eq_stop > 3, "InvalidIndex: equity index must contain a nonempty EQ[name]");
+        const auto eq_stop = EquityNameEnd(name);
         const String_ eq_name = name.substr(3, eq_stop - 3);
-        REQUIRE(eq_name.find_first_of("[]\"'\r\n") == String_::npos && name.find(']', eq_stop + 1) == String_::npos,
-                "InvalidIndex: malformed equity index brackets or name");
         const auto tenor_start = eq_stop + 1;
         if (tenor_start == name.size())
             return std::make_unique<Equity_>(eq_name, nullptr, nullptr);
 
         if (name[tenor_start] == '@') {
             auto delivery_date = Date::FromString(name.substr(tenor_start + 1, name.length() - tenor_start - 1));
-            REQUIRE(delivery_date.IsValid(), "InvalidIndex: invalid equity delivery date");
+            REQUIRE(delivery_date.IsValid(), "invalid equity delivery date");
             return std::make_unique<Equity_>(eq_name, &delivery_date, nullptr);
         }
 
         if (name[tenor_start] == '>') {
             String_ delay_increment = name.substr(tenor_start + 1, name.length() - tenor_start - 1);
-            REQUIRE(!delay_increment.empty() && delay_increment.front() != '&' && delay_increment.back() != '&' &&
-                        delay_increment.find("&&") == String_::npos,
-                    "InvalidIndex: equity delivery increment contains an empty component");
-            REQUIRE(!Date::ParseIncrement(delay_increment).IsEmpty(), "InvalidIndex: invalid equity delivery increment");
+            ValidateDeliveryIncrement(delay_increment);
             return std::make_unique<Equity_>(eq_name, nullptr, &delay_increment);
         }
-        THROW("InvalidIndex: unexpected trailing equity index characters");
+        THROW("unexpected trailing equity index characters");
+    } catch (const Exception_& error) {
+        InvalidEquity(name, error);
     } catch (const std::logic_error& error) {
-        THROW("InvalidIndex: " + name + "; " + String_(error.what()));
+        InvalidEquity(name, error);
     }
 } // namespace Dal::Index

--- a/dal-cpp/dal/indice/parser/equity.cpp
+++ b/dal-cpp/dal/indice/parser/equity.cpp
@@ -4,29 +4,40 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
-#include <dal/indice/parser/equity.hpp>
+
 #include <dal/indice/index/equity.hpp>
+#include <dal/indice/parser/equity.hpp>
+#include <dal/time/dateincrement.hpp>
 #include <dal/time/dateutils.hpp>
 
 namespace Dal::Index {
-    std::unique_ptr<Index_> EquityParser(const String_& name) {
-        auto eq_start = name.find_first_of("[");
-        auto eq_stop = name.find_first_of("]");
-
-        String_ eq_name = name.substr(eq_start + 1, eq_stop - eq_start - 1);
-        auto tenor_start = name.find_first_of("@>", eq_stop + 1);
-        if (tenor_start == String_::npos)
+    std::unique_ptr<Index_> EquityParser(const String_& name) try {
+        NOTICE(name);
+        const auto eq_stop = name.find(']');
+        REQUIRE(name.substr(0, 3) == "EQ[" && eq_stop != String_::npos && eq_stop > 3, "InvalidIndex: equity index must contain a nonempty EQ[name]");
+        const String_ eq_name = name.substr(3, eq_stop - 3);
+        REQUIRE(eq_name.find_first_of("[]\"'\r\n") == String_::npos && name.find(']', eq_stop + 1) == String_::npos,
+                "InvalidIndex: malformed equity index brackets or name");
+        const auto tenor_start = eq_stop + 1;
+        if (tenor_start == name.size())
             return std::make_unique<Equity_>(eq_name, nullptr, nullptr);
 
         if (name[tenor_start] == '@') {
             auto delivery_date = Date::FromString(name.substr(tenor_start + 1, name.length() - tenor_start - 1));
+            REQUIRE(delivery_date.IsValid(), "InvalidIndex: invalid equity delivery date");
             return std::make_unique<Equity_>(eq_name, &delivery_date, nullptr);
         }
 
         if (name[tenor_start] == '>') {
             String_ delay_increment = name.substr(tenor_start + 1, name.length() - tenor_start - 1);
+            REQUIRE(!delay_increment.empty() && delay_increment.front() != '&' && delay_increment.back() != '&' &&
+                        delay_increment.find("&&") == String_::npos,
+                    "InvalidIndex: equity delivery increment contains an empty component");
+            REQUIRE(!Date::ParseIncrement(delay_increment).IsEmpty(), "InvalidIndex: invalid equity delivery increment");
             return std::make_unique<Equity_>(eq_name, nullptr, &delay_increment);
         }
-        THROW("index pattern is not good");
+        THROW("InvalidIndex: unexpected trailing equity index characters");
+    } catch (const std::logic_error& error) {
+        THROW("InvalidIndex: " + name + "; " + String_(error.what()));
     }
 } // namespace Dal::Index

--- a/dal-cpp/dal/indice/parser/fx.cpp
+++ b/dal-cpp/dal/indice/parser/fx.cpp
@@ -12,7 +12,10 @@ namespace Dal::Index {
         auto fx_start = name.find_first_of("[");
         auto fx_stop = name.find_first_of("]");
         auto fx_sep = name.find_first_of("/");
-        REQUIRE(fx_start != String_::npos && fx_stop != String_::npos && fx_sep != String_::npos, "fx index pattern is not good");
+        REQUIRE(name.substr(0, 3) == "FX[" && fx_start == 2 && fx_stop != String_::npos && fx_stop + 1 == name.size() && fx_sep != String_::npos &&
+                    fx_sep > fx_start + 1 && fx_sep + 1 < fx_stop && name.find('[', fx_start + 1) == String_::npos &&
+                    name.find('/', fx_sep + 1) == String_::npos,
+                "InvalidIndex: FX requires the complete FX[foreign/domestic] name");
 
         String_ fgn = name.substr(fx_start + 1, fx_sep - fx_start - 1);
         String_ dom = name.substr(fx_sep + 1, fx_stop - fx_sep - 1);

--- a/dal-cpp/dal/script/event.cpp
+++ b/dal-cpp/dal/script/event.cpp
@@ -194,6 +194,8 @@ namespace Dal::Script {
     }
 
     void ScriptProduct_::DebugJson(std::ostream& ost) const {
+        REQUIRE2(preparationError_.empty(),
+                 "DebugSchemaUnsupported: dal.script-product/1 does not support FIX; use DebugTree to inspect the contract", ScriptError_);
         ost << "{\"schema\":\"dal.script-product/1\"";
         if (!variables_.empty()) {
             ost << ",\"variables\":[";

--- a/dal-cpp/dal/script/event.cpp
+++ b/dal-cpp/dal/script/event.cpp
@@ -22,11 +22,7 @@ namespace Dal::Script {
         for (const auto &processedEvent: preprocessed.events_) {
             auto event = parser.Parse(processedEvent.second, preprocessed.sources_.at(processedEvent.first));
             if (preparationError_.empty())
-                for (const auto& statement : event)
-                    if (const auto* fix = FindUnpreparedFixing(*statement)) {
-                        preparationError_ = fix->PreparationError();
-                        break;
-                    }
+                preparationError_ = parser.PreparationError();
             if (processedEvent.first >= eval_data) {
                 eventDates_.push_back(processedEvent.first);
                 events_.push_back(std::move(event));
@@ -115,7 +111,7 @@ namespace Dal::Script {
         return maxNestedIfs;
     }
 
-    void ScriptProduct_::RequirePreparedFixings() const { REQUIRE2(preparationError_.empty(), preparationError_, ScriptError_); }
+    void ScriptProduct_::ThrowPreparationError() const { THROW2(preparationError_, ScriptError_); }
 
     namespace {
         //  A fresh debugger per statement: the IR of previous statements would

--- a/dal-cpp/dal/script/event.cpp
+++ b/dal-cpp/dal/script/event.cpp
@@ -20,12 +20,19 @@ namespace Dal::Script {
         Parser_ parser(preprocessed.constVariables_);
         const auto eval_data = Global::Dates_::EvaluationDate();
         for (const auto &processedEvent: preprocessed.events_) {
+            auto event = parser.Parse(processedEvent.second, preprocessed.sources_.at(processedEvent.first));
+            if (preparationError_.empty())
+                for (const auto& statement : event)
+                    if (const auto* fix = FindUnpreparedFixing(*statement)) {
+                        preparationError_ = fix->PreparationError();
+                        break;
+                    }
             if (processedEvent.first >= eval_data) {
                 eventDates_.push_back(processedEvent.first);
-                events_.push_back(parser.Parse(processedEvent.second));
+                events_.push_back(std::move(event));
             } else {
                 pastEventDates_.push_back(processedEvent.first);
-                pastEvents_.push_back(parser.Parse(processedEvent.second));
+                pastEvents_.push_back(std::move(event));
             }
         }
     }
@@ -47,6 +54,7 @@ namespace Dal::Script {
     }
 
     Vector_<> ScriptProduct_::PastEvaluate() const {
+        RequirePreparedFixings();
         PastEvaluator_<double> pastEvaluator(Vector_<double>(variables_.size(), 0.0), consVariablesValues_);
         Visit(pastEvaluator, true, false);
         return pastEvaluator.Variables();
@@ -77,6 +85,7 @@ namespace Dal::Script {
     }
 
     size_t ScriptProduct_::PreProcess(bool fuzzy, bool skip_domain) {
+        RequirePreparedFixings();
         IndexVariables();
         variableValues_ = PastEvaluate();
 
@@ -105,6 +114,8 @@ namespace Dal::Script {
 
         return maxNestedIfs;
     }
+
+    void ScriptProduct_::RequirePreparedFixings() const { REQUIRE2(preparationError_.empty(), preparationError_, ScriptError_); }
 
     namespace {
         //  A fresh debugger per statement: the IR of previous statements would
@@ -244,6 +255,7 @@ namespace Dal::Script {
     }
 
     ScriptCompiled_ ScriptProduct_::Compile(bool fuzzy) const {
+        RequirePreparedFixings();
         REQUIRE2(preProcessed_, "product is not pre-processed: call PreProcess() before Compile()", ScriptError_);
 
         Vector_<Vector_<int>> nodeStreams;

--- a/dal-cpp/dal/script/event.hpp
+++ b/dal-cpp/dal/script/event.hpp
@@ -70,6 +70,8 @@ namespace Dal::Script {
 
         //  Set by PreProcess().
         bool preProcessed_ = false;
+        String_ preparationError_;
+        void RequirePreparedFixings() const;
 
     public:
         ScriptProduct_(const Vector_<Cell_>& dates, const Vector_<String_>& events, String_ payoff = "")
@@ -139,6 +141,7 @@ namespace Dal::Script {
         }
 
         template <class T_, class E_> void Evaluate(const Scenario_<T_>& scenario, E_& eval) const {
+            RequirePreparedFixings();
             eval.SetScenario(&scenario);
             eval.Init();
             for (size_t i = 0; i < events_.size(); ++i) {

--- a/dal-cpp/dal/script/event.hpp
+++ b/dal-cpp/dal/script/event.hpp
@@ -71,7 +71,11 @@ namespace Dal::Script {
         //  Set by PreProcess().
         bool preProcessed_ = false;
         String_ preparationError_;
-        void RequirePreparedFixings() const;
+        [[noreturn]] void ThrowPreparationError() const;
+        void RequirePreparedFixings() const {
+            if (!preparationError_.empty())
+                ThrowPreparationError();
+        }
 
     public:
         ScriptProduct_(const Vector_<Cell_>& dates, const Vector_<String_>& events, String_ payoff = "")

--- a/dal-cpp/dal/script/lexer.cpp
+++ b/dal-cpp/dal/script/lexer.cpp
@@ -32,7 +32,7 @@ namespace Dal::Script {
             const auto context = [&] { return "; " + source.Describe() + "; input=" + str.substr(start); };
             ++cur;
             while (cur < str.size() && str[cur] != ']') {
-                REQUIRE2(str[cur] != '[' && str[cur] != '\'' && str[cur] != '"' && str[cur] != '(' && str[cur] != ')',
+                REQUIRE2(str[cur] != '[' && str[cur] != '\'' && str[cur] != '"',
                          "InvalidIndex: malformed index literal" + context(), ScriptError_);
                 ++cur;
             }

--- a/dal-cpp/dal/script/lexer.cpp
+++ b/dal-cpp/dal/script/lexer.cpp
@@ -87,6 +87,8 @@ namespace Dal::Script {
     }
 
     Vector_<std::pair<size_t, size_t>> IndexLiteralRanges(const String_& str) {
+        if (str.find('[') == String_::npos)
+            return {};
         Vector_<std::pair<size_t, size_t>> result;
         SourceLocation_ source;
         for (size_t pos = 0; pos < str.size();) {

--- a/dal-cpp/dal/script/lexer.cpp
+++ b/dal-cpp/dal/script/lexer.cpp
@@ -2,17 +2,122 @@
 // Created by wegam on 2026/5/30.
 //
 
+#include <cctype>
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
 #include <dal/script/lexer.hpp>
-#include <regex>
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal::Script {
+    namespace {
+        bool IsWord(char c) { return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '.'; }
+        bool IsSpace(char c) { return std::isspace(static_cast<unsigned char>(c)); }
+
+        void AdvanceSource(const String_& str, size_t offset, SourceLocation_* source) {
+            while (source->offset_ < offset) {
+                if (str[source->offset_++] == '\n') {
+                    ++source->line_;
+                    source->column_ = 1;
+                } else
+                    ++source->column_;
+            }
+        }
+
+        size_t IndexLiteralEnd(const String_& str, size_t start, const SourceLocation_& source) {
+            size_t cur = start;
+            while (cur < str.size() && IsWord(str[cur]))
+                ++cur;
+            if (cur == start || cur == str.size() || str[cur] != '[')
+                return start;
+            const auto context = [&] { return "; " + source.Describe() + "; input=" + str.substr(start); };
+            ++cur;
+            while (cur < str.size() && str[cur] != ']') {
+                REQUIRE2(str[cur] != '[' && str[cur] != '\'' && str[cur] != '"' && str[cur] != '(' && str[cur] != ')',
+                         "InvalidIndex: malformed index literal" + context(), ScriptError_);
+                ++cur;
+            }
+            REQUIRE2(cur != str.size(), "InvalidIndex: missing closing ']'" + context(), ScriptError_);
+            ++cur;
+            while (cur < str.size() && str[cur] != ',' && str[cur] != ')') {
+                REQUIRE2(str[cur] != '[' && str[cur] != ']' && str[cur] != '\'' && str[cur] != '"',
+                         "InvalidIndex: malformed index suffix" + context(), ScriptError_);
+                ++cur;
+            }
+            while (cur > start && IsSpace(str[cur - 1]))
+                --cur;
+            return cur;
+        }
+    } // namespace
+
+    String_ SourceLocation_::Describe() const {
+        String_ result("line=" + std::to_string(line_) + ", column=" + std::to_string(column_) + ", offset=" + std::to_string(offset_));
+        if (row_)
+            result += String_(", row=" + std::to_string(row_));
+        if (eventDate_)
+            result += ", event=" + Date::ToString(*eventDate_);
+        return result;
+    }
+
+    Vector_<std::pair<size_t, size_t>> IndexLiteralRanges(const String_& str) {
+        Vector_<std::pair<size_t, size_t>> result;
+        SourceLocation_ source;
+        for (size_t pos = 0; pos < str.size();) {
+            AdvanceSource(str, pos, &source);
+            const auto end = IndexLiteralEnd(str, pos, source);
+            if (end != pos) {
+                result.emplace_back(pos, end);
+                pos = end;
+            } else if (IsWord(str[pos])) {
+                do {
+                    ++pos;
+                } while (pos < str.size() && IsWord(str[pos]));
+            } else
+                ++pos;
+        }
+        return result;
+    }
+
+    Vector_<Token_> Lex(const String_& str, const Vector_<SourceOrigin_>& origins) {
+        Vector_<Token_> result;
+        SourceLocation_ source;
+        size_t origin = 0;
+        for (size_t pos = 0; pos < str.size();) {
+            if (IsSpace(str[pos])) {
+                ++pos;
+                continue;
+            }
+            AdvanceSource(str, pos, &source);
+            while (origin < origins.size() && origins[origin].offset_ <= pos) {
+                source.row_ = origins[origin].row_;
+                source.eventDate_ = origins[origin].eventDate_;
+                ++origin;
+            }
+            const auto literalEnd = IndexLiteralEnd(str, pos, source);
+            if (literalEnd != pos) {
+                result.push_back({source, IndexLiteral_{str.substr(pos, literalEnd - pos)}});
+                pos = literalEnd;
+                continue;
+            }
+            size_t end = pos + 1;
+            if (IsWord(str[pos])) {
+                while (end < str.size() && IsWord(str[end]))
+                    ++end;
+            } else if ((str[pos] == '!' || str[pos] == '<' || str[pos] == '>') && end < str.size() && str[end] == '=') {
+                ++end;
+            } else {
+                REQUIRE2(String_("/-,;:()+*^<>=").find(str[pos]) != String_::npos,
+                         "InvalidIndex: unexpected character '" + String_(1, str[pos]) + "'; " + source.Describe(), ScriptError_);
+            }
+            result.push_back({source, String_(str.substr(pos, end - pos))});
+            pos = end;
+        }
+        return result;
+    }
+
     Vector_<String_> Tokenize(const String_& str) {
-        static const std::regex r(R"([\w.]+|[/-]|,|;|:|[\(\)\+\*\^]|!=|>=|<=|[<>=])");
-        Vector_<String_> v;
-        for (std::regex_iterator<String_::const_iterator> it(str.begin(), str.end(), r), end; it != end; ++it)
-            v.push_back(String_((*it)[0]));
-        return v;
+        Vector_<String_> result;
+        for (const auto& token : Lex(str))
+            result.push_back(token.Text());
+        return result;
     }
 } // namespace Dal::Script

--- a/dal-cpp/dal/script/lexer.cpp
+++ b/dal-cpp/dal/script/lexer.cpp
@@ -10,8 +10,14 @@
 
 namespace Dal::Script {
     namespace {
-        bool IsWord(char c) { return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '.'; }
-        bool IsSpace(char c) { return std::isspace(static_cast<unsigned char>(c)); }
+        bool IsWord(char c) { return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_' || c == '.'; }
+        bool IsSpace(char c) { return std::isspace(static_cast<unsigned char>(c)) != 0; }
+
+        size_t WordEnd(const String_& str, size_t start) {
+            while (start < str.size() && IsWord(str[start]))
+                ++start;
+            return start;
+        }
 
         void AdvanceSource(const String_& str, size_t offset, SourceLocation_* source) {
             while (source->offset_ < offset) {
@@ -23,29 +29,51 @@ namespace Dal::Script {
             }
         }
 
+        String_ IndexContext(const String_& str, const SourceLocation_& source) {
+            return "; " + source.Describe() + "; input=" + str.substr(source.offset_);
+        }
+
+        size_t IndexBodyEnd(const String_& str, size_t start, const SourceLocation_& source) {
+            const auto close = str.find(']', start);
+            REQUIRE2(close != String_::npos, "InvalidIndex: missing closing ']'" + IndexContext(str, source), ScriptError_);
+            REQUIRE2(str.find_first_of("[\"'", start) >= close, "InvalidIndex: malformed index literal" + IndexContext(str, source), ScriptError_);
+            return close + 1;
+        }
+
+        size_t IndexSuffixEnd(const String_& str, size_t start, const SourceLocation_& source) {
+            auto end = str.find_first_of(",)", start);
+            if (end == String_::npos)
+                end = str.size();
+            REQUIRE2(str.find_first_of("[]\"'", start) >= end, "InvalidIndex: malformed index suffix" + IndexContext(str, source), ScriptError_);
+            while (end > start && IsSpace(str[end - 1]))
+                --end;
+            return end;
+        }
+
         size_t IndexLiteralEnd(const String_& str, size_t start, const SourceLocation_& source) {
-            size_t cur = start;
-            while (cur < str.size() && IsWord(str[cur]))
-                ++cur;
-            if (cur == start || cur == str.size() || str[cur] != '[')
+            const auto open = WordEnd(str, start);
+            if (open == start || open == str.size() || str[open] != '[')
                 return start;
-            const auto context = [&] { return "; " + source.Describe() + "; input=" + str.substr(start); };
-            ++cur;
-            while (cur < str.size() && str[cur] != ']') {
-                REQUIRE2(str[cur] != '[' && str[cur] != '\'' && str[cur] != '"',
-                         "InvalidIndex: malformed index literal" + context(), ScriptError_);
-                ++cur;
+            return IndexSuffixEnd(str, IndexBodyEnd(str, open + 1, source), source);
+        }
+
+        void ApplyOrigins(const Vector_<SourceOrigin_>& origins, size_t pos, size_t* origin, SourceLocation_* source) {
+            while (*origin < origins.size() && origins[*origin].offset_ <= pos) {
+                source->row_ = origins[*origin].row_;
+                source->eventDate_ = origins[*origin].eventDate_;
+                ++*origin;
             }
-            REQUIRE2(cur != str.size(), "InvalidIndex: missing closing ']'" + context(), ScriptError_);
-            ++cur;
-            while (cur < str.size() && str[cur] != ',' && str[cur] != ')') {
-                REQUIRE2(str[cur] != '[' && str[cur] != ']' && str[cur] != '\'' && str[cur] != '"',
-                         "InvalidIndex: malformed index suffix" + context(), ScriptError_);
-                ++cur;
-            }
-            while (cur > start && IsSpace(str[cur - 1]))
-                --cur;
-            return cur;
+        }
+
+        size_t ScriptTokenEnd(const String_& str, size_t pos, const SourceLocation_& source) {
+            if (IsWord(str[pos]))
+                return WordEnd(str, pos);
+            const size_t end = pos + 1;
+            if (String_("!<>").find(str[pos]) != String_::npos && end < str.size() && str[end] == '=')
+                return end + 1;
+            REQUIRE2(String_("/-,;:()+*^<>=").find(str[pos]) != String_::npos,
+                     "InvalidIndex: unexpected character '" + String_(1, str[pos]) + "'; " + source.Describe(), ScriptError_);
+            return end;
         }
     } // namespace
 
@@ -87,27 +115,14 @@ namespace Dal::Script {
                 continue;
             }
             AdvanceSource(str, pos, &source);
-            while (origin < origins.size() && origins[origin].offset_ <= pos) {
-                source.row_ = origins[origin].row_;
-                source.eventDate_ = origins[origin].eventDate_;
-                ++origin;
-            }
+            ApplyOrigins(origins, pos, &origin, &source);
             const auto literalEnd = IndexLiteralEnd(str, pos, source);
             if (literalEnd != pos) {
                 result.push_back({source, IndexLiteral_{str.substr(pos, literalEnd - pos)}});
                 pos = literalEnd;
                 continue;
             }
-            size_t end = pos + 1;
-            if (IsWord(str[pos])) {
-                while (end < str.size() && IsWord(str[end]))
-                    ++end;
-            } else if ((str[pos] == '!' || str[pos] == '<' || str[pos] == '>') && end < str.size() && str[end] == '=') {
-                ++end;
-            } else {
-                REQUIRE2(String_("/-,;:()+*^<>=").find(str[pos]) != String_::npos,
-                         "InvalidIndex: unexpected character '" + String_(1, str[pos]) + "'; " + source.Describe(), ScriptError_);
-            }
+            const auto end = ScriptTokenEnd(str, pos, source);
             result.push_back({source, String_(str.substr(pos, end - pos))});
             pos = end;
         }

--- a/dal-cpp/dal/script/lexer.hpp
+++ b/dal-cpp/dal/script/lexer.hpp
@@ -4,10 +4,47 @@
 
 #pragma once
 
+#include <optional>
+#include <variant>
+
 #include <dal/math/vectors.hpp>
 #include <dal/string/strings.hpp>
+#include <dal/time/date.hpp>
 
 namespace Dal::Script {
+    struct SourceLocation_ {
+        size_t offset_ = 0;
+        size_t line_ = 1;
+        size_t column_ = 1;
+        size_t row_ = 0;
+        std::optional<Date_> eventDate_;
+
+        [[nodiscard]] String_ Describe() const;
+    };
+
+    struct SourceOrigin_ {
+        size_t offset_;
+        size_t row_;
+        Date_ eventDate_;
+    };
+
+    struct IndexLiteral_ {
+        String_ raw_;
+    };
+
+    struct Token_ {
+        SourceLocation_ source_;
+        std::variant<String_, IndexLiteral_> value_;
+
+        [[nodiscard]] const String_& Text() const {
+            if (const auto* literal = std::get_if<IndexLiteral_>(&value_))
+                return literal->raw_;
+            return std::get<String_>(value_);
+        }
+    };
+
+    Vector_<Token_> Lex(const String_& str, const Vector_<SourceOrigin_>& origins = {});
+    Vector_<std::pair<size_t, size_t>> IndexLiteralRanges(const String_& str);
     // Shared tokenizer for the preprocessor and parser; see docs/methodology/script_engine.md §"Lexer".
     Vector_<String_> Tokenize(const String_& str);
 } // namespace Dal::Script

--- a/dal-cpp/dal/script/node.hpp
+++ b/dal-cpp/dal/script/node.hpp
@@ -12,6 +12,7 @@
 #include <dal/script/nodebase.hpp>
 #include <dal/string/strings.hpp>
 #include <dal/time/date.hpp>
+#include <dal/utilities/exceptions.hpp>
 
 namespace Dal {
     class Index_;

--- a/dal-cpp/dal/script/node.hpp
+++ b/dal-cpp/dal/script/node.hpp
@@ -5,10 +5,17 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <variant>
+
+#include <dal/script/lexer.hpp>
 #include <dal/script/nodebase.hpp>
 #include <dal/string/strings.hpp>
+#include <dal/time/date.hpp>
 
+namespace Dal {
+    class Index_;
+} // namespace Dal
 
 namespace Dal::Script {
     struct ExprNode_ : public Node_ {
@@ -69,6 +76,31 @@ namespace Dal::Script {
 
     //	Market access
     struct NodeSpot_ : public Visitable_<ExprNode_, NodeSpot_, VISITORS> {};
+
+    struct NodeFix_ : public Visitable_<ExprNode_, NodeFix_, VISITORS> {
+        IndexLiteral_ literal_;
+        Handle_<Index_> index_;
+        std::optional<Date_> fixingDate_;
+        SourceLocation_ source_;
+
+        NodeFix_(IndexLiteral_ literal, Handle_<Index_> index, std::optional<Date_> fixingDate, SourceLocation_ source)
+            : literal_(std::move(literal)), index_(std::move(index)), fixingDate_(fixingDate), source_(source) {}
+
+        [[nodiscard]] String_ PreparationError() const {
+            return "PreparationRequired: FIX requires a prepared observation; index=" + literal_.raw_ + "; " + source_.Describe();
+        }
+
+        [[noreturn]] void RequirePreparation() const { THROW2(PreparationError(), ScriptError_); }
+    };
+
+    inline const NodeFix_* FindUnpreparedFixing(const Node_& node) {
+        if (const auto* fix = dynamic_cast<const NodeFix_*>(&node))
+            return fix;
+        for (const auto& argument : node.arguments_)
+            if (const auto* fix = FindUnpreparedFixing(*argument))
+                return fix;
+        return nullptr;
+    }
 
     //  Const
     struct NodeConst_ : public Visitable_<ExprNode_, NodeConst_, VISITORS> {

--- a/dal-cpp/dal/script/parser.cpp
+++ b/dal-cpp/dal/script/parser.cpp
@@ -322,30 +322,35 @@ namespace Dal::Script {
         std::optional<Date_> fixingDate;
         if (cur != end && cur->Text() == ",") {
             ++cur;
-            const auto dateSource = cur == end ? source : cur->source_;
-            String_ date;
-            size_t nextOffset = dateSource.offset_;
-            bool contiguous = true;
-            while (cur != end && cur->Text() != ")") {
-                contiguous = contiguous && cur->source_.offset_ == nextOffset;
-                date += cur->Text();
-                nextOffset = cur->source_.offset_ + cur->Text().size();
-                ++cur;
-            }
-            static const std::regex ISO_DATE("[0-9]{4}-[0-9]{2}-[0-9]{2}");
-            REQUIRE2(contiguous && std::regex_match(date, ISO_DATE),
-                     "InvalidFixingDate: FIX requires a strict YYYY-MM-DD date literal; input=" + date + "; " + dateSource.Describe(), ScriptError_);
-            try {
-                fixingDate = Date::FromString(date);
-                REQUIRE(fixingDate->IsValid(), "date is outside the supported range");
-            } catch (const Exception_& error) {
-                THROW2("InvalidFixingDate: " + date + "; " + dateSource.Describe() + "; " + String_(error.what()), ScriptError_);
-            }
+            fixingDate = ParseFixingDate(cur, end, source);
         }
         REQUIRE2(cur != end && cur->Text() == ")", "InvalidIndex: FIX requires one index and an optional date; " + functionSource.Describe(),
                  ScriptError_);
         ++cur;
         return MakeNode<NodeFix_>(literal, index, fixingDate, source);
+    }
+
+    Date_ Parser_::ParseFixingDate(TokIt_& cur, const TokIt_& end, const SourceLocation_& fallback) {
+        const auto dateSource = cur == end ? fallback : cur->source_;
+        String_ date;
+        size_t nextOffset = dateSource.offset_;
+        bool contiguous = true;
+        while (cur != end && cur->Text() != ")") {
+            contiguous = contiguous && cur->source_.offset_ == nextOffset;
+            date += cur->Text();
+            nextOffset = cur->source_.offset_ + cur->Text().size();
+            ++cur;
+        }
+        static const std::regex ISO_DATE("[0-9]{4}-[0-9]{2}-[0-9]{2}");
+        REQUIRE2(contiguous && std::regex_match(date, ISO_DATE),
+                 "InvalidFixingDate: FIX requires a strict YYYY-MM-DD date literal; input=" + date + "; " + dateSource.Describe(), ScriptError_);
+        try {
+            const auto fixingDate = Date::FromString(date);
+            REQUIRE(fixingDate.IsValid(), "date is outside the supported range");
+            return fixingDate;
+        } catch (const Exception_& error) {
+            THROW2("InvalidFixingDate: " + date + "; " + dateSource.Describe() + "; " + String_(error.what()), ScriptError_);
+        }
     }
 
     Vector_<Expression_> Parser_::ParseFuncArg(TokIt_& cur, const TokIt_& end) {

--- a/dal-cpp/dal/script/parser.cpp
+++ b/dal-cpp/dal/script/parser.cpp
@@ -4,24 +4,25 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/platform/strict.hpp>
-#include <dal/script/parser.hpp>
+
+#include <dal/indice/index.hpp>
+#include <dal/indice/indexparse.hpp>
 #include <dal/script/node.hpp>
+#include <dal/script/parser.hpp>
 #include <dal/script/visitor/all.hpp>
-#include <dal/time/daybasis.hpp>
 #include <dal/time/dateutils.hpp>
+#include <dal/time/daybasis.hpp>
 
 namespace {
-    const std::set<Dal::String_> RESERVED_KEY_WORDS = {
-            "IF", "END", "THEN", "ELSE", "DCF", "PAYS", "AND", "OR", "SPOT", "MAX", "MIN",
-            "LOG", "SQRT", "EXP"
-    };
+    const std::set<Dal::String_> RESERVED_KEY_WORDS = {"IF",   "END", "THEN", "ELSE", "DCF",  "PAYS", "AND", "OR",
+                                                       "SPOT", "MAX", "MIN",  "LOG",  "SQRT", "EXP",  "FIX"};
 } // namespace
 
 namespace Dal::Script {
     Expression_ Parser_::ParseExpr(TokIt_& cur, const TokIt_& end) {
         auto lhs = ParseExprL2(cur, end);
-        while (cur != end && ((*cur)[0] == '+' || (*cur)[0] == '-')) {
-            char op = (*cur)[0];
+        while (cur != end && (cur->Text()[0] == '+' || cur->Text()[0] == '-')) {
+            char op = cur->Text()[0];
             ++cur;
             REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
             auto rhs = ParseExprL2(cur, end);
@@ -32,8 +33,8 @@ namespace Dal::Script {
 
     Expression_ Parser_::ParseExprL2(TokIt_& cur, const TokIt_& end) {
         auto lhs = ParseExprL3(cur, end);
-        while (cur != end && ((*cur)[0] == '*' || (*cur)[0] == '/')) {
-            char op = (*cur)[0];
+        while (cur != end && (cur->Text()[0] == '*' || cur->Text()[0] == '/')) {
+            char op = cur->Text()[0];
             ++cur;
             REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
             auto rhs = ParseExprL3(cur, end);
@@ -44,7 +45,7 @@ namespace Dal::Script {
 
     Expression_ Parser_::ParseExprL3(TokIt_& cur, const TokIt_& end) {
         auto lhs = ParseExprL4(cur, end);
-        while (cur != end && (*cur)[0] == '^') {
+        while (cur != end && cur->Text()[0] == '^') {
             ++cur;
             REQUIRE(cur != end, "unexpected end of statement");
             auto rhs = ParseExprL4(cur, end);
@@ -54,8 +55,8 @@ namespace Dal::Script {
     }
 
     Expression_ Parser_::ParseExprL4(TokIt_& cur, const TokIt_& end) {
-        if (cur != end && ((*cur)[0] == '+' || (*cur)[0] == '-')) {
-            char op = (*cur)[0];
+        if (cur != end && (cur->Text()[0] == '+' || cur->Text()[0] == '-')) {
+            char op = cur->Text()[0];
             ++cur;
             REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
             auto rhs = ParseExprL4(cur, end);
@@ -68,40 +69,43 @@ namespace Dal::Script {
     }
 
     Expression_ Parser_::ParseVarConstFunc(TokIt_& cur, const TokIt_& end) {
-        if ((*cur)[0] == '.' || ((*cur)[0] >= '0' && (*cur)[0] <= '9'))
+        REQUIRE2(cur != end, "unexpected end of expression", ScriptError_);
+        if (cur->Text() == "FIX")
+            return ParseFix(cur, end);
+        if (cur->Text()[0] == '.' || (cur->Text()[0] >= '0' && cur->Text()[0] <= '9'))
             return ParseConst(cur);
 
         Expression_ top;
         bool empty = true;
         unsigned minArg, maxArg;
-        if(*cur == "SPOT") {
+        if (cur->Text() == "SPOT") {
             top = MakeBaseNode<NodeSpot_>();
             minArg = maxArg = 0;
-        } else if (*cur == "LOG") {
+        } else if (cur->Text() == "LOG") {
             top = MakeBaseNode<NodeLog_>();
             minArg = maxArg = 1;
-        } else if (*cur == "SQRT") {
+        } else if (cur->Text() == "SQRT") {
             top = MakeBaseNode<NodeSqrt_>();
             minArg = maxArg = 1;
-        } else if(*cur == "EXP") {
+        } else if (cur->Text() == "EXP") {
             top = MakeBaseNode<NodeExp_>();
             minArg = maxArg = 1;
-        } else if (*cur == "MIN") {
+        } else if (cur->Text() == "MIN") {
             top = MakeBaseNode<NodeMin_>();
             minArg = 2;
             maxArg = 1000;
-        } else if (*cur == "MAX") {
+        } else if (cur->Text() == "MAX") {
             top = MakeBaseNode<NodeMax_>();
             minArg = 2;
             maxArg = 1000;
-        } else if(*cur == "DCF") {
+        } else if (cur->Text() == "DCF") {
             top = MakeBaseNode<NodeConst_>(0.0);
             minArg = 3;
             maxArg = 3;
         }
 
         if (top) {
-            String_ func = *cur;
+            String_ func = cur->Text();
             ++cur;
 
             if (func == "DCF") {
@@ -122,22 +126,25 @@ namespace Dal::Script {
     }
 
     Expression_ Parser_::ParseConst(TokIt_& cur) {
-        double v = String::ToDouble(*cur);
+        double v = String::ToDouble(cur->Text());
         auto top = MakeNode<NodeConst_>(v);
         ++cur;
         return std::move(top);
     }
 
     Expression_ Parser_::ParseVar(TokIt_& cur) {
-        REQUIRE2((*cur)[0] >= 'A' && (*cur)[0] <= 'z', String_("Variable name ") + *cur + " is invalid", ScriptError_);
-        REQUIRE2(RESERVED_KEY_WORDS.find(*cur) == RESERVED_KEY_WORDS.end(),
-                 String_("Variable name ") + *cur + " is conflicted with an existing key word", ScriptError_);
-        String_ name(*cur);
+        REQUIRE2(cur->Text() != "FIX", "ReservedIdentifier: FIX is a function; rename the variable; " + cur->source_.Describe(), ScriptError_);
+        REQUIRE2(!std::holds_alternative<IndexLiteral_>(cur->value_),
+                 "InvalidIndex: index literal is only allowed inside FIX; " + cur->source_.Describe(), ScriptError_);
+        REQUIRE2(cur->Text()[0] >= 'A' && cur->Text()[0] <= 'z', String_("Variable name ") + cur->Text() + " is invalid", ScriptError_);
+        REQUIRE2(RESERVED_KEY_WORDS.find(cur->Text()) == RESERVED_KEY_WORDS.end(),
+                 String_("Variable name ") + cur->Text() + " is conflicted with an existing key word", ScriptError_);
+        String_ name(cur->Text());
         Expression_ top;
         if (constVariables_.find(name) == constVariables_.end())
-            top = MakeNode<NodeVar_>(String_(*cur));
+            top = MakeNode<NodeVar_>(String_(cur->Text()));
         else
-            top = MakeNode<NodeConstVar_>(String_(*cur), constVariables_[name]);
+            top = MakeNode<NodeConstVar_>(String_(cur->Text()), constVariables_[name]);
         ++cur;
         return std::move(top);
     }
@@ -146,19 +153,19 @@ namespace Dal::Script {
         ++cur;
         REQUIRE2(cur != end, "`if` is not followed by `then`", ScriptError_);
         auto cond = ParseCond(cur, end);
-        if (cur == end || *cur != "then")
+        if (cur == end || cur->Text() != "then")
             THROW2("`if` is not followed by `then`", ScriptError_);
         ++cur;
         Vector_<Statement_> stats;
-        while (cur != end && *cur != "ELSE" && *cur != "END")
+        while (cur != end && cur->Text() != "ELSE" && cur->Text() != "END")
             stats.push_back(ParseStatement(cur, end));
 
         REQUIRE2(cur != end, "`if/then` is not followed by `else` or `end`", ScriptError_);
         Vector_<Statement_> elseStats;
         int elseIdx = -1;
-        while (*cur == "ELSE") {
+        while (cur->Text() == "ELSE") {
             ++cur;
-            while (cur != end && *cur != "END")
+            while (cur != end && cur->Text() != "END")
                 elseStats.push_back(ParseStatement(cur, end));
             REQUIRE2(cur != end, "`if/then/else` is not followed by `end`", ScriptError_);
             elseIdx = static_cast<int>(stats.size()) + 1;
@@ -193,7 +200,7 @@ namespace Dal::Script {
 
     Expression_ Parser_::ParseCond(TokIt_& cur, const TokIt_& end) {
         auto lhs = ParseCondL2(cur, end);
-        while (cur != end && *cur == "OR") {
+        while (cur != end && cur->Text() == "OR") {
             ++cur;
             REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
             auto rhs = ParseCondL2(cur, end);
@@ -204,7 +211,7 @@ namespace Dal::Script {
 
     Expression_ Parser_::ParseCondL2(TokIt_& cur, const TokIt_& end) {
         auto lhs = ParseParentheses<&Parser_::ParseCond, &Parser_::ParseCondElem>(cur, end);
-        while (cur != end && *cur == "AND") {
+        while (cur != end && cur->Text() == "AND") {
             ++cur;
             REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
             auto rhs = ParseParentheses<&Parser_::ParseCond, &Parser_::ParseCondElem>(cur, end);
@@ -216,7 +223,7 @@ namespace Dal::Script {
     Expression_ Parser_::ParseCondElem(TokIt_& cur, const TokIt_& end) {
         auto lhs = ParseExpr(cur, end);
         REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
-        String_ comparator = *cur;
+        String_ comparator = cur->Text();
         ++cur;
         REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
         auto rhs = ParseExpr(cur, end);
@@ -243,48 +250,48 @@ namespace Dal::Script {
 
     void Parser_::ParseCondOptionals(TokIt_& cur, const TokIt_& end, double& eps) {
         eps = -1.0;
-        while (cur != end && (*cur == ";" || *cur == ":")) {
-            const char c = (*cur)[0];
+        while (cur != end && (cur->Text() == ";" || cur->Text() == ":")) {
+            const char c = cur->Text()[0];
             ++cur;
             REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
-            eps = String::ToDouble(*cur);
+            eps = String::ToDouble(cur->Text());
             ++cur;
         }
     }
 
     double Parser_::ParseDCF(TokIt_& cur, const TokIt_& end) {
         // TODO: we assume `DCF` function won't contain another nested function
-        REQUIRE2(cur != end && (*cur)[0] == '(', "missing opening '(' after `DCF`", ScriptError_);
+        REQUIRE2(cur != end && cur->Text()[0] == '(', "missing opening '(' after `DCF`", ScriptError_);
         auto closeIt = FindMatch<'(', ')'>(cur, end);
         ++cur;
 
         // Parse basis and dates between parentheses
         REQUIRE2(cur != closeIt, "missing `basis` for `DCF`", ScriptError_);
         String_ day_basis = "";
-        while (cur != closeIt && (*cur)[0] != ',') {
-            day_basis += *cur;
+        while (cur != closeIt && cur->Text()[0] != ',') {
+            day_basis += cur->Text();
             ++cur;
         }
         REQUIRE2(cur != closeIt, "missing `start` for `DCF`", ScriptError_);
         ++cur;
-        while (cur != closeIt && (*cur)[0] == ',')
+        while (cur != closeIt && cur->Text()[0] == ',')
             ++cur;
         REQUIRE2(cur != closeIt, "missing `start` for `DCF`", ScriptError_);
 
         String_ start_date = "";
-        while (cur != closeIt && (*cur)[0] != ',') {
-            start_date += *cur;
+        while (cur != closeIt && cur->Text()[0] != ',') {
+            start_date += cur->Text();
             ++cur;
         }
         REQUIRE2(cur != closeIt, "missing `end` for `DCF`", ScriptError_);
         ++cur;
-        while (cur != closeIt && (*cur)[0] == ',')
+        while (cur != closeIt && cur->Text()[0] == ',')
             ++cur;
         REQUIRE2(cur != closeIt, "missing `end` for `DCF`", ScriptError_);
 
         String_ end_date = "";
-        while (cur != closeIt && (*cur)[0] != ',') {
-            end_date += *cur;
+        while (cur != closeIt && cur->Text()[0] != ',') {
+            end_date += cur->Text();
             ++cur;
         }
         REQUIRE2(cur == closeIt, "too many arguments for `DCF`", ScriptError_);
@@ -294,8 +301,55 @@ namespace Dal::Script {
         return DayBasis_(day_basis)(Date::FromString(start_date), Date::FromString(end_date), nullptr);
     }
 
+    Expression_ Parser_::ParseFix(TokIt_& cur, const TokIt_& end) {
+        const auto functionSource = cur->source_;
+        ++cur;
+        REQUIRE2(cur != end && cur->Text() == "(",
+                 "ReservedIdentifier: FIX is a function; use FIX(index[,date]) or rename the variable; " + functionSource.Describe(), ScriptError_);
+        ++cur;
+        REQUIRE2(cur != end && std::holds_alternative<IndexLiteral_>(cur->value_),
+                 "InvalidIndex: FIX requires an unquoted index literal; " + functionSource.Describe(), ScriptError_);
+        const auto literal = std::get<IndexLiteral_>(cur->value_);
+        const auto source = cur->source_;
+        Handle_<Index_> index;
+        try {
+            index = Handle_<Index_>(Index::Parse(literal.raw_));
+        } catch (const Exception_& error) {
+            THROW2(String_(error.what()) + "; " + source.Describe() + "; input=" + literal.raw_, ScriptError_);
+        }
+        REQUIRE2(!index.IsEmpty(), "InvalidIndex: parser returned an empty index; " + source.Describe(), ScriptError_);
+        ++cur;
+        std::optional<Date_> fixingDate;
+        if (cur != end && cur->Text() == ",") {
+            ++cur;
+            const auto dateSource = cur == end ? source : cur->source_;
+            String_ date;
+            size_t nextOffset = dateSource.offset_;
+            bool contiguous = true;
+            while (cur != end && cur->Text() != ")") {
+                contiguous = contiguous && cur->source_.offset_ == nextOffset;
+                date += cur->Text();
+                nextOffset = cur->source_.offset_ + cur->Text().size();
+                ++cur;
+            }
+            static const std::regex ISO_DATE("[0-9]{4}-[0-9]{2}-[0-9]{2}");
+            REQUIRE2(contiguous && std::regex_match(date, ISO_DATE),
+                     "InvalidFixingDate: FIX requires a strict YYYY-MM-DD date literal; input=" + date + "; " + dateSource.Describe(), ScriptError_);
+            try {
+                fixingDate = Date::FromString(date);
+                REQUIRE(fixingDate->IsValid(), "date is outside the supported range");
+            } catch (const Exception_& error) {
+                THROW2("InvalidFixingDate: " + date + "; " + dateSource.Describe() + "; " + String_(error.what()), ScriptError_);
+            }
+        }
+        REQUIRE2(cur != end && cur->Text() == ")", "InvalidIndex: FIX requires one index and an optional date; " + functionSource.Describe(),
+                 ScriptError_);
+        ++cur;
+        return MakeNode<NodeFix_>(literal, index, fixingDate, source);
+    }
+
     Vector_<Expression_> Parser_::ParseFuncArg(TokIt_& cur, const TokIt_& end) {
-        REQUIRE2(cur != end && (*cur)[0] == '(', "No opening ( following function name", ScriptError_);
+        REQUIRE2(cur != end && cur->Text()[0] == '(', "No opening ( following function name", ScriptError_);
         auto closeIt = FindMatch<'(', ')'>(cur, end);
 
         //	Parse expressions between parentheses
@@ -303,7 +357,7 @@ namespace Dal::Script {
         ++cur;
         while (cur != closeIt) {
             args.push_back(ParseExpr(cur, end));
-            if (cur != end && (*cur)[0] == ',')
+            if (cur != end && cur->Text()[0] == ',')
                 ++cur;
             else if (cur != closeIt)
                 THROW2("Arguments must be separated by commas", ScriptError_);
@@ -348,20 +402,21 @@ namespace Dal::Script {
     }
 
     Statement_ Parser_::ParseStatement(TokIt_& cur, const TokIt_& end) {
-        if (*cur == "IF")
+        if (cur->Text() == "IF")
             return ParseIf(cur, end);
         auto lhs = ParseVar(cur);
         REQUIRE2(cur != end, "unexpected end of statement", ScriptError_);
-        if (*cur == "=")
+        if (cur->Text() == "=")
             return ParseAssign(cur, end, lhs);
-        else if (*cur == "PAYS") return ParsePays(cur, end, lhs);
+        else if (cur->Text() == "PAYS")
+            return ParsePays(cur, end, lhs);
         THROW2("statement without an instruction", ScriptError_);
     }
 
-    Event_ Parser_::Parse(const String_& event) {
+    Event_ Parser_::Parse(const String_& event, const Vector_<SourceOrigin_>& origins) {
         Event_ e;
-        auto tokens = Tokenize(event);
-        Vector_<String_>::const_iterator it = tokens.begin();
+        auto tokens = Lex(event, origins);
+        Vector_<Token_>::const_iterator it = tokens.begin();
         while (it != tokens.end())
             e.push_back(ParseStatement(it, tokens.end()));
         return e;

--- a/dal-cpp/dal/script/parser.cpp
+++ b/dal-cpp/dal/script/parser.cpp
@@ -327,7 +327,10 @@ namespace Dal::Script {
         REQUIRE2(cur != end && cur->Text() == ")", "InvalidIndex: FIX requires one index and an optional date; " + functionSource.Describe(),
                  ScriptError_);
         ++cur;
-        return MakeNode<NodeFix_>(literal, index, fixingDate, source);
+        auto node = MakeNode<NodeFix_>(literal, index, fixingDate, source);
+        if (preparationError_.empty())
+            preparationError_ = node->PreparationError();
+        return node;
     }
 
     Date_ Parser_::ParseFixingDate(TokIt_& cur, const TokIt_& end, const SourceLocation_& fallback) {
@@ -419,6 +422,7 @@ namespace Dal::Script {
     }
 
     Event_ Parser_::Parse(const String_& event, const Vector_<SourceOrigin_>& origins) {
+        preparationError_.clear();
         Event_ e;
         auto tokens = Lex(event, origins);
         Vector_<Token_>::const_iterator it = tokens.begin();

--- a/dal-cpp/dal/script/parser.hpp
+++ b/dal-cpp/dal/script/parser.hpp
@@ -13,7 +13,7 @@
 namespace Dal::Script {
 
     class Parser_ {
-        using TokIt_ = Vector_<String_>::const_iterator;
+        using TokIt_ = Vector_<Token_>::const_iterator;
         std::map<String_, double> constVariables_;
 
         // Helpers
@@ -26,7 +26,7 @@ namespace Dal::Script {
             unsigned opens = 1;
             ++cur;
             while (cur != end && opens > 0) {
-                opens += ((*cur)[0] == OpChar) - ((*cur)[0] == ClChar);
+                opens += (cur->Text()[0] == OpChar) - (cur->Text()[0] == ClChar);
                 ++cur;
             }
 
@@ -40,21 +40,22 @@ namespace Dal::Script {
 
         template <ParseFunc FuncOnMatch_, ParseFunc FuncOnNoMatch_>
         Expression_ ParseParentheses(TokIt_& cur, const TokIt_& end) {
+            REQUIRE2(cur != end, "unexpected end of expression", ScriptError_);
             Expression_ tree;
 
             // Do we have an opening "("?
-            if( *cur == "(") {
+            if (cur->Text() == "(") {
                 // Find match
                 auto closeIt = FindMatch<'(',')'>(cur, end);
 
                 // Parse the parentheses condition/expression, including nested parentheses,
                 // by recursively calling the parent parseCond/parseExpr
                 tree = (this->*FuncOnMatch_)(++cur, closeIt);
+                REQUIRE2(cur == closeIt, "unexpected trailing tokens in parentheses", ScriptError_);
 
                 // Advance cur after matching ")"
                 cur = ++closeIt;
-            }
-            else {
+            } else {
                 // No (, so leftmost we move one level up
                 tree = (this->*FuncOnNoMatch_)(cur, end);
             }
@@ -85,6 +86,7 @@ namespace Dal::Script {
         Expression_ ParseCondElem(TokIt_& cur, const TokIt_& end);
         Vector_<Expression_> ParseFuncArg(TokIt_& cur, const TokIt_& end);
         double ParseDCF(TokIt_& cur, const TokIt_& end);
+        Expression_ ParseFix(TokIt_& cur, const TokIt_& end);
 
         Statement_ ParseIf(TokIt_& cur, const TokIt_& end);
 
@@ -96,6 +98,6 @@ namespace Dal::Script {
     public:
         explicit Parser_(const std::map<String_, double>& constVariables = std::map<String_, double>()): constVariables_(constVariables) {}
         Statement_ ParseStatement(TokIt_& cur, const TokIt_& end);
-        Event_ Parse(const String_& event);
+        Event_ Parse(const String_& event, const Vector_<SourceOrigin_>& origins = {});
     };
 } // namespace Dal::Script

--- a/dal-cpp/dal/script/parser.hpp
+++ b/dal-cpp/dal/script/parser.hpp
@@ -15,6 +15,7 @@ namespace Dal::Script {
     class Parser_ {
         using TokIt_ = Vector_<Token_>::const_iterator;
         std::map<String_, double> constVariables_;
+        String_ preparationError_;
 
         // Helpers
 
@@ -100,5 +101,6 @@ namespace Dal::Script {
         explicit Parser_(const std::map<String_, double>& constVariables = std::map<String_, double>()): constVariables_(constVariables) {}
         Statement_ ParseStatement(TokIt_& cur, const TokIt_& end);
         Event_ Parse(const String_& event, const Vector_<SourceOrigin_>& origins = {});
+        [[nodiscard]] const String_& PreparationError() const { return preparationError_; }
     };
 } // namespace Dal::Script

--- a/dal-cpp/dal/script/parser.hpp
+++ b/dal-cpp/dal/script/parser.hpp
@@ -87,6 +87,7 @@ namespace Dal::Script {
         Vector_<Expression_> ParseFuncArg(TokIt_& cur, const TokIt_& end);
         double ParseDCF(TokIt_& cur, const TokIt_& end);
         Expression_ ParseFix(TokIt_& cur, const TokIt_& end);
+        Date_ ParseFixingDate(TokIt_& cur, const TokIt_& end, const SourceLocation_& fallback);
 
         Statement_ ParseIf(TokIt_& cur, const TokIt_& end);
 

--- a/dal-cpp/dal/script/preprocessor.cpp
+++ b/dal-cpp/dal/script/preprocessor.cpp
@@ -11,6 +11,41 @@
 #include <regex>
 
 namespace Dal::Script {
+    namespace {
+        template <class F_> String_ ExpandWithSource(F_ expand, size_t row, std::optional<Date_> date) {
+            try {
+                return expand();
+            } catch (const ScriptError_& error) {
+                String_ context("; row=" + std::to_string(row));
+                if (date)
+                    context += ", event=" + Date::ToString(*date);
+                THROW2(String_(error.what()) + context, ScriptError_);
+            }
+        }
+
+        void AppendEvent(PreprocessedEvents_* result, const Date_& date, const String_& statement, size_t row) {
+            auto found = result->events_.find(date);
+            const size_t offset = found == result->events_.end() ? 0 : found->second.size() + 1;
+            result->sources_[date].push_back({offset, row, date});
+            if (found == result->events_.end())
+                result->events_[date] = statement;
+            else
+                found->second += "\n" + statement;
+        }
+
+        String_ ReplaceOutsideIndices(const String_& statement, const String_& pattern, const String_& replacement) {
+            const std::regex expression(pattern, std::regex_constants::icase);
+            String_ result;
+            size_t start = 0;
+            for (const auto& range : IndexLiteralRanges(statement)) {
+                result += std::regex_replace(String_(statement.substr(start, range.first - start)), expression, replacement);
+                result += statement.substr(range.first, range.second - range.first);
+                start = range.second;
+            }
+            return result + std::regex_replace(String_(statement.substr(start)), expression, replacement);
+        }
+    } // namespace
+
     bool Preprocessor_::IsSchedule(const String_& desc) const {
         return desc.find(":") != String_::npos;
     }
@@ -23,21 +58,15 @@ namespace Dal::Script {
                                         const std::map<String_, String_>& macros) const {
         String_ replaced = statement;
         for (const auto& macro : macros)
-            replaced = std::regex_replace(replaced,
-                                          std::regex(macro.first, std::regex_constants::icase),
-                                          macro.second);
+            replaced = ReplaceOutsideIndices(replaced, macro.first, macro.second);
         return replaced;
     }
 
     String_ Preprocessor_::ExpandSchedulePlaceholders(const String_& statement,
                                                       const Date_& begin,
                                                       const Date_& end) const {
-        String_ replaced = std::regex_replace(statement,
-                                              std::regex("PeriodBegin", std::regex_constants::icase),
-                                              Date::ToString(begin));
-        replaced = std::regex_replace(replaced,
-                                      std::regex("PeriodEnd", std::regex_constants::icase),
-                                      Date::ToString(end));
+        String_ replaced = ReplaceOutsideIndices(statement, "PeriodBegin", Date::ToString(begin));
+        replaced = ReplaceOutsideIndices(replaced, "PeriodEnd", Date::ToString(end));
         return replaced;
     }
 
@@ -47,7 +76,9 @@ namespace Dal::Script {
         auto& constVariables = result.constVariables_;
         auto& processedEvents = result.events_;
 
+        size_t row = 0;
         for (const auto& event : events) {
+            ++row;
             const Cell_& cell = event.first;
             if (!Cell::IsDate(cell)) {
                 // distinguish macro/const-variable definitions from schedules
@@ -55,24 +86,23 @@ namespace Dal::Script {
                 if (IsSchedule(desc)) {
                     // find a schedule
                     auto schedule = ParseSchedule(Tokenize(desc));
-                    String_ replaced = ExpandMacros(event.second, macros);
+                    String_ replaced = ExpandWithSource([&] { return ExpandMacros(event.second, macros); }, row, std::nullopt);
 
                     for (const auto& s : schedule) {
                         auto startDate = std::get<0>(s);
                         auto endDate = std::get<1>(s);
                         auto fixDate = std::get<2>(s);
                         // Replace placeholders of `PeriodBegin` and `PeriodEnd`
-                        auto final_statement = ExpandSchedulePlaceholders(replaced, startDate, endDate);
+                        auto final_statement =
+                            ExpandWithSource([&] { return ExpandSchedulePlaceholders(replaced, startDate, endDate); }, row, fixDate);
 
-                        if (processedEvents.find(fixDate) != processedEvents.end())
-                            processedEvents[fixDate] += "\n" + final_statement;
-                        else
-                            processedEvents[fixDate] = final_statement;
+                        AppendEvent(&result, fixDate, final_statement, row);
                     }
                 } else {
+                    REQUIRE2(desc != "FIX", String_("ReservedIdentifier: FIX is a function; rename the definition; row=" + std::to_string(row)),
+                             ScriptError_);
                     REQUIRE2(macros.find(desc) == macros.end(), "macro name has already registered", ScriptError_);
-                    REQUIRE2(constVariables.find(desc) == constVariables.end(),
-                             "const macro name has already registered", ScriptError_);
+                    REQUIRE2(constVariables.find(desc) == constVariables.end(), "const macro name has already registered", ScriptError_);
                     REQUIRE2(processedEvents.empty(), "macros should always at the front", ScriptError_);
 
                     if (IsConstVariable(event.second))
@@ -81,12 +111,9 @@ namespace Dal::Script {
                         macros[desc] = event.second;
                 }
             } else {
-                String_ replaced = ExpandMacros(event.second, macros);
                 auto d = Cell::ToDate(cell);
-                if (processedEvents.find(d) != processedEvents.end())
-                    processedEvents[d] += "\n" + replaced;
-                else
-                    processedEvents[d] = replaced;
+                String_ replaced = ExpandWithSource([&] { return ExpandMacros(event.second, macros); }, row, d);
+                AppendEvent(&result, d, replaced, row);
             }
         }
         return result;

--- a/dal-cpp/dal/script/preprocessor.hpp
+++ b/dal-cpp/dal/script/preprocessor.hpp
@@ -6,8 +6,10 @@
 
 #include <map>
 #include <utility>
+
 #include <dal/math/cell.hpp>
 #include <dal/math/vectors.hpp>
+#include <dal/script/lexer.hpp>
 #include <dal/string/strings.hpp>
 #include <dal/time/date.hpp>
 
@@ -17,6 +19,7 @@ namespace Dal::Script {
     struct PreprocessedEvents_ {
         std::map<String_, double> constVariables_;
         std::map<Date_, String_> events_;
+        std::map<Date_, Vector_<SourceOrigin_>> sources_;
     };
 
     class Preprocessor_ {

--- a/dal-cpp/dal/script/visitor/compiler.hpp
+++ b/dal-cpp/dal/script/visitor/compiler.hpp
@@ -266,6 +266,7 @@ namespace Dal::Script {
         void Visit(const NodeFalse_&) { nodeStream_.emplace_back(fuzzy_ ? FuzzyFalse : False); }
 
         void Visit(const NodeSpot_&) { nodeStream_.emplace_back(Spot); }
+        void Visit(const NodeFix_& node) { node.RequirePreparation(); }
 
         void Visit(const NodeCollect_& node) { VisitArguments(node); }
 

--- a/dal-cpp/dal/script/visitor/debugger.hpp
+++ b/dal-cpp/dal/script/visitor/debugger.hpp
@@ -303,6 +303,8 @@ namespace Dal::Script {
             out = node.name;
         else if (node.kind == "spot")
             out = String_("spot()");
+        else if (node.kind == "fix")
+            out = node.label;
         else if (node.kind == "true" || node.kind == "false")
             out = String_(node.kind == "true" ? st.trueS : st.falseS);
         else
@@ -652,10 +654,10 @@ namespace Dal::Script {
         void Visit(const NodePays_& node) { Debug(node, {"PAYS", "pays"}); }
         void Visit(const NodeSpot_& node) { Debug(node, {"SPOT", "spot"}); }
         void Visit(const NodeFix_& node) {
-            String_ label = "FIX[" + node.literal_.raw_;
+            String_ label = "FIX(" + node.literal_.raw_;
             if (node.fixingDate_)
-                label += "," + Date::ToString(*node.fixingDate_);
-            Debug(node, {label + "]", "fix"});
+                label += ", " + Date::ToString(*node.fixingDate_);
+            Debug(node, {label + ")", "fix"});
         }
 
         void Visit(const NodeIf_& node) {

--- a/dal-cpp/dal/script/visitor/debugger.hpp
+++ b/dal-cpp/dal/script/visitor/debugger.hpp
@@ -651,6 +651,12 @@ namespace Dal::Script {
         void Visit(const NodeAssign_& node) { Debug(node, {"ASSIGN", "assign"}); }
         void Visit(const NodePays_& node) { Debug(node, {"PAYS", "pays"}); }
         void Visit(const NodeSpot_& node) { Debug(node, {"SPOT", "spot"}); }
+        void Visit(const NodeFix_& node) {
+            String_ label = "FIX[" + node.literal_.raw_;
+            if (node.fixingDate_)
+                label += "," + Date::ToString(*node.fixingDate_);
+            Debug(node, {label + "]", "fix"});
+        }
 
         void Visit(const NodeIf_& node) {
             DebugNode_ ir;

--- a/dal-cpp/dal/script/visitor/domainproc.hpp
+++ b/dal-cpp/dal/script/visitor/domainproc.hpp
@@ -354,6 +354,7 @@ namespace Dal::Script {
 
         void Visit(NodeConst_& node) { domStack_.Push(node.constVal_); }
         void Visit(NodeConstVar_& node) { domStack_.Push(node.constVal_); }
+        void Visit(NodeFix_& node) { node.RequirePreparation(); }
 
         // Scenario
         void Visit(NodeSpot_&) {

--- a/dal-cpp/dal/script/visitor/evaluator.hpp
+++ b/dal-cpp/dal/script/visitor/evaluator.hpp
@@ -214,6 +214,7 @@ namespace Dal::Script {
         FORCE_INLINE void Visit(const NodeFalse_& node) { bStack_.Push(false); }
 
         FORCE_INLINE void Visit(const NodeSpot_& node) { dStack_.Push((*scenario_)[curEvt_].spot_); }
+        void Visit(const NodeFix_& node) { node.RequirePreparation(); }
 
         FORCE_INLINE void Visit(const NodeCollect_& node) { this->VisitArguments(node); }
     };

--- a/dal-cpp/tests/indice/parser/test_equity.cpp
+++ b/dal-cpp/tests/indice/parser/test_equity.cpp
@@ -54,3 +54,11 @@ TEST(IndexTest, TestParserDeliveryOfParsedForms) {
     ASSERT_TRUE(eq_with_delay != nullptr);
     ASSERT_EQ(eq_with_delay->Delivery(fixing_time), Date_(2022, 4, 22));
 }
+
+TEST(IndexTest, TestParserRejectsIncompleteCompoundDelivery) {
+    for (const auto* name : {"EQ[IBM]>3M&", "EQ[IBM]>&3M", "EQ[IBM]>3M&&6M"}) {
+        SCOPED_TRACE(name);
+        ASSERT_THROW(Index::EquityParser(name), Dal::Exception_);
+    }
+    ASSERT_EQ(Index::EquityParser("EQ[IBM]>3M&IMM")->Name(), "EQ[IBM]>3M&IMM");
+}

--- a/dal-cpp/tests/indice/parser/test_equity.cpp
+++ b/dal-cpp/tests/indice/parser/test_equity.cpp
@@ -62,3 +62,16 @@ TEST(IndexTest, TestParserRejectsIncompleteCompoundDelivery) {
     }
     ASSERT_EQ(Index::EquityParser("EQ[IBM]>3M&IMM")->Name(), "EQ[IBM]>3M&IMM");
 }
+
+TEST(IndexTest, TestEquityDeliveryErrorsRetainIndexDiagnostic) {
+    for (const auto* name : {"EQ[IBM]@not-a-date", "EQ[IBM]@2026-02-30", "EQ[IBM]>invalid", "EQ[IBM]>999999999999999999999M"}) {
+        SCOPED_TRACE(name);
+        try {
+            static_cast<void>(Index::EquityParser(name));
+            FAIL() << "invalid delivery must fail";
+        } catch (const Dal::Exception_& error) {
+            ASSERT_NE(std::string(error.what()).find("InvalidIndex"), std::string::npos);
+            ASSERT_NE(std::string(error.what()).find(name), std::string::npos);
+        }
+    }
+}

--- a/dal-cpp/tests/indice/parser/test_indexparse.cpp
+++ b/dal-cpp/tests/indice/parser/test_indexparse.cpp
@@ -37,10 +37,20 @@ TEST(IndexParseTest, TestParseRejectsUnknownPrefix) {
     ASSERT_THROW((void)Index::Parse(String_("IR:USD,3M")), Dal::Exception_);
 }
 
-TEST(IndexParseTest, TestParseBareNameReturnsNull) {
-    // bare names route to the (not yet supported) supershot parser, which yields null
-    std::unique_ptr<Index_> index(Index::Parse(String_("IBM")));
-    ASSERT_TRUE(index == nullptr);
+TEST(IndexParseTest, TestParseRejectsBareNameAndNullParser) {
+    ASSERT_THROW(Index::Parse("IBM"), Dal::Exception_);
+    ASSERT_THROW(Index::Parse(""), Dal::Exception_);
+    Index::RegisterParser("NULL_TEST", [](const String_&) -> std::unique_ptr<Index_> { return nullptr; });
+    ASSERT_THROW(Index::Parse("NULL_TEST[ABC]"), Dal::Exception_);
+}
+
+TEST(IndexParseTest, TestParseRejectsMalformedAndTrailingInput) {
+    for (const auto* text : {"EQ[]", "EQ[AAPL", "EQ[[AAPL]]", "EQ[AAPL]]", "EQ[AAPL]junk", "EQ[AAPL]junk>3M", "EQ[AAPL]@2026-12-31junk", "EQ[AAPL]>",
+                             "EQ[AAPL]>3Mjunk", "EQ[AAPL]@", "EQ[\"AAPL\"]", "FX[EUR/USD]junk", "FX[[EUR/USD]]", "FX[EUR/USD]]", "FX[/USD]",
+                             "FX[EUR/]", "FX[EUR/USD/JPY]", "FX[EUR/USD]>3M"}) {
+        SCOPED_TRACE(text);
+        ASSERT_THROW(Index::Parse(text), Dal::Exception_);
+    }
 }
 
 TEST(IndexParseTest, TestCloneRoundTripsThroughName) {

--- a/dal-cpp/tests/script/test_lexer.cpp
+++ b/dal-cpp/tests/script/test_lexer.cpp
@@ -41,7 +41,7 @@ TEST(ScriptLexerTest, TestTokenizeScheduleColon) {
         ASSERT_EQ(tokens[i], expected[i]);
 }
 
-TEST(ScriptObservationTest, TestIndexLiteralTokens) {
+TEST(ScriptLexerTest, TestIndexLiteralTokens) {
     const auto tokens = Tokenize("x = FIX(FX[EUR/USD]) + FIX(EQ[Aapl]@2026-12-31, 2026-09-11)");
     ASSERT_EQ(tokens[4], "FX[EUR/USD]");
     ASSERT_EQ(tokens[9], "EQ[Aapl]@2026-12-31");

--- a/dal-cpp/tests/script/test_lexer.cpp
+++ b/dal-cpp/tests/script/test_lexer.cpp
@@ -40,3 +40,14 @@ TEST(ScriptLexerTest, TestTokenizeScheduleColon) {
     for (size_t i = 0; i < expected.size(); ++i)
         ASSERT_EQ(tokens[i], expected[i]);
 }
+
+TEST(ScriptObservationTest, TestIndexLiteralTokens) {
+    const auto tokens = Tokenize("x = FIX(FX[EUR/USD]) + FIX(EQ[Aapl]@2026-12-31, 2026-09-11)");
+    ASSERT_EQ(tokens[4], "FX[EUR/USD]");
+    ASSERT_EQ(tokens[9], "EQ[Aapl]@2026-12-31");
+    const auto positioned = Lex("FIX(FX[EUR/USD])");
+    const auto* literal = std::get_if<IndexLiteral_>(&positioned[2].value_);
+    ASSERT_NE(literal, nullptr);
+    ASSERT_EQ(literal->raw_, "FX[EUR/USD]");
+    ASSERT_EQ(positioned[2].source_.offset_, 4);
+}

--- a/dal-cpp/tests/script/test_observation.cpp
+++ b/dal-cpp/tests/script/test_observation.cpp
@@ -6,6 +6,7 @@
 
 #include <dal/platform/platform.hpp>
 #include <dal/indice/index.hpp>
+#include <dal/indice/indexparse.hpp>
 #include <dal/script/event.hpp>
 #include <dal/script/parser.hpp>
 #include <dal/script/preprocessor.hpp>
@@ -27,6 +28,27 @@ TEST(ScriptObservationTest, TestIndexLiteral) {
     for (const auto* text : {"x = FIX(EQ[AAPL])", "x = FIX(FX[EUR/USD])", "x = FIX(EQ[AAPL]>3M)", "x = FIX(EQ[AAPL]@2026-12-31, 2026-09-11)"}) {
         SCOPED_TRACE(text);
         ASSERT_NO_THROW(parser.Parse(text));
+    }
+}
+
+TEST(ScriptObservationTest, TestBracketContentsPreserveIndiceIdentity) {
+    for (const auto* name : {"EQ[AAPL.O]", "EQ[BRK/B]", "EQ[AAPL,CLASS-A]", "EQ[AAPL(US)]", "EQ[AAPL)US(]", "EQ[PeriodBegin(),PeriodEnd]>3M&IMM"}) {
+        SCOPED_TRACE(name);
+        const auto index = Index::Parse(name);
+        ASSERT_NE(index, nullptr);
+        ASSERT_EQ(index->Name(), name);
+        Event_ event;
+        ASSERT_NO_THROW(event = Parser_().Parse("x = MAX(FIX(" + String_(name) + ", 2026-09-11), 0)"));
+        const auto* fix = dynamic_cast<const NodeFix_*>(event[0]->arguments_[1]->arguments_[0].get());
+        ASSERT_NE(fix, nullptr);
+        ASSERT_EQ(fix->index_->Name(), index->Name());
+        ASSERT_EQ(std::string(fix->literal_.raw_.begin(), fix->literal_.raw_.end()), name);
+        ASSERT_TRUE(fix->fixingDate_.has_value());
+        ASSERT_EQ(*fix->fixingDate_, Date_(2026, 9, 11));
+        const ObservationPreprocessor_ preprocessor;
+        ASSERT_EQ(preprocessor.ExpandMacros("FIX(" + String_(name) + ")", {{"AAPL", "CHANGED"}, {"US", "CHANGED"}}), "FIX(" + String_(name) + ")");
+        ASSERT_EQ(preprocessor.ExpandSchedulePlaceholders("FIX(" + String_(name) + ")", Date_(2026, 9, 11), Date_(2026, 9, 12)),
+                  "FIX(" + String_(name) + ")");
     }
 }
 
@@ -130,6 +152,39 @@ TEST(ScriptObservationTest, TestScheduleSourceContext) {
     }
 }
 
+TEST(ScriptObservationTest, TestSameDateSourceOriginsAfterMacroExpansion) {
+    const Date_ date(2030, 9, 12);
+    const auto processed = Preprocessor_().Process(
+        {{Cell_("ASSET"), "eQ[PeriodBegin]@2026-12-31"}, {Cell_(date), "x = SPOT()"}, {Cell_(date), "y = FIX(ASSET, 2026-09-11)"}});
+    const auto& statement = processed.events_.at(date);
+    auto event = Parser_().Parse(statement, processed.sources_.at(date));
+    ASSERT_EQ(event.size(), 2);
+    const auto* fix = dynamic_cast<const NodeFix_*>(event[1]->arguments_[1].get());
+    ASSERT_NE(fix, nullptr);
+    ASSERT_EQ(std::string(fix->literal_.raw_.begin(), fix->literal_.raw_.end()), "eQ[PeriodBegin]@2026-12-31");
+    ASSERT_EQ(fix->index_->Name(), "EQ[PeriodBegin]@2026-12-31");
+    ASSERT_EQ(fix->source_.row_, 3);
+    ASSERT_EQ(fix->source_.offset_, statement.find("eQ["));
+    ASSERT_EQ(fix->source_.line_, 2);
+    ASSERT_EQ(fix->source_.column_, 9);
+    ASSERT_TRUE(fix->source_.eventDate_.has_value());
+    ASSERT_EQ(*fix->source_.eventDate_, date);
+}
+
+TEST(ScriptObservationTest, TestNullParserRetainsSourceContext) {
+    Index::RegisterParser("SCRIPT_NULL_TEST", [](const String_&) -> std::unique_ptr<Index_> { return nullptr; });
+    const Date_ date(2030, 9, 12);
+    const auto processed = Preprocessor_().Process({{Cell_(date), "x = SPOT()"}, {Cell_(date), "y = FIX(SCRIPT_NULL_TEST[Asset])"}});
+    try {
+        Parser_().Parse(processed.events_.at(date), processed.sources_.at(date));
+        FAIL() << "a null index must fail with its originating source context";
+    } catch (const ScriptError_& error) {
+        const std::string message(error.what());
+        for (const auto* expected : {"InvalidIndex", "SCRIPT_NULL_TEST[Asset]", "row=2", "line=2", "column=9", "event=2030-09-12"})
+            ASSERT_NE(message.find(expected), std::string::npos) << expected;
+    }
+}
+
 TEST(ScriptObservationTest, TestPreparationRequiredBeforeLegacyProcessing) {
     for (const auto date : {Date_(2020, 9, 11), Date_(2030, 9, 11)}) {
         for (const bool skipDomain : {false, true}) {
@@ -158,7 +213,7 @@ namespace {
 
 TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
     auto event = Parser_().Parse("x = FIX(EQ[AAPL])");
-    const auto& node = *event[0]->arguments_[1];
+    auto& node = *event[0]->arguments_[1];
     Evaluator_<double> tree({});
     Evaluator_<AAD::Number_> aad({});
     PastEvaluator_<double> past({});
@@ -166,6 +221,8 @@ TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
     FuzzyEvaluator_<AAD::Number_> fuzzyAad({}, {}, 0, 0.1);
     Compiler_ compiler;
     Compiler_ fuzzyCompiler(true);
+    DomainProcessor_ domain(0, false);
+    DomainProcessor_ fuzzyDomain(0, true);
     AssertPreparationRequired([&] { node.Accept(tree); });
     AssertPreparationRequired([&] { node.Accept(aad); });
     AssertPreparationRequired([&] { node.Accept(past); });
@@ -173,6 +230,8 @@ TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
     AssertPreparationRequired([&] { node.Accept(fuzzyAad); });
     AssertPreparationRequired([&] { node.Accept(compiler); });
     AssertPreparationRequired([&] { node.Accept(fuzzyCompiler); });
+    AssertPreparationRequired([&] { node.Accept(domain); });
+    AssertPreparationRequired([&] { node.Accept(fuzzyDomain); });
 }
 
 TEST(ScriptObservationTest, TestPreparationRequiredProductEntryPoints) {
@@ -181,4 +240,11 @@ TEST(ScriptObservationTest, TestPreparationRequiredProductEntryPoints) {
     AssertPreparationRequired([&] { static_cast<void>(product.PastEvaluate()); });
     auto evaluator = product.BuildEvaluator<double>();
     AssertPreparationRequired([&] { product.Evaluate(Scenario_<double>{}, evaluator); });
+    auto aad = product.BuildEvaluator<AAD::Number_>();
+    auto fuzzy = product.BuildFuzzyEvaluator<double>(1, 0.1);
+    auto fuzzyAad = product.BuildFuzzyEvaluator<AAD::Number_>(1, 0.1);
+    AssertPreparationRequired([&] { product.Evaluate(Scenario_<AAD::Number_>{}, aad); });
+    AssertPreparationRequired([&] { product.Evaluate(Scenario_<double>{}, fuzzy); });
+    AssertPreparationRequired([&] { product.Evaluate(Scenario_<AAD::Number_>{}, fuzzyAad); });
+    AssertPreparationRequired([&] { static_cast<void>(product.Compile(true)); });
 }

--- a/dal-cpp/tests/script/test_observation.cpp
+++ b/dal-cpp/tests/script/test_observation.cpp
@@ -186,6 +186,42 @@ TEST(ScriptObservationTest, TestSameDateSourceOriginsAfterMacroExpansion) {
     ASSERT_EQ(*fix->source_.eventDate_, date);
 }
 
+TEST(ScriptObservationTest, TestParserPreparationDiagnosticReset) {
+    Parser_ parser;
+    const Date_ date(2030, 9, 12);
+    const auto event = parser.Parse("IF 1 = 0 THEN x = FIX(eQ[First]) ELSE x = FIX(EQ[Second]) END", {{0, 3, date}});
+    const auto* first = FindUnpreparedFixing(*event[0]);
+    ASSERT_NE(first, nullptr);
+    ASSERT_EQ(parser.PreparationError(), first->PreparationError());
+    ASSERT_NE(parser.PreparationError().find("row=3"), String_::npos);
+
+    ASSERT_NO_THROW(parser.Parse("x = SPOT()"));
+    ASSERT_TRUE(parser.PreparationError().empty());
+    ASSERT_NO_THROW(parser.Parse("x = FIX(FX[EUR/USD])"));
+    ASSERT_NE(parser.PreparationError().find("FX[EUR/USD]"), String_::npos);
+    ASSERT_EQ(parser.PreparationError().find("row=3"), String_::npos);
+    ASSERT_NO_THROW(parser.Parse(""));
+    ASSERT_TRUE(parser.PreparationError().empty());
+}
+
+TEST(ScriptObservationTest, TestProductRetainsFirstPreparationDiagnostic) {
+    const Date_ past(2020, 9, 11);
+    const Date_ future(2030, 9, 11);
+    ScriptProduct_ product({Cell_(past), Cell_(future)}, {"IF 1 = 0 THEN x = FIX(eQ[First]) ELSE x = 1 END", "x = FIX(EQ[Second])"});
+    product.ParseEvents({{Cell_(future), "y = SPOT()"}});
+    try {
+        product.PreProcess(false, true);
+        FAIL() << "first FIX must survive later events and parsing";
+    } catch (const ScriptError_& error) {
+        const std::string message(error.what());
+        for (const auto* expected : {"PreparationRequired", "eQ[First]", "row=1", "event=2020-09-11"})
+            ASSERT_NE(message.find(expected), std::string::npos) << expected;
+        ASSERT_EQ(message.find("Second"), std::string::npos);
+    }
+    ScriptProduct_ legacy({Cell_(future)}, {"x = SPOT()"});
+    ASSERT_NO_THROW(legacy.PreProcess(false, true));
+}
+
 TEST(ScriptObservationTest, TestNullParserRetainsSourceContext) {
     Index::RegisterParser("SCRIPT_NULL_TEST", [](const String_&) -> std::unique_ptr<Index_> { return nullptr; });
     const Date_ date(2030, 9, 12);

--- a/dal-cpp/tests/script/test_observation.cpp
+++ b/dal-cpp/tests/script/test_observation.cpp
@@ -1,0 +1,184 @@
+//
+// Created by Codex on 2026/9/12.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/platform/platform.hpp>
+#include <dal/indice/index.hpp>
+#include <dal/script/event.hpp>
+#include <dal/script/parser.hpp>
+#include <dal/script/preprocessor.hpp>
+#include <dal/script/visitor/all.hpp>
+
+using namespace Dal;
+using namespace Dal::Script;
+
+namespace {
+    class ObservationPreprocessor_ : public Preprocessor_ {
+    public:
+        using Preprocessor_::ExpandMacros;
+        using Preprocessor_::ExpandSchedulePlaceholders;
+    };
+} // namespace
+
+TEST(ScriptObservationTest, TestIndexLiteral) {
+    Parser_ parser;
+    for (const auto* text : {"x = FIX(EQ[AAPL])", "x = FIX(FX[EUR/USD])", "x = FIX(EQ[AAPL]>3M)", "x = FIX(EQ[AAPL]@2026-12-31, 2026-09-11)"}) {
+        SCOPED_TRACE(text);
+        ASSERT_NO_THROW(parser.Parse(text));
+    }
+}
+
+TEST(ScriptObservationTest, TestProtectedExpansion) {
+    ObservationPreprocessor_ preprocessor;
+    const auto expanded = preprocessor.ExpandMacros("x = FIX(ASSET, PeriodBegin) + SCALE",
+                                                    {{"ASSET", "EQ[PeriodBegin]>PeriodEnd"}, {"PeriodBegin", "CHANGED"}, {"SCALE", "2"}});
+    ASSERT_EQ(expanded, "x = FIX(EQ[PeriodBegin]>PeriodEnd, CHANGED) + 2");
+    const auto scheduled = preprocessor.ExpandSchedulePlaceholders("x = FIX(EQ[PeriodBegin], PeriodBegin) + FIX(EQ[AAPL]>PeriodEnd)",
+                                                                   Date_(2026, 9, 11), Date_(2026, 9, 12));
+    ASSERT_EQ(scheduled, "x = FIX(EQ[PeriodBegin], 2026-09-11) + FIX(EQ[AAPL]>PeriodEnd)");
+    ASSERT_EQ(preprocessor.ExpandMacros("x = FIX(FX[EUR/USD]) + FIX(EQ[SCALE]@2026-12-31)", {{"USD", "JPY"}, {"SCALE", "BAD"}}),
+              "x = FIX(FX[EUR/USD]) + FIX(EQ[SCALE]@2026-12-31)");
+}
+
+TEST(ScriptObservationTest, TestInvalidSyntax) {
+    Parser_ parser;
+    for (const auto* text : {"FIX()",
+                             "FIX(EQ[AAPL],)",
+                             "FIX(EQ[AAPL],2026-09-11,2026-09-12)",
+                             "FIX(\"EQ[AAPL]\")",
+                             "FIX('EQ[AAPL]')",
+                             "FIX(EQ[AAPL)",
+                             "FIX(EQ[AAPL]])",
+                             "FIX(EQ[[AAPL]])",
+                             "FIX(EQ[AAPL]junk)",
+                             "FIX(FX[EUR/USD]junk)",
+                             "FIX(EQ[])",
+                             "FIX(XX[AAPL])",
+                             "FIX(asset)",
+                             "FIX(EQ[AAPL],date)",
+                             "FIX(EQ[AAPL],2026-9-11)",
+                             "FIX(EQ[AAPL],2026-02-30)",
+                             "FIX(EQ[AAPL],2026-09-11+1)",
+                             "FIX(EQ[AAPL],2026-09-11T00:00:00)",
+                             "FIX(EQ[AAPL],2026 - 09 - 11)",
+                             "SPOT(EQ[AAPL])",
+                             "FIX(EQ[AAPL])$",
+                             "(FIX(EQ[AAPL]) 123)",
+                             "FIX(EQ[AAPL])[]"}) {
+        SCOPED_TRACE(text);
+        ASSERT_THROW(parser.Parse("x = " + String_(text)), ScriptError_);
+    }
+    ASSERT_NO_THROW(parser.Parse("x = SPOT()"));
+}
+
+TEST(ScriptObservationTest, TestReservedIdentifier) {
+    for (const auto* statement : {"FIX = 1", "fix PAYS 2", "x = fix"}) {
+        SCOPED_TRACE(statement);
+        try {
+            Parser_().Parse(statement);
+            FAIL() << "FIX must be reserved";
+        } catch (const ScriptError_& error) {
+            ASSERT_NE(std::string(error.what()).find("ReservedIdentifier"), std::string::npos);
+        }
+    }
+    for (const auto* value : {"2.0", "SPOT()"}) {
+        try {
+            static_cast<void>(Preprocessor_().Process({{Cell_("fIx"), String_(value)}}));
+            FAIL() << "FIX macro must be reserved";
+        } catch (const ScriptError_& error) {
+            ASSERT_NE(std::string(error.what()).find("ReservedIdentifier"), std::string::npos);
+            ASSERT_NE(std::string(error.what()).find("row=1"), std::string::npos);
+        }
+    }
+}
+
+TEST(ScriptObservationTest, TestLiteralIdentityDateAndSource) {
+    auto event = Parser_().Parse("\n  x = FIX(eQ[Aapl]@2026-12-31, 2026-09-11)");
+    const auto* node = dynamic_cast<const NodeFix_*>(event[0]->arguments_[1].get());
+    ASSERT_NE(node, nullptr);
+    ASSERT_EQ(std::string(node->literal_.raw_.begin(), node->literal_.raw_.end()), "eQ[Aapl]@2026-12-31");
+    ASSERT_EQ(node->index_->Name(), "EQ[Aapl]@2026-12-31");
+    ASSERT_TRUE(node->fixingDate_.has_value());
+    ASSERT_EQ(*node->fixingDate_, Date_(2026, 9, 11));
+    ASSERT_EQ(node->source_.offset_, 11);
+    ASSERT_EQ(node->source_.line_, 2);
+    ASSERT_EQ(node->source_.column_, 11);
+    ASSERT_FALSE(node->isConst_);
+
+    auto defaultDate = Parser_().Parse("x = FIX(FX[USD/EUR])");
+    const auto* fx = dynamic_cast<const NodeFix_*>(defaultDate[0]->arguments_[1].get());
+    ASSERT_NE(fx, nullptr);
+    ASSERT_FALSE(fx->fixingDate_.has_value());
+    ASSERT_EQ(fx->index_->Name(), "FX[USD/EUR]");
+}
+
+TEST(ScriptObservationTest, TestScheduleSourceContext) {
+    for (const auto* index : {"UNKNOWN[AAPL]", "EQ[[AAPL]]"}) {
+        try {
+            const ScriptProduct_ product({Cell_("SCALE"), Cell_("START: 2026-09-11 END: 2026-09-12 FREQ: 1m CALENDAR: CN.SSE")},
+                                         {"2.0", "x = FIX(" + String_(index) + ", PeriodBegin)"});
+            FAIL() << "invalid index must fail with originating row and expanded date";
+        } catch (const ScriptError_& error) {
+            const std::string message(error.what());
+            const char* expected = String_(index).substr(0, 2) == "EQ" ? "InvalidIndex" : "UnknownIndex";
+            ASSERT_NE(message.find(expected), std::string::npos);
+            ASSERT_NE(message.find("row=2"), std::string::npos);
+            ASSERT_NE(message.find("event=2026-09-"), std::string::npos);
+        }
+    }
+}
+
+TEST(ScriptObservationTest, TestPreparationRequiredBeforeLegacyProcessing) {
+    for (const auto date : {Date_(2020, 9, 11), Date_(2030, 9, 11)}) {
+        for (const bool skipDomain : {false, true}) {
+            ScriptProduct_ product({Cell_(date)}, {"IF 1 = 0 THEN x = FIX(EQ[AAPL]) ELSE x = 1 END"});
+            try {
+                product.PreProcess(false, skipDomain);
+                FAIL() << "unprepared FIX must fail even in an unreachable branch";
+            } catch (const ScriptError_& error) {
+                ASSERT_NE(std::string(error.what()).find("PreparationRequired"), std::string::npos);
+            }
+        }
+    }
+}
+
+namespace {
+    template <class F_> void AssertPreparationRequired(F_ action) {
+        try {
+            action();
+            FAIL() << "unprepared FIX must require preparation";
+        } catch (const ScriptError_& error) {
+            ASSERT_NE(std::string(error.what()).find("PreparationRequired"), std::string::npos);
+            ASSERT_NE(std::string(error.what()).find("EQ[AAPL]"), std::string::npos);
+        }
+    }
+} // namespace
+
+TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
+    auto event = Parser_().Parse("x = FIX(EQ[AAPL])");
+    const auto& node = *event[0]->arguments_[1];
+    Evaluator_<double> tree({});
+    Evaluator_<AAD::Number_> aad({});
+    PastEvaluator_<double> past({});
+    FuzzyEvaluator_<double> fuzzy({}, {}, 0, 0.1);
+    FuzzyEvaluator_<AAD::Number_> fuzzyAad({}, {}, 0, 0.1);
+    Compiler_ compiler;
+    Compiler_ fuzzyCompiler(true);
+    AssertPreparationRequired([&] { node.Accept(tree); });
+    AssertPreparationRequired([&] { node.Accept(aad); });
+    AssertPreparationRequired([&] { node.Accept(past); });
+    AssertPreparationRequired([&] { node.Accept(fuzzy); });
+    AssertPreparationRequired([&] { node.Accept(fuzzyAad); });
+    AssertPreparationRequired([&] { node.Accept(compiler); });
+    AssertPreparationRequired([&] { node.Accept(fuzzyCompiler); });
+}
+
+TEST(ScriptObservationTest, TestPreparationRequiredProductEntryPoints) {
+    const ScriptProduct_ product({Cell_(Date_(2030, 9, 11))}, {"IF 1 = 0 THEN x = FIX(EQ[AAPL]) ELSE x = 1 END"});
+    AssertPreparationRequired([&] { static_cast<void>(product.Compile()); });
+    AssertPreparationRequired([&] { static_cast<void>(product.PastEvaluate()); });
+    auto evaluator = product.BuildEvaluator<double>();
+    AssertPreparationRequired([&] { product.Evaluate(Scenario_<double>{}, evaluator); });
+}

--- a/dal-cpp/tests/script/test_observation.cpp
+++ b/dal-cpp/tests/script/test_observation.cpp
@@ -95,6 +95,21 @@ TEST(ScriptObservationTest, TestInvalidSyntax) {
     ASSERT_NO_THROW(parser.Parse("x = SPOT()"));
 }
 
+TEST(ScriptObservationTest, TestInvalidDeliveryDiagnostic) {
+    for (const auto* name : {"EQ[AAPL]@not-a-date", "EQ[AAPL]@2026-02-30", "EQ[AAPL]>invalid"}) {
+        SCOPED_TRACE(name);
+        try {
+            static_cast<void>(Parser_().Parse("x = FIX(" + String_(name) + ")"));
+            FAIL() << "invalid delivery must fail";
+        } catch (const ScriptError_& error) {
+            const std::string message(error.what());
+            ASSERT_NE(message.find("InvalidIndex"), std::string::npos);
+            ASSERT_NE(message.find(name), std::string::npos);
+            ASSERT_NE(message.find("column=9"), std::string::npos);
+        }
+    }
+}
+
 TEST(ScriptObservationTest, TestReservedIdentifier) {
     for (const auto* statement : {"FIX = 1", "fix PAYS 2", "x = fix"}) {
         SCOPED_TRACE(statement);
@@ -212,6 +227,7 @@ namespace {
 } // namespace
 
 TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
+    AAD::Clear(*AAD::Tape());
     auto event = Parser_().Parse("x = FIX(EQ[AAPL])");
     auto& node = *event[0]->arguments_[1];
     Evaluator_<double> tree({});
@@ -223,6 +239,7 @@ TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
     Compiler_ fuzzyCompiler(true);
     DomainProcessor_ domain(0, false);
     DomainProcessor_ fuzzyDomain(0, true);
+    AAD::NewRecording(*AAD::Tape());
     AssertPreparationRequired([&] { node.Accept(tree); });
     AssertPreparationRequired([&] { node.Accept(aad); });
     AssertPreparationRequired([&] { node.Accept(past); });
@@ -235,6 +252,7 @@ TEST(ScriptObservationTest, TestPreparationRequiredVisitors) {
 }
 
 TEST(ScriptObservationTest, TestPreparationRequiredProductEntryPoints) {
+    AAD::Clear(*AAD::Tape());
     const ScriptProduct_ product({Cell_(Date_(2030, 9, 11))}, {"IF 1 = 0 THEN x = FIX(EQ[AAPL]) ELSE x = 1 END"});
     AssertPreparationRequired([&] { static_cast<void>(product.Compile()); });
     AssertPreparationRequired([&] { static_cast<void>(product.PastEvaluate()); });
@@ -243,6 +261,7 @@ TEST(ScriptObservationTest, TestPreparationRequiredProductEntryPoints) {
     auto aad = product.BuildEvaluator<AAD::Number_>();
     auto fuzzy = product.BuildFuzzyEvaluator<double>(1, 0.1);
     auto fuzzyAad = product.BuildFuzzyEvaluator<AAD::Number_>(1, 0.1);
+    AAD::NewRecording(*AAD::Tape());
     AssertPreparationRequired([&] { product.Evaluate(Scenario_<AAD::Number_>{}, aad); });
     AssertPreparationRequired([&] { product.Evaluate(Scenario_<double>{}, fuzzy); });
     AssertPreparationRequired([&] { product.Evaluate(Scenario_<AAD::Number_>{}, fuzzyAad); });

--- a/dal-cpp/tests/script/visitor/test_debugger.cpp
+++ b/dal-cpp/tests/script/visitor/test_debugger.cpp
@@ -315,3 +315,40 @@ TEST(ScriptTest, TestDebuggerEmptyProductJsonAndTree) {
     product.DebugTree(tree);
     ASSERT_EQ(tree.str(), "");
 }
+
+TEST(ScriptTest, TestDebuggerTreePreservesFixIdentityAndDate) {
+    for (const auto* observation : {"FIX(EQ[Aapl])", "FIX(FX[EUR/USD], 2026-09-11)", "FIX(EQ[AAPL]>3M)", "FIX(EQ[AAPL]@2026-12-31, 2026-09-11)"}) {
+        SCOPED_TRACE(observation);
+        const ScriptProduct_ product({Cell_(Date_(2030, 9, 22))}, {"x = 1 + " + String_(observation)});
+        for (const bool ascii : {false, true}) {
+            for (const int width : {20, 125}) {
+                std::ostringstream tree;
+                product.DebugTree(tree, ascii, width);
+                ASSERT_NE(tree.str().find(observation), std::string::npos);
+                ASSERT_NE(tree.str().find("1"), std::string::npos);
+            }
+        }
+        std::ostringstream text;
+        product.Debug(text);
+        ASSERT_NE(text.str().find(observation), std::string::npos);
+    }
+}
+
+TEST(ScriptTest, TestDebuggerLegacyJsonRejectsFixBeforeOutput) {
+    const auto evaluationDate = XGLOBAL::SetEvaluationDateInScope(Date_(2026, 9, 12));
+    for (const auto date : {Date_(2026, 9, 11), Date_(2026, 9, 22)}) {
+        for (const auto* statement : {"x = 1 + FIX(EQ[AAPL], 2026-09-11)", "IF 1 = 0 THEN x = FIX(EQ[AAPL]@2026-12-31, 2026-09-11) ELSE x = 1 END"}) {
+            SCOPED_TRACE(statement);
+            const ScriptProduct_ product({Cell_(date)}, {statement});
+            std::ostringstream json;
+            try {
+                product.DebugJson(json);
+                FAIL() << "schema /1 cannot represent FIX observations";
+            } catch (const ScriptError_& error) {
+                ASSERT_NE(std::string(error.what()).find("DebugSchemaUnsupported"), std::string::npos);
+                ASSERT_NE(std::string(error.what()).find("dal.script-product/1"), std::string::npos);
+            }
+            ASSERT_TRUE(json.str().empty());
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ Deep dives into the quantitative methods and algorithms implemented in DAL:
 
 - **[script_engine.md](methodology/script_engine.md)** — Script Engine
   - Preprocessing pipeline (macros, schedules, constant variables)
+  - Unquoted `FIX(index[,date])` parsing, protected index literals, and execution limits
   - Domain processor (variable range analysis, always-true/false flags)
   - Constant condition processor (dead-branch pruning)
   - Fuzzy evaluator (smooth transitions for pathwise AAD; nested-if merging)

--- a/docs/methodology/index_parsing.md
+++ b/docs/methodology/index_parsing.md
@@ -21,8 +21,10 @@ wraps a handle with its name so scenario containers can order indices.
 tries composite parsing, then single-index parsing. Single parsing splits the
 name at the first `:` or `[`: the prefix before the separator selects a
 parser from a process-wide registry, and the selected parser interprets the
-remainder of the string. A name with no separator currently matches nothing,
-and an unregistered prefix throws.
+complete string. A bare or empty name, or a registered parser returning a null
+result, throws `InvalidIndex`; an unregistered prefix throws `UnknownIndex`.
+The built-in EQ and FX parsers require the complete supported name and reject
+malformed brackets or trailing characters.
 
 Parsers self-register through `Index::RegisterParser(name, func)` under a
 mutex. The built-in registrations are installed once by
@@ -49,12 +51,27 @@ The equity grammar is `EQ[stock]` with an optional delivery suffix
 - `EQ[stock]>3M` — forward whose delivery is the fixing date stepped by a
   date increment (see [dates, calendars, and schedules](dates.md)).
 
+The stock name must be nonempty and cannot contain nested brackets, quotes, or
+line breaks. Other name content is retained, including punctuation such as
+`AAPL(US)` or `BRK/B`. An explicit delivery date must be valid, and a delivery
+increment must parse completely; compound increments cannot contain empty
+components such as the trailing component in `3M&`.
+
 ## FX names
 
 The FX grammar is `FX[fgn/dom]` (`dal-cpp/dal/indice/parser/fx.cpp`) — for
 example `FX[USD/JPY]` is one USD priced in JPY. `Index::Fx_::Fixing` first
 looks up `FX[fgn/dom]` in the environment's fixings and falls back to the
 reciprocal of `FX[dom/fgn]`.
+
+Both currency codes must be nonempty and valid. The grammar requires exactly
+one slash and a final closing bracket with no delivery suffix or trailing text.
+The two FX directions retain distinct names.
+
+The script [named fixing syntax](script_engine.md#named-fixing-syntax) passes
+these complete index literals to `Index::Parse`. Successful parsing establishes
+index identity only; script `FIX` execution currently raises
+`PreparationRequired`.
 
 ## IR indices are constructed, not parsed
 

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -51,13 +51,13 @@ that the preprocessor protects from substitution.
 The parser implements expressions as a cascade of precedence levels, each
 delegating to the next tighter level:
 
-| Level | Operator class          | Produces                                                                                                           |
-|-------|-------------------------|--------------------------------------------------------------------------------------------------------------------|
-| L1    | `+`, `-` (binary)       | `NodeAdd_`, `NodeSub_`                                                                                             |
-| L2    | `*`, `/`                | `NodeMulti_`, `NodeDiv_`                                                                                           |
-| L3    | `^` (right-assoc)       | `NodePow_`                                                                                                         |
-| L4    | unary `+`, `-`          | `NodeUPlus_`, `NodeUMinus_`                                                                                        |
-| Atom  | literal, variable, func | `NodeConst_`, `NodeVar_`/`NodeConstVar_`, `NodeSpot_`, `NodeLog_`, `NodeExp_`, `NodeSqrt_`, `NodeMin_`, `NodeMax_` |
+| Level | Operator class          | Produces                                                                                                                       |
+|-------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| L1    | `+`, `-` (binary)       | `NodeAdd_`, `NodeSub_`                                                                                                         |
+| L2    | `*`, `/`                | `NodeMulti_`, `NodeDiv_`                                                                                                       |
+| L3    | `^` (right-assoc)       | `NodePow_`                                                                                                                     |
+| L4    | unary `+`, `-`          | `NodeUPlus_`, `NodeUMinus_`                                                                                                    |
+| Atom  | literal, variable, func | `NodeConst_`, `NodeVar_`/`NodeConstVar_`, `NodeSpot_`, `NodeFix_`, `NodeLog_`, `NodeExp_`, `NodeSqrt_`, `NodeMin_`, `NodeMax_` |
 
 Parenthesised sub-expressions re-enter at the top level through a shared
 `ParseParentheses` helper. Conditions form a parallel cascade — `OR` (loosest)
@@ -645,14 +645,17 @@ include past events, tagged with their phase:
   has been through `IndexVariables`; every AST node becomes an object with a
   unique pre-order `id` and a stable snake_case `kind` (`add`, `sub`, `mul`,
   `div`, `pow`, `log`, `exp`, `sqrt`, `max`, `min`, `neg`, `uplus`, `eq0`,
-  `gt0`, `ge0`, `and`, `or`, `not`, `assign`, `pays`, `if`, `spot`, `fix`, `const`,
+  `gt0`, `ge0`, `and`, `or`, `not`, `assign`, `pays`, `if`, `spot`, `const`,
   `var`, `const_var`, `true`, `false`, `collect`). Structured kinds get
   structured fields — `condition`/`then`/`else` for `if`, `target`/`value`
   for `assign` and `pays`, `mode`/`eps` (continuous) or `mode`/`lb`/`rb`
   (discrete) for comparisons — and everything else uses `children`. Numbers
   use the shortest decimal form that round-trips; a continuous comparison
   reports the smoothing width in `eps`, where `-1` means the script did not
-  set one (the default smoothing factor applies).
+  set one (the default smoothing factor applies). Products containing any
+  `FIX` raise `DebugSchemaUnsupported` before writing any JSON, including FIX
+  in past events or dead branches, because schema `/1` cannot represent the
+  complete named observation.
 - **Tree** — `ScriptProduct_::DebugTree(ost, ascii, width)` writes a
   human-friendly rendering: statements collapse to inline math while they fit
   the width budget (`width` caps the line width, default 125), for example
@@ -663,11 +666,11 @@ include past events, tagged with their phase:
   every symbol to a pure-ASCII set for constrained consoles — Unicode output
   needs a UTF-8 terminal (on Windows, Windows Terminal or `chcp 65001`).
 
-For `NodeFix_`, the legacy text dump includes the raw index and optional fixing
-date in its `FIX[...]` label. JSON records only the structural `fix` kind for
-this leaf, without index/date fields, and the tree renderer omits the leaf.
-Use the legacy text dump to inspect the index and date; a successful debug dump
-does not establish that the product can be valued.
+For `NodeFix_`, the legacy text and ASCII/Unicode tree dumps preserve the raw
+index and optional fixing date as `FIX(index)` or `FIX(index, date)`, including
+inside nested expressions. The tree keeps the complete leaf even when it
+exceeds the requested width. These human-readable dumps inspect the contract;
+they do not establish that the product can be valued.
 
 The dal-public wrappers `DebugScriptProductJson` and
 `DebugScriptProductTree` run `IndexVariables` on a private copy before

--- a/docs/methodology/script_engine.md
+++ b/docs/methodology/script_engine.md
@@ -31,13 +31,20 @@ control flow all share one polymorphic hierarchy.
 
 ### Lexer
 
-`Tokenize` (`dal-cpp/dal/script/lexer.hpp`) is the single tokenization primitive
-in the engine. Both halves of the pipeline consume it: the preprocessor
-(`Preprocessor_`, the definition front-end) tokenizes directive values, and the
-parser (`Parser_`, the payoff back-end) tokenizes statement text. Housing it in
-its own translation unit — rather than inside either consumer — keeps the two
-halves decoupled and avoids a circular ownership relationship between the
-front-end that resolves schedules and the back-end that builds the AST.
+`Lex` (`dal-cpp/dal/script/lexer.hpp`) produces positioned `Token_` values for
+the parser. Each token holds either ordinary text or an `IndexLiteral_` with
+the complete raw index spelling. `SourceLocation_` carries the character offset
+and one-based line and column in the expanded event text; source origins from
+the preprocessor add the original one-based table row and expanded event date.
+`Tokenize` projects these tokens to strings for schedule parsing and existing
+callers that do not need type or position information.
+
+The lexer preserves bracket contents, FX slashes, and EQ delivery suffixes as
+one index literal. Commas and parentheses inside brackets remain name content;
+the index argument ends at a comma or closing parenthesis outside the brackets.
+Nested brackets, quotes, unmatched brackets, and unsupported script characters
+raise errors. The shared `IndexLiteralRanges` scan also identifies the regions
+that the preprocessor protects from substitution.
 
 ### Precedence Levels
 
@@ -60,12 +67,55 @@ binds over `AND`, which binds over comparison elements — producing `NodeOr_`,
 ### Reserved Keywords and Variables
 
 A fixed reserved-word set (`IF`, `THEN`, `ELSE`, `END`, `PAYS`, `AND`, `OR`,
-`SPOT`, `MAX`, `MIN`, `LOG`, `SQRT`, `EXP`, `DCF`) cannot be used as variable
+`SPOT`, `FIX`, `MAX`, `MIN`, `LOG`, `SQRT`, `EXP`, `DCF`) cannot be used as variable
 names. Any other alphabetic token becomes either a `NodeVar_` (looked up in the
 preprocessor's constant-variable map and promoted to `NodeConstVar_` if it
 resolves there). Statements are either assignments (`=`, `NodeAssign_`), pays
 clauses (`PAYS`, `NodePays_`), or `IF/THEN/ELSE/END` blocks (`NodeIf_`, with
 `firstElse_` indexing the else-branch within `arguments_`).
+
+`FIX` is also reserved for macro and constant-variable definitions. A conflicting
+definition or variable produces `ReservedIdentifier` with source context and a
+request to rename it. Keyword comparisons are case-insensitive.
+
+### Named Fixing Syntax
+
+`FIX(index)` and `FIX(index, date)` parse to a `NodeFix_` leaf. These are
+accepted expressions:
+
+```text
+FIX(EQ[AAPL])
+FIX(FX[EUR/USD])
+FIX(EQ[AAPL]>3M)
+FIX(EQ[AAPL]@2026-12-31, 2026-09-11)
+```
+
+The first argument must be a complete unquoted index literal. The parser passes
+its raw spelling to `Index::Parse` and retains the returned index handle; the
+full identity includes FX direction and any EQ delivery suffix. Index grammar
+and complete-input validation belong to [index parsing](index_parsing.md).
+Unknown names, malformed names, and parsers returning no index fail with script
+source context.
+
+The optional second argument must be a contiguous, valid `YYYY-MM-DD` calendar
+date. In the last example, `2026-12-31` belongs to the index's delivery identity,
+while `2026-09-11` is the fixing date. A schedule placeholder may supply the
+date only after preprocessing has expanded it to that literal. `FIX()` is
+invalid, as are quoted or runtime index arguments, runtime or arithmetic dates,
+timestamps, and extra arguments. `SPOT()` remains the zero-argument model-spot
+expression; it does not accept named arguments.
+
+`NodeFix_` retains the raw `IndexLiteral_`, immutable `Index_` handle, optional
+`Date_`, and `SourceLocation_`. An omitted fixing date remains unset in this
+node. Parsing performs no fixing lookup or model binding.
+
+**Execution limit:** `FIX` currently supports parsing and AST inspection only.
+There is no script fixing-preparation or named-pricing API. Products containing
+any `FIX` raise `PreparationRequired` from `PreProcess`, `Compile`,
+`PastEvaluate`, and `Evaluate`, including when the node is in a dead branch.
+Direct domain, compiler, and numeric evaluator visitors also reject `NodeFix_`.
+The simulation and evaluation pipeline described below therefore applies to
+scripts without `FIX`.
 
 ### Comparators and Smoothing Hints
 
@@ -137,6 +187,9 @@ as the path value.
 The `Preprocessor_` class in `dal-cpp/dal/script/preprocessor.hpp` resolves a raw
 `(Cell_, String_)` events table into `PreprocessedEvents_`: a map of constant
 variables (`String_ -> double`) and dated event descriptions (`Date_ -> String_`).
+It also records source origins for each event description. Statements sharing
+an event date are concatenated in input/expansion order while retaining their
+individual table rows for parser diagnostics.
 
 The class is built for extension: `Process` orchestrates a fixed pipeline while
 every meaningful decision delegates to a protected virtual method, so a derived
@@ -147,12 +200,20 @@ re-implementing the orchestration.
 |-----------------------------------|------------------------------------------------------------------|
 | `IsSchedule(desc)`                | True when a non-date directive description denotes a schedule    |
 | `IsConstVariable(value)`          | True when a non-date directive value defines a constant variable |
-| `ExpandMacros(stmt, macros)`      | Replace every registered macro name in a statement with its body |
-| `ExpandSchedulePlaceholders(...)` | Replace `PeriodBegin` / `PeriodEnd` placeholders for one period  |
+| `ExpandMacros(stmt, macros)`      | Replace macro names outside complete index literals              |
+| `ExpandSchedulePlaceholders(...)` | Replace period placeholders outside complete index literals      |
 
 The default implementation recognises simple textual macros and period-based
 schedule expansion; a derived preprocessor can override any of these to support
 domain-specific directive syntax without touching the orchestration logic.
+
+Macro and schedule-placeholder substitutions protect complete index literals,
+including delivery suffixes. For `FIX(EQ[PeriodBegin], PeriodBegin)`, only the
+second argument expands to a date. A macro may expand into a complete index
+literal; each subsequent substitution rescans the result so the new literal is
+protected too. Outside these regions, macros retain their case-insensitive
+regular-expression replacement in map order, followed by `PeriodBegin` and
+`PeriodEnd` expansion for schedules.
 
 ## Domain Processor
 
@@ -584,7 +645,7 @@ include past events, tagged with their phase:
   has been through `IndexVariables`; every AST node becomes an object with a
   unique pre-order `id` and a stable snake_case `kind` (`add`, `sub`, `mul`,
   `div`, `pow`, `log`, `exp`, `sqrt`, `max`, `min`, `neg`, `uplus`, `eq0`,
-  `gt0`, `ge0`, `and`, `or`, `not`, `assign`, `pays`, `if`, `spot`, `const`,
+  `gt0`, `ge0`, `and`, `or`, `not`, `assign`, `pays`, `if`, `spot`, `fix`, `const`,
   `var`, `const_var`, `true`, `false`, `collect`). Structured kinds get
   structured fields — `condition`/`then`/`else` for `if`, `target`/`value`
   for `assign` and `pays`, `mode`/`eps` (continuous) or `mode`/`lb`/`rb`
@@ -601,6 +662,12 @@ include past events, tagged with their phase:
   branches are marked `▶` (then) and `▷` (else). `ascii = true` switches
   every symbol to a pure-ASCII set for constrained consoles — Unicode output
   needs a UTF-8 terminal (on Windows, Windows Terminal or `chcp 65001`).
+
+For `NodeFix_`, the legacy text dump includes the raw index and optional fixing
+date in its `FIX[...]` label. JSON records only the structural `fix` kind for
+this leaf, without index/date fields, and the tree renderer omits the leaf.
+Use the legacy text dump to inspect the index and date; a successful debug dump
+does not establish that the product can be valued.
 
 The dal-public wrappers `DebugScriptProductJson` and
 `DebugScriptProductTree` run `IndexVariables` on a private copy before


### PR DESCRIPTION
## Summary

- Accept unquoted `FIX(index)` and `FIX(index, YYYY-MM-DD)` while preserving complete EQ/FX identities, delivery suffixes, and source context through macro and schedule expansion.
- Reject malformed, unknown, null, and partially consumed indices with complete-input diagnostics, including invalid EQ delivery dates and increments; reserve `FIX` and retain zero-argument `SPOT()` compatibility.
- Add the frontend node and visitor connections. FIX evaluation raises `PreparationRequired` at this stage; fixing I/O, model binding, and observation preparation remain later work. Record the first FIX during parsing and keep the successful execution check inline to preserve legacy-script performance.
- Preserve the complete observation in human-readable debug trees; reject FIX in legacy JSON schema `/1` with `DebugSchemaUnsupported` before writing incomplete output.
- Update the script and index parsing documentation and record the syntax and compatibility changes in the changelog.

## Test plan

- [x] Fresh `NUM_CORES=8 bash ./build_linux.sh`: 1,592 CTest cases passed, 0 failed.
- [x] Separate Adept and CoDiPack all-target builds and full nonbenchmark CTest suites: 1,584 cases passed on each backend, including public API and portable Excel tests.
- [x] Regression coverage includes protected index punctuation, macro/schedule source context, malformed delivery diagnostics, execution guards in separate processes, and complete debug output.
- [x] Local Lizard analysis: the four originally reported complexity violations are now 4/4/8/4; affected functions satisfy the limit of 8.
- [x] `python3 .github/scripts/check_docs.py`: all 54 Markdown files passed after integration with current master.
- [x] Independent dal-reviewer: Approve on `b5ffaf47d257b656327040fd81dc863aa2491a89`, no findings; 247 reviewer checks passed and the independent performance evidence was accepted.
- [x] Independent paired Python performance verification: all 90 cases passed under the unchanged two-round, best-of-ten, 4% policy, using isolated builds and identical CPU affinity/thread settings. Construction round deltas were -13.57%/-14.04%; vanilla tree evaluation was -0.86%/+1.11%. Local WSL timing noise is recorded in the performance report.

Local testing used Linux Release with native AADET, Adept and CoDiPack. Windows/MSVC, Python bindings, XAD and remote Codacy checks require CI verification on the final pushed head.

Closes #355
Closes DAL-198
