### PR TITLE
fix: give DAL-199 fixing histories distinct C++ types

### DIFF
--- a/.codex/artifacts/api-notes/dal-199-fixhistory-identity.md
+++ b/.codex/artifacts/api-notes/dal-199-fixhistory-identity.md
@@ -1,0 +1,176 @@
+# DAL-199 prerequisite: distinct fixing-history C++ identities
+
+Status: approved API direction for the inherited ODR repair. This note controls
+implementation, testing, documentation, and review on
+`fix/dal-199-fixing-history-definition`, based on `65c6b87a`.
+
+## Decision and audience
+
+Rename the standalone map wrapper in `dal-cpp/dal/indice/fixings.hpp` from
+`Dal::FixHistory_` to `Dal::IndexFixHistory_`. Preserve the active vector
+aggregate `Dal::FixHistory_` in `dal-cpp/dal/storage/globals.hpp` exactly.
+Each qualified type name then has one definition across translation units.
+Do not provide an alias, compatibility macro, conditional definition, or old
+map-wrapper class under the qualified name `Dal::FixHistory_`.
+
+This is a core C++ source/ABI repair for direct `DAL::cpp` consumers. The
+public-facade, Python, and Excel calling surfaces need no changes.
+
+## Verified current surfaces
+
+- `indice/fixings.hpp:25` currently declares the map-owning class, with public
+  `vals_t = std::map<DateTime_, double>`, an explicit copying constructor,
+  private `vals_`, and `Find(time, quiet = false)`.
+- `storage/globals.hpp:21` independently declares the vector-owning aggregate,
+  with public `Vector_<pair<DateTime_, double>> vals_`. `Global::Fixings_::History`
+  returns it; `XGLOBAL::StoreFixings` accepts it with `append = true`.
+- Repository-wide symbol search finds the map wrapper used only in its own
+  declaration, `Find` definition, and `FixHistory::Empty()` implementation.
+  Global capture in `indice/fixingsnapshot.cpp`, curve code, and existing
+  snapshot/curve tests use the vector aggregate.
+- `indice/index.hpp` exposes the separate storable `Dal::Fixings_` through
+  `FixingsAccess_`; `Index::PastFixing` calls `LookupFixing`. Neither is the
+  standalone map wrapper.
+- `dal-public/src/global.hpp` exposes initialization and evaluation dates.
+  `dal-public/src/curveprotocol.hpp:85` constructs `MarketFixingSnapshot_` from
+  nested maps. Python's snapshot class/builder in `bindings/curve.cpp:521` and
+  Excel's `MarketFixingSnapshot_New` in `src/__curveprotocol.cpp:181` use that
+  separate snapshot type. Neither legacy history wrapper is directly bound.
+
+The independent review in `dal-199-inherited-triage.md` supplies the inherited
+baseline comparison, same-TU redefinition failure, and separate-TU ASan
+heap-buffer-overflow evidence. Those tests were performed by the reviewer;
+this API pass does not claim to have rerun them. The active F2 implementation
+handoff in `.codex/artifacts/reviews/dal-199/implementation.md` on the feature
+branch confirms that F2 composes index fixing access with global snapshot
+capture and changes no facade/Python/Excel entry point.
+
+## Proposed surface
+
+```cpp
+namespace Dal {
+    class IndexFixHistory_ {
+    public:
+        using vals_t = std::map<DateTime_, double>;
+
+    private:
+        vals_t vals_;
+
+    public:
+        explicit IndexFixHistory_(const vals_t& vals) : vals_(vals) {}
+        double Find(const DateTime_& fix_time, bool quiet = false) const;
+    };
+
+    namespace FixHistory {
+        const IndexFixHistory_& Empty();
+    }
+}
+```
+
+Update the constructor, out-of-line `Find` definition, and return/local/nested
+type names in `FixHistory::Empty()`. Keep the `FixHistory` namespace and `Empty`
+function name; renaming these would add unrelated migration. `Empty()` remains
+a reference to one process-lifetime const empty map wrapper.
+
+Keep `Fixings_`, `FixingsAccess_`, `LookupFixing`, global storage signatures and
+representation, snapshot behavior, generated storable records, and archive
+format unchanged. No new adapter or implicit conversion is required.
+
+## Lookup and error contract
+
+`IndexFixHistory_` copies its supplied map and performs exact `DateTime_` lookup.
+It does not apply name parsing, FX inversion, nearest-date search, or snapshot
+validation. A missing time with `quiet = false` retains the existing exception
+and message `no fixings for that time`; `quiet = true` retains `-INF`. An empty
+history follows the same rule. Existing finite/nonfinite/value acceptance is
+unchanged; richer input diagnostics are outside this identity repair.
+
+The vector aggregate stays default/aggregate constructible with directly
+mutable `vals_`. Existing storage semantics remain: `StoreFixings` merges when
+`append` is true, replaces when false, lets later supplied values overwrite the
+same timestamp, stores chronological rows, and returns the stored row count.
+No mutation-synchronization guarantee is added.
+
+Typical migrated core use, with both header families intentionally visible:
+
+```cpp
+#include <dal/platform/platform.hpp>
+#include <dal/indice/fixings.hpp>
+#include <dal/storage/globals.hpp>
+
+const Dal::DateTime_ time(Dal::Date_(2026, 9, 11), 0, 0);
+const Dal::IndexFixHistory_ history({{time, 123.0}});
+const double observed = history.Find(time);
+const Dal::IndexFixHistory_& empty = Dal::FixHistory::Empty();
+
+Dal::FixHistory_ stored;
+stored.vals_.push_back({time, observed});
+```
+
+## Compatibility and alternatives
+
+External C++ map-wrapper callers must replace the old type name and its nested
+`vals_t` references with `IndexFixHistory_`. Explicit declarations receiving
+`FixHistory::Empty()` must use the new type; `auto` callers need no source edit.
+Vector/global callers retain their names, signatures, layout, and source use.
+
+Require a clean rebuild of DAL and dependent C++ objects, including bindings
+and executables. Do not mix objects compiled against the old conflicting
+definitions with repaired objects: old weak special-member symbols can retain
+the defect. This is not a binary-compatible map-wrapper rename; method symbols
+and C++ type identity change. An unchanged `Empty` function symbol on an ABI
+that omits return types is not evidence of binary compatibility. The published
+`docs/public-api.md` contract describes core as a source-level API whose
+consumers track core changes and gives no facade ABI isolation guarantee.
+
+No Python function/class/keyword, Excel registration/argument, facade builder,
+default, error text, serialized storable name, or example API changes are needed.
+Rebuilding those binaries against repaired core code remains necessary.
+
+A unified type could retain a map constructor and `Find` while exposing a vector
+`vals_`, but that requires new lookup rules for arbitrary mutable vector order
+and duplicate timestamps, changes map-wrapper layout, and risks aggregate
+initialization compatibility. A dual-container design additionally requires a
+coherency rule for public vector mutation. Neither is a minimal compatible fix.
+Renaming the heavily used vector surface creates needless migrations; removing
+the map wrapper loses its API entirely. Separate names preserve both behaviors.
+
+## Documentation handoff
+
+The doc writer should record a breaking core C++ rename and rebuild requirement
+in `CHANGELOG.md`; this meets its explicit breaking-public-API criterion despite
+having no in-repository map-wrapper clients. Add a short current-state note in
+`docs/methodology/index_parsing.md` distinguishing `IndexFixHistory_` exact map
+lookup, the `FixHistory::Empty()` result, the global vector `FixHistory_`, and
+the separate environment storable `Fixings_`. Keep migration history in the
+changelog. No new methodology page, Python/Excel documentation, or example
+program is warranted. Final wording and placement belong to the doc writer.
+
+## Acceptance evidence for implementer, tester, and reviewer
+
+1. A same-TU regression includes `indice/fixings.hpp` and `storage/globals.hpp`
+   with their usual platform prerequisites and constructs both histories.
+   Demonstrate that this fails on the baseline and compiles after repair.
+   Exercise present/missing/quiet map lookup, the empty singleton, and a
+   nonempty vector history; exact hits and the legacy missing behavior must pass.
+2. Adapt the existing independent three-file reproducer by renaming only its
+   map-wrapper references, compile with `-O0 -fsanitize=address`, and run with
+   both map-first and vector-first object link order. Both must terminate without
+   sanitizer failures. Confirm distinct special-member identities with `nm -C`
+   where emitted; do not encode compiler-specific 48/24-byte sizes in tests.
+3. Existing snapshot/global fixing and affected curve regressions pass on the
+   baseline repair branch. After integrating the prerequisite, F2 fixing
+   environment, preparation, snapshot, and script regressions also pass. The
+   tester/reviewer retain their normal native/public suite requirements.
+4. The final diff preserves the vector definition, lookup bodies, defaults,
+   storable metadata, and facade/binding signatures. Search confirms there is
+   one `Dal::FixHistory_` definition and no alias or map wrapper with that name.
+   Documentation states the source migration and clean-rebuild requirement.
+
+## Open questions
+
+There is no blocking business/API decision. External use of the map wrapper
+cannot be established from the repository; the explicit migration notice covers
+that uncertainty. Broader fixing error handling and synchronization changes are
+outside this authorized minimum repair. This note adds no code, tests, or build
+changes and should be retired once the repair's current-state docs are accepted.

--- a/.codex/artifacts/reviews/dal-199-fixhistory/documentation.md
+++ b/.codex/artifacts/reviews/dal-199-fixhistory/documentation.md
@@ -1,0 +1,52 @@
+DAL-199 prerequisite documentation handoff, 2026-09-13. Reconciled against
+tester head `18ff785769581fb1ea0f0c978d46e5d43a4540ec`, production handoff
+`b15e5340853d6d074c4fd9be969ac16141d36080`, and the approved API note
+`.codex/artifacts/api-notes/dal-199-fixhistory-identity.md`. The containing
+commit is the documentation handoff on `fix/dal-199-fixing-history-definition`.
+
+## Documentation and CHANGELOG Decision
+
+- Read both complete target documents, the API decision, implementation and
+  independent testing reports, and the full production diff. Inspected
+  `dal-cpp/dal/indice/fixings.hpp`, `dal-cpp/dal/indice/fixings.cpp`,
+  `dal-cpp/dal/indice/index.hpp`, and `dal-cpp/dal/storage/globals.hpp`.
+  Confirmed the public-facade, Python, and Excel trees
+  have no delta; symbol search finds no direct history-wrapper references in
+  those surfaces or the examples.
+- `docs/methodology/index_parsing.md` now distinguishes the copied-map
+  `Dal::IndexFixHistory_`, the process-lifetime const result of
+  `FixHistory::Empty()`, the vector aggregate `Dal::FixHistory_` used by global
+  storage, and the separate named storable `Dal::Fixings_` in fixing access
+  environments. It records exact lookup and unchanged missing/quiet behavior,
+  without adding value validation, FX inversion, or synchronization promises.
+- CHANGELOG decision: a September 13 entry is required because direct core
+  consumers face a breaking C++ source/ABI rename. It identifies map-wrapper
+  type and nested `vals_t` migration, explicitly typed `Empty()` results, the
+  preserved global vector name/layout, absence of a map compatibility alias,
+  and a clean rebuild of DAL plus all dependent C++ objects/binaries including
+  bindings and executables. Old conflicting objects cannot be mixed with the
+  repaired build. The entry preserves unchanged lookup, facade/binding, and
+  serialization contracts.
+- No methodology page was added, removed, or renamed; `docs/README.md` and
+  the `CLAUDE.md` methodology list need no change. No Python/Excel API guide,
+  example, C++, test, generated, or configuration edit is needed in this role.
+  Migration history is confined to CHANGELOG; methodology is current-state.
+
+## Validation and Remaining Gates
+
+- `python3 .github/scripts/check_docs.py`: passed across all repository
+  Markdown, including local links/anchors, tables, trailing whitespace, final
+  newlines, and metadata/workflow rules.
+- `git diff --check` and `git diff --cached --check`: passed. Exact staged
+  scope is the two published documents above and this evidence artifact.
+- Independent tester evidence at the stated head is a clean native full
+  build/install run with 1595/1595 tests passing, both header orders compiling,
+  and freshly compiled actual-header cross-TU `-O0` ASan reproductions passing
+  in both link orders. Full commands/configuration/limits are in `testing.md`
+  alongside this file. This documentation pass did not rerun runtime tests or
+  broaden those claims to full-suite sanitizers, Windows/XLL, or Python.
+- No material documentation/source mismatch remains for this rename. The
+  original F2 checkout was untouched; this prerequisite branch contains no F2
+  preparation or debug repair. Independent final review, publication, and
+  integration/revalidation with F2 remain with the orchestrator. No push or
+  platform/GitHub write was performed by this role.

--- a/.codex/artifacts/reviews/dal-199-fixhistory/implementation.md
+++ b/.codex/artifacts/reviews/dal-199-fixhistory/implementation.md
@@ -1,0 +1,94 @@
+# DAL-199 prerequisite implementation
+
+Base: `65c6b87a088ba12cddfa57dcc111250c9bfae16a`, branch
+`fix/dal-199-fixing-history-definition`. The API direction is controlled by
+`.codex/artifacts/api-notes/dal-199-fixhistory-identity.md`.
+
+## Change and compatibility
+
+The only production changes rename the map wrapper in
+`dal-cpp/dal/indice/fixings.hpp/.cpp` to `Dal::IndexFixHistory_`, including its
+constructor, `Find`, and the return/local type of `FixHistory::Empty()`.
+The global vector aggregate `Dal::FixHistory_` remains unchanged. No alias
+reintroduces the conflicting qualified identity. Lookup bodies, defaults,
+missing error text, storable metadata, global storage, and bindings are unchanged.
+
+Direct C++ map-wrapper users must migrate the type name and rebuild DAL plus
+dependent objects. The API note records this source/ABI migration; the doc
+writer owns published migration wording and the changelog. No F2 implementation,
+public pricing behavior, `.claude`, or public documentation changed here.
+
+Permanent regressions in `tests/indice/test_fixhistory.cpp` and
+`tests/indice/test_fixhistory_reverse_headers.cpp` deliberately exercise both
+header orders. They assert distinct C++ identities, aggregate vector
+construction, exact map lookup, copied map ownership, finite zero/negative
+values, unchanged missing/quiet behavior, empty singleton identity, and global
+vector storage/append round trips. Existing CMake test globs register both files.
+
+## RED
+
+The independent triage reproducer was copied to `build/fixhistory-repro/`, using
+the actual headers from this repair checkout. No DAL implementation is linked
+into the three-file layout reproducer.
+
+```bash
+c++ -std=c++17 -I dal-cpp -fsyntax-only build/fixhistory-repro/headers.cpp
+c++ -std=c++17 -I dal-cpp -I dal-cpp/externals/googletest/googletest/include -fsyntax-only dal-cpp/tests/indice/test_fixhistory.cpp dal-cpp/tests/indice/test_fixhistory_reverse_headers.cpp
+c++ -std=c++17 -O0 -g -fsanitize=address -fno-omit-frame-pointer -I dal-cpp build/fixhistory-repro/map.cpp build/fixhistory-repro/vector.cpp build/fixhistory-repro/main.cpp -o build/fixhistory-repro/red
+./build/fixhistory-repro/red
+```
+
+Header compilation exits 1 with `Dal::FixHistory_` redefinition in both orders.
+The ASan compilation succeeds, but execution exits 1 with heap-buffer-overflow:
+destroying the vector history invokes the conflicting map destructor. Logs:
+`build/fixhistory-repro/{headers-red,tests-red,asan-red}.log`.
+
+## GREEN
+
+The same syntax-only commands now exit 0. Logs are
+`build/fixhistory-repro/{headers-green,tests-green}.log`.
+Only map-wrapper type references in the reproducer's `map.cpp` changed;
+`vector.cpp` and `main.cpp` compare byte-for-byte equal to the independent
+originals (`cmp` exit 0).
+
+From `build/fixhistory-repro/`:
+
+```bash
+c++ -std=c++17 -O0 -g -fsanitize=address -fno-omit-frame-pointer -I ../../dal-cpp -c map.cpp vector.cpp main.cpp
+c++ -fsanitize=address map.o vector.o main.o -o green-map-first
+./green-map-first
+c++ -fsanitize=address vector.o map.o main.o -o green-vector-first
+./green-vector-first
+nm -C green-map-first
+```
+
+Both link orders exit 0 without sanitizer diagnostics. The symbol dump shows
+separate weak destructors for `Dal::IndexFixHistory_` and `Dal::FixHistory_` at
+different addresses. No compiler-specific object sizes are asserted. Logs:
+`build/fixhistory-repro/asan-green-{map-first,vector-first}.log` and
+`build/fixhistory-repro/symbols-green.log`.
+
+Core configuration/build:
+
+```bash
+cmake --preset=Release-linux -S . -B build/Release-linux -DDAL_CPP_BUILD_EXAMPLES=OFF -DDAL_BUILD_PUBLIC=ON
+cmake --build build/Release-linux --target dal_cpp_tests -j12
+```
+
+Both commands exit 0 (`build/fixhistory-{configure,green-build}.log`). Focused
+runtime verification:
+
+```bash
+./build/Release-linux/dal-cpp/dal_cpp_tests --gtest_filter='FixHistoryTest.*:FixingSnapshotTest.*:XccyPricingTest.*:XccyJointCalibrationTest.TestOmittedFixingsCaptureAllHistoricalRequestsOnceAndExplicitSnapshotRemainsAuthoritative:RateCashflowPricingTest.TestPreparedTradesRefreshFixingsAndValuationTime'
+```
+
+Result: 44/44 tests from five suites passed, including all three new permanent
+regressions (`build/fixhistory-green-tests.log`). Source search finds only the
+global `struct FixHistory_` definition. The diff for `storage/globals.hpp/.cpp`
+is empty. Changed production lines and new tests are clang-formatted, preserving
+the intentionally opposite include orders; working/cached whitespace checks pass.
+
+Required gtest/rapidjson/machinist submodules were initialized at pinned SHAs;
+no gitlink changed. Full native/public suites, documentation, independent review,
+separate repair publication, and integration/revalidation with F2 remain owned
+by the subsequent specialists. No new broad history redesign was introduced.

--- a/.codex/artifacts/reviews/dal-199-fixhistory/testing.md
+++ b/.codex/artifacts/reviews/dal-199-fixhistory/testing.md
@@ -1,0 +1,119 @@
+DAL-199 prerequisite independent tester handoff, 2026-09-13. Tested production
+head: `b15e5340853d6d074c4fd9be969ac16141d36080`, based on
+`65c6b87a088ba12cddfa57dcc111250c9bfae16a`, in the isolated
+`fix/dal-199-fixing-history-definition` checkout. The containing commit adds
+only this active report. The original F2 checkout and its builds were untouched.
+
+All requested local repair checks pass. The inherited same-name map/vector
+destructor collision no longer occurs in the independently rebuilt actual-header
+reproducer in either object link order. Documentation, independent final review,
+publication, and separate integration/revalidation with F2 remain outstanding.
+
+## Running existing tests
+
+Read AGENTS.md, the tester contract and test references, the approved
+`.codex/artifacts/api-notes/dal-199-fixhistory-identity.md`, implementation
+evidence, production diff, and both permanent regression translation units.
+
+Verified the production delta only changes the map wrapper's class/constructor,
+Find definition, and Empty result/local/nested type names. The map is now
+IndexFixHistory_; the vector remains FixHistory_. The diff against the base is
+empty for storage/globals.hpp/.cpp, indice/fixingsnapshot.cpp, dal-public,
+dal-python and dal-excel. Lookup bodies, defaults, errors, and storage/binding
+behavior are unchanged.
+
+The full Linux workflow used a new build directory and new install prefix,
+verified absent before configuration. It reused neither the implementer's
+existing objects nor any F2 build output. Initialized only the missing pinned
+XAD submodule needed by examples; no gitlink changed. Removed any prior root
+test_output.txt and ran:
+
+```bash
+NUM_CORES=12 DAL_BUILD_DIR=build/dal-199-fixhistory-tester-clean DAL_INSTALL_DIR=build/stage/dal-199-fixhistory-tester-clean ADDITIONAL_CMAKE_FLAGS='-DDAL_BUILD_EXCEL_PORTABLE_TESTS=ON' bash ./build_linux.sh > test_output.txt 2>&1
+```
+
+Exit 0, including configure, all-target compilation, installation and CTest:
+`100% tests passed, 0 tests failed out of 1595`, 8.39 seconds.
+Fresh logs: root `test_output.txt` and `build/fixhistory-tester-native-full.log`.
+
+Configuration: Linux Release, GCC 15.2.0, native AADET; core/public/portable
+Excel tests and examples enabled. Python and benchmarks disabled, with the
+standard script excluding the benchmark label. Discovery comprises 1,457 main
+core tests, four allocation/boundary tests, 105 public API tests, and 29 portable
+Excel contracts (`build/fixhistory-tester-discovery.log`).
+
+The three new FixHistoryTest cases pass in this fresh full run. They cover
+both header orders, distinct C++ identities, vector aggregate construction,
+map copy ownership, exact midnight/intraday lookup, zero/negative values,
+missing/quiet results, unchanged missing text, the Empty singleton, and global
+storage replacement/append with chronological round-trip and overwritten quote.
+Existing FixingSnapshotTest and affected curve suites also pass, including raw
+requested timestamps, reverse FX, invalid quotes, frozen snapshots, refreshing
+historical requests and explicit snapshot authority.
+
+## Independent header and sanitizer verification
+
+Created fresh scratch files under `build/fixhistory-tester-repro/`. Both
+header-order files include the actual repaired platform, indice/fixings and
+storage/globals headers and construct both history types. This command exits 0:
+
+```bash
+c++ -std=c++17 -I dal-cpp -fsyntax-only build/fixhistory-tester-repro/headers-map-first.cpp build/fixhistory-tester-repro/headers-vector-first.cpp
+```
+
+Captured output: `build/fixhistory-tester-repro/headers.log` (empty, no errors).
+For the separate-TU ASan check, copied the independent triage's vector.cpp and
+main.cpp unchanged; cmp against `../dal-199-triage-scratch/` exits 0 for both.
+The map.cpp only changes the map-wrapper type references to IndexFixHistory_.
+Using actual headers, freshly compiled all three objects from that scratch
+directory, then linked and ran both orders:
+
+```bash
+c++ -std=c++17 -O0 -g -fsanitize=address -fno-omit-frame-pointer -I ../../dal-cpp -c map.cpp vector.cpp main.cpp
+c++ -fsanitize=address map.o vector.o main.o -o map-first
+./map-first
+c++ -fsanitize=address vector.o map.o main.o -o vector-first
+./vector-first
+```
+
+Compilation, both links, and both executions exit 0. Runtime logs contain only
+the reproducer's size diagnostics and no ASan error; no object size is asserted.
+Logs: `build/fixhistory-tester-repro/compile.log`, `asan-map-first.log`, and
+`asan-vector-first.log`. This tester reran repaired GREEN, not the baseline RED;
+the latter is independently captured in the earlier triage/implementation record.
+
+`nm -C` on the fresh objects verifies map.o emits only
+IndexFixHistory_::~IndexFixHistory_ and vector.o only FixHistory_::~FixHistory_.
+The linked executable has distinct destructor addresses. Logs:
+`build/fixhistory-tester-repro/object-symbols.log` and `linked-symbols.log`.
+The fresh native core archive exports IndexFixHistory_::Find and has no old
+FixHistory_::Find symbol (`build/fixhistory-tester-library-symbols.log`).
+Source search finds exactly the global struct FixHistory_ definition and no
+alias, compatibility macro, conditional map definition, or map class under
+that qualified name. The remaining FixHistory_ destructor belongs to the
+preserved global vector, as required.
+
+## Authoring tests and repairing failures
+
+No additional permanent tests were necessary: the implementer's three new
+regressions and existing snapshot/curve suites cover this narrowly scoped
+identity repair. No test, production, generated, configuration or documentation
+files were edited by the tester. No test or build failures occurred during this
+independent repair pass. Scratch reproducers/logs are untracked build evidence;
+only this report is committed. Working and exact scoped staged whitespace
+checks pass.
+
+## Remaining delivery requirements and limits
+
+The approved API note requires direct C++ map-wrapper callers to migrate the
+type and vals_t references to IndexFixHistory_, update explicitly typed Empty
+results, and cleanly rebuild DAL plus every dependent C++ object/binary. The
+unchanged global vector name and unchanged Empty function spelling do not make
+old conflicting objects safe to mix with repaired objects. The doc writer must
+publish that source/ABI migration and rebuild requirement before delivery.
+
+No local Windows/XLL or Python runtime is claimed. Alternate AAD repetition is
+unnecessary for this pure C++ type-identity change; sanitizer coverage is the
+specific actual-header cross-TU reproducer, not the entire native suite. F2 is
+not present on this prerequisite branch and must be integrated and independently
+revalidated afterward. No local repair-testing blocker remains.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ Each entry is a short bullet under a dated heading, in the form:
 
 Only add a heading when a qualifying change ships. Do not create empty future headings.
 
+## 2026-09-13
+
+- **Fixing-history C++ identities** — renamed the map wrapper in
+  `dal-cpp/dal/indice/fixings.hpp` from `Dal::FixHistory_` to
+  `Dal::IndexFixHistory_`, removing a conflicting definition that could cause
+  cross-translation-unit destructor corruption. **Breaking source/ABI change
+  for direct core C++ consumers:** migrate map-wrapper type names and nested
+  `vals_t` references to `IndexFixHistory_`, including explicitly typed results
+  of `FixHistory::Empty()`; callers using `auto` for that result need no source
+  edit. The vector aggregate `Dal::FixHistory_` in
+  `dal-cpp/dal/storage/globals.hpp` retains its name and layout; there is no
+  compatibility alias for the map wrapper. Cleanly rebuild DAL and all
+  dependent C++ objects and binaries, including bindings and executables.
+  Do not mix objects built against the old conflicting definitions with
+  repaired objects. Lookup behavior, public-facade/Python/Excel signatures,
+  and serialized fixing records are unchanged. See the
+  [current container contract](docs/methodology/index_parsing.md#fixing-history-containers).
+
 ## 2026-09-12
 
 - **Script FIX syntax** — added parsing for unquoted `FIX(index[,date])`,

--- a/dal-cpp/dal/indice/fixings.cpp
+++ b/dal-cpp/dal/indice/fixings.cpp
@@ -20,8 +20,8 @@ namespace Dal {
             return new Fixings_(name_, ZipToMap(fixing_times_, fixings_));
         }
     } // namespace
-    const FixHistory_& FixHistory::Empty() {
-        static const FixHistory_ RET_VAL((FixHistory_::vals_t()));
+    const IndexFixHistory_& FixHistory::Empty() {
+        static const IndexFixHistory_ RET_VAL((IndexFixHistory_::vals_t()));
         return RET_VAL;
     }
 
@@ -34,7 +34,7 @@ namespace Dal {
         return pf->second;
     }
 
-    double FixHistory_::Find(const DateTime_& fix_time, bool quiet) const { return LookupFixing(vals_, fix_time, quiet); }
+    double IndexFixHistory_::Find(const DateTime_& fix_time, bool quiet) const { return LookupFixing(vals_, fix_time, quiet); }
 
     void Fixings_::Write(Archive::Store_& dst) const {
         Fixings::XWrite(dst, name_, MapValues(vals_), Keys(vals_));

--- a/dal-cpp/dal/indice/fixings.hpp
+++ b/dal-cpp/dal/indice/fixings.hpp
@@ -22,7 +22,7 @@ fixing_times is datetime[]
 -IF-------------------------------------------------------------------------*/
 
 namespace Dal {
-    class FixHistory_ {
+    class IndexFixHistory_ {
     public:
         using vals_t = std::map<DateTime_, double>;
 
@@ -30,12 +30,12 @@ namespace Dal {
         vals_t vals_;
 
     public:
-        explicit FixHistory_(const vals_t& vals) : vals_(vals) {}
+        explicit IndexFixHistory_(const vals_t& vals) : vals_(vals) {}
         double Find(const DateTime_& fix_time, bool quiet = false) const;
     };
 
     namespace FixHistory {
-        const FixHistory_& Empty();
+        const IndexFixHistory_& Empty();
     } // namespace FixHistory
 
     double LookupFixing(const std::map<DateTime_, double>& vals, const DateTime_& fixTime, bool quiet = false);

--- a/dal-cpp/tests/indice/test_fixhistory.cpp
+++ b/dal-cpp/tests/indice/test_fixhistory.cpp
@@ -1,0 +1,53 @@
+//
+// Created by Codex on 2026/9/13.
+//
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <dal/platform/platform.hpp>
+
+#include <dal/indice/fixings.hpp>
+
+#include <dal/storage/globals.hpp>
+
+using namespace Dal;
+
+static_assert(!std::is_same_v<IndexFixHistory_, FixHistory_>);
+static_assert(std::is_aggregate_v<FixHistory_>);
+static_assert(std::is_same_v<decltype(FixHistory::Empty()), const IndexFixHistory_&>);
+
+TEST(FixHistoryTest, TestDistinctHistoriesAndExactLookup) {
+    const DateTime_ midnight(Date_(2026, 9, 11), 0.0);
+    const DateTime_ intraday(Date_(2026, 9, 11), 11, 0);
+    IndexFixHistory_::vals_t values = {{midnight, 0.0}, {intraday, -80.0}};
+    const IndexFixHistory_ indexed(values);
+    values[midnight] = 100.0;
+    ASSERT_DOUBLE_EQ(indexed.Find(midnight), 0.0);
+    ASSERT_DOUBLE_EQ(indexed.Find(intraday), -80.0);
+
+    FixHistory_ global;
+    global.vals_ = {{midnight, indexed.Find(midnight)}, {intraday, indexed.Find(intraday)}};
+    ASSERT_EQ(global.vals_.size(), 2);
+    ASSERT_EQ(global.vals_[0].first, midnight);
+    ASSERT_DOUBLE_EQ(global.vals_[0].second, 0.0);
+    ASSERT_DOUBLE_EQ(global.vals_[1].second, -80.0);
+
+    const DateTime_ missing(Date_(2026, 9, 11), 10, 0);
+    ASSERT_DOUBLE_EQ(indexed.Find(missing, true), -INF);
+    try {
+        static_cast<void>(indexed.Find(missing));
+        FAIL() << "a different timestamp must remain missing";
+    } catch (const Exception_& error) {
+        ASSERT_NE(std::string(error.what()).find("no fixings for that time"), std::string::npos);
+    }
+}
+
+TEST(FixHistoryTest, TestEmptyHistorySingleton) {
+    const IndexFixHistory_& first = FixHistory::Empty();
+    ASSERT_EQ(&first, &FixHistory::Empty());
+    const DateTime_ time(Date_(2026, 9, 11), 0.0);
+    ASSERT_DOUBLE_EQ(first.Find(time, true), -INF);
+    ASSERT_THROW(first.Find(time), Exception_);
+}

--- a/dal-cpp/tests/indice/test_fixhistory_reverse_headers.cpp
+++ b/dal-cpp/tests/indice/test_fixhistory_reverse_headers.cpp
@@ -1,0 +1,33 @@
+//
+// Created by Codex on 2026/9/13.
+//
+
+#include <gtest/gtest.h>
+
+#include <dal/platform/platform.hpp>
+
+#include <dal/storage/globals.hpp>
+
+#include <dal/indice/fixings.hpp>
+
+using namespace Dal;
+
+TEST(FixHistoryTest, TestGlobalFirstHeadersAndStorageRoundTrip) {
+    const DateTime_ first(Date_(2026, 9, 11), 0.0);
+    const DateTime_ second(Date_(2026, 9, 12), 0.0);
+    FixHistory_ global;
+    global.vals_ = {{second, 90.0}, {first, 80.0}};
+    ASSERT_EQ(XGLOBAL::StoreFixings("EQ[DAL199_HISTORY_IDENTITY]", global, false), 2);
+    global.vals_ = {{first, 81.0}};
+    ASSERT_EQ(XGLOBAL::StoreFixings("EQ[DAL199_HISTORY_IDENTITY]", global), 2);
+    const FixHistory_ restored = Global::Fixings_().History("EQ[DAL199_HISTORY_IDENTITY]");
+    ASSERT_EQ(restored.vals_.size(), 2);
+    ASSERT_EQ(restored.vals_[0].first, first);
+    ASSERT_DOUBLE_EQ(restored.vals_[0].second, 81.0);
+    ASSERT_EQ(restored.vals_[1].first, second);
+    ASSERT_DOUBLE_EQ(restored.vals_[1].second, 90.0);
+
+    const IndexFixHistory_ indexed({{first, restored.vals_[0].second}, {second, restored.vals_[1].second}});
+    ASSERT_DOUBLE_EQ(indexed.Find(first), 81.0);
+    ASSERT_DOUBLE_EQ(indexed.Find(second), 90.0);
+}

--- a/docs/methodology/index_parsing.md
+++ b/docs/methodology/index_parsing.md
@@ -15,6 +15,28 @@ exact `DateTime_` in its map. A missing record or time throws unless the
 caller passes the `quiet` flag, which returns $-\infty$ instead. `IndexKey_`
 wraps a handle with its name so scenario containers can order indices.
 
+## Fixing history containers
+
+These core fixing containers serve different roles:
+
+- `Dal::IndexFixHistory_` in `dal-cpp/dal/indice/fixings.hpp` owns a copy of
+  a `std::map<DateTime_, double>` (`vals_t`). `Find(time, quiet = false)`
+  performs exact timestamp lookup. `Dal::FixHistory::Empty()` returns a
+  reference to a process-lifetime const empty `IndexFixHistory_`.
+- `Dal::FixHistory_` in `dal-cpp/dal/storage/globals.hpp` is the global-store
+  aggregate with a public vector of timestamp/value pairs, `vals_`.
+  `Global::Fixings_::History(name)` returns it, and `XGLOBAL::StoreFixings`
+  accepts it. It has a separate C++ type identity from `IndexFixHistory_`.
+- `Dal::Fixings_` in `dal-cpp/dal/indice/fixings.hpp` is the named `Storable_`
+  with a const timestamp/value map. `FixingsAccess_` holds these records for
+  environment-based index lookup; it does not hold `IndexFixHistory_` objects.
+
+`IndexFixHistory_::Find` delegates to `LookupFixing`. A missing exact timestamp
+throws with `no fixings for that time`, or returns $-\infty$ when `quiet` is
+true. This lookup does not select nearby dates, validate quote values, parse
+index names, or invert FX quotes. Index-specific behavior belongs to the
+index's virtual `Fixing` implementation.
+
 ## Parse dispatch
 
 `Index::Parse(const String_&)` (`dal-cpp/dal/indice/indexparse.cpp`) first


### PR DESCRIPTION
## Summary

- Fix an inherited one-definition-rule violation: the global vector history and the index map history previously shared the name `Dal::FixHistory_` with incompatible layouts. Independent cross-translation-unit AddressSanitizer testing reproduced destruction through the wrong type.
- Rename the legacy map wrapper to `IndexFixHistory_`, preserving the active global vector history and existing lookup behavior. Direct C++ map-wrapper callers must use the new type name and rebuild; facade, Python, and Excel signatures are unchanged.
- Add regressions that include both header families in both orders and exercise both history types.

## Test plan

- [x] Reproduce baseline header redefinition and cross-translation-unit sanitizer failure.
- [x] Compile both header orders and pass repaired ASan reproducer in both object link orders; distinct destructor symbols verified.
- [x] Core build and 44 focused history, snapshot, and curve tests passed.
- [x] Independent clean canonical Linux build/install: 1,595 tests passed, including public C++ and portable Excel; fresh actual-header ASan passed both link orders.
- [x] Documentation/CHANGELOG migration and mandatory clean-rebuild note; 58 Markdown files passed documentation checks.
- [x] Independent DAL reviewer approved `c121fa1d316ea0ebd936c0bb4ae387c4d64e88cc`; reproduced both header-order and ASan checks, with no findings.
- [x] Required Linux and Windows CI gates passed at `c121fa1d316ea0ebd936c0bb4ae387c4d64e88cc`.

This is a prerequisite repair discovered during DAL-199/F2 verification. It does not complete the F2 feature and carries no issue-closing intent. F2 is tracked in PR #367; its integrated implementation, tests, documentation, and independent review are complete, with final review cleanup and merge gates handled there.
